### PR TITLE
add gmp so that docker images build correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ ENV DEBCONF_NOWARNINGS yes
 ENV TERM linux
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+    libgmp3-dev && \
+  rm -rf /var/lib/apt/lists/*
+
 # Install go
 # ADD tendermint user
 RUN useradd tendermint
@@ -16,12 +21,12 @@ RUN useradd tendermint
 RUN usermod -s /sbin/nologin tendermint
 
 ADD . /go/src/github.com/tendermint/tendermint
-WORKDIR /go/src/github.com/tendermint/tendermint 
+WORKDIR /go/src/github.com/tendermint/tendermint
 RUN make
 
 # Set environment variables
 USER tendermint
 ENV USER tendermint
 ENV TMROOT /tendermint_root
-# docker run -v $(pwd)/tendermint_root:/tendermint_root 
+# docker run -v $(pwd)/tendermint_root:/tendermint_root
 CMD [ "./build/tendermint", "node" ]


### PR DESCRIPTION
This PR adds gmp to the docker build process which is required by the Tendermint VM to perform `ecrecover` properly. 