### PR TITLE
cleanup rpc tests, use tx_utils

### DIFF
--- a/rpc/core_client/client.go
+++ b/rpc/core_client/client.go
@@ -157,7 +157,7 @@ func argsToURLValues(argNames []string, args ...interface{}) (url.Values, error)
 
 /*rpc-gen:imports:
 github.com/tendermint/tendermint/binary
-github.com/tendermint/tendermint/rpc/types
+rpctypes github.com/tendermint/tendermint/rpc/types
 net/http
 io/ioutil
 fmt

--- a/rpc/core_client/client_methods.go
+++ b/rpc/core_client/client_methods.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tendermint/tendermint/account"
 	"github.com/tendermint/tendermint/binary"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
-	"github.com/tendermint/tendermint/rpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/types"
 	"github.com/tendermint/tendermint/types"
 	"io/ioutil"
 	"net/http"

--- a/rpc/test/ws_helpers.go
+++ b/rpc/test/ws_helpers.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/tendermint/tendermint/binary"
-	"github.com/tendermint/tendermint/rpc/types"
 	_ "github.com/tendermint/tendermint/config/tendermint_test"
+	"github.com/tendermint/tendermint/rpc/types"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -173,14 +173,14 @@ func unmarshalValidateSend(amt uint64, toAddr []byte) func(string, []byte) error
 			return fmt.Errorf("Eventid is not correct. Got %s, expected %s", response.Event, eid)
 		}
 		tx := response.Data
-		if bytes.Compare(tx.Inputs[0].Address, userByteAddr) != 0 {
-			return fmt.Errorf("Senders do not match up! Got %x, expected %x", tx.Inputs[0].Address, userByteAddr)
+		if bytes.Compare(tx.Inputs[0].Address, user[0].Address) != 0 {
+			return fmt.Errorf("Senders do not match up! Got %x, expected %x", tx.Inputs[0].Address, user[0].Address)
 		}
 		if tx.Inputs[0].Amount != amt {
 			return fmt.Errorf("Amt does not match up! Got %d, expected %d", tx.Inputs[0].Amount, amt)
 		}
 		if bytes.Compare(tx.Outputs[0].Address, toAddr) != 0 {
-			return fmt.Errorf("Receivers do not match up! Got %x, expected %x", tx.Outputs[0].Address, userByteAddr)
+			return fmt.Errorf("Receivers do not match up! Got %x, expected %x", tx.Outputs[0].Address, user[0].Address)
 		}
 		return nil
 	}
@@ -210,8 +210,8 @@ func unmarshalValidateCall(amt uint64, returnCode []byte) func(string, []byte) e
 			return fmt.Errorf(response.Data.Exception)
 		}
 		tx := response.Data.Tx
-		if bytes.Compare(tx.Input.Address, userByteAddr) != 0 {
-			return fmt.Errorf("Senders do not match up! Got %x, expected %x", tx.Input.Address, userByteAddr)
+		if bytes.Compare(tx.Input.Address, user[0].Address) != 0 {
+			return fmt.Errorf("Senders do not match up! Got %x, expected %x", tx.Input.Address, user[0].Address)
 		}
 		if tx.Input.Amount != amt {
 			return fmt.Errorf("Amt does not match up! Got %d, expected %d", tx.Input.Amount, amt)

--- a/types/tx_utils.go
+++ b/types/tx_utils.go
@@ -36,6 +36,18 @@ func (tx *SendTx) AddInput(st AccountGetter, pubkey account.PubKey, amt uint64) 
 	return nil
 }
 
+func (tx *SendTx) AddInputWithNonce(pubkey account.PubKey, amt, nonce uint64) error {
+	addr := pubkey.Address()
+	tx.Inputs = append(tx.Inputs, &TxInput{
+		Address:   addr,
+		Amount:    amt,
+		Sequence:  uint(nonce) + 1,
+		Signature: account.SignatureEd25519{},
+		PubKey:    pubkey,
+	})
+	return nil
+}
+
 func (tx *SendTx) AddOutput(addr []byte, amt uint64) error {
 	tx.Outputs = append(tx.Outputs, &TxOutput{
 		Address: addr,
@@ -63,10 +75,16 @@ func NewCallTx(st AccountGetter, from account.PubKey, to, data []byte, amt, gasL
 		return nil, fmt.Errorf("Invalid address %X from pubkey %X", addr, from)
 	}
 
+	nonce := uint64(acc.Sequence)
+	return NewCallTxWithNonce(from, to, data, amt, gasLimit, fee, nonce), nil
+}
+
+func NewCallTxWithNonce(from account.PubKey, to, data []byte, amt, gasLimit, fee, nonce uint64) *CallTx {
+	addr := from.Address()
 	input := &TxInput{
 		Address:   addr,
 		Amount:    amt,
-		Sequence:  uint(acc.Sequence) + 1,
+		Sequence:  uint(nonce) + 1,
 		Signature: account.SignatureEd25519{},
 		PubKey:    from,
 	}
@@ -77,7 +95,7 @@ func NewCallTx(st AccountGetter, from account.PubKey, to, data []byte, amt, gasL
 		GasLimit: gasLimit,
 		Fee:      fee,
 		Data:     data,
-	}, nil
+	}
 }
 
 func (tx *CallTx) Sign(privAccount *account.PrivAccount) {
@@ -111,6 +129,18 @@ func (tx *BondTx) AddInput(st AccountGetter, pubkey account.PubKey, amt uint64) 
 		Address:   addr,
 		Amount:    amt,
 		Sequence:  uint(acc.Sequence) + 1,
+		Signature: account.SignatureEd25519{},
+		PubKey:    pubkey,
+	})
+	return nil
+}
+
+func (tx *BondTx) AddInputWithNonce(pubkey account.PubKey, amt, nonce uint64) error {
+	addr := pubkey.Address()
+	tx.Inputs = append(tx.Inputs, &TxInput{
+		Address:   addr,
+		Amount:    amt,
+		Sequence:  uint(nonce) + 1,
 		Signature: account.SignatureEd25519{},
 		PubKey:    pubkey,
 	})


### PR DESCRIPTION
Felt an overwhelming urge to do this. Simplifies some of the functions, makes it more extensible, uses the client functions in tx_utils (I was inspired by starting to write the tests for namereg ...)