### PR TITLE
Vm fixes

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1012,6 +1012,7 @@ func (cs *ConsensusState) stageBlock(block *types.Block, blockParts *types.PartS
 	}
 
 	// Already staged?
+	// XXX: check hash better than pointer?
 	if cs.stagedBlock == block {
 		return nil
 	}

--- a/merkle/iavl_tree.go
+++ b/merkle/iavl_tree.go
@@ -3,6 +3,7 @@ package merkle
 import (
 	"bytes"
 	"container/list"
+	"fmt"
 	"sync"
 
 	"github.com/tendermint/tendermint/binary"
@@ -144,20 +145,20 @@ func (t *IAVLTree) GetByIndex(index uint64) (key interface{}, value interface{})
 	return t.root.getByIndex(t, index)
 }
 
-func (t *IAVLTree) Remove(key interface{}) (value interface{}, removed bool) {
+func (t *IAVLTree) Remove(key interface{}) (value interface{}, removed error) {
 	if t.root == nil {
-		return nil, false
+		return nil, fmt.Errorf("Root is nil")
 	}
 	newRootHash, newRoot, _, value, removed := t.root.remove(t, key)
-	if !removed {
-		return nil, false
+	if removed != nil {
+		return nil, removed
 	}
 	if newRoot == nil && newRootHash != nil {
 		t.root = t.ndb.GetNode(t, newRootHash)
 	} else {
 		t.root = newRoot
 	}
-	return value, true
+	return value, nil
 }
 
 func (t *IAVLTree) Iterate(fn func(key interface{}, value interface{}) bool) (stopped bool) {

--- a/merkle/types.go
+++ b/merkle/types.go
@@ -7,7 +7,7 @@ type Tree interface {
 	Get(key interface{}) (index uint64, value interface{})
 	GetByIndex(index uint64) (key interface{}, value interface{})
 	Set(key interface{}, value interface{}) (updated bool)
-	Remove(key interface{}) (value interface{}, removed bool)
+	Remove(key interface{}) (value interface{}, removed error)
 	HashWithCount() (hash []byte, count uint64)
 	Hash() (hash []byte)
 	Save() (hash []byte)

--- a/state/genesis.go
+++ b/state/genesis.go
@@ -103,7 +103,7 @@ func MakeGenesisState(db dbm.DB, genDoc *GenesisDoc) *State {
 	accounts.Save()
 	validatorInfos.Save()
 
-	return &State{
+	s := &State{
 		DB:                   db,
 		LastBlockHeight:      0,
 		LastBlockHash:        nil,
@@ -115,4 +115,6 @@ func MakeGenesisState(db dbm.DB, genDoc *GenesisDoc) *State {
 		accounts:             accounts,
 		validatorInfos:       validatorInfos,
 	}
+	s.blockState = NewTransState(&TransStateWrapper{s})
+	return s
 }

--- a/vm/test/fake_app_state.go
+++ b/vm/test/fake_app_state.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	. "github.com/tendermint/tendermint/common"
 	. "github.com/tendermint/tendermint/vm"
 	"github.com/tendermint/tendermint/vm/sha3"
@@ -87,33 +85,6 @@ func (fas *FakeAppState) SetStorage(addr Word, key Word, value Word) (bool, erro
 
 func (fas *FakeAppState) AddLog(log *Log) {
 	fas.logs = append(fas.logs, log)
-}
-
-func main() {
-	appState := &FakeAppState{
-		accounts: make(map[string]*Account),
-		storage:  make(map[string]Word),
-		logs:     nil,
-	}
-	params := Params{
-		BlockHeight: 0,
-		BlockHash:   Zero,
-		BlockTime:   0,
-		GasLimit:    0,
-	}
-	ourVm := NewVM(appState, params, Zero)
-
-	// Create accounts
-	account1 := &Account{
-		Address: Uint64ToWord(100),
-	}
-	account2 := &Account{
-		Address: Uint64ToWord(101),
-	}
-
-	var gas uint64 = 1000
-	output, err := ourVm.Call(account1, account2, []byte{0x5B, 0x60, 0x00, 0x56}, []byte{}, 0, &gas)
-	fmt.Printf("Output: %v Error: %v\n", output, err)
 }
 
 // Creates a 20 byte address and bumps the nonce.

--- a/vm/test/fake_app_state.go
+++ b/vm/test/fake_app_state.go
@@ -17,24 +17,24 @@ func (fas *FakeAppState) GetAccount(addr Word) (*Account, error) {
 	if account != nil {
 		return account, nil
 	} else {
-		return nil, Errorf("Invalid account addr: %v", addr)
+		return nil, Errorf("Invalid account addr: %x", addr)
 	}
 }
 
 func (fas *FakeAppState) UpdateAccount(account *Account) error {
 	_, ok := fas.accounts[account.Address.String()]
 	if !ok {
-		return Errorf("Invalid account addr: %v", account.Address.String())
+		return Errorf("Invalid account addr: %x", account.Address.String())
 	} else {
 		// Nothing to do
 		return nil
 	}
 }
 
-func (fas *FakeAppState) DeleteAccount(account *Account) error {
+func (fas *FakeAppState) RemoveAccount(account *Account) error {
 	_, ok := fas.accounts[account.Address.String()]
 	if !ok {
-		return Errorf("Invalid account addr: %v", account.Address.String())
+		return Errorf("Invalid account addr: %x", account.Address.String())
 	} else {
 		// Delete account
 		delete(fas.accounts, account.Address.String())
@@ -54,14 +54,14 @@ func (fas *FakeAppState) CreateAccount(creator *Account) (*Account, error) {
 			StorageRoot: Zero,
 		}, nil
 	} else {
-		return nil, Errorf("Invalid account addr: %v", addr)
+		return nil, Errorf("Invalid account addr: %x", addr)
 	}
 }
 
 func (fas *FakeAppState) GetStorage(addr Word, key Word) (Word, error) {
 	_, ok := fas.accounts[addr.String()]
 	if !ok {
-		return Zero, Errorf("Invalid account addr: %v", addr)
+		return Zero, Errorf("Invalid account addr: %x", addr)
 	}
 
 	value, ok := fas.storage[addr.String()+key.String()]
@@ -75,7 +75,7 @@ func (fas *FakeAppState) GetStorage(addr Word, key Word) (Word, error) {
 func (fas *FakeAppState) SetStorage(addr Word, key Word, value Word) (bool, error) {
 	_, ok := fas.accounts[addr.String()]
 	if !ok {
-		return false, Errorf("Invalid account addr: %v", addr)
+		return false, Errorf("Invalid account addr: %x", addr)
 	}
 
 	_, ok = fas.storage[addr.String()+key.String()]

--- a/vm/test/vm_test.go
+++ b/vm/test/vm_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	. "github.com/tendermint/tendermint/vm"
+	"testing"
+	"time"
+)
+
+func newVM() *VM {
+	appState := &FakeAppState{
+		accounts: make(map[string]*Account),
+		storage:  make(map[string]Word),
+		logs:     nil,
+	}
+	params := Params{
+		BlockHeight: 0,
+		BlockHash:   Zero,
+		BlockTime:   0,
+		GasLimit:    0,
+	}
+	return NewVM(appState, params, Zero)
+}
+
+func TestVM(t *testing.T) {
+	dbg
+	ourVm := newVM()
+
+	// Create accounts
+	account1 := &Account{
+		Address: Uint64ToWord(100),
+	}
+	account2 := &Account{
+		Address: Uint64ToWord(101),
+	}
+
+	var gas uint64 = 1000
+	N := []byte{0xff, 0xff}
+	// Loop N times
+	code := []byte{0x60, 0x00, 0x60, 0x20, 0x52, 0x5B, byte(0x60 + len(N) - 1)}
+	for i := 0; i < len(N); i++ {
+		code = append(code, N[i])
+	}
+	code = append(code, []byte{0x60, 0x20, 0x51, 0x12, 0x15, 0x60, byte(0x1b + len(N)), 0x57, 0x60, 0x01, 0x60, 0x20, 0x51, 0x01, 0x60, 0x20, 0x52, 0x60, 0x05, 0x56, 0x5B}...)
+	start := time.Now()
+	output, err := ourVm.Call(account1, account2, code, []byte{}, 0, &gas)
+	fmt.Printf("Output: %v Error: %v\n", output, err)
+	fmt.Println("Call took:", time.Since(start))
+}
+
+/*
+	// infinite loop
+	code := []byte{0x5B, 0x60, 0x00, 0x56}
+	// mstore
+	code := []byte{0x60, 0x00, 0x60, 0x20}
+	// mstore, mload
+	code := []byte{0x60, 0x01, 0x60, 0x20, 0x52, 0x60, 0x20, 0x51}
+*/

--- a/vm/test/vm_test.go
+++ b/vm/test/vm_test.go
@@ -1,30 +1,40 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	. "github.com/tendermint/tendermint/vm"
+	"strings"
 	"testing"
 	"time"
 )
 
-func newVM() *VM {
-	appState := &FakeAppState{
+func newAppState() *FakeAppState {
+	return &FakeAppState{
 		accounts: make(map[string]*Account),
 		storage:  make(map[string]Word),
 		logs:     nil,
 	}
-	params := Params{
+}
+
+func newParams() Params {
+	return Params{
 		BlockHeight: 0,
 		BlockHash:   Zero,
 		BlockTime:   0,
 		GasLimit:    0,
 	}
-	return NewVM(appState, params, Zero)
+}
+
+func makeBytes(n int) []byte {
+	b := make([]byte, n)
+	rand.Read(b)
+	return b
 }
 
 func TestVM(t *testing.T) {
-	dbg
-	ourVm := newVM()
+	ourVm := NewVM(newAppState(), newParams(), Zero)
 
 	// Create accounts
 	account1 := &Account{
@@ -46,6 +56,35 @@ func TestVM(t *testing.T) {
 	output, err := ourVm.Call(account1, account2, code, []byte{}, 0, &gas)
 	fmt.Printf("Output: %v Error: %v\n", output, err)
 	fmt.Println("Call took:", time.Since(start))
+}
+
+func TestSubcurrency(t *testing.T) {
+	st := newAppState()
+	// Create accounts
+	account1 := &Account{
+		Address: BytesToWord(makeBytes(20)),
+	}
+	account2 := &Account{
+		Address: BytesToWord(makeBytes(20)),
+	}
+	st.accounts[account1.Address.String()] = account1
+	st.accounts[account2.Address.String()] = account2
+
+	ourVm := NewVM(st, newParams(), Zero)
+
+	var gas uint64 = 1000
+	code_parts := []string{"620f42403355",
+		"7c0100000000000000000000000000000000000000000000000000000000",
+		"600035046315cf268481141561004657",
+		"6004356040526040515460605260206060f35b63693200ce81141561008757",
+		"60043560805260243560a052335460c0523360e05260a05160c05112151561008657",
+		"60a05160c0510360e0515560a0516080515401608051555b5b505b6000f3"}
+	code, _ := hex.DecodeString(strings.Join(code_parts, ""))
+	fmt.Printf("Code: %x\n", code)
+	data, _ := hex.DecodeString("693200CE0000000000000000000000004B4363CDE27C2EB05E66357DB05BC5C88F850C1A0000000000000000000000000000000000000000000000000000000000000005")
+	output, err := ourVm.Call(account1, account2, code, data, 0, &gas)
+	fmt.Printf("Output: %v Error: %v\n", output, err)
+
 }
 
 /*

--- a/vm/types.go
+++ b/vm/types.go
@@ -48,7 +48,7 @@ type AppState interface {
 	// Accounts
 	GetAccount(addr Word) (*Account, error)
 	UpdateAccount(*Account) error
-	DeleteAccount(*Account) error
+	RemoveAccount(*Account) error
 	CreateAccount(*Account) (*Account, error)
 
 	// Storage

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -23,11 +23,20 @@ var (
 	ErrInvalidContract     = errors.New("Invalid contract")
 )
 
+type Debug bool
+
 const (
-	dataStackCapacity = 1024
-	callStackCapacity = 100         // TODO ensure usage.
-	memoryCapacity    = 1024 * 1024 // 1 MB
+	dataStackCapacity       = 1024
+	callStackCapacity       = 100         // TODO ensure usage.
+	memoryCapacity          = 1024 * 1024 // 1 MB
+	dbg               Debug = true
 )
+
+func (d Debug) Printf(s string, a ...interface{}) {
+	if d {
+		fmt.Printf(s, a...)
+	}
+}
 
 type VM struct {
 	appState AppState
@@ -89,7 +98,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 		}
 
 		var op = codeGetOp(code, pc)
-		fmt.Printf("(pc) %-3d (op) %-14s (st) %-4d ", pc, op.String(), stack.Len())
+		dbg.Printf("(pc) %-3d (op) %-14s (st) %-4d ", pc, op.String(), stack.Len())
 
 		switch op {
 
@@ -99,88 +108,88 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 		case ADD: // 0x01
 			x, y := stack.Pop64(), stack.Pop64()
 			stack.Push64(x + y)
-			fmt.Printf(" %v + %v = %v\n", x, y, x+y)
+			dbg.Printf(" %v + %v = %v\n", x, y, x+y)
 
 		case MUL: // 0x02
 			x, y := stack.Pop64(), stack.Pop64()
 			stack.Push64(x * y)
-			fmt.Printf(" %v * %v = %v\n", x, y, x*y)
+			dbg.Printf(" %v * %v = %v\n", x, y, x*y)
 
 		case SUB: // 0x03
 			x, y := stack.Pop64(), stack.Pop64()
 			stack.Push64(x - y)
-			fmt.Printf(" %v - %v = %v\n", x, y, x-y)
+			dbg.Printf(" %v - %v = %v\n", x, y, x-y)
 
 		case DIV: // 0x04
 			x, y := stack.Pop64(), stack.Pop64()
 			if y == 0 { // TODO
 				stack.Push(Zero)
-				fmt.Printf(" %v / %v = %v (TODO)\n", x, y, 0)
+				dbg.Printf(" %v / %v = %v (TODO)\n", x, y, 0)
 			} else {
 				stack.Push64(x / y)
-				fmt.Printf(" %v / %v = %v\n", x, y, x/y)
+				dbg.Printf(" %v / %v = %v\n", x, y, x/y)
 			}
 
 		case SDIV: // 0x05
 			x, y := int64(stack.Pop64()), int64(stack.Pop64())
 			if y == 0 { // TODO
 				stack.Push(Zero)
-				fmt.Printf(" %v / %v = %v (TODO)\n", x, y, 0)
+				dbg.Printf(" %v / %v = %v (TODO)\n", x, y, 0)
 			} else {
 				stack.Push64(uint64(x / y))
-				fmt.Printf(" %v / %v = %v\n", x, y, x/y)
+				dbg.Printf(" %v / %v = %v\n", x, y, x/y)
 			}
 
 		case MOD: // 0x06
 			x, y := stack.Pop64(), stack.Pop64()
 			if y == 0 { // TODO
 				stack.Push(Zero)
-				fmt.Printf(" %v %% %v = %v (TODO)\n", x, y, 0)
+				dbg.Printf(" %v %% %v = %v (TODO)\n", x, y, 0)
 			} else {
 				stack.Push64(x % y)
-				fmt.Printf(" %v %% %v = %v\n", x, y, x%y)
+				dbg.Printf(" %v %% %v = %v\n", x, y, x%y)
 			}
 
 		case SMOD: // 0x07
 			x, y := int64(stack.Pop64()), int64(stack.Pop64())
 			if y == 0 { // TODO
 				stack.Push(Zero)
-				fmt.Printf(" %v %% %v = %v (TODO)\n", x, y, 0)
+				dbg.Printf(" %v %% %v = %v (TODO)\n", x, y, 0)
 			} else {
 				stack.Push64(uint64(x % y))
-				fmt.Printf(" %v %% %v = %v\n", x, y, x%y)
+				dbg.Printf(" %v %% %v = %v\n", x, y, x%y)
 			}
 
 		case ADDMOD: // 0x08
 			x, y, z := stack.Pop64(), stack.Pop64(), stack.Pop64()
 			if z == 0 { // TODO
 				stack.Push(Zero)
-				fmt.Printf(" (%v + %v) %% %v = %v (TODO)\n", x, y, z, 0)
+				dbg.Printf(" (%v + %v) %% %v = %v (TODO)\n", x, y, z, 0)
 			} else {
 				stack.Push64(x % y)
-				fmt.Printf(" (%v + %v) %% %v = %v\n", x, y, z, (x+y)%z)
+				dbg.Printf(" (%v + %v) %% %v = %v\n", x, y, z, (x+y)%z)
 			}
 
 		case MULMOD: // 0x09
 			x, y, z := stack.Pop64(), stack.Pop64(), stack.Pop64()
 			if z == 0 { // TODO
 				stack.Push(Zero)
-				fmt.Printf(" (%v + %v) %% %v = %v (TODO)\n", x, y, z, 0)
+				dbg.Printf(" (%v + %v) %% %v = %v (TODO)\n", x, y, z, 0)
 			} else {
 				stack.Push64(x % y)
-				fmt.Printf(" (%v + %v) %% %v = %v\n", x, y, z, (x*y)%z)
+				dbg.Printf(" (%v + %v) %% %v = %v\n", x, y, z, (x*y)%z)
 			}
 
 		case EXP: // 0x0A
 			x, y := stack.Pop64(), stack.Pop64()
 			stack.Push64(ExpUint64(x, y))
-			fmt.Printf(" %v ** %v = %v\n", x, y, uint64(math.Pow(float64(x), float64(y))))
+			dbg.Printf(" %v ** %v = %v\n", x, y, uint64(math.Pow(float64(x), float64(y))))
 
 		case SIGNEXTEND: // 0x0B
 			x, y := stack.Pop64(), stack.Pop64()
 			res := (y << uint(x)) >> x
 			stack.Push64(res)
-			fmt.Printf(" (%v << %v) >> %v = %v\n", y, x, x, res)
+			dbg.Printf(" (%v << %v) >> %v = %v\n", y, x, x, res)
 
 		case LT: // 0x10
 			x, y := stack.Pop64(), stack.Pop64()
@@ -189,7 +198,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			} else {
 				stack.Push(Zero)
 			}
-			fmt.Printf(" %v < %v = %v\n", x, y, x < y)
+			dbg.Printf(" %v < %v = %v\n", x, y, x < y)
 
 		case GT: // 0x11
 			x, y := stack.Pop64(), stack.Pop64()
@@ -198,7 +207,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			} else {
 				stack.Push(Zero)
 			}
-			fmt.Printf(" %v > %v = %v\n", x, y, x > y)
+			dbg.Printf(" %v > %v = %v\n", x, y, x > y)
 
 		case SLT: // 0x12
 			x, y := int64(stack.Pop64()), int64(stack.Pop64())
@@ -207,7 +216,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			} else {
 				stack.Push(Zero)
 			}
-			fmt.Printf(" %v < %v = %v\n", x, y, x < y)
+			dbg.Printf(" %v < %v = %v\n", x, y, x < y)
 
 		case SGT: // 0x13
 			x, y := int64(stack.Pop64()), int64(stack.Pop64())
@@ -216,7 +225,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			} else {
 				stack.Push(Zero)
 			}
-			fmt.Printf(" %v > %v = %v\n", x, y, x > y)
+			dbg.Printf(" %v > %v = %v\n", x, y, x > y)
 
 		case EQ: // 0x14
 			x, y := stack.Pop64(), stack.Pop64()
@@ -225,7 +234,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			} else {
 				stack.Push(Zero)
 			}
-			fmt.Printf(" %v == %v = %v\n", x, y, x == y)
+			dbg.Printf(" %v == %v = %v\n", x, y, x == y)
 
 		case ISZERO: // 0x15
 			x := stack.Pop64()
@@ -234,27 +243,27 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			} else {
 				stack.Push(Zero)
 			}
-			fmt.Printf(" %v == 0 = %v\n", x, x == 0)
+			dbg.Printf(" %v == 0 = %v\n", x, x == 0)
 
 		case AND: // 0x16
 			x, y := stack.Pop64(), stack.Pop64()
 			stack.Push64(x & y)
-			fmt.Printf(" %v & %v = %v\n", x, y, x&y)
+			dbg.Printf(" %v & %v = %v\n", x, y, x&y)
 
 		case OR: // 0x17
 			x, y := stack.Pop64(), stack.Pop64()
 			stack.Push64(x | y)
-			fmt.Printf(" %v | %v = %v\n", x, y, x|y)
+			dbg.Printf(" %v | %v = %v\n", x, y, x|y)
 
 		case XOR: // 0x18
 			x, y := stack.Pop64(), stack.Pop64()
 			stack.Push64(x ^ y)
-			fmt.Printf(" %v ^ %v = %v\n", x, y, x^y)
+			dbg.Printf(" %v ^ %v = %v\n", x, y, x^y)
 
 		case NOT: // 0x19
 			x := stack.Pop64()
 			stack.Push64(^x)
-			fmt.Printf(" !%v = %v\n", x, ^x)
+			dbg.Printf(" !%v = %v\n", x, ^x)
 
 		case BYTE: // 0x1A
 			idx, val := stack.Pop64(), stack.Pop()
@@ -263,7 +272,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 				res = val[idx]
 			}
 			stack.Push64(uint64(res))
-			fmt.Printf(" => 0x%X\n", res)
+			dbg.Printf(" => 0x%X\n", res)
 
 		case SHA3: // 0x20
 			if ok = useGas(gas, GasSha3); !ok {
@@ -276,11 +285,11 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			}
 			data = sha3.Sha3(data)
 			stack.PushBytes(data)
-			fmt.Printf(" => (%v) %X\n", size, data)
+			dbg.Printf(" => (%v) %X\n", size, data)
 
 		case ADDRESS: // 0x30
 			stack.Push(callee.Address)
-			fmt.Printf(" => %X\n", callee.Address)
+			dbg.Printf(" => %X\n", callee.Address)
 
 		case BALANCE: // 0x31
 			addr := stack.Pop()
@@ -293,19 +302,19 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			}
 			balance := account.Balance
 			stack.Push64(balance)
-			fmt.Printf(" => %v (%X)\n", balance, addr)
+			dbg.Printf(" => %v (%X)\n", balance, addr)
 
 		case ORIGIN: // 0x32
 			stack.Push(vm.origin)
-			fmt.Printf(" => %X\n", vm.origin)
+			dbg.Printf(" => %X\n", vm.origin)
 
 		case CALLER: // 0x33
 			stack.Push(caller.Address)
-			fmt.Printf(" => %X\n", caller.Address)
+			dbg.Printf(" => %X\n", caller.Address)
 
 		case CALLVALUE: // 0x34
 			stack.Push64(value)
-			fmt.Printf(" => %v\n", value)
+			dbg.Printf(" => %v\n", value)
 
 		case CALLDATALOAD: // 0x35
 			offset := stack.Pop64()
@@ -314,11 +323,11 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 				return nil, firstErr(err, ErrInputOutOfBounds)
 			}
 			stack.Push(RightPadWord(data))
-			fmt.Printf(" => 0x%X\n", data)
+			dbg.Printf(" => 0x%X\n", data)
 
 		case CALLDATASIZE: // 0x36
 			stack.Push64(uint64(len(input)))
-			fmt.Printf(" => %d\n", len(input))
+			dbg.Printf(" => %d\n", len(input))
 
 		case CALLDATACOPY: // 0x37
 			memOff := stack.Pop64()
@@ -333,12 +342,12 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 				return nil, firstErr(err, ErrMemoryOutOfBounds)
 			}
 			copy(dest, data)
-			fmt.Printf(" => [%v, %v, %v] %X\n", memOff, inputOff, length, data)
+			dbg.Printf(" => [%v, %v, %v] %X\n", memOff, inputOff, length, data)
 
 		case CODESIZE: // 0x38
 			l := uint64(len(code))
 			stack.Push64(l)
-			fmt.Printf(" => %d\n", l)
+			dbg.Printf(" => %d\n", l)
 
 		case CODECOPY: // 0x39
 			memOff := stack.Pop64()
@@ -354,11 +363,11 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 				return nil, firstErr(err, ErrMemoryOutOfBounds)
 			}
 			copy(dest, data)
-			fmt.Printf(" => [%v, %v, %v] %X\n", memOff, codeOff, length, data)
+			dbg.Printf(" => [%v, %v, %v] %X\n", memOff, codeOff, length, data)
 
 		case GASPRICE_DEPRECATED: // 0x3A
 			stack.Push(Zero)
-			fmt.Printf(" => %X (GASPRICE IS DEPRECATED)\n")
+			dbg.Printf(" => %X (GASPRICE IS DEPRECATED)\n")
 
 		case EXTCODESIZE: // 0x3B
 			addr := stack.Pop()
@@ -372,7 +381,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			code := account.Code
 			l := uint64(len(code))
 			stack.Push64(l)
-			fmt.Printf(" => %d\n", l)
+			dbg.Printf(" => %d\n", l)
 
 		case EXTCODECOPY: // 0x3C
 			addr := stack.Pop()
@@ -396,33 +405,33 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 				return nil, firstErr(err, ErrMemoryOutOfBounds)
 			}
 			copy(dest, data)
-			fmt.Printf(" => [%v, %v, %v] %X\n", memOff, codeOff, length, data)
+			dbg.Printf(" => [%v, %v, %v] %X\n", memOff, codeOff, length, data)
 
 		case BLOCKHASH: // 0x40
 			stack.Push(Zero)
-			fmt.Printf(" => 0x%X (NOT SUPPORTED)\n", stack.Peek().Bytes())
+			dbg.Printf(" => 0x%X (NOT SUPPORTED)\n", stack.Peek().Bytes())
 
 		case COINBASE: // 0x41
 			stack.Push(Zero)
-			fmt.Printf(" => 0x%X (NOT SUPPORTED)\n", stack.Peek().Bytes())
+			dbg.Printf(" => 0x%X (NOT SUPPORTED)\n", stack.Peek().Bytes())
 
 		case TIMESTAMP: // 0x42
 			time := vm.params.BlockTime
 			stack.Push64(uint64(time))
-			fmt.Printf(" => 0x%X\n", time)
+			dbg.Printf(" => 0x%X\n", time)
 
 		case BLOCKHEIGHT: // 0x43
 			number := uint64(vm.params.BlockHeight)
 			stack.Push64(number)
-			fmt.Printf(" => 0x%X\n", number)
+			dbg.Printf(" => 0x%X\n", number)
 
 		case GASLIMIT: // 0x45
 			stack.Push64(vm.params.GasLimit)
-			fmt.Printf(" => %v\n", vm.params.GasLimit)
+			dbg.Printf(" => %v\n", vm.params.GasLimit)
 
 		case POP: // 0x50
 			stack.Pop()
-			fmt.Printf(" => %v\n", vm.params.GasLimit)
+			dbg.Printf(" => %v\n", vm.params.GasLimit)
 
 		case MLOAD: // 0x51
 			offset := stack.Pop64()
@@ -431,16 +440,16 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 				return nil, firstErr(err, ErrMemoryOutOfBounds)
 			}
 			stack.Push(RightPadWord(data))
-			fmt.Printf(" => 0x%X\n", data)
+			dbg.Printf(" => 0x%X\n", data)
 
 		case MSTORE: // 0x52
 			offset, data := stack.Pop64(), stack.Pop()
-			dest, ok := subslice(memory, offset, 32, true)
+			dest, ok := subslice(memory, offset, 32, false)
 			if !ok {
 				return nil, firstErr(err, ErrMemoryOutOfBounds)
 			}
-			copy(dest, data[:])
-			fmt.Printf(" => 0x%X\n", data)
+			copy(dest, flip(data[:]))
+			dbg.Printf(" => 0x%X\n", data)
 
 		case MSTORE8: // 0x53
 			offset, val := stack.Pop64(), byte(stack.Pop64()&0xFF)
@@ -448,13 +457,13 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 				return nil, firstErr(err, ErrMemoryOutOfBounds)
 			}
 			memory[offset] = val
-			fmt.Printf(" => [%v] 0x%X\n", offset, val)
+			dbg.Printf(" => [%v] 0x%X\n", offset, val)
 
 		case SLOAD: // 0x54
 			loc := stack.Pop()
 			data, _ := vm.appState.GetStorage(callee.Address, loc)
 			stack.Push(data)
-			fmt.Printf(" {0x%X : 0x%X}\n", loc, data)
+			dbg.Printf(" {0x%X : 0x%X}\n", loc, data)
 
 		case SSTORE: // 0x55
 			loc, data := stack.Pop(), stack.Pop()
@@ -467,7 +476,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			} else {
 				useGas(gas, GasStorageCreate)
 			}
-			fmt.Printf(" {0x%X : 0x%X}\n", loc, data)
+			dbg.Printf(" {0x%X : 0x%X}\n", loc, data)
 
 		case JUMP: // 0x56
 			err = jump(code, stack.Pop64(), &pc)
@@ -479,7 +488,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 				err = jump(code, pos, &pc)
 				continue
 			}
-			fmt.Printf(" ~> false\n")
+			dbg.Printf(" ~> false\n")
 
 		case PC: // 0x58
 			stack.Push64(pc)
@@ -489,10 +498,10 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 
 		case GAS: // 0x5A
 			stack.Push64(*gas)
-			fmt.Printf(" => %X\n", *gas)
+			dbg.Printf(" => %X\n", *gas)
 
 		case JUMPDEST: // 0x5B
-			fmt.Printf("\n")
+			dbg.Printf("\n")
 			// Do nothing
 
 		case PUSH1, PUSH2, PUSH3, PUSH4, PUSH5, PUSH6, PUSH7, PUSH8, PUSH9, PUSH10, PUSH11, PUSH12, PUSH13, PUSH14, PUSH15, PUSH16, PUSH17, PUSH18, PUSH19, PUSH20, PUSH21, PUSH22, PUSH23, PUSH24, PUSH25, PUSH26, PUSH27, PUSH28, PUSH29, PUSH30, PUSH31, PUSH32:
@@ -504,17 +513,17 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			res := RightPadWord(codeSegment)
 			stack.Push(res)
 			pc += a
-			fmt.Printf(" => 0x%X\n", res)
+			dbg.Printf(" => 0x%X\n", res)
 
 		case DUP1, DUP2, DUP3, DUP4, DUP5, DUP6, DUP7, DUP8, DUP9, DUP10, DUP11, DUP12, DUP13, DUP14, DUP15, DUP16:
 			n := int(op - DUP1 + 1)
 			stack.Dup(n)
-			fmt.Printf(" => [%d] 0x%X\n", n, stack.Peek().Bytes())
+			dbg.Printf(" => [%d] 0x%X\n", n, stack.Peek().Bytes())
 
 		case SWAP1, SWAP2, SWAP3, SWAP4, SWAP5, SWAP6, SWAP7, SWAP8, SWAP9, SWAP10, SWAP11, SWAP12, SWAP13, SWAP14, SWAP15, SWAP16:
 			n := int(op - SWAP1 + 2)
 			stack.Swap(n)
-			fmt.Printf(" => [%d]\n", n)
+			dbg.Printf(" => [%d]\n", n)
 
 		case LOG0, LOG1, LOG2, LOG3, LOG4:
 			n := int(op - LOG0)
@@ -534,7 +543,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 				vm.params.BlockHeight,
 			}
 			vm.appState.AddLog(log)
-			fmt.Printf(" => %v\n", log)
+			dbg.Printf(" => %v\n", log)
 
 		case CREATE: // 0xF0
 			contractValue := stack.Pop64()
@@ -554,7 +563,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			newAccount, err := vm.appState.CreateAccount(callee)
 			if err != nil {
 				stack.Push(Zero)
-				fmt.Printf(" (*) 0x0 %v\n", err)
+				dbg.Printf(" (*) 0x0 %v\n", err)
 			} else {
 				// Run the input to get the contract code.
 				ret, err_ := vm.Call(callee, newAccount, input, input, contractValue, gas)
@@ -571,7 +580,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			addr, value := stack.Pop(), stack.Pop64()
 			inOffset, inSize := stack.Pop64(), stack.Pop64()   // inputs
 			retOffset, retSize := stack.Pop64(), stack.Pop64() // outputs
-			fmt.Printf(" => %X\n", addr)
+			dbg.Printf(" => %X\n", addr)
 
 			// Get the arguments from the memory
 			args, ok := subslice(memory, inOffset, inSize, false)
@@ -624,7 +633,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			// Handle remaining gas.
 			*gas += gasLimit
 
-			fmt.Printf("resume %X (%v)\n", callee.Address, gas)
+			dbg.Printf("resume %X (%v)\n", callee.Address, gas)
 
 		case RETURN: // 0xF3
 			offset, size := stack.Pop64(), stack.Pop64()
@@ -632,7 +641,7 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			if !ok {
 				return nil, firstErr(err, ErrMemoryOutOfBounds)
 			}
-			fmt.Printf(" => [%v, %v] (%d) 0x%X\n", offset, size, len(ret), ret)
+			dbg.Printf(" => [%v, %v] (%d) 0x%X\n", offset, size, len(ret), ret)
 			return ret, nil
 
 		case SUICIDE: // 0xFF
@@ -649,11 +658,11 @@ func (vm *VM) call(caller, callee *Account, code, input []byte, value uint64, ga
 			receiver.Balance += balance
 			vm.appState.UpdateAccount(receiver)
 			vm.appState.DeleteAccount(callee)
-			fmt.Printf(" => (%X) %v\n", addr[:4], balance)
+			dbg.Printf(" => (%X) %v\n", addr[:4], balance)
 			fallthrough
 
 		default:
-			fmt.Printf("(pc) %-3v Invalid opcode %X\n", pc, op)
+			dbg.Printf("(pc) %-3v Invalid opcode %X\n", pc, op)
 			panic(fmt.Errorf("Invalid opcode %X", op))
 		}
 
@@ -688,10 +697,10 @@ func codeGetOp(code []byte, n uint64) OpCode {
 func jump(code []byte, to uint64, pc *uint64) (err error) {
 	dest := codeGetOp(code, to)
 	if dest != JUMPDEST {
-		fmt.Printf(" ~> %v invalid jump dest %v\n", to, dest)
+		dbg.Printf(" ~> %v invalid jump dest %v\n", to, dest)
 		return ErrInvalidJumpDest
 	}
-	fmt.Printf(" ~> %v\n", to)
+	dbg.Printf(" ~> %v\n", to)
 	*pc = to
 	return nil
 }
@@ -724,8 +733,11 @@ func transfer(from, to *Account, amount uint64) error {
 }
 
 func flip(in []byte) []byte {
+	l2 := len(in) / 2
 	flipped := make([]byte, len(in))
-	for i := 0; i < len(flipped)/2; i++ {
+	// copy the middle bit (if its even it will get overwritten)
+	flipped[l2] = in[l2]
+	for i := 0; i < l2; i++ {
 		flipped[i] = in[len(in)-1-i]
 		flipped[len(in)-1-i] = in[i]
 	}


### PR DESCRIPTION
- fixes some bugs in op implementations
- flip storage keys and values (so they are always big endian in storage, addresses are left padded)
- change `VMAppState` to `TransState`
- `TransState` has a `BackendState` that can be synced to for greater persistence
- Unified `BackendState` interface to support `TransState` (so a per tx TransState can sync with the per block TransState), and `State` (so a per block TransState can sync with the state tree)
- Save storage root for accounts after modification and persist
- Add `GetStorage` method to State