### PR TITLE
EventMsgCreate

### DIFF
--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -71,7 +71,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("genesis_file", rootDir+"/genesis.json")
 	mapConfig.SetDefault("moniker", "anonymous")
 	mapConfig.SetDefault("node_laddr", "0.0.0.0:36656")
-	mapConfig.SetDefault("fast_sync", true)
+	mapConfig.SetDefault("fast_sync", false)
 	mapConfig.SetDefault("addrbook_file", rootDir+"/addrbook.json")
 	mapConfig.SetDefault("priv_validator_file", rootDir+"/priv_validator.json")
 	mapConfig.SetDefault("db_backend", "memdb")
@@ -94,7 +94,7 @@ network = "tendermint_test"
 moniker = "__MONIKER__"
 node_laddr = "0.0.0.0:36656"
 seeds = ""
-fast_sync = true
+fast_sync = false
 db_backend = "memdb"
 log_level = "debug"
 rpc_laddr = "0.0.0.0:36657"

--- a/rpc/test/client_ws_test.go
+++ b/rpc/test/client_ws_test.go
@@ -91,7 +91,26 @@ func TestWSDoubleFire(t *testing.T) {
 	})
 }
 
-// create a contract, wait for the event, and send it a msg, validate the return
+// create a contract, wait for the create event
+func TestWSCreate(t *testing.T) {
+	con := newWSCon(t)
+	eid1 := types.EventStringAccCreate(userByteAddr)
+	subscribe(t, con, eid1)
+	defer func() {
+		unsubscribe(t, con, eid1)
+		con.Close()
+	}()
+	amt := uint64(10000)
+	code, returnCode, _ := simpleContract()
+	var contractAddr []byte
+	// wait for the contract to be created
+	waitForEvent(t, con, eid1, true, func() {
+		_, receipt := broadcastTx(t, "JSONRPC", userByteAddr, nil, code, userBytePriv, amt, 1000, 1000)
+		contractAddr = receipt.ContractAddr
+	}, unmarshalValidateCreate(amt, returnCode))
+}
+
+// create a contract, wait for the input event, and send it a msg, validate the return
 func TestWSCallWait(t *testing.T) {
 	con := newWSCon(t)
 	eid1 := types.EventStringAccInput(userByteAddr)

--- a/state/execution.go
+++ b/state/execution.go
@@ -462,7 +462,11 @@ func ExecTx(blockCache *BlockCache, tx_ types.Tx, runCall bool, evc events.Firea
 			// a separate event will be fired from vm for each additional call
 			if evc != nil {
 				evc.FireEvent(types.EventStringAccInput(tx.Input.Address), types.EventMsgCallTx{tx, ret, exception})
-				evc.FireEvent(types.EventStringAccOutput(tx.Address), types.EventMsgCallTx{tx, ret, exception})
+				if createAccount {
+					evc.FireEvent(types.EventStringAccCreate(tx.Input.Address), types.EventMsgCreate{callee.Address.Postfix(20), account.HashSignBytes(tx)})
+				} else {
+					evc.FireEvent(types.EventStringAccOutput(tx.Address), types.EventMsgCallTx{tx, ret, exception})
+				}
 			}
 		} else {
 			// The mempool does not call txs until

--- a/types/events.go
+++ b/types/events.go
@@ -18,6 +18,10 @@ func EventStringAccReceive(addr []byte) string {
 	return fmt.Sprintf("Acc/%X/Receive", addr)
 }
 
+func EventStringAccCreate(addr []byte) string {
+	return fmt.Sprintf("Acc/%X/Create", addr)
+}
+
 func EventStringBond() string {
 	return "Bond"
 }
@@ -65,6 +69,11 @@ type EventMsgCall struct {
 	TxId      []byte    `json:"tx_id"`
 	Return    []byte    `json:"return"`
 	Exception string    `json:"exception"`
+}
+
+type EventMsgCreate struct {
+	Address []byte `json:"address"`
+	TxId    []byte `json:"txid"`
 }
 
 /*


### PR DESCRIPTION
This one partially for discussion.

It fires an EventMsgCreate when a CallTx creates a contract (subscription on creator's address). Maybe we don't really need it.
I also haven't addressed using a special event for CREATE. it would probably have to go in the run loop, or else triggered from Call with some "newAccount" flag in the vm. 

If we don't add this, we should at least turn off fast_sync in the tests and remove the FireEvent(output) on creates (unless we fire on the created address, but that seems kind of dumb, since who will subscribe to addresses not created yet besides the overly cunning?)