### PR TITLE
Develop ethan

### DIFF
--- a/DOCKER/run.sh
+++ b/DOCKER/run.sh
@@ -4,7 +4,7 @@ if [[ $BARAK_SEED ]]; then
 	cat ./cmd/barak/$BARAK_SEED | ./build/barak &
 fi
 
-if [[ $FAST_SYNC ]]; then
+if [ "$FAST_SYNC" = "true" ]; then
 	./build/tendermint node --fast_sync
 else 
 	./build/tendermint node

--- a/rpc/test/client_rpc_test.go
+++ b/rpc/test/client_rpc_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// When run with `-test.short` we only run:
+// TestHTTPStatus, TestHTTPBroadcast, TestJSONStatus, TestJSONBroadcast, TestWSConnect, TestWSSend
+
 //--------------------------------------------------------------------------------
 // Test the HTTP client
 
@@ -13,14 +16,23 @@ func TestHTTPStatus(t *testing.T) {
 }
 
 func TestHTTPGenPriv(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testGenPriv(t, "HTTP")
 }
 
 func TestHTTPGetAccount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testGetAccount(t, "HTTP")
 }
 
 func TestHTTPSignedTx(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testSignedTx(t, "HTTP")
 }
 
@@ -29,18 +41,30 @@ func TestHTTPBroadcastTx(t *testing.T) {
 }
 
 func TestHTTPGetStorage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testGetStorage(t, "HTTP")
 }
 
 func TestHTTPCallCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testCallCode(t, "HTTP")
 }
 
 func TestHTTPCallContract(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testCall(t, "HTTP")
 }
 
 func TestHTTPNameReg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testNameReg(t, "HTTP")
 }
 
@@ -52,14 +76,23 @@ func TestJSONStatus(t *testing.T) {
 }
 
 func TestJSONGenPriv(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testGenPriv(t, "JSONRPC")
 }
 
 func TestJSONGetAccount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testGetAccount(t, "JSONRPC")
 }
 
 func TestJSONSignedTx(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testSignedTx(t, "JSONRPC")
 }
 
@@ -68,17 +101,29 @@ func TestJSONBroadcastTx(t *testing.T) {
 }
 
 func TestJSONGetStorage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testGetStorage(t, "JSONRPC")
 }
 
 func TestJSONCallCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testCallCode(t, "JSONRPC")
 }
 
 func TestJSONCallContract(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testCall(t, "JSONRPC")
 }
 
 func TestJSONNameReg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	testNameReg(t, "JSONRPC")
 }

--- a/rpc/test/client_ws_test.go
+++ b/rpc/test/client_ws_test.go
@@ -37,6 +37,9 @@ func _TestWSNewBlock(t *testing.T) {
 
 // receive a few new block messages in a row, with increasing height
 func TestWSBlockchainGrowth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	con := newWSCon(t)
 	eid := types.EventStringNewBlock()
 	subscribe(t, con, eid)
@@ -72,6 +75,9 @@ func TestWSSend(t *testing.T) {
 
 // ensure events are only fired once for a given transaction
 func TestWSDoubleFire(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	con := newWSCon(t)
 	eid := types.EventStringAccInput(user[0].Address)
 	subscribe(t, con, eid)
@@ -97,6 +103,9 @@ func TestWSDoubleFire(t *testing.T) {
 
 // create a contract, wait for the event, and send it a msg, validate the return
 func TestWSCallWait(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	con := newWSCon(t)
 	eid1 := types.EventStringAccInput(user[0].Address)
 	subscribe(t, con, eid1)
@@ -133,6 +142,9 @@ func TestWSCallWait(t *testing.T) {
 // create a contract and send it a msg without waiting. wait for contract event
 // and validate return
 func TestWSCallNoWait(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	con := newWSCon(t)
 	amt, gasLim, fee := int64(10000), int64(1000), int64(1000)
 	code, _, returnVal := simpleContract()
@@ -159,6 +171,9 @@ func TestWSCallNoWait(t *testing.T) {
 
 // create two contracts, one of which calls the other
 func TestWSCallCall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	con := newWSCon(t)
 	amt, gasLim, fee := int64(10000), int64(1000), int64(1000)
 	code, _, returnVal := simpleContract()

--- a/state/test.go
+++ b/state/test.go
@@ -69,8 +69,7 @@ func RandValidator(randBonded bool, minBonded int64) (*ValidatorInfo, *Validator
 	return valInfo, val, privVal
 }
 
-func RandGenesisState(numAccounts int, randBalance bool, minBalance int64, numValidators int, randBonded bool, minBonded int64) (*State, []*account.PrivAccount, []*PrivValidator) {
-	db := dbm.NewMemDB()
+func RandGenesisDoc(numAccounts int, randBalance bool, minBalance int64, numValidators int, randBonded bool, minBonded int64) (*GenesisDoc, []*account.PrivAccount, []*PrivValidator) {
 	accounts := make([]GenesisAccount, numAccounts)
 	privAccounts := make([]*account.PrivAccount, numAccounts)
 	defaultPerms := ptypes.DefaultAccountPermissions
@@ -100,15 +99,19 @@ func RandGenesisState(numAccounts int, randBalance bool, minBalance int64, numVa
 		privValidators[i] = privVal
 	}
 	sort.Sort(PrivValidatorsByAddress(privValidators))
-	s0 := MakeGenesisState(db, &GenesisDoc{
+	return &GenesisDoc{
 		GenesisTime: time.Now(),
 		ChainID:     "tendermint_test",
 		Accounts:    accounts,
 		Validators:  validators,
-		Params: &GenesisParams{
-			GlobalPermissions: &defaultPerms,
-		},
-	})
+	}, privAccounts, privValidators
+
+}
+
+func RandGenesisState(numAccounts int, randBalance bool, minBalance int64, numValidators int, randBonded bool, minBonded int64) (*State, []*account.PrivAccount, []*PrivValidator) {
+	db := dbm.NewMemDB()
+	genDoc, privAccounts, privValidators := RandGenesisDoc(numAccounts, randBalance, minBalance, numValidators, randBonded, minBonded)
+	s0 := MakeGenesisState(db, genDoc)
 	s0.Save()
 	return s0, privAccounts, privValidators
 }


### PR DESCRIPTION
RandGenesisDoc so tools can import
-test.short to skip most of the rpc tests (still tests fundamentals tho, only takes few seconds instead of minute or two)