### PR TITLE
Barak refactor & listener commands

### DIFF
--- a/INSTALL/README.md
+++ b/INSTALL/README.md
@@ -19,12 +19,10 @@ Don't use `apt-get install golang`, it's still on an old version.
 
 WARNING: THIS STEP WILL GIVE CONTROL OF THE CURRENT USER TO THE DEV TEAM.
 
-    go get -u github.com/tendermint/tendermint/cmd/barak # get+update
-    go install github.com/tendermint/tendermint/cmd/barak # install
+    go get -u github.com/tendermint/tendermint/cmd/barak
     nohup barak -options-file="$GOPATH/src/github.com/tendermint/tendermint/cmd/barak/seed0" &
 
 ### Install/Update Tendermint
 
-    go get -u github.com/tendermint/tendermint/cmd/tendermint  # get+update
-    go install github.com/tendermint/tendermint/cmd/tendermint # install
+    go get -u github.com/tendermint/tendermint/cmd/tendermint
     tendermint node

--- a/cmd/barak/barak.go
+++ b/cmd/barak/barak.go
@@ -175,6 +175,10 @@ func (brk *Barak) CloseListener(addr string) {
 	filtered := []net.Listener{}
 	for _, listener := range brk.listeners {
 		if listener.Addr().String() == addr {
+			err := listener.Close()
+			if err != nil {
+				fmt.Printf("Error closing listener: %v\n", err)
+			}
 			continue
 		}
 		filtered = append(filtered, listener)

--- a/cmd/barak/barak.go
+++ b/cmd/barak/barak.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/tendermint/tendermint/binary"
+	. "github.com/tendermint/tendermint/cmd/barak/types"
+	. "github.com/tendermint/tendermint/common"
+	pcm "github.com/tendermint/tendermint/process"
+	"github.com/tendermint/tendermint/rpc/server"
+)
+
+type BarakOptions struct {
+	Validators    []Validator
+	ListenAddress string
+	StartNonce    uint64
+	Registries    []string
+}
+
+// Read options from a file, or stdin if optionsFile is ""
+func ReadBarakOptions(optFile string) *BarakOptions {
+	var optBytes []byte
+	var err error
+	if optFile != "" {
+		optBytes, err = ioutil.ReadFile(optFile)
+	} else {
+		optBytes, err = ioutil.ReadAll(os.Stdin)
+	}
+	if err != nil {
+		panic(Fmt("Error reading input: %v", err))
+	}
+	opt := binary.ReadJSON(&BarakOptions{}, optBytes, &err).(*BarakOptions)
+	if err != nil {
+		panic(Fmt("Error parsing input: %v", err))
+	}
+	return opt
+}
+
+func ensureRootDir() (rootDir string) {
+	rootDir = os.Getenv("BRKROOT")
+	if rootDir == "" {
+		rootDir = os.Getenv("HOME") + "/.barak"
+	}
+	err := EnsureDir(rootDir)
+	if err != nil {
+		panic(Fmt("Error creating barak rootDir: %v", err))
+	}
+	return
+}
+
+func NewBarakFromOptions(opt *BarakOptions) *Barak {
+	rootDir := ensureRootDir()
+	barak := NewBarak(rootDir, opt.StartNonce, opt.Validators)
+	for _, registry := range opt.Registries {
+		barak.AddRegistry(registry)
+	}
+	barak.OpenListener(opt.ListenAddress)
+
+	// Debug.
+	fmt.Printf("Options: %v\n", opt)
+	fmt.Printf("Barak: %v\n", barak)
+	return barak
+}
+
+//--------------------------------------------------------------------------------
+
+type Barak struct {
+	mtx        sync.Mutex
+	pid        int
+	nonce      uint64
+	processes  map[string]*pcm.Process
+	validators []Validator
+	listeners  []net.Listener
+	rootDir    string
+	registries []string
+}
+
+func NewBarak(rootDir string, nonce uint64, validators []Validator) *Barak {
+	return &Barak{
+		pid:        os.Getpid(),
+		nonce:      nonce,
+		processes:  make(map[string]*pcm.Process),
+		validators: validators,
+		listeners:  nil,
+		rootDir:    rootDir,
+		registries: nil,
+	}
+}
+
+func (brk *Barak) RootDir() string {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	return brk.rootDir
+}
+
+func (brk *Barak) ListProcesses() []*pcm.Process {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	processes := []*pcm.Process{}
+	for _, process := range processes {
+		processes = append(processes, process)
+	}
+	return processes
+}
+
+func (brk *Barak) GetProcess(label string) *pcm.Process {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	return brk.processes[label]
+}
+
+func (brk *Barak) AddProcess(label string, process *pcm.Process) error {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	existing := brk.processes[label]
+	if existing != nil && existing.EndTime.IsZero() {
+		return fmt.Errorf("Process already exists: %v", label)
+	}
+	brk.processes[label] = process
+	return nil
+}
+
+func (brk *Barak) StopProcess(label string, kill bool) error {
+	barak.mtx.Lock()
+	proc := barak.processes[label]
+	barak.mtx.Unlock()
+
+	if proc == nil {
+		return fmt.Errorf("Process does not exist: %v", label)
+	}
+
+	err := pcm.Stop(proc, kill)
+	return err
+}
+
+func (brk *Barak) ListValidators() []Validator {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	return brk.validators
+}
+
+func (brk *Barak) ListListeners() []net.Listener {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	return brk.listeners
+}
+
+func (brk *Barak) OpenListener(addr string) net.Listener {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	// Start rpc server.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/download", ServeFileHandler)
+	mux.HandleFunc("/register", RegisterHandler)
+	// TODO: mux.HandleFunc("/upload", UploadFile)
+	rpcserver.RegisterRPCFuncs(mux, Routes)
+	listener := rpcserver.StartHTTPServer(addr, mux)
+	brk.listeners = append(brk.listeners, listener)
+	return listener
+}
+
+func (brk *Barak) CloseListener(addr string) {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	filtered := []net.Listener{}
+	for _, listener := range brk.listeners {
+		if listener.Addr().String() == addr {
+			continue
+		}
+		filtered = append(filtered, listener)
+	}
+	brk.listeners = filtered
+}
+
+func (brk *Barak) GetRegistries() []string {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	return brk.registries
+}
+
+func (brk *Barak) AddRegistry(registry string) {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	brk.registries = append(brk.registries, registry)
+}
+
+func (brk *Barak) RemoveRegistry(registry string) {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	filtered := []string{}
+	for _, reg := range brk.registries {
+		if registry == reg {
+			continue
+		}
+		filtered = append(filtered, reg)
+	}
+	brk.registries = filtered
+}
+
+func (brk *Barak) StartRegisterRoutine() {
+	// Register this barak with central listener
+	go func() {
+		// Workaround around issues when registries register on themselves upon startup.
+		time.Sleep(3 * time.Second)
+		for {
+			// Every hour, register with the registries.
+			for _, registry := range brk.registries {
+				resp, err := http.Get(registry + "/register")
+				if err != nil {
+					fmt.Printf("Error registering to registry %v:\n  %v\n", registry, err)
+				} else if resp.StatusCode != 200 {
+					body, _ := ioutil.ReadAll(resp.Body)
+					fmt.Printf("Error registering to registry %v:\n  %v\n", registry, string(body))
+				} else {
+					body, _ := ioutil.ReadAll(resp.Body)
+					fmt.Printf("Successfully registered with registry %v\n  %v\n", registry, string(body))
+				}
+			}
+			time.Sleep(1 * time.Hour)
+		}
+	}()
+}
+
+// Write pid to file.
+func (brk *Barak) WritePidFile() {
+	err := WriteFileAtomic(brk.rootDir+"/pidfile", []byte(Fmt("%v", brk.pid)))
+	if err != nil {
+		panic(Fmt("Error writing pidfile: %v", err))
+	}
+}
+
+func (brk *Barak) CheckIncrNonce(newNonce uint64) error {
+	brk.mtx.Lock()
+	defer brk.mtx.Unlock()
+	if brk.nonce+1 != newNonce {
+		return errors.New("Replay error")
+	}
+	brk.nonce += 1
+	return nil
+}

--- a/cmd/barak/types/command.go
+++ b/cmd/barak/types/command.go
@@ -18,22 +18,26 @@ type NoncedCommand struct {
 type Command interface{}
 
 const (
-	commandTypeRunProcess    = 0x01
+	commandTypeStartProcess  = 0x01
 	commandTypeStopProcess   = 0x02
 	commandTypeListProcesses = 0x03
 	commandTypeServeFile     = 0x04
+	commandTypeOpenListener  = 0x05
+	commandTypeCloseListener = 0x06
 )
 
 // for binary.readReflect
 var _ = binary.RegisterInterface(
 	struct{ Command }{},
-	binary.ConcreteType{CommandRunProcess{}, commandTypeRunProcess},
+	binary.ConcreteType{CommandStartProcess{}, commandTypeStartProcess},
 	binary.ConcreteType{CommandStopProcess{}, commandTypeStopProcess},
 	binary.ConcreteType{CommandListProcesses{}, commandTypeListProcesses},
 	binary.ConcreteType{CommandServeFile{}, commandTypeServeFile},
+	binary.ConcreteType{CommandOpenListener{}, commandTypeOpenListener},
+	binary.ConcreteType{CommandCloseListener{}, commandTypeCloseListener},
 )
 
-type CommandRunProcess struct {
+type CommandStartProcess struct {
 	Wait     bool
 	Label    string
 	ExecPath string
@@ -50,4 +54,12 @@ type CommandListProcesses struct{}
 
 type CommandServeFile struct {
 	Path string
+}
+
+type CommandOpenListener struct {
+	Addr string
+}
+
+type CommandCloseListener struct {
+	Addr string
 }

--- a/cmd/barak/types/responses.go
+++ b/cmd/barak/types/responses.go
@@ -13,7 +13,7 @@ type ResponseStatus struct {
 type ResponseRegister struct {
 }
 
-type ResponseRunProcess struct {
+type ResponseStartProcess struct {
 	Success bool
 	Output  string
 }
@@ -23,4 +23,11 @@ type ResponseStopProcess struct {
 
 type ResponseListProcesses struct {
 	Processes []*pcm.Process
+}
+
+type ResponseOpenListener struct {
+	Addr string
+}
+
+type ResponseCloseListener struct {
 }

--- a/cmd/debora/commands.go
+++ b/cmd/debora/commands.go
@@ -18,6 +18,7 @@ import (
 // When multiple are involved, the workflow is different.
 // (First the command(s) are signed by all validators,
 //  and then it is broadcast).
+// TODO: Implement a reasonable workflow with multiple validators.
 
 func StartProcess(privKey acm.PrivKey, remote string, command btypes.CommandStartProcess) (response btypes.ResponseStartProcess, err error) {
 	nonce, err := GetNonce(remote)
@@ -40,6 +41,26 @@ func StopProcess(privKey acm.PrivKey, remote string, command btypes.CommandStopP
 }
 
 func ListProcesses(privKey acm.PrivKey, remote string, command btypes.CommandListProcesses) (response btypes.ResponseListProcesses, err error) {
+	nonce, err := GetNonce(remote)
+	if err != nil {
+		return response, err
+	}
+	commandBytes, signature := SignCommand(privKey, nonce+1, command)
+	_, err = RunAuthCommand(remote, commandBytes, []acm.Signature{signature}, &response)
+	return response, err
+}
+
+func OpenListener(privKey acm.PrivKey, remote string, command btypes.CommandOpenListener) (response btypes.ResponseOpenListener, err error) {
+	nonce, err := GetNonce(remote)
+	if err != nil {
+		return response, err
+	}
+	commandBytes, signature := SignCommand(privKey, nonce+1, command)
+	_, err = RunAuthCommand(remote, commandBytes, []acm.Signature{signature}, &response)
+	return response, err
+}
+
+func CloseListener(privKey acm.PrivKey, remote string, command btypes.CommandCloseListener) (response btypes.ResponseCloseListener, err error) {
 	nonce, err := GetNonce(remote)
 	if err != nil {
 		return response, err

--- a/cmd/debora/commands.go
+++ b/cmd/debora/commands.go
@@ -19,7 +19,7 @@ import (
 // (First the command(s) are signed by all validators,
 //  and then it is broadcast).
 
-func RunProcess(privKey acm.PrivKey, remote string, command btypes.CommandRunProcess) (response btypes.ResponseRunProcess, err error) {
+func StartProcess(privKey acm.PrivKey, remote string, command btypes.CommandStartProcess) (response btypes.ResponseStartProcess, err error) {
 	nonce, err := GetNonce(remote)
 	if err != nil {
 		return response, err

--- a/cmd/debora/main.go
+++ b/cmd/debora/main.go
@@ -87,7 +87,7 @@ func main() {
 		cli.Command{
 			Name:   "run",
 			Usage:  "run process",
-			Action: cliRunProcess,
+			Action: cliStartProcess,
 			Flags: []cli.Flag{
 				labelFlag,
 				bgFlag,
@@ -145,14 +145,14 @@ func cliGetStatus(c *cli.Context) {
 	wg.Wait()
 }
 
-func cliRunProcess(c *cli.Context) {
+func cliStartProcess(c *cli.Context) {
 	args := c.Args()
 	if len(args) < 1 {
 		Exit("Must specify <execPath> <args...>")
 	}
 	execPath := args[0]
 	args = args[1:]
-	command := btypes.CommandRunProcess{
+	command := btypes.CommandStartProcess{
 		Wait:     !c.Bool("bg"),
 		Label:    c.String("label"),
 		ExecPath: execPath,
@@ -164,7 +164,7 @@ func cliRunProcess(c *cli.Context) {
 		wg.Add(1)
 		go func(remote string) {
 			defer wg.Done()
-			response, err := RunProcess(Config.PrivKey, remote, command)
+			response, err := StartProcess(Config.PrivKey, remote, command)
 			if err != nil {
 				fmt.Printf("%v failure. %v\n", remote, err)
 			} else {

--- a/cmd/debora/main.go
+++ b/cmd/debora/main.go
@@ -257,7 +257,7 @@ func cliListProcesses(c *cli.Context) {
 func cliOpenListener(c *cli.Context) {
 	args := c.Args()
 	if len(args) < 1 {
-		Exit("Must specify <listenAddr e.g. 0.0.0.0:46660>")
+		Exit("Must specify <listenAddr e.g. [::]:46661>")
 	}
 	listenAddr := args[0]
 	command := btypes.CommandOpenListener{

--- a/rpc/server/http_server.go
+++ b/rpc/server/http_server.go
@@ -16,19 +16,20 @@ import (
 	. "github.com/tendermint/tendermint/rpc/types"
 )
 
-func StartHTTPServer(listenAddr string, handler http.Handler) {
+func StartHTTPServer(listenAddr string, handler http.Handler) net.Listener {
 	log.Info(Fmt("Starting RPC HTTP server on %v", listenAddr))
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		Exit(Fmt("Failed to listen to %v", listenAddr))
+	}
 	go func() {
-		listener, err := net.Listen("tcp", listenAddr)
-		if err != nil {
-			Exit(Fmt("Failed to listen to %v", listenAddr))
-		}
 		res := http.Serve(
 			listener,
 			RecoverAndLogHandler(handler),
 		)
 		log.Crit("RPC HTTP server stopped", "result", res)
 	}()
+	return listener
 }
 
 func WriteRPCResponse(w http.ResponseWriter, res RPCResponse) {

--- a/rpc/server/http_server.go
+++ b/rpc/server/http_server.go
@@ -16,11 +16,11 @@ import (
 	. "github.com/tendermint/tendermint/rpc/types"
 )
 
-func StartHTTPServer(listenAddr string, handler http.Handler) net.Listener {
+func StartHTTPServer(listenAddr string, handler http.Handler) (net.Listener, error) {
 	log.Info(Fmt("Starting RPC HTTP server on %v", listenAddr))
 	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
-		Exit(Fmt("Failed to listen to %v", listenAddr))
+		return nil, fmt.Errorf("Failed to listen to %v", listenAddr)
 	}
 	go func() {
 		res := http.Serve(
@@ -29,7 +29,7 @@ func StartHTTPServer(listenAddr string, handler http.Handler) net.Listener {
 		)
 		log.Crit("RPC HTTP server stopped", "result", res)
 	}()
-	return listener
+	return listener, nil
 }
 
 func WriteRPCResponse(w http.ResponseWriter, res RPCResponse) {


### PR DESCRIPTION
We can open/close new listeners on Barak.
This will be used for upgrading barak:
1. Open barak listener 46661
2. Debora tests for functionality on 46661
3. If good, closes debora listener 46660
4. Create a new barak daemon on 46660
5. Test new barak daemon on 46660
6. If good, kill the original barak process