### PR TITLE
Account interface for vm

### DIFF
--- a/account/vm_account.go
+++ b/account/vm_account.go
@@ -1,0 +1,29 @@
+package account
+
+import (
+	"github.com/tendermint/tendermint/vm"
+)
+
+func (acc *VmAccount) GetAddress() vm.Word         { return acc.Address }
+func (acc *VmAccount) GetBalance() uint64          { return acc.Balance }
+func (acc *VmAccount) GetCode() []byte             { return acc.Code }
+func (acc *VmAccount) GetNonce() uint64            { return acc.Nonce }
+func (acc *VmAccount) GetStorageRoot() vm.Word     { return acc.StorageRoot }
+func (acc *VmAccount) SetAddress(addr vm.Word)     { acc.Address = addr }
+func (acc *VmAccount) SetBalance(balance uint64)   { acc.Balance = balance }
+func (acc *VmAccount) SetCode(code []byte)         { acc.Code = code }
+func (acc *VmAccount) SetNonce(nonce uint64)       { acc.Nonce = nonce }
+func (acc *VmAccount) SetStorageRoot(root vm.Word) { acc.StorageRoot = root }
+
+//-----------------------------------------------------------------------------
+
+type VmAccount struct {
+	Address     vm.Word
+	Balance     uint64
+	Code        []byte
+	Nonce       uint64
+	StorageRoot vm.Word
+
+	// not needed for vm but required for sanity
+	PubKey PubKey
+}

--- a/vm/types.go
+++ b/vm/types.go
@@ -27,12 +27,18 @@ func (w Word) IsZero() bool {
 
 //-----------------------------------------------------------------------------
 
-type Account struct {
-	Address     Word
-	Balance     uint64
-	Code        []byte
-	Nonce       uint64
-	StorageRoot Word
+type Account interface {
+	GetAddress() Word
+	GetBalance() uint64
+	GetCode() []byte
+	GetNonce() uint64
+	GetStorageRoot() Word
+
+	SetAddress(Word)
+	SetBalance(uint64)
+	SetCode([]byte)
+	SetNonce(uint64)
+	SetStorageRoot(Word)
 }
 
 type Log struct {
@@ -45,10 +51,10 @@ type Log struct {
 type AppState interface {
 
 	// Accounts
-	GetAccount(addr Word) (*Account, error)
-	UpdateAccount(*Account) error
-	DeleteAccount(*Account) error
-	CreateAccount(*Account) (*Account, error)
+	GetAccount(addr Word) (Account, error)
+	UpdateAccount(Account) error
+	DeleteAccount(Account) error
+	CreateAccount(Account) (Account, error)
 
 	// Storage
 	GetStorage(Word, Word) (Word, error)


### PR DESCRIPTION
Introduces an `Account` interface into the vm, implemented by `account.VmAccount`, using `vm.Word` where necessary and maintaining the `PubKey` to avoid serialization panics on PubKey = nil