### PR TITLE
Namereg

### DIFF
--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -71,7 +71,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("genesis_file", rootDir+"/genesis.json")
 	mapConfig.SetDefault("moniker", "anonymous")
 	mapConfig.SetDefault("node_laddr", "0.0.0.0:36656")
-	mapConfig.SetDefault("fast_sync", true)
+	mapConfig.SetDefault("fast_sync", false)
 	mapConfig.SetDefault("addrbook_file", rootDir+"/addrbook.json")
 	mapConfig.SetDefault("priv_validator_file", rootDir+"/priv_validator.json")
 	mapConfig.SetDefault("db_backend", "memdb")
@@ -94,7 +94,7 @@ network = "tendermint_test"
 moniker = "__MONIKER__"
 node_laddr = "0.0.0.0:36656"
 seeds = ""
-fast_sync = true
+fast_sync = false
 db_backend = "memdb"
 log_level = "debug"
 rpc_laddr = "0.0.0.0:36657"
@@ -105,24 +105,37 @@ func defaultConfig(moniker string) (defaultConfig string) {
 	return
 }
 
+// priv keys generated deterministically eg rpc/tests/helpers.go
 var defaultGenesis = `{
   "accounts": [
     {
-      "address": "1D7A91CB32F758A02EBB9BE1FB6F8DEE56F90D42",
-      "amount":  200000000
+	    "address": "E9B5D87313356465FAE33C406CE2C2979DE60BCB",
+	    "amount": 200000000
     },
     {
-      "address": "AC89A6DDF4C309A89A2C4078CE409A5A7B282270",
-      "amount":  200000000
+	    "address": "DFE4AFFA4CEE17CD01CB9E061D77C3ECED29BD88",
+	    "amount": 200000000
+    },
+    {
+	    "address": "F60D30722E7B497FA532FB3207C3FB29C31B1992",
+	    "amount": 200000000
+    },
+    {
+	    "address": "336CB40A5EB92E496E19B74FDFF2BA017C877FD6",
+	    "amount": 200000000
+    },
+    {
+	    "address": "D218F0F439BF0384F6F5EF8D0F8B398D941BD1DC",
+	    "amount": 200000000
     }
   ],
   "validators": [
     {
-      "pub_key": [1, "06FBAC4E285285D1D91FCBC7E91C780ADA11516F67462340B3980CE2B94940E8"],
+      "pub_key": [1, "583779C3BFA3F6C7E23C7D830A9C3D023A216B55079AD38BFED1207B94A19548"],
       "amount": 1000000,
       "unbond_to": [
         {
-          "address": "1D7A91CB32F758A02EBB9BE1FB6F8DEE56F90D42",
+          "address": "E9B5D87313356465FAE33C406CE2C2979DE60BCB",
           "amount":  100000
         }
       ]

--- a/rpc/core/names.go
+++ b/rpc/core/names.go
@@ -6,7 +6,6 @@ import (
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
-// XXX: need we be careful about rendering bytes as string or is that their problem ?
 func NameRegEntry(name string) (*ctypes.ResponseNameRegEntry, error) {
 	st := consensusState.GetState() // performs a copy
 	entry := st.GetNameRegEntry(name)

--- a/rpc/core/names.go
+++ b/rpc/core/names.go
@@ -1,0 +1,17 @@
+package core
+
+import (
+	"fmt"
+
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+)
+
+// XXX: need we be careful about rendering bytes as string or is that their problem ?
+func NameRegEntry(name []byte) (*ctypes.ResponseNameRegEntry, error) {
+	st := consensusState.GetState() // performs a copy
+	entry := st.GetNameRegEntry(name)
+	if entry == nil {
+		return nil, fmt.Errorf("Name %s not found", name)
+	}
+	return &ctypes.ResponseNameRegEntry{entry}, nil
+}

--- a/rpc/core/names.go
+++ b/rpc/core/names.go
@@ -7,7 +7,7 @@ import (
 )
 
 // XXX: need we be careful about rendering bytes as string or is that their problem ?
-func NameRegEntry(name []byte) (*ctypes.ResponseNameRegEntry, error) {
+func NameRegEntry(name string) (*ctypes.ResponseNameRegEntry, error) {
 	st := consensusState.GetState() // performs a copy
 	entry := st.GetNameRegEntry(name)
 	if entry == nil {

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -19,6 +19,7 @@ var Routes = map[string]*rpc.RPCFunc{
 	"broadcast_tx":            rpc.NewRPCFunc(BroadcastTx, []string{"tx"}),
 	"list_unconfirmed_txs":    rpc.NewRPCFunc(ListUnconfirmedTxs, []string{}),
 	"list_accounts":           rpc.NewRPCFunc(ListAccounts, []string{}),
+	"name_reg_entry":          rpc.NewRPCFunc(NameRegEntry, []string{"name"}),
 	"unsafe/gen_priv_account": rpc.NewRPCFunc(GenPrivAccount, []string{}),
 	"unsafe/sign_tx":          rpc.NewRPCFunc(SignTx, []string{"tx", "privAccounts"}),
 }

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -100,3 +100,7 @@ type ResponseDumpConsensusState struct {
 	RoundState      string   `json:"round_state"`
 	PeerRoundStates []string `json:"peer_round_states"`
 }
+
+type ResponseNameRegEntry struct {
+	Entry *types.NameRegEntry `json:"entry"`
+}

--- a/rpc/core_client/client.go
+++ b/rpc/core_client/client.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"github.com/tendermint/tendermint/binary"
 	rpctypes "github.com/tendermint/tendermint/rpc/types"
-	// NOTE: do not import rpc/core.
-	// What kind of client imports all of core logic? :P
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -30,6 +28,7 @@ var reverseFuncMap = map[string]string{
 	"DumpStorage":    "dump_storage",
 	"BroadcastTx":    "broadcast_tx",
 	"ListAccounts":   "list_accounts",
+	"NameRegEntry":   "name_reg_entry",
 	"GenPrivAccount": "unsafe/gen_priv_account",
 	"SignTx":         "unsafe/sign_tx",
 }
@@ -157,7 +156,7 @@ func argsToURLValues(argNames []string, args ...interface{}) (url.Values, error)
 
 /*rpc-gen:imports:
 github.com/tendermint/tendermint/binary
-github.com/tendermint/tendermint/rpc/types
+rpctypes github.com/tendermint/tendermint/rpc/types
 net/http
 io/ioutil
 fmt

--- a/rpc/core_client/client_methods.go
+++ b/rpc/core_client/client_methods.go
@@ -27,7 +27,7 @@ type Client interface {
 	ListAccounts() (*ctypes.ResponseListAccounts, error)
 	ListUnconfirmedTxs() (*ctypes.ResponseListUnconfirmedTxs, error)
 	ListValidators() (*ctypes.ResponseListValidators, error)
-	NameRegEntry(name []byte) (*ctypes.ResponseNameRegEntry, error)
+	NameRegEntry(name string) (*ctypes.ResponseNameRegEntry, error)
 	NetInfo() (*ctypes.ResponseNetInfo, error)
 	SignTx(tx types.Tx, privAccounts []*account.PrivAccount) (*ctypes.ResponseSignTx, error)
 	Status() (*ctypes.ResponseStatus, error)
@@ -423,7 +423,7 @@ func (c *ClientHTTP) ListValidators() (*ctypes.ResponseListValidators, error) {
 	return response.Result, nil
 }
 
-func (c *ClientHTTP) NameRegEntry(name []byte) (*ctypes.ResponseNameRegEntry, error) {
+func (c *ClientHTTP) NameRegEntry(name string) (*ctypes.ResponseNameRegEntry, error) {
 	values, err := argsToURLValues([]string{"name"}, name)
 	if err != nil {
 		return nil, err
@@ -894,7 +894,7 @@ func (c *ClientJSON) ListValidators() (*ctypes.ResponseListValidators, error) {
 	return response.Result, nil
 }
 
-func (c *ClientJSON) NameRegEntry(name []byte) (*ctypes.ResponseNameRegEntry, error) {
+func (c *ClientJSON) NameRegEntry(name string) (*ctypes.ResponseNameRegEntry, error) {
 	request := rpctypes.RPCRequest{
 		JSONRPC: "2.0",
 		Method:  reverseFuncMap["NameRegEntry"],

--- a/rpc/test/client_rpc_test.go
+++ b/rpc/test/client_rpc_test.go
@@ -40,6 +40,10 @@ func TestHTTPCallContract(t *testing.T) {
 	testCall(t, "HTTP")
 }
 
+func TestHTTPNameReg(t *testing.T) {
+	testNameReg(t, "HTTP")
+}
+
 //--------------------------------------------------------------------------------
 // Test the JSONRPC client
 
@@ -73,4 +77,8 @@ func TestJSONCallCode(t *testing.T) {
 
 func TestJSONCallContract(t *testing.T) {
 	testCall(t, "JSONRPC")
+}
+
+func TestJSONNameReg(t *testing.T) {
+	testNameReg(t, "JSONRPC")
 }

--- a/rpc/test/client_ws_test.go
+++ b/rpc/test/client_ws_test.go
@@ -50,7 +50,7 @@ func TestWSBlockchainGrowth(t *testing.T) {
 
 // send a transaction and validate the events from listening for both sender and receiver
 func TestWSSend(t *testing.T) {
-	toAddr := []byte{20, 143, 25, 63, 16, 177, 83, 29, 91, 91, 54, 23, 233, 46, 190, 121, 122, 34, 86, 54}
+	toAddr := user[1].Address
 	amt := uint64(100)
 
 	con := newWSCon(t)
@@ -80,7 +80,7 @@ func TestWSDoubleFire(t *testing.T) {
 		con.Close()
 	}()
 	amt := uint64(100)
-	toAddr := []byte{20, 143, 25, 63, 16, 177, 83, 29, 91, 91, 54, 23, 233, 46, 190, 121, 122, 34, 86, 54}
+	toAddr := user[1].Address
 	// broadcast the transaction, wait to hear about it
 	waitForEvent(t, con, eid, true, func() {
 		tx := makeDefaultSendTxSigned(t, wsTyp, toAddr, amt)

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -90,7 +90,7 @@ func init() {
 func makeDefaultSendTx(t *testing.T, typ string, addr []byte, amt uint64) *types.SendTx {
 	nonce := getNonce(t, typ, user[0].Address)
 	tx := types.NewSendTx()
-	tx.AddInputWithNonce(user[0].PubKey, amt, nonce)
+	tx.AddInputWithNonce(user[0].PubKey, amt, nonce+1)
 	tx.AddOutput(addr, amt)
 	return tx
 }
@@ -103,14 +103,14 @@ func makeDefaultSendTxSigned(t *testing.T, typ string, addr []byte, amt uint64) 
 
 func makeDefaultCallTx(t *testing.T, typ string, addr, code []byte, amt, gasLim, fee uint64) *types.CallTx {
 	nonce := getNonce(t, typ, user[0].Address)
-	tx := types.NewCallTxWithNonce(user[0].PubKey, addr, code, amt, gasLim, fee, nonce)
+	tx := types.NewCallTxWithNonce(user[0].PubKey, addr, code, amt, gasLim, fee, nonce+1)
 	tx.Sign(user[0])
 	return tx
 }
 
 func makeDefaultNameTx(t *testing.T, typ string, name, value string, amt, fee uint64) *types.NameTx {
 	nonce := getNonce(t, typ, user[0].Address)
-	tx := types.NewNameTxWithNonce(user[0].PubKey, name, value, amt, fee, nonce)
+	tx := types.NewNameTxWithNonce(user[0].PubKey, name, value, amt, fee, nonce+1)
 	tx.Sign(user[0])
 	return tx
 }
@@ -119,7 +119,7 @@ func makeDefaultNameTx(t *testing.T, typ string, name, value string, amt, fee ui
 // rpc call wrappers (fail on err)
 
 // get an account's nonce
-func getNonce(t *testing.T, typ string, addr []byte) uint64 {
+func getNonce(t *testing.T, typ string, addr []byte) uint {
 	client := clients[typ]
 	ac, err := client.GetAccount(addr)
 	if err != nil {
@@ -128,7 +128,7 @@ func getNonce(t *testing.T, typ string, addr []byte) uint64 {
 	if ac.Account == nil {
 		return 0
 	}
-	return uint64(ac.Account.Sequence)
+	return ac.Account.Sequence
 }
 
 // get the account

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -116,6 +116,13 @@ func makeDefaultCallTx(t *testing.T, typ string, addr, code []byte, amt, gasLim,
 	return tx
 }
 
+func makeDefaultNameTx(t *testing.T, typ string, name, value []byte, amt, fee uint64) *types.NameTx {
+	nonce := getNonce(t, typ, user[0].Address)
+	tx := types.NewNameTxWithNonce(user[0].PubKey, name, value, amt, fee, nonce)
+	tx.Sign(user[0])
+	return tx
+}
+
 //-------------------------------------------------------------------------------
 // rpc call wrappers (fail on err)
 
@@ -204,6 +211,16 @@ func callContract(t *testing.T, client cclient.Client, address, data, expected [
 	if bytes.Compare(ret, LeftPadWord256(expected).Bytes()) != 0 {
 		t.Fatalf("Conflicting return value. Got %x, expected %x", ret, expected)
 	}
+}
+
+// get the namereg entry
+func getNameRegEntry(t *testing.T, typ string, name []byte) *types.NameRegEntry {
+	client := clients[typ]
+	r, err := client.NameRegEntry(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r.Entry
 }
 
 //--------------------------------------------------------------------------------

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -116,7 +116,7 @@ func makeDefaultCallTx(t *testing.T, typ string, addr, code []byte, amt, gasLim,
 	return tx
 }
 
-func makeDefaultNameTx(t *testing.T, typ string, name, value []byte, amt, fee uint64) *types.NameTx {
+func makeDefaultNameTx(t *testing.T, typ string, name, value string, amt, fee uint64) *types.NameTx {
 	nonce := getNonce(t, typ, user[0].Address)
 	tx := types.NewNameTxWithNonce(user[0].PubKey, name, value, amt, fee, nonce)
 	tx.Sign(user[0])
@@ -214,7 +214,7 @@ func callContract(t *testing.T, client cclient.Client, address, data, expected [
 }
 
 // get the namereg entry
-func getNameRegEntry(t *testing.T, typ string, name []byte) *types.NameRegEntry {
+func getNameRegEntry(t *testing.T, typ string, name string) *types.NameRegEntry {
 	client := clients[typ]
 	r, err := client.NameRegEntry(name)
 	if err != nil {

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -2,7 +2,6 @@ package rpctest
 
 import (
 	"bytes"
-	"encoding/hex"
 	"strconv"
 	"testing"
 	"time"
@@ -29,8 +28,7 @@ var (
 	mempoolCount = 0
 
 	// make keys
-	userPriv = "C453604BD6480D5538B4C6FD2E3E314B5BCE518D75ADE4DA3DA85AB8ADFD819606FBAC4E285285D1D91FCBC7E91C780ADA11516F67462340B3980CE2B94940E8"
-	user     = makeUsers(2)
+	user = makeUsers(5)
 
 	clients = map[string]cclient.Client{
 		"JSONRPC": cclient.NewClient(requestAddr, "JSONRPC"),
@@ -38,6 +36,7 @@ var (
 	}
 )
 
+// deterministic account generation, synced with genesis file in config/tendermint_test/config.go
 func makeUsers(n int) []*account.PrivAccount {
 	accounts := []*account.PrivAccount{}
 	for i := 0; i < n; i++ {
@@ -45,13 +44,6 @@ func makeUsers(n int) []*account.PrivAccount {
 		user := account.GenPrivAccountFromSecret(secret)
 		accounts = append(accounts, user)
 	}
-
-	// include our validator
-	var byteKey [64]byte
-	userPrivByteSlice, _ := hex.DecodeString(userPriv)
-	copy(byteKey[:], userPrivByteSlice)
-	privAcc := account.GenPrivAccountFromKey(byteKey)
-	accounts[0] = privAcc
 	return accounts
 }
 

--- a/rpc/test/tests.go
+++ b/rpc/test/tests.go
@@ -202,8 +202,8 @@ func testNameReg(t *testing.T, typ string) {
 
 	amt, fee := uint64(6969), uint64(1000)
 	// since entries ought to be unique and these run against different clients, we append the typ
-	name := []byte("ye-old-domain-name-" + typ)
-	data := []byte("these are amongst the things I wish to bestow upon the youth of generations come: a safe supply of honey, and a better money. For what else shall they need?")
+	name := "ye-old-domain-name-" + typ
+	data := "these are amongst the things I wish to bestow upon the youth of generations come: a safe supply of honey, and a better money. For what else shall they need?"
 	tx := makeDefaultNameTx(t, typ, name, data, amt, fee)
 	broadcastTx(t, typ, tx)
 
@@ -215,7 +215,7 @@ func testNameReg(t *testing.T, typ string) {
 
 	entry := getNameRegEntry(t, typ, name)
 
-	if bytes.Compare(entry.Data, data) != 0 {
+	if entry.Data != data {
 		t.Fatal(fmt.Sprintf("Got %s, expected %s", entry.Data, data))
 	}
 

--- a/rpc/test/tests.go
+++ b/rpc/test/tests.go
@@ -237,7 +237,7 @@ func testNameReg(t *testing.T, typ string) {
 	// try to update as non owner, should fail
 	nonce := getNonce(t, typ, user[1].Address)
 	data2 := "this is not my beautiful house"
-	tx = types.NewNameTxWithNonce(user[1].PubKey, name, data2, amt, fee, nonce)
+	tx = types.NewNameTxWithNonce(user[1].PubKey, name, data2, amt, fee, nonce+1)
 	tx.Sign(user[1])
 	_, err := client.BroadcastTx(tx)
 	if err == nil {

--- a/state/block_cache.go
+++ b/state/block_cache.go
@@ -245,7 +245,6 @@ func (cache *BlockCache) Sync() {
 
 	// Determine order for names
 	// note names may be of any length less than some limit
-	// and are arbitrary byte arrays...
 	nameStrs := []string{}
 	for nameStr := range cache.names {
 		nameStrs = append(nameStrs, nameStr)
@@ -256,9 +255,9 @@ func (cache *BlockCache) Sync() {
 	for _, nameStr := range nameStrs {
 		entry, removed, dirty := cache.names[nameStr].unpack()
 		if removed {
-			removed := cache.backend.RemoveNameRegEntry(entry.Name)
+			removed := cache.backend.RemoveNameRegEntry(nameStr)
 			if !removed {
-				panic(Fmt("Could not remove namereg entry to be removed: %X", entry.Name))
+				panic(Fmt("Could not remove namereg entry to be removed: %s", nameStr))
 			}
 		} else {
 			if entry == nil {

--- a/state/block_cache.go
+++ b/state/block_cache.go
@@ -128,15 +128,15 @@ func (cache *BlockCache) SetStorage(addr Word256, key Word256, value Word256) {
 //-------------------------------------
 // BlockCache.names
 
-func (cache *BlockCache) GetNameRegEntry(name []byte) *types.NameRegEntry {
-	entry, removed, _ := cache.names[string(name)].unpack()
+func (cache *BlockCache) GetNameRegEntry(name string) *types.NameRegEntry {
+	entry, removed, _ := cache.names[name].unpack()
 	if removed {
 		return nil
 	} else if entry != nil {
 		return entry
 	} else {
 		entry = cache.backend.GetNameRegEntry(name)
-		cache.names[string(name)] = nameInfo{entry, false, false}
+		cache.names[name] = nameInfo{entry, false, false}
 		return entry
 	}
 }
@@ -144,22 +144,22 @@ func (cache *BlockCache) GetNameRegEntry(name []byte) *types.NameRegEntry {
 func (cache *BlockCache) UpdateNameRegEntry(entry *types.NameRegEntry) {
 	name := entry.Name
 	// SANITY CHECK
-	_, removed, _ := cache.names[string(name)].unpack()
+	_, removed, _ := cache.names[name].unpack()
 	if removed {
 		panic("UpdateNameRegEntry on a removed name")
 	}
 	// SANITY CHECK END
-	cache.names[string(name)] = nameInfo{entry, false, true}
+	cache.names[name] = nameInfo{entry, false, true}
 }
 
-func (cache *BlockCache) RemoveNameRegEntry(name []byte) {
+func (cache *BlockCache) RemoveNameRegEntry(name string) {
 	// SANITY CHECK
-	_, removed, _ := cache.names[string(name)].unpack()
+	_, removed, _ := cache.names[name].unpack()
 	if removed {
 		panic("RemoveNameRegEntry on a removed entry")
 	}
 	// SANITY CHECK END
-	cache.names[string(name)] = nameInfo{nil, true, false}
+	cache.names[name] = nameInfo{nil, true, false}
 }
 
 // BlockCache.names

--- a/state/execution.go
+++ b/state/execution.go
@@ -296,7 +296,7 @@ func ExecTx(blockCache *BlockCache, tx_ types.Tx, runCall bool, evc events.Firea
 
 	// TODO: do something with fees
 	fees := uint64(0)
-	_s := blockCache.State() // hack to access validators and event switch.
+	_s := blockCache.State() // hack to access validators and block height
 
 	// Exec tx
 	switch tx := tx_.(type) {
@@ -475,6 +475,102 @@ func ExecTx(blockCache *BlockCache, tx_ types.Tx, runCall bool, evc events.Firea
 			}
 			blockCache.UpdateAccount(inAcc)
 		}
+
+		return nil
+
+	case *types.NameTx:
+		var inAcc *account.Account
+
+		// Validate input
+		inAcc = blockCache.GetAccount(tx.Input.Address)
+		if inAcc == nil {
+			log.Debug(Fmt("Can't find in account %X", tx.Input.Address))
+			return types.ErrTxInvalidAddress
+		}
+		// pubKey should be present in either "inAcc" or "tx.Input"
+		if err := checkInputPubKey(inAcc, tx.Input); err != nil {
+			log.Debug(Fmt("Can't find pubkey for %X", tx.Input.Address))
+			return err
+		}
+		signBytes := account.SignBytes(tx)
+		err := validateInput(inAcc, signBytes, tx.Input)
+		if err != nil {
+			log.Debug(Fmt("validateInput failed on %X:", tx.Input.Address))
+			return err
+		}
+		// fee is in addition to the amount which is used to determine the TTL
+		if tx.Input.Amount < tx.Fee {
+			log.Debug(Fmt("Sender did not send enough to cover the fee %X", tx.Input.Address))
+			return types.ErrTxInsufficientFunds
+		}
+
+		value := tx.Input.Amount - tx.Fee
+
+		// let's say cost of a name for one block is len(data) + 32
+		// TODO: the casting is dangerous and things can overflow (below)!
+		// we should make LastBlockHeight a uint64
+		costPerBlock := uint(len(tx.Data) + 32)
+		expiresIn := uint(value / uint64(costPerBlock))
+
+		// check if the name exists
+		entry := blockCache.GetNameRegEntry(tx.Name)
+
+		if entry != nil {
+			var expired bool
+			// if the entry already exists, and hasn't expired, we must be owner
+			if entry.Expires > _s.LastBlockHeight {
+				// ensure we are owner
+				if bytes.Compare(entry.Owner, tx.Input.Address) != 0 {
+					log.Debug(Fmt("Sender %X is trying to update a name (%s) for which he is not owner", tx.Input.Address, tx.Name))
+					return types.ErrTxInvalidAddress // (?)
+				}
+			} else {
+				expired = true
+			}
+
+			// no value and empty data means delete the entry
+			if value == 0 && len(tx.Data) == 0 {
+				// maybe we reward you for telling us we can delete this crap
+				// (owners if not expired, anyone if expired)
+				blockCache.RemoveNameRegEntry(entry.Name)
+			} else {
+				// update the entry by bumping the expiry
+				// and changing the data
+				if expired {
+					entry.Expires = _s.LastBlockHeight + expiresIn
+				} else {
+					// since the size of the data may have changed
+					// we use the total amount of "credit"
+					credit := uint64((entry.Expires - _s.LastBlockHeight) * uint(len(entry.Data)))
+					credit += value
+					expiresIn = uint(credit) / costPerBlock
+					entry.Expires = _s.LastBlockHeight + expiresIn
+				}
+				entry.Data = tx.Data
+				blockCache.UpdateNameRegEntry(entry)
+			}
+		} else {
+			if expiresIn < 5 {
+				return fmt.Errorf("Names must be registered for at least 5 blocks")
+			}
+			// entry does not exist, so create it
+			entry = &types.NameRegEntry{
+				Name:    tx.Name,
+				Owner:   tx.Input.Address,
+				Data:    tx.Data,
+				Expires: _s.LastBlockHeight + expiresIn,
+			}
+			blockCache.UpdateNameRegEntry(entry)
+		}
+
+		// TODO: something with the value sent?
+
+		// Good!
+		inAcc.Sequence += 1
+		inAcc.Balance -= value
+		blockCache.UpdateAccount(inAcc)
+
+		// TODO: maybe we want to take funds on error and allow txs in that don't do anythingi?
 
 		return nil
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -527,7 +527,7 @@ func ExecTx(blockCache *BlockCache, tx_ types.Tx, runCall bool, evc events.Firea
 				// ensure we are owner
 				if bytes.Compare(entry.Owner, tx.Input.Address) != 0 {
 					log.Debug(Fmt("Sender %X is trying to update a name (%s) for which he is not owner", tx.Input.Address, tx.Name))
-					return types.ErrTxInvalidAddress // (?)
+					return types.ErrIncorrectOwner
 				}
 			} else {
 				expired = true

--- a/state/genesis.go
+++ b/state/genesis.go
@@ -99,9 +99,14 @@ func MakeGenesisState(db dbm.DB, genDoc *GenesisDoc) *State {
 		}
 	}
 
+	// Make namereg tree
+	nameReg := merkle.NewIAVLTree(binary.BasicCodec, NameRegCodec, 0, db)
+	// TODO: add names to genesis.json
+
 	// IAVLTrees must be persisted before copy operations.
 	accounts.Save()
 	validatorInfos.Save()
+	nameReg.Save()
 
 	return &State{
 		DB:                   db,
@@ -114,5 +119,6 @@ func MakeGenesisState(db dbm.DB, genDoc *GenesisDoc) *State {
 		UnbondingValidators:  NewValidatorSet(nil),
 		accounts:             accounts,
 		validatorInfos:       validatorInfos,
+		nameReg:              nameReg,
 	}
 }

--- a/state/state.go
+++ b/state/state.go
@@ -3,6 +3,7 @@ package state
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/tendermint/tendermint/account"
@@ -35,6 +36,7 @@ type State struct {
 	UnbondingValidators  *ValidatorSet
 	accounts             merkle.Tree // Shouldn't be accessed directly.
 	validatorInfos       merkle.Tree // Shouldn't be accessed directly.
+	nameReg              merkle.Tree // Shouldn't be accessed directly.
 
 	evc events.Fireable // typically an events.EventCache
 }
@@ -59,6 +61,9 @@ func LoadState(db dbm.DB) *State {
 		validatorInfosHash := binary.ReadByteSlice(r, n, err)
 		s.validatorInfos = merkle.NewIAVLTree(binary.BasicCodec, ValidatorInfoCodec, 0, db)
 		s.validatorInfos.Load(validatorInfosHash)
+		nameRegHash := binary.ReadByteSlice(r, n, err)
+		s.nameReg = merkle.NewIAVLTree(binary.BasicCodec, NameRegCodec, 0, db)
+		s.nameReg.Load(nameRegHash)
 		if *err != nil {
 			panic(*err)
 		}
@@ -70,6 +75,7 @@ func LoadState(db dbm.DB) *State {
 func (s *State) Save() {
 	s.accounts.Save()
 	s.validatorInfos.Save()
+	s.nameReg.Save()
 	buf, n, err := new(bytes.Buffer), new(int64), new(error)
 	binary.WriteUvarint(s.LastBlockHeight, buf, n, err)
 	binary.WriteByteSlice(s.LastBlockHash, buf, n, err)
@@ -80,6 +86,7 @@ func (s *State) Save() {
 	binary.WriteBinary(s.UnbondingValidators, buf, n, err)
 	binary.WriteByteSlice(s.accounts.Hash(), buf, n, err)
 	binary.WriteByteSlice(s.validatorInfos.Hash(), buf, n, err)
+	binary.WriteByteSlice(s.nameReg.Hash(), buf, n, err)
 	if *err != nil {
 		panic(*err)
 	}
@@ -101,6 +108,7 @@ func (s *State) Copy() *State {
 		UnbondingValidators:  s.UnbondingValidators.Copy(),  // copy the valSet lazily.
 		accounts:             s.accounts.Copy(),
 		validatorInfos:       s.validatorInfos.Copy(),
+		nameReg:              s.nameReg.Copy(),
 		evc:                  nil,
 	}
 }
@@ -112,6 +120,7 @@ func (s *State) Hash() []byte {
 		s.UnbondingValidators,
 		s.accounts,
 		s.validatorInfos,
+		s.nameReg,
 	}
 	return merkle.HashFromHashables(hashables)
 }
@@ -267,6 +276,46 @@ func (s *State) LoadStorage(hash []byte) (storage merkle.Tree) {
 }
 
 // State.storage
+//-------------------------------------
+// State.nameReg
+
+func (s *State) GetNameRegEntry(name []byte) *types.NameRegEntry {
+	_, value := s.nameReg.Get(name)
+	if value == nil {
+		return nil
+	}
+	entry := value.(*types.NameRegEntry)
+	// XXX: do we need to copy?
+	return entry
+}
+
+func (s *State) UpdateNameRegEntry(entry *types.NameRegEntry) bool {
+	return s.nameReg.Set(entry.Name, entry)
+}
+
+func (s *State) RemoveNameRegEntry(name []byte) bool {
+	_, removed := s.nameReg.Remove(name)
+	return removed
+}
+
+func (s *State) GetNames() merkle.Tree {
+	return s.nameReg.Copy()
+}
+
+func NameRegEncoder(o interface{}, w io.Writer, n *int64, err *error) {
+	binary.WriteBinary(o.(*types.NameRegEntry), w, n, err)
+}
+
+func NameRegDecoder(r io.Reader, n *int64, err *error) interface{} {
+	return binary.ReadBinary(&types.NameRegEntry{}, r, n, err)
+}
+
+var NameRegCodec = binary.Codec{
+	Encode: NameRegEncoder,
+	Decode: NameRegDecoder,
+}
+
+// State.nameReg
 //-------------------------------------
 
 // Implements events.Eventable. Typically uses events.EventCache

--- a/state/state.go
+++ b/state/state.go
@@ -279,21 +279,20 @@ func (s *State) LoadStorage(hash []byte) (storage merkle.Tree) {
 //-------------------------------------
 // State.nameReg
 
-func (s *State) GetNameRegEntry(name []byte) *types.NameRegEntry {
+func (s *State) GetNameRegEntry(name string) *types.NameRegEntry {
 	_, value := s.nameReg.Get(name)
 	if value == nil {
 		return nil
 	}
 	entry := value.(*types.NameRegEntry)
-	// XXX: do we need to copy?
-	return entry
+	return entry.Copy()
 }
 
 func (s *State) UpdateNameRegEntry(entry *types.NameRegEntry) bool {
 	return s.nameReg.Set(entry.Name, entry)
 }
 
-func (s *State) RemoveNameRegEntry(name []byte) bool {
+func (s *State) RemoveNameRegEntry(name string) bool {
 	_, removed := s.nameReg.Remove(name)
 	return removed
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -180,7 +180,7 @@ func TestTxSequence(t *testing.T) {
 	for i := -1; i < 3; i++ {
 		sequence := acc0.Sequence + uint(i)
 		tx := types.NewSendTx()
-		tx.AddInputWithNonce(acc0PubKey, 1, uint64(sequence))
+		tx.AddInputWithNonce(acc0PubKey, 1, sequence)
 		tx.AddOutput(acc1.Address, 1)
 		tx.Inputs[0].Signature = privAccounts[0].Sign(tx)
 		stateCopy := state.Copy()

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -21,6 +21,15 @@ func execTxWithState(state *State, tx types.Tx, runCall bool) error {
 	}
 }
 
+func execTxWithStateNewBlock(state *State, tx types.Tx, runCall bool) error {
+	if err := execTxWithState(state, tx, runCall); err != nil {
+		return err
+	}
+
+	state.LastBlockHeight += 1
+	return nil
+}
+
 func TestCopyState(t *testing.T) {
 	// Generate a random state
 	s0, privAccounts, _ := RandGenesisState(10, true, 1000, 5, true, 1000)
@@ -166,31 +175,13 @@ func TestTxSequence(t *testing.T) {
 	acc0PubKey := privAccounts[0].PubKey
 	acc1 := state.GetAccount(privAccounts[1].PubKey.Address())
 
-	// Try executing a SendTx with various sequence numbers.
-	makeSendTx := func(sequence uint) *types.SendTx {
-		return &types.SendTx{
-			Inputs: []*types.TxInput{
-				&types.TxInput{
-					Address:  acc0.Address,
-					Amount:   1,
-					Sequence: sequence,
-					PubKey:   acc0PubKey,
-				},
-			},
-			Outputs: []*types.TxOutput{
-				&types.TxOutput{
-					Address: acc1.Address,
-					Amount:  1,
-				},
-			},
-		}
-	}
-
 	// Test a variety of sequence numbers for the tx.
 	// The tx should only pass when i == 1.
 	for i := -1; i < 3; i++ {
 		sequence := acc0.Sequence + uint(i)
-		tx := makeSendTx(sequence)
+		tx := types.NewSendTx()
+		tx.AddInputWithNonce(acc0PubKey, 1, uint64(sequence))
+		tx.AddOutput(acc1.Address, 1)
 		tx.Inputs[0].Signature = privAccounts[0].Sign(tx)
 		stateCopy := state.Copy()
 		err := execTxWithState(stateCopy, tx, true)
@@ -218,6 +209,130 @@ func TestTxSequence(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestNameTxs(t *testing.T) {
+	state, privAccounts, _ := RandGenesisState(3, true, 1000, 1, true, 1000)
+
+	types.MinNameRegistrationPeriod = 5
+	startingBlock := uint64(state.LastBlockHeight)
+
+	// try some bad names. these should all fail
+	names := []string{"", "\n", "123#$%", "\x00", string([]byte{20, 40, 60, 80}), "baffledbythespectacleinallofthisyouseeehesaidwithouteyes", "no spaces please"}
+	data := "something about all this just doesn't feel right."
+	fee := uint64(1000)
+	numDesiredBlocks := uint64(5)
+	for _, name := range names {
+		amt := fee + numDesiredBlocks*types.NameCostPerByte*types.NameCostPerBlock*types.BaseEntryCost(name, data)
+		tx, _ := types.NewNameTx(state, privAccounts[0].PubKey, name, data, amt, fee)
+		tx.Sign(privAccounts[0])
+
+		if err := execTxWithState(state, tx, true); err == nil {
+			t.Fatalf("Expected invalid name error from %s", name)
+		}
+	}
+
+	// try some bad data. these should all fail
+	name := "hold_it_chum"
+	datas := []string{"cold&warm", "!@#$%^&*()", "<<<>>>>", "because why would you ever need a ~ or a & or even a % in a json file? make your case and we'll talk"}
+	for _, data := range datas {
+		amt := fee + numDesiredBlocks*types.NameCostPerByte*types.NameCostPerBlock*types.BaseEntryCost(name, data)
+		tx, _ := types.NewNameTx(state, privAccounts[0].PubKey, name, data, amt, fee)
+		tx.Sign(privAccounts[0])
+
+		if err := execTxWithState(state, tx, true); err == nil {
+			t.Fatalf("Expected invalid data error from %s", data)
+		}
+	}
+
+	validateEntry := func(t *testing.T, entry *types.NameRegEntry, name, data string, addr []byte, expires uint64) {
+
+		if entry == nil {
+			t.Fatalf("Could not find name %s", name)
+		}
+		if bytes.Compare(entry.Owner, addr) != 0 {
+			t.Fatalf("Wrong owner. Got %X expected %X", entry.Owner, addr)
+		}
+		if data != entry.Data {
+			t.Fatalf("Wrong data. Got %s expected %s", entry.Data, data)
+		}
+		if name != entry.Name {
+			t.Fatalf("Wrong name. Got %s expected %s", entry.Name, name)
+		}
+		if expires != entry.Expires {
+			t.Fatalf("Wrong expiry. Got %d, expected %d", entry.Expires, expires)
+		}
+	}
+
+	// try a good one, check data, owner, expiry
+	name = "looking_good/karaoke_bar"
+	data = "on this side of neptune there are 1234567890 people: first is OMNIVORE. Or is it. Ok this is pretty restrictive. No exclamations :(. Faces tho :')"
+	amt := fee + numDesiredBlocks*types.NameCostPerByte*types.NameCostPerBlock*types.BaseEntryCost(name, data)
+	tx, _ := types.NewNameTx(state, privAccounts[0].PubKey, name, data, amt, fee)
+	tx.Sign(privAccounts[0])
+	if err := execTxWithState(state, tx, true); err != nil {
+		t.Fatal(err)
+	}
+	entry := state.GetNameRegEntry(name)
+	validateEntry(t, entry, name, data, privAccounts[0].Address, startingBlock+numDesiredBlocks)
+
+	// fail to update it as non-owner, in same block
+	tx, _ = types.NewNameTx(state, privAccounts[1].PubKey, name, data, amt, fee)
+	tx.Sign(privAccounts[1])
+	if err := execTxWithState(state, tx, true); err == nil {
+		t.Fatal("Expected error")
+	}
+
+	// update it as owner, just to increase expiry, in same block
+	// NOTE: we have to resend the data or it will clear it (is this what we want?)
+	tx, _ = types.NewNameTx(state, privAccounts[0].PubKey, name, data, amt, fee)
+	tx.Sign(privAccounts[0])
+	if err := execTxWithStateNewBlock(state, tx, true); err != nil {
+		t.Fatal(err)
+	}
+	entry = state.GetNameRegEntry(name)
+	validateEntry(t, entry, name, data, privAccounts[0].Address, startingBlock+numDesiredBlocks*2)
+
+	// update it as owner, just to increase expiry, in next block
+	tx, _ = types.NewNameTx(state, privAccounts[0].PubKey, name, data, amt, fee)
+	tx.Sign(privAccounts[0])
+	if err := execTxWithStateNewBlock(state, tx, true); err != nil {
+		t.Fatal(err)
+	}
+	entry = state.GetNameRegEntry(name)
+	validateEntry(t, entry, name, data, privAccounts[0].Address, startingBlock+numDesiredBlocks*3)
+
+	// fail to update it as non-owner
+	state.LastBlockHeight = uint(entry.Expires - 1)
+	tx, _ = types.NewNameTx(state, privAccounts[1].PubKey, name, data, amt, fee)
+	tx.Sign(privAccounts[1])
+	if err := execTxWithState(state, tx, true); err == nil {
+		t.Fatal("Expected error")
+	}
+
+	// once expires, non-owner succeeds
+	state.LastBlockHeight = uint(entry.Expires)
+	tx, _ = types.NewNameTx(state, privAccounts[1].PubKey, name, data, amt, fee)
+	tx.Sign(privAccounts[1])
+	if err := execTxWithState(state, tx, true); err != nil {
+		t.Fatal(err)
+	}
+	entry = state.GetNameRegEntry(name)
+	validateEntry(t, entry, name, data, privAccounts[1].Address, uint64(state.LastBlockHeight)+numDesiredBlocks)
+
+	// update it as new owner, with new data (longer), but keep the expiry!
+	data = "In the beginning there was no thing, not even the beginning. It hadn't been here, no there, nor for that matter anywhere, not especially because it had not to even exist, let alone to not. Nothing especially odd about that."
+	oldCredit := amt - fee
+	numDesiredBlocks = 10
+	amt = fee + (numDesiredBlocks*types.NameCostPerByte*types.NameCostPerBlock*types.BaseEntryCost(name, data) - oldCredit)
+	tx, _ = types.NewNameTx(state, privAccounts[1].PubKey, name, data, amt, fee)
+	tx.Sign(privAccounts[1])
+	if err := execTxWithState(state, tx, true); err != nil {
+		t.Fatal(err)
+	}
+	entry = state.GetNameRegEntry(name)
+	validateEntry(t, entry, name, data, privAccounts[1].Address, uint64(state.LastBlockHeight)+numDesiredBlocks)
+
 }
 
 // TODO: test overflows.
@@ -268,7 +383,7 @@ func TestTxs(t *testing.T) {
 		}
 	}
 
-	// CallTx.
+	// CallTx. Just runs through it and checks the transfer. See vm, rpc tests for more
 	{
 		state := state.Copy()
 		newAcc1 := state.GetAccount(acc1.Address)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -304,8 +304,8 @@ func TestTxs(t *testing.T) {
 
 	// NameTx.
 	{
-		entryName := []byte("satoshi")
-		entryData := []byte(`
+		entryName := "satoshi"
+		entryData := `
 A  purely   peer-to-peer   version   of   electronic   cash   would   allow   online
 payments  to  be  sent   directly  from  one  party  to  another  without   going  through  a
 financial institution.   Digital signatures provide part of the solution, but the main
@@ -319,7 +319,7 @@ long as a majority of CPU power is controlled by nodes that are not cooperating 
 attack the network, they'll generate the longest chain and outpace attackers.   The
 network itself requires minimal structure.   Messages are broadcast on a best effort
 basis,   and   nodes   can   leave  and   rejoin   the  network   at  will,  accepting   the   longest
-proof-of-work chain as proof of what happened while they were gone `)
+proof-of-work chain as proof of what happened while they were gone `
 		entryAmount := uint64(10000)
 
 		state := state.Copy()
@@ -348,8 +348,17 @@ proof-of-work chain as proof of what happened while they were gone `)
 		if entry == nil {
 			t.Errorf("Expected an entry but got nil")
 		}
