### PR TITLE
add handshakeTimeout, bound chunkLength, comments

### DIFF
--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -110,23 +110,23 @@ var defaultGenesis = `{
   "chain_id" : "tendermint_test",
   "accounts": [
     {
-	    "address": "C3C1AF26C0CB2C1DB233D8936AD2C6335AAB6844",
+	    "address": "E9B5D87313356465FAE33C406CE2C2979DE60BCB",
 	    "amount": 200000000
     },
     {
-	    "address": "C76F0E490A003FDB4A94B310C354F1650A6F97B7",
+	    "address": "DFE4AFFA4CEE17CD01CB9E061D77C3ECED29BD88",
 	    "amount": 200000000
     },
     {
-	    "address": "576C84059355CD3B8CBDD81C3FCBC5CE5B6632E0",
+	    "address": "F60D30722E7B497FA532FB3207C3FB29C31B1992",
 	    "amount": 200000000
     },
     {
-	    "address": "CD9AB051EDEA88E61ABDF2A1ACF10C3803F0972F",
+	    "address": "336CB40A5EB92E496E19B74FDFF2BA017C877FD6",
 	    "amount": 200000000
     },
     {
-	    "address": "4EE2D93B0A1FBA4E9EBE20E088AA122002A2EB0C",
+	    "address": "D218F0F439BF0384F6F5EF8D0F8B398D941BD1DC",
 	    "amount": 200000000
     }
   ],


### PR DESCRIPTION
- ReadFull hangs forever unless we set a timeout on the conn (not sure this matters for sconn.Read(), but it does for shareEphPubKey

- sconn.Read was missing a bounds check such that a malicious `chunkLength` would crash the node

- there's also a question in there about the size of the buffer used for `shareAuthSignature`

Unfortunately, I couldn't think of an easy way to implement tests for my fixes (I tested both manually).