-		if bytes.Compare(entry.Data, entryData) != 0 {
+		if entry.Data != entryData {
 			t.Errorf("Wrong data stored")
+		}
+
+		// test a bad string
+		tx.Data = string([]byte{0, 1, 2, 3, 127, 128, 129, 200, 251})
+		tx.Input.Sequence += 1
+		tx.Input.Signature = privAccounts[0].Sign(tx)
+		err = execTxWithState(state, tx, true)
+		if err != types.ErrTxInvalidString {
+			t.Errorf("Expected invalid string error. Got: %s", err.Error())
 		}
 	}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -333,6 +333,44 @@ func TestNameTxs(t *testing.T) {
 	entry = state.GetNameRegEntry(name)
 	validateEntry(t, entry, name, data, privAccounts[1].Address, uint64(state.LastBlockHeight)+numDesiredBlocks)
 
+	// test removal
+	amt = fee
+	data = ""
+	tx, _ = types.NewNameTx(state, privAccounts[1].PubKey, name, data, amt, fee)
+	tx.Sign(privAccounts[1])
+	if err := execTxWithStateNewBlock(state, tx, true); err != nil {
+		t.Fatal(err)
+	}
+	entry = state.GetNameRegEntry(name)
+	if entry != nil {
+		t.Fatal("Expected removed entry to be nil")
+	}
+
+	// create entry by key0,
+	// test removal by key1 after expiry
+	name = "looking_good/karaoke_bar"
+	data = "some data"
+	amt = fee + numDesiredBlocks*types.NameCostPerByte*types.NameCostPerBlock*types.BaseEntryCost(name, data)
+	tx, _ = types.NewNameTx(state, privAccounts[0].PubKey, name, data, amt, fee)
+	tx.Sign(privAccounts[0])
+	if err := execTxWithState(state, tx, true); err != nil {
+		t.Fatal(err)
+	}
+	entry = state.GetNameRegEntry(name)
+	validateEntry(t, entry, name, data, privAccounts[0].Address, uint64(state.LastBlockHeight)+numDesiredBlocks)
+	state.LastBlockHeight = uint(entry.Expires)
+
+	amt = fee
+	data = ""
+	tx, _ = types.NewNameTx(state, privAccounts[1].PubKey, name, data, amt, fee)
+	tx.Sign(privAccounts[1])
+	if err := execTxWithStateNewBlock(state, tx, true); err != nil {
+		t.Fatal(err)
+	}
+	entry = state.GetNameRegEntry(name)
+	if entry != nil {
+		t.Fatal("Expected removed entry to be nil")
+	}
 }
 
 // TODO: test overflows.

--- a/types/names.go
+++ b/types/names.go
@@ -1,8 +1,13 @@
 package types
 
 type NameRegEntry struct {
-	Name    []byte // registered name for the entry
-	Owner   []byte // address that created the entry
-	Data    []byte // binary encoded byte array
-	Expires uint   // block at which this entry expires
+	Name    string `json:"name"`    // registered name for the entry
+	Owner   []byte `json:"owner"`   // address that created the entry
+	Data    string `json:"data"`    // binary encoded byte array
+	Expires uint64 `json:"expires"` // block at which this entry expires
+}
+
+func (entry *NameRegEntry) Copy() *NameRegEntry {
+	entryCopy := *entry
+	return &entryCopy
 }

--- a/types/names.go
+++ b/types/names.go
@@ -1,5 +1,40 @@
 package types
 
+import (
+	"regexp"
+)
+
+var (
+	MinNameRegistrationPeriod uint64 = 5
+
+	// cost for storing a name for a block is
+	// CostPerBlock*CostPerByte*(len(data) + 32)
+	NameCostPerByte  uint64 = 1
+	NameCostPerBlock uint64 = 1
+
+	MaxNameLength = 32
+	MaxDataLength = 1 << 16
+
+	// Name should be alphanum, underscore, slash
+	// Data should be anything permitted in JSON
+	regexpAlphaNum = regexp.MustCompile("^[a-zA-Z0-9_/]*$")
+	regexpJSON     = regexp.MustCompile(`^[a-zA-Z0-9_/ \-"':,\n\t.{}()\[\]]*$`)
+)
+
+// filter strings
+func validateNameRegEntryName(name string) bool {
+	return regexpAlphaNum.Match([]byte(name))
+}
+
+func validateNameRegEntryData(data string) bool {
+	return regexpJSON.Match([]byte(data))
+}
+
+// base cost is "effective" number of bytes
+func BaseEntryCost(name, data string) uint64 {
+	return uint64(len(data) + 32)
+}
+
 type NameRegEntry struct {
 	Name    string `json:"name"`    // registered name for the entry
 	Owner   []byte `json:"owner"`   // address that created the entry

--- a/types/names.go
+++ b/types/names.go
@@ -1,0 +1,8 @@
+package types
+
+type NameRegEntry struct {
+	Name    []byte // registered name for the entry
+	Owner   []byte // address that created the entry
+	Data    []byte // binary encoded byte array
+	Expires uint   // block at which this entry expires
+}

--- a/types/tx.go
+++ b/types/tx.go
@@ -20,6 +20,7 @@ var (
 	ErrTxInvalidPubKey        = errors.New("Error invalid pubkey")
 	ErrTxInvalidSignature     = errors.New("Error invalid signature")
 	ErrTxInvalidString        = errors.New("Error invalid string")
+	ErrIncorrectOwner         = errors.New("Error incorrect owner")
 )
 
 type ErrTxInvalidSequence struct {

--- a/types/tx_utils.go
+++ b/types/tx_utils.go
@@ -106,7 +106,7 @@ func (tx *CallTx) Sign(privAccount *account.PrivAccount) {
 //----------------------------------------------------------------------------
 // NameTx interface for creating tx
 
-func NewNameTx(st AccountGetter, from account.PubKey, name, data []byte, amt, fee uint64) (*NameTx, error) {
+func NewNameTx(st AccountGetter, from account.PubKey, name, data string, amt, fee uint64) (*NameTx, error) {
 	addr := from.Address()
 	acc := st.GetAccount(addr)
 	if acc == nil {
@@ -117,7 +117,7 @@ func NewNameTx(st AccountGetter, from account.PubKey, name, data []byte, amt, fe
 	return NewNameTxWithNonce(from, name, data, amt, fee, nonce), nil
 }
 
-func NewNameTxWithNonce(from account.PubKey, name, data []byte, amt, fee, nonce uint64) *NameTx {
+func NewNameTxWithNonce(from account.PubKey, name, data string, amt, fee, nonce uint64) *NameTx {
 	addr := from.Address()
 	input := &TxInput{
 		Address:   addr,

--- a/types/tx_utils.go
+++ b/types/tx_utils.go
@@ -104,6 +104,43 @@ func (tx *CallTx) Sign(privAccount *account.PrivAccount) {
 }
 
 //----------------------------------------------------------------------------
+// NameTx interface for creating tx
+
+func NewNameTx(st AccountGetter, from account.PubKey, name, data []byte, amt, fee uint64) (*NameTx, error) {
+	addr := from.Address()
+	acc := st.GetAccount(addr)
+	if acc == nil {
+		return nil, fmt.Errorf("Invalid address %X from pubkey %X", addr, from)
+	}
+
+	nonce := uint64(acc.Sequence)
+	return NewNameTxWithNonce(from, name, data, amt, fee, nonce), nil
+}
+
+func NewNameTxWithNonce(from account.PubKey, name, data []byte, amt, fee, nonce uint64) *NameTx {
+	addr := from.Address()
+	input := &TxInput{
+		Address:   addr,
+		Amount:    amt,
+		Sequence:  uint(nonce) + 1,
+		Signature: account.SignatureEd25519{},
+		PubKey:    from,
+	}
+
+	return &NameTx{
+		Input: input,
+		Name:  name,
+		Data:  data,
+		Fee:   fee,
+	}
+}
+
+func (tx *NameTx) Sign(privAccount *account.PrivAccount) {
+	tx.Input.PubKey = privAccount.PubKey
+	tx.Input.Signature = privAccount.Sign(tx)
+}
+
+//----------------------------------------------------------------------------
 // BondTx interface for adding inputs/outputs and adding signatures
 
 func NewBondTx(pubkey account.PubKey) (*BondTx, error) {

--- a/types/tx_utils.go
+++ b/types/tx_utils.go
@@ -25,23 +25,15 @@ func (tx *SendTx) AddInput(st AccountGetter, pubkey account.PubKey, amt uint64) 
 	if acc == nil {
 		return fmt.Errorf("Invalid address %X from pubkey %X", addr, pubkey)
 	}
-
-	tx.Inputs = append(tx.Inputs, &TxInput{
-		Address:   addr,
-		Amount:    amt,
-		Sequence:  uint(acc.Sequence) + 1,
-		Signature: account.SignatureEd25519{},
-		PubKey:    pubkey,
-	})
-	return nil
+	return tx.AddInputWithNonce(pubkey, amt, acc.Sequence+1)
 }
 
-func (tx *SendTx) AddInputWithNonce(pubkey account.PubKey, amt, nonce uint64) error {
+func (tx *SendTx) AddInputWithNonce(pubkey account.PubKey, amt uint64, nonce uint) error {
 	addr := pubkey.Address()
 	tx.Inputs = append(tx.Inputs, &TxInput{
 		Address:   addr,
 		Amount:    amt,
-		Sequence:  uint(nonce) + 1,
+		Sequence:  nonce,
 		Signature: account.SignatureEd25519{},
 		PubKey:    pubkey,
 	})
@@ -75,16 +67,16 @@ func NewCallTx(st AccountGetter, from account.PubKey, to, data []byte, amt, gasL
 		return nil, fmt.Errorf("Invalid address %X from pubkey %X", addr, from)
 	}
 
-	nonce := uint64(acc.Sequence)
+	nonce := acc.Sequence + 1
 	return NewCallTxWithNonce(from, to, data, amt, gasLimit, fee, nonce), nil
 }
 
-func NewCallTxWithNonce(from account.PubKey, to, data []byte, amt, gasLimit, fee, nonce uint64) *CallTx {
+func NewCallTxWithNonce(from account.PubKey, to, data []byte, amt, gasLimit, fee uint64, nonce uint) *CallTx {
 	addr := from.Address()
 	input := &TxInput{
 		Address:   addr,
 		Amount:    amt,
-		Sequence:  uint(nonce) + 1,
+		Sequence:  nonce,
 		Signature: account.SignatureEd25519{},
 		PubKey:    from,
 	}
@@ -113,16 +105,16 @@ func NewNameTx(st AccountGetter, from account.PubKey, name, data string, amt, fe
 		return nil, fmt.Errorf("Invalid address %X from pubkey %X", addr, from)
 	}
 
-	nonce := uint64(acc.Sequence)
+	nonce := acc.Sequence + 1
 	return NewNameTxWithNonce(from, name, data, amt, fee, nonce), nil
 }
 
-func NewNameTxWithNonce(from account.PubKey, name, data string, amt, fee, nonce uint64) *NameTx {
+func NewNameTxWithNonce(from account.PubKey, name, data string, amt, fee uint64, nonce uint) *NameTx {
 	addr := from.Address()
 	input := &TxInput{
 		Address:   addr,
 		Amount:    amt,
-		Sequence:  uint(nonce) + 1,
+		Sequence:  nonce,
 		Signature: account.SignatureEd25519{},
 		PubKey:    from,
 	}
@@ -161,23 +153,15 @@ func (tx *BondTx) AddInput(st AccountGetter, pubkey account.PubKey, amt uint64) 
 	if acc == nil {
 		return fmt.Errorf("Invalid address %X from pubkey %X", addr, pubkey)
 	}
-
-	tx.Inputs = append(tx.Inputs, &TxInput{
-		Address:   addr,
-		Amount:    amt,
-		Sequence:  uint(acc.Sequence) + 1,
-		Signature: account.SignatureEd25519{},
-		PubKey:    pubkey,
-	})
-	return nil
+	return tx.AddInputWithNonce(pubkey, amt, acc.Sequence+1)
 }
 
-func (tx *BondTx) AddInputWithNonce(pubkey account.PubKey, amt, nonce uint64) error {
+func (tx *BondTx) AddInputWithNonce(pubkey account.PubKey, amt uint64, nonce uint) error {
 	addr := pubkey.Address()
 	tx.Inputs = append(tx.Inputs, &TxInput{
 		Address:   addr,
 		Amount:    amt,
-		Sequence:  uint(nonce) + 1,
+		Sequence:  nonce,
 		Signature: account.SignatureEd25519{},
 		PubKey:    pubkey,
 	})


### PR DESCRIPTION
Things left undone: finer economic details like what to do with value sent to pay for entries, possible rewards for removers of expired entries, and whether or not to use a runCall dichotomy and/or include "invalid" nametxs eg by non-owners trying to update and failing (so we can take their fees). For now we use no runCall flag so all NameTxs are fully processed by the mempool and an error is a tx error (not included in block)