### PR TITLE
Consensus tests

### DIFF
--- a/consensus/height_vote_set.go
+++ b/consensus/height_vote_set.go
@@ -77,7 +77,7 @@ func (hvs *HeightVoteSet) addRound(round int) {
 	if _, ok := hvs.roundVoteSets[round]; ok {
 		PanicSanity("addRound() for an existing round")
 	}
-	log.Info("addRound(round)", "round", round)
+	log.Debug("addRound(round)", "round", round)
 	prevotes := types.NewVoteSet(hvs.height, round, types.VoteTypePrevote, hvs.valSet)
 	precommits := types.NewVoteSet(hvs.height, round, types.VoteTypePrecommit, hvs.valSet)
 	hvs.roundVoteSets[round] = RoundVoteSet{
@@ -120,7 +120,7 @@ func (hvs *HeightVoteSet) Precommits(round int) *types.VoteSet {
 	return hvs.getVoteSet(round, types.VoteTypePrecommit)
 }
 
-// Last round that has +2/3 prevotes for a particular block or nik.
+// Last round that has +2/3 prevotes for a particular block or nil.
 // Returns -1 if no such round exists.
 func (hvs *HeightVoteSet) POLRound() int {
 	hvs.mtx.Lock()
@@ -134,7 +134,7 @@ func (hvs *HeightVoteSet) POLRound() int {
 }
 
 func (hvs *HeightVoteSet) getVoteSet(round int, type_ byte) *types.VoteSet {
-	log.Info("getVoteSet(round)", "round", round, "type", type_)
+	log.Debug("getVoteSet(round)", "round", round, "type", type_)
 	rvs, ok := hvs.roundVoteSets[round]
 	if !ok {
 		return nil

--- a/consensus/height_vote_set.go
+++ b/consensus/height_vote_set.go
@@ -88,7 +88,7 @@ func (hvs *HeightVoteSet) addRound(round int) {
 
 // Duplicate votes return added=false, err=nil.
 // By convention, peerKey is "" if origin is self.
-func (hvs *HeightVoteSet) AddByAddress(address []byte, vote *types.Vote, peerKey string) (added bool, index int, err error) {
+func (hvs *HeightVoteSet) AddByIndex(valIndex int, vote *types.Vote, peerKey string) (added bool, address []byte, err error) {
 	hvs.mtx.Lock()
 	defer hvs.mtx.Unlock()
 	voteSet := hvs.getVoteSet(vote.Round, vote.Type)
@@ -104,7 +104,7 @@ func (hvs *HeightVoteSet) AddByAddress(address []byte, vote *types.Vote, peerKey
 		}
 		return
 	}
-	added, index, err = voteSet.AddByAddress(address, vote)
+	added, address, err = voteSet.AddByIndex(valIndex, vote)
 	return
 }
 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -143,6 +143,7 @@ func (conR *ConsensusReactor) Receive(chId byte, peer *p2p.Peer, msgBytes []byte
 	_, msg, err := DecodeMessage(msgBytes)
 	if err != nil {
 		log.Warn("Error decoding message", "channel", chId, "peer", peer, "msg", msg, "error", err, "bytes", msgBytes)
+		// TODO punish peer?
 		return
 	}
 	log.Debug("Receive", "channel", chId, "peer", peer, "msg", msg, "rsHeight", rs.Height)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -185,50 +185,29 @@ func (conR *ConsensusReactor) Receive(chId byte, peer *p2p.Peer, msgBytes []byte
 		}
 		switch msg := msg.(type) {
 		case *VoteMessage:
-			vote := msg.Vote
-			var validators *types.ValidatorSet
-			if rs.Height == vote.Height {
-				validators = rs.Validators
-			} else if rs.Height == vote.Height+1 {
-				if !(rs.Step == RoundStepNewHeight && vote.Type == types.VoteTypePrecommit) {
-					return // Wrong height, not a LastCommit straggler commit.
-				}
-				validators = rs.LastValidators
-			} else {
-				return // Wrong height. Not necessarily a bad peer.
+			vote, valIndex := msg.Vote, msg.ValidatorIndex
+
+			// attempt to add the vote and dupeout the validator if its a duplicate signature
+			added, err := conR.conS.TryAddVote(rs, vote, valIndex, peer.Key)
+			if err == ErrAddingVote {
+				// TODO: punish peer
+			} else if err != nil {
+				return
 			}
 
-			// We have vote/validators.  Height may not be rs.Height
-
-			address, _ := validators.GetByIndex(msg.ValidatorIndex)
-			added, index, err := conR.conS.AddVote(address, vote, peer.Key)
-			if err != nil {
-				// If conflicting sig, broadcast evidence tx for slashing. Else punish peer.
-				if errDupe, ok := err.(*types.ErrVoteConflictingSignature); ok {
-					log.Warn("Found conflicting vote. Publish evidence")
-					evidenceTx := &types.DupeoutTx{
-						Address: address,
-						VoteA:   *errDupe.VoteA,
-						VoteB:   *errDupe.VoteB,
-					}
-					conR.conS.mempoolReactor.BroadcastTx(evidenceTx) // shouldn't need to check returned err
-				} else {
-					// Probably an invalid signature. Bad peer.
-					log.Warn("Error attempting to add vote", "error", err)
-					// TODO: punish peer
-				}
-			}
 			ps.EnsureVoteBitArrays(rs.Height, rs.Validators.Size())
 			ps.EnsureVoteBitArrays(rs.Height-1, rs.LastCommit.Size())
-			ps.SetHasVote(vote, index)
+			ps.SetHasVote(vote, valIndex)
+
 			if added {
 				// If rs.Height == vote.Height && rs.Round < vote.Round,
 				// the peer is sending us CatchupCommit precommits.
 				// We could make note of this and help filter in broadcastHasVoteMessage().
-				conR.broadcastHasVoteMessage(vote, index)
+				conR.broadcastHasVoteMessage(vote, valIndex)
 			}
 
 		default:
+			// TODO: should these be punishable?
 			log.Warn(Fmt("Unknown message type %v", reflect.TypeOf(msg)))
 		}
 	default:

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -180,6 +180,7 @@ var (
 	ErrInvalidProposalSignature = errors.New("Error invalid proposal signature")
 	ErrInvalidProposalPOLRound  = errors.New("Error invalid proposal POL round")
 	ErrAddingVote               = errors.New("Error adding vote")
+	ErrVoteHeightMismatch       = errors.New("Error vote height mismatch")
 )
 
 //-----------------------------------------------------------------------------
@@ -543,33 +544,24 @@ func (cs *ConsensusState) EnterPropose(height int, round int) {
 	}
 	log.Info(Fmt("EnterPropose(%v/%v). Current: %v/%v/%v", height, round, cs.Height, cs.Round, cs.Step))
 
-	var enterPrevote = make(chan struct{}, 1)
-
 	defer func() {
 		// Done EnterPropose:
 		cs.Round = round
 		cs.Step = RoundStepPropose
-		enterPrevote <- struct{}{}
+		cs.newStepCh <- cs.getRoundState()
+
+		// If we have the whole proposal + POL, then goto Prevote now.
+		// else, we'll EnterPrevote when the rest of the proposal is received (in AddProposalBlockPart),
+		// or else after timeoutPropose
+		if cs.isProposalComplete() {
+			go cs.EnterPrevote(height, cs.Round)
+		}
 	}()
 
-	// EnterPrevote after timeoutPropose or if the proposal is complete
+	// This step times out after `timeoutPropose`
 	go func() {
-		ticker := time.NewTicker(timeoutPropose)
-	LOOP:
-		for {
-			select {
-			case <-ticker.C:
-				cs.timeoutChan <- TimeoutEvent{RoundStepPropose, height, round}
-				break LOOP
-			case <-enterPrevote:
-				// If we already have the proposal + POL, then goto Prevote
-				if cs.isProposalComplete() {
-					break LOOP
-				}
-			}
-		}
-		cs.newStepCh <- cs.getRoundState()
-		go cs.EnterPrevote(height, round)
+		time.Sleep(timeoutPropose)
+		cs.EnterPrevote(height, round)
 	}()
 
 	// Nothing more to do if we're not a validator
@@ -581,7 +573,7 @@ func (cs *ConsensusState) EnterPropose(height int, round int) {
 		log.Info("EnterPropose: Not our turn to propose", "proposer", cs.Validators.Proposer().Address, "privValidator", cs.privValidator)
 	} else {
 		log.Info("EnterPropose: Our turn to propose", "proposer", cs.Validators.Proposer().Address, "privValidator", cs.privValidator)
-		cs.decideProposal(height, round) // if this takes longer than timeoutPropose we'll catch it in a later EnterPropose
+		cs.decideProposal(height, round)
 	}
 }
 
@@ -632,8 +624,7 @@ func (cs *ConsensusState) isProposalComplete() bool {
 }
 
 // Create the next block to propose and return it.
-// NOTE: make it side-effect free for clarity.
-// XXX: where are the side-effects?
+// NOTE: keep it side-effect free for clarity.
 func (cs *ConsensusState) createProposalBlock() (block *types.Block, blockParts *types.PartSet) {
 	var validation *types.Validation
 	if cs.Height == 1 {
@@ -765,10 +756,9 @@ func (cs *ConsensusState) EnterPrevoteWait(height int, round int) {
 // Enter: +2/3 precomits for block or nil.
 // Enter: `timeoutPrevote` after any +2/3 prevotes.
 // Enter: any +2/3 precommits for next round.
-// Lock & precommit the ProposalBlock if we have enough prevotes for it,
+// Lock & precommit the ProposalBlock if we have enough prevotes for it (a POL in this round)
 // else, unlock an existing lock and precommit nil if +2/3 of prevotes were nil,
 // else, precommit nil otherwise.
-// NOTE: we don't precommit our locked block (unless theres another POL for it) because it complicates unlocking and accountability
 func (cs *ConsensusState) EnterPrecommit(height int, round int) {
 	cs.mtx.Lock()
 	defer cs.mtx.Unlock()
@@ -791,9 +781,7 @@ func (cs *ConsensusState) EnterPrecommit(height int, round int) {
 
 	hash, partsHeader, ok := cs.Votes.Prevotes(round).TwoThirdsMajority()
 
-	// If we don't have two thirds of prevotes, just precommit nil
-	// NOTE: alternatively, if we have seen a POL since our last precommit,
-	// we could precommit that
+	// If we don't have two thirds of prevotes, we must precommit nil
 	if !ok {
 		if cs.LockedBlock != nil {
 			log.Info("EnterPrecommit: No +2/3 prevotes during EnterPrecommit while we're locked. Precommitting nil")
@@ -833,7 +821,7 @@ func (cs *ConsensusState) EnterPrecommit(height int, round int) {
 
 	// If +2/3 prevoted for proposal block, stage and precommit it
 	if cs.ProposalBlock.HashesTo(hash) {
-		log.Info("EnterPrecommit: +2/3 prevoted proposal block.", "hash", fmt.Sprintf("%X", hash))
+		log.Info("EnterPrecommit: +2/3 prevoted proposal block.", "hash", hash)
 		// Validate the block.
 		if err := cs.stageBlock(cs.ProposalBlock, cs.ProposalBlockParts); err != nil {
 			PanicConsensus(Fmt("EnterPrecommit: +2/3 prevoted for an invalid block: %v", err))
@@ -923,20 +911,10 @@ func (cs *ConsensusState) EnterCommit(height int, commitRound int) {
 
 	// The Locked* fields no longer matter.
 	// Move them over to ProposalBlock if they match the commit hash,
-	// otherwise they can now be cleared.
-	// XXX: can't we just wait to clear them in updateToState ?
-	// XXX: it's causing a race condition in tests where they get cleared
-	// before we can check the lock!
+	// otherwise they'll be cleared in updateToState.
 	if cs.LockedBlock.HashesTo(hash) {
 		cs.ProposalBlock = cs.LockedBlock
 		cs.ProposalBlockParts = cs.LockedBlockParts
-		/*cs.LockedRound = 0
-		cs.LockedBlock = nil
-		cs.LockedBlockParts = nil*/
-	} else {
-		/*cs.LockedRound = 0
-		cs.LockedBlock = nil
-		cs.LockedBlockParts = nil*/
 	}
 
 	// If we don't have the block being committed, set up to get it.
@@ -1077,7 +1055,6 @@ func (cs *ConsensusState) AddProposalBlockPart(height int, part *types.Part) (ad
 		log.Info("Received complete proposal", "hash", cs.ProposalBlock.Hash())
 		if cs.Step == RoundStepPropose && cs.isProposalComplete() {
 			// Move onto the next step
-			// XXX: isn't this unecessary since propose will either do this or timeout into it
 			go cs.EnterPrevote(height, cs.Round)
 		} else if cs.Step == RoundStepCommit {
 			// If we're waiting on the proposal block...
@@ -1088,35 +1065,23 @@ func (cs *ConsensusState) AddProposalBlockPart(height int, part *types.Part) (ad
 	return added, nil
 }
 
-func (cs *ConsensusState) AddVote(address []byte, vote *types.Vote, peerKey string) (added bool, index int, err error) {
+func (cs *ConsensusState) AddVote(valIndex int, vote *types.Vote, peerKey string) (added bool, address []byte, err error) {
 	cs.mtx.Lock()
 	defer cs.mtx.Unlock()
 
-	return cs.addVote(address, vote, peerKey)
+	return cs.addVote(valIndex, vote, peerKey)
 }
 
 // Attempt to add the vote. if its a duplicate signature, dupeout the validator
-func (cs *ConsensusState) TryAddVote(rs *RoundState, vote *types.Vote, valIndex int, peerKey string) (bool, error) {
-	var validators *types.ValidatorSet
-	if rs.Height == vote.Height {
-		validators = rs.Validators
-	} else if rs.Height == vote.Height+1 {
-		if !(rs.Step == RoundStepNewHeight && vote.Type == types.VoteTypePrecommit) {
-			return false, fmt.Errorf("TryAddVote: Wrong height, not a LastCommit straggler commit.")
-		}
-		validators = rs.LastValidators
-	} else {
-		return false, fmt.Errorf("TryAddVote: Wrong height. Not necessarily a bad peer.")
-	}
-
-	// We have vote/validators.  Height may not be rs.Height
-
-	address, _ := validators.GetByIndex(valIndex)
-	added, index, err := cs.AddVote(address, vote, peerKey)
-	_ = index // should be same as valIndex
+func (cs *ConsensusState) TryAddVote(valIndex int, vote *types.Vote, peerKey string) (bool, error) {
+	added, address, err := cs.AddVote(valIndex, vote, peerKey)
 	if err != nil {
-		// If conflicting sig, broadcast evidence tx for slashing. Else punish peer.
-		if errDupe, ok := err.(*types.ErrVoteConflictingSignature); ok {
+		// If the vote height is off, we'll just ignore it,
+		// But if it's a conflicting sig, broadcast evidence tx for slashing
+		// and otherwise punish peer.
+		if err == ErrVoteHeightMismatch {
+			return added, err
+		} else if errDupe, ok := err.(*types.ErrVoteConflictingSignature); ok {
 			log.Warn("Found conflicting vote. Publish evidence")
 			evidenceTx := &types.DupeoutTx{
 				Address: address,
@@ -1136,12 +1101,17 @@ func (cs *ConsensusState) TryAddVote(rs *RoundState, vote *types.Vote, valIndex 
 
 //-----------------------------------------------------------------------------
 
-func (cs *ConsensusState) addVote(address []byte, vote *types.Vote, peerKey string) (added bool, index int, err error) {
+func (cs *ConsensusState) addVote(valIndex int, vote *types.Vote, peerKey string) (added bool, address []byte, err error) {
 	log.Debug("addVote", "voteHeight", vote.Height, "voteType", vote.Type, "csHeight", cs.Height)
 
 	// A precommit for the previous height?
-	if vote.Height+1 == cs.Height && vote.Type == types.VoteTypePrecommit {
-		added, index, err = cs.LastCommit.AddByAddress(address, vote)
+	if vote.Height+1 == cs.Height {
+		if !(cs.Step == RoundStepNewHeight && vote.Type == types.VoteTypePrecommit) {
+			// TODO: give the reason ..
+			// fmt.Errorf("TryAddVote: Wrong height, not a LastCommit straggler commit.")
+			return added, nil, ErrVoteHeightMismatch
+		}
+		added, address, err = cs.LastCommit.AddByIndex(valIndex, vote)
 		if added {
 			log.Info(Fmt("Added to lastPrecommits: %v", cs.LastCommit.StringShort()))
 		}
@@ -1151,7 +1121,7 @@ func (cs *ConsensusState) addVote(address []byte, vote *types.Vote, peerKey stri
 	// A prevote/precommit for this height?
 	if vote.Height == cs.Height {
 		height := cs.Height
-		added, index, err = cs.Votes.AddByAddress(address, vote, peerKey)
+		added, address, err = cs.Votes.AddByIndex(valIndex, vote, peerKey)
 		if added {
 			switch vote.Type {
 			case types.VoteTypePrevote:
@@ -1213,8 +1183,10 @@ func (cs *ConsensusState) addVote(address []byte, vote *types.Vote, peerKey stri
 				PanicSanity(Fmt("Unexpected vote type %X", vote.Type)) // Should not happen.
 			}
 		}
-		// Either duplicate, or error upon cs.Votes.AddByAddress()
+		// Either duplicate, or error upon cs.Votes.AddByIndex()
 		return
+	} else {
+		err = ErrVoteHeightMismatch
 	}
 
 	// Height mismatch, bad peer?
@@ -1269,7 +1241,9 @@ func (cs *ConsensusState) signAddVote(type_ byte, hash []byte, header types.Part
 	}
 	vote, err := cs.signVote(type_, hash, header)
 	if err == nil {
-		_, _, err := cs.addVote(cs.privValidator.Address, vote, "")
+		// NOTE: store our index in the cs so we don't have to do this every time
+		valIndex, _ := cs.Validators.GetByAddress(cs.privValidator.Address)
+		_, _, err := cs.addVote(valIndex, vote, "")
 		log.Notice("Signed and added vote", "height", cs.Height, "round", cs.Round, "vote", vote, "error", err)
 		return vote
 	} else {

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1145,5 +1145,13 @@ func TestHalt1(t *testing.T) {
 
 	// receiving that precommit should take us straight to commit
 	ensureNewStep(t, cs1)
+	log.Warn("done enter commit!")
+
+	// update to state
+	ensureNewStep(t, cs1)
+
+	if cs1.Height != 2 {
+		t.Fatal("expected height to increment")
+	}
 
 }

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -4,35 +4,428 @@ import (
 	"testing"
 
 	_ "github.com/tendermint/tendermint/config/tendermint_test"
+	"github.com/tendermint/tendermint/types"
 )
 
-func TestEnterProposeNoPrivValidator(t *testing.T) {
-	cs, _ := randConsensusState()
-	cs.EnterPropose(1, 0)
-	rs := cs.GetRoundState()
-	if rs.Proposal != nil {
-		t.Error("Expected to make no proposal, since no privValidator")
-	}
-}
-
-func TestEnterPropose(t *testing.T) {
-	cs, privValidators := randConsensusState()
-	val0 := privValidators[0]
-	cs.SetPrivValidator(val0)
-
-	cs.EnterPropose(1, 0)
-	rs := cs.GetRoundState()
-
-	// Check that Proposal, ProposalBlock, ProposalBlockParts are set.
-	if rs.Proposal == nil {
-		t.Error("rs.Proposal should be set")
-	}
-	if rs.ProposalBlock == nil {
-		t.Error("rs.ProposalBlock should be set")
-	}
-	if rs.ProposalBlockParts.Total() == 0 {
-		t.Error("rs.ProposalBlockParts should be set")
-	}
-}
-
 // TODO write better consensus state tests
+
+// a non-validator should timeout of the prevote round
+func TestEnterProposeNoPrivValidator(t *testing.T) {
+	css, _ := simpleConsensusState(1)
+	cs := css[0]
+
+	// starts a go routine for EnterPropose
+	cs.EnterNewRound(cs.Height, 0)
+
+	// if we're not a validator, EnterPropose should timeout
+	select {
+	case rs := <-cs.NewStepCh():
+		log.Info(rs.String())
+		t.Fatal("Expected EnterPropose to timeout before going to EnterPrevote")
+	case <-cs.timeoutChan:
+		rs := cs.GetRoundState()
+		if rs.Proposal != nil {
+			t.Error("Expected to make no proposal, since no privValidator")
+		}
+		break
+	}
+}
+
+// a validator should not timeout of the prevote round (TODO: unless the block is really big!)
+func TestEnterPropose(t *testing.T) {
+	css, privVals := simpleConsensusState(1)
+	cs := css[0]
+	cs.SetPrivValidator(privVals[0])
+
+	// starts a go routine for EnterPropose
+	cs.EnterNewRound(cs.Height, 0)
+
+	// if we are a validator, we expect it not to timeout
+	// and to be in PreVote
+	select {
+	case <-cs.NewStepCh():
+		rs := cs.GetRoundState()
+
+		// Check that Proposal, ProposalBlock, ProposalBlockParts are set.
+		if rs.Proposal == nil {
+			t.Error("rs.Proposal should be set")
+		}
+		if rs.ProposalBlock == nil {
+			t.Error("rs.ProposalBlock should be set")
+		}
+		if rs.ProposalBlockParts.Total() == 0 {
+			t.Error("rs.ProposalBlockParts should be set")
+		}
+		break
+	case <-cs.timeoutChan:
+		t.Fatal("Expected EnterPropose not to timeout")
+	}
+}
+
+// propose, prevote, and precommit a block
+func TestFullRound1(t *testing.T) {
+	css, privVals := simpleConsensusState(1)
+	cs := css[0]
+	cs.SetPrivValidator(privVals[0])
+
+	// starts a go routine for EnterPropose
+	cs.EnterNewRound(cs.Height, 0)
+	// wait to finish propose and prevote
+	_, _ = <-cs.NewStepCh(), <-cs.NewStepCh()
+
+	// we should now be in precommit
+	// verify our prevote is there
+	validatePrevote(t, cs, 0, privVals[0], cs.ProposalBlock.Hash())
+	// wait to finish precommit
+	<-cs.NewStepCh()
+
+	// the proposed block should now be locked and our precommit added
+	validatePrecommit(t, cs, 0, 0, privVals[0], cs.ProposalBlock)
+}
+
+// nil is proposed, so prevote and precommit nil
+func TestFullRoundNil(t *testing.T) {
+	css, privVals := simpleConsensusState(1)
+	cs := css[0]
+	cs.newStepCh = make(chan *RoundState) // so it blocks
+
+	// starts a go routine for EnterPropose
+	cs.EnterNewRound(cs.Height, 0)
+
+	// wait to finish propose (we should time out)
+	<-cs.timeoutChan
+	cs.SetPrivValidator(privVals[0])
+	<-cs.NewStepCh()
+
+	// wait to finish prevote
+	<-cs.NewStepCh()
+
+	// we should now be in precommit
+	// verify our vote is there
+	validatePrevote(t, cs, 0, privVals[0], nil)
+	// wait to finish precommit
+	<-cs.NewStepCh()
+	// we should have precommitted nil
+	validatePrecommit(t, cs, 0, 0, privVals[0], nil)
+}
+
+// run through propose, prevote, precommit commit with two validators
+// where the first validator has to wait for votes from the second
+func TestFullRound2(t *testing.T) {
+	css, privVals := simpleConsensusState(2)
+	cs1, cs2 := css[0], css[1]
+	cs1.newStepCh = make(chan *RoundState) // so it blocks
+	cs2.newStepCh = make(chan *RoundState) // so it blocks
+
+	cs1.SetPrivValidator(privVals[0])
+	cs2.SetPrivValidator(privVals[1])
+
+	// start round and wait for propose and prevote
+	cs1.EnterNewRound(cs1.Height, 0)
+	_, _ = <-cs1.NewStepCh(), <-cs1.NewStepCh()
+
+	// we should now be stuck in limbo forever, waiting for more prevotes
+	ensureNoNewStep(t, cs1)
+
+	// prevote arrives from cs2:
+	addVoteToFrom(t, types.VoteTypePrevote, cs1, cs2, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header())
+
+	// wait to finish precommit
+	<-cs1.NewStepCh()
+
+	// the proposed block should now be locked and our precommit added
+	validatePrecommit(t, cs1, 0, 0, privVals[0], cs1.ProposalBlock)
+
+	// we should now be stuck in limbo forever, waiting for more precommits
+	ensureNoNewStep(t, cs1)
+
+	// precommit arrives from cs2:
+	addVoteToFrom(t, types.VoteTypePrecommit, cs1, cs2, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header())
+
+	// wait to finish commit, propose in next height
+	_, rs := <-cs1.NewStepCh(), <-cs1.NewStepCh()
+	if rs.Height != 2 {
+		t.Fatal("Expected height to increment")
+	}
+}
+
+// two validators, a series of rounds in which the first validator is locked
+func TestLockNoPOL(t *testing.T) {
+	css, privVals := simpleConsensusState(2)
+	cs1, cs2 := css[0], css[1]
+	cs1.newStepCh = make(chan *RoundState) // so it blocks
+
+	cs1.SetPrivValidator(privVals[0])
+	cs2.SetPrivValidator(privVals[1])
+
+	/* Round 1
+	Proposer: cs1 proposes B
+	Prevotes:
+		cs1: B
+		cs2: B
+	Precommits:
+		cs1: B
+		cs2: B2
+	*/
+
+	// start round and wait for propose and prevote
+	cs1.EnterNewRound(cs1.Height, 0)
+	_, _ = <-cs1.NewStepCh(), <-cs1.NewStepCh()
+
+	// we should now be stuck in limbo forever, waiting for more prevotes
+	// prevote arrives from cs2:
+	addVoteToFrom(t, types.VoteTypePrevote, cs1, cs2, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header())
+
+	// wait to finish precommit
+	<-cs1.NewStepCh()
+
+	// the proposed block should now be locked and our precommit added
+	validatePrecommit(t, cs1, 0, 0, privVals[0], cs1.ProposalBlock)
+
+	// we should now be stuck in limbo forever, waiting for more precommits
+	// lets add one for a different block
+	// NOTE: in practice we should never get to a point where there are precommits for different blocks at the same round
+	hash := cs1.ProposalBlock.Hash()
+	hash[0] = byte((hash[0] + 1) % 255)
+	addVoteToFrom(t, types.VoteTypePrecommit, cs1, cs2, hash, cs1.ProposalBlockParts.Header())
+
+	// (note we're entering precommit for a second time this round)
+	// but with invalid args. then we EnterPrecommitWait, and the timeout to new round
+	_, _ = <-cs1.NewStepCh(), <-cs1.timeoutChan
+
+	/*Round2
+	Proposer: cs1 reproposes B
+	Prevotes:
+		cs1: B
+		cs2: B2
+	*/
+
+	cs2.Round += 1
+
+	// go to prevote
+	<-cs1.NewStepCh()
+
+	// now we're on a new round and the proposer
+	if cs1.ProposalBlock != cs1.LockedBlock {
+		t.Fatalf("Expected proposal block to be locked block. Got %v, Expected %v", cs1.ProposalBlock, cs1.LockedBlock)
+	}
+
+	// wait to finish prevote
+	<-cs1.NewStepCh()
+
+	// we should have prevoted our locked block
+	validatePrevote(t, cs1, 1, privVals[0], cs1.LockedBlock.Hash())
+
+	// add a conflicting prevote from the other validator
+	addVoteToFrom(t, types.VoteTypePrevote, cs1, cs2, hash, cs1.ProposalBlockParts.Header())
+
+	// now we're going to enter prevote again, but with invalid args
+	// and then prevote wait, which should timeout. then wait for precommit
+	_, _, _ = <-cs1.NewStepCh(), <-cs1.timeoutChan, <-cs1.NewStepCh()
+
+	// the proposed block should still be locked and our precommit added
+	// TODO: we should actually be precommitting nil
+	validatePrecommit(t, cs1, 1, 0, privVals[0], cs1.ProposalBlock)
+
+	// add conflicting precommit from cs2
+	// NOTE: in practice we should never get to a point where there are precommits for different blocks at the same round
+	addVoteToFrom(t, types.VoteTypePrecommit, cs1, cs2, hash, cs1.ProposalBlockParts.Header())
+
+	// (note we're entering precommit for a second time this round, but with invalid args
+	// then we EnterPrecommitWait and timeout into NewRound
+	_, _ = <-cs1.NewStepCh(), <-cs1.timeoutChan
+
+	/* Round3
+	Proposer: cs2, but cs1 doesn't receive anything
+	Prevotes:
+		cs1: B
+		cs2: B2
+	*/
+
+	cs2.Round += 1
+
+	// now we're on a new round and not the proposer, so wait for timeout
+	<-cs1.timeoutChan
+	if cs1.ProposalBlock != nil {
+		t.Fatal("Expected proposal block to be nil")
+	}
+	// go to prevote, prevote for locked block
+	_, _ = <-cs1.NewStepCh(), <-cs1.NewStepCh()
+	validatePrevote(t, cs1, 0, privVals[0], cs1.LockedBlock.Hash())
+
+	// TODO: quick fastforward to new round, set proposer
+	addVoteToFrom(t, types.VoteTypePrevote, cs1, cs2, hash, cs1.ProposalBlockParts.Header())
+	_, _, _ = <-cs1.NewStepCh(), <-cs1.timeoutChan, <-cs1.NewStepCh()
+	validatePrecommit(t, cs1, 2, 0, privVals[0], cs1.LockedBlock)                              // TODO: should be nil
+	addVoteToFrom(t, types.VoteTypePrecommit, cs1, cs2, hash, cs1.ProposalBlockParts.Header()) // NOTE: conflicting precommits at same height
+
+	<-cs1.NewStepCh()
+
+	// before we time out into new round, set next proposer
+	// and next proposal block
+	_, v1 := cs1.Validators.GetByAddress(privVals[0].Address)
+	v1.VotingPower = 1
+	if updated := cs1.Validators.Update(v1); !updated {
+		t.Fatal("failed to update validator")
+	}
+
+	cs2.decideProposal(cs2.Height, cs2.Round+1)
+	prop, propBlock := cs2.Proposal, cs2.ProposalBlock
+	if prop == nil || propBlock == nil {
+		t.Fatal("Failed to create proposal block with cs2")
+	}
+
+	cs2.Round += 1
+
+	<-cs1.timeoutChan
+
+	/* Round4
+	Proposer: cs2 proposes C
+	Prevotes:
+		cs1: B
+		cs2: C
+	Precommits:
+		cs1: B
+		cs2: C
+	*/
+
+	// now we're on a new round and not the proposer, so wait for timeout
+	<-cs1.timeoutChan
+	// set the proposal block
+	cs1.Proposal, cs1.ProposalBlock = prop, propBlock
+	// go to prevote, prevote for locked block (not proposal)
+	_, _ = <-cs1.NewStepCh(), <-cs1.NewStepCh()
+	validatePrevote(t, cs1, 0, privVals[0], cs1.LockedBlock.Hash())
+
+	addVoteToFrom(t, types.VoteTypePrevote, cs1, cs2, propBlock.Hash(), propBlock.MakePartSet().Header())
+	_, _, _ = <-cs1.NewStepCh(), <-cs1.timeoutChan, <-cs1.NewStepCh()
+	validatePrecommit(t, cs1, 2, 0, privVals[0], cs1.LockedBlock)                                           // TODO: should be nil
+	addVoteToFrom(t, types.VoteTypePrecommit, cs1, cs2, propBlock.Hash(), propBlock.MakePartSet().Header()) // NOTE: conflicting precommits at same height
+}
+
+func TestBadProposal(t *testing.T) {
+	css, privVals := simpleConsensusState(2)
+	cs1, cs2 := css[0], css[1]
+	cs1.newStepCh = make(chan *RoundState) // so it blocks
+
+	cs1.SetPrivValidator(privVals[0])
+	cs2.SetPrivValidator(privVals[1])
+
+	// make the second validator the proposer
+	_, v1 := cs1.Validators.GetByAddress(privVals[0].Address)
+	v1.Accum, v1.VotingPower = 0, 0
+	if updated := cs1.Validators.Update(v1); !updated {
+		t.Fatal("failed to update validator")
+	}
+	_, v2 := cs1.Validators.GetByAddress(privVals[1].Address)
+	v2.Accum, v2.VotingPower = 100, 100
+	if updated := cs1.Validators.Update(v2); !updated {
+		t.Fatal("failed to update validator")
+	}
+
+	// make the proposal
+	propBlock, _ := cs2.createProposalBlock()
+	if propBlock == nil {
+		t.Fatal("Failed to create proposal block with cs2")
+	}
+	// make the block bad by tampering with statehash
+	stateHash := propBlock.StateHash
+	stateHash[0] = byte((stateHash[0] + 1) % 255)
+	propBlock.StateHash = stateHash
+	propBlockParts := propBlock.MakePartSet()
+	proposal := types.NewProposal(cs2.Height, cs2.Round, propBlockParts.Header(), cs2.Votes.POLRound())
+	if err := cs2.privValidator.SignProposal(cs2.state.ChainID, proposal); err != nil {
+		t.Fatal("failed to sign bad proposal", err)
+	}
+
+	// start round
+	cs1.EnterNewRound(cs1.Height, 0)
+
+	// now we're on a new round and not the proposer, so wait for timeout
+	<-cs1.timeoutChan
+	// set the proposal block
+	cs1.Proposal, cs1.ProposalBlock = proposal, propBlock
+	// fix the voting powers
+	// make the second validator the proposer
+	_, v1 = cs1.Validators.GetByAddress(privVals[0].Address)
+	_, v2 = cs1.Validators.GetByAddress(privVals[1].Address)
+	v1.Accum, v1.VotingPower = v2.Accum, v2.VotingPower
+	if updated := cs1.Validators.Update(v1); !updated {
+		t.Fatal("failed to update validator")
+	}
+	// go to prevote, prevote for nil (proposal is bad)
+	_, _ = <-cs1.NewStepCh(), <-cs1.NewStepCh()
+	validatePrevote(t, cs1, 0, privVals[0], nil)
+
+	addVoteToFrom(t, types.VoteTypePrevote, cs1, cs2, propBlock.Hash(), propBlock.MakePartSet().Header())
+	_, _, _ = <-cs1.NewStepCh(), <-cs1.timeoutChan, <-cs1.NewStepCh()
+	validatePrecommit(t, cs1, 0, 0, privVals[0], nil)
+	addVoteToFrom(t, types.VoteTypePrecommit, cs1, cs2, propBlock.Hash(), propBlock.MakePartSet().Header())
+}
+
+//--------
+// if we were locked but now we have 2/3 prevotes for something else, clear the lock
+// if we might be behind and we've seen any 2/3 prevotes, round skip to new round, precommit, or prevote
+// if the proposals pol round is the vote round and the proposal's complete, EnterPrevote for cs.Round (> vote.Round)
+
+// once +2/3 prevote and +1/3 precommit for a block, the network will forever be locked on it
+func TestNetworkLock(t *testing.T) {
+	css, privVals := simpleConsensusState(4)
+	cs1, cs2, cs3, cs4 := css[0], css[1], css[2], css[3]
+	cs1.newStepCh = make(chan *RoundState) // so it blocks
+
+	cs1.SetPrivValidator(privVals[0])
+	cs2.SetPrivValidator(privVals[1])
+	cs3.SetPrivValidator(privVals[2])
+	cs4.SetPrivValidator(privVals[3])
+
+	// everything done from perspective of cs1
+
+	/* Round 1
+	Proposer: cs1 proposes B
+	Prevotes:
+		cs1: B
+		cs2: B
+		cs3: B
+		cs4: nil // eg. didn't get proposal
+	Precommits:
+		cs1: B
+		cs2: B
+		cs3: _ // eg. we didn't see it
+		cs4: nil // eg. didn't see the 2/3 prevotes
+
+	NOTE: now that +1/3 has precommitted for B, the network is locked on B
+	*/
+
+	// start round and wait for propose and prevote
+	cs1.EnterNewRound(cs1.Height, 0)
+	_, _ = <-cs1.NewStepCh(), <-cs1.NewStepCh()
+
+	// we should now be stuck in limbo forever, waiting for more prevotes
+	addVoteToFrom(t, types.VoteTypePrevote, cs1, cs2, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header())
+	addVoteToFrom(t, types.VoteTypePrevote, cs1, cs3, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header())
+	addVoteToFrom(t, types.VoteTypePrevote, cs1, cs4, nil, types.PartSetHeader{})
+
+	// wait to finish precommit
+	<-cs1.NewStepCh()
+
+	// the proposed block should now be locked and our precommit added
+	validatePrecommit(t, cs1, 0, 0, privVals[0], cs1.ProposalBlock)
+
+	// add precommits from cs2 and cs4 (we failed to get one from cs3)
+	addVoteToFrom(t, types.VoteTypePrecommit, cs1, cs2, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header())
+	addVoteToFrom(t, types.VoteTypePrecommit, cs1, cs4, nil, types.PartSetHeader{})
+
+	// (note we're entering precommit for a second time this round)
+	// but with invalid args. then we EnterPrecommitWait, and the timeout to new round
+	_, _ = <-cs1.NewStepCh(), <-cs1.timeoutChan
+
+	/*Round2
+	Proposer: cs1 reproposes B
+	Prevotes:
+		cs1: B
+		cs2: B
+		cs3: B
+	*/
+
+}

--- a/consensus/test.go
+++ b/consensus/test.go
@@ -61,26 +61,30 @@ func validatePrevote(t *testing.T, cs *ConsensusState, round int, privVal *types
 	}
 }
 
-func validatePrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound int, privVal *types.PrivValidator, block *types.Block) {
+func validatePrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound int, privVal *types.PrivValidator, votedBlock, lockedBlock *types.Block) {
 	precommits := cs.Votes.Precommits(thisRound)
 	var vote *types.Vote
 	if vote = precommits.GetByAddress(privVal.Address); vote == nil {
 		panic("Failed to find precommit from validator")
 	}
 
-	if block == nil {
+	if votedBlock == nil {
 		if vote.BlockHash != nil {
 			panic("Expected precommit to be for nil")
 		}
-		if cs.LockedRound != lockRound || cs.LockedBlock != nil {
-			panic("Expected to be locked on nil")
-		}
 	} else {
-		if !bytes.Equal(vote.BlockHash, block.Hash()) {
+		if !bytes.Equal(vote.BlockHash, votedBlock.Hash()) {
 			panic("Expected precommit to be for proposal block")
 		}
-		if cs.LockedRound != lockRound || cs.LockedBlock != block {
-			panic(fmt.Sprintf("Expected block to be locked on round %d, got %d. Got locked block %v, expected %v", lockRound, cs.LockedRound, cs.LockedBlock, block))
+	}
+
+	if lockedBlock == nil {
+		if cs.LockedRound != lockRound || cs.LockedBlock != nil {
+			panic(fmt.Sprintf("Expected to be locked on nil. Got %v", cs.LockedBlock))
+		}
+	} else {
+		if cs.LockedRound != lockRound || cs.LockedBlock != lockedBlock {
+			panic(fmt.Sprintf("Expected block to be locked on round %d, got %d. Got locked block %v, expected %v", lockRound, cs.LockedRound, cs.LockedBlock, lockedBlock))
 		}
 	}
 

--- a/consensus/test.go
+++ b/consensus/test.go
@@ -50,7 +50,17 @@ func ensureNoNewStep(t *testing.T, cs *ConsensusState) {
 	case <-timeout.C:
 		break
 	case <-cs.NewStepCh():
-		t.Fatal("We should be stuck waiting for more votes, not moving to the next step")
+		panic("We should be stuck waiting for more votes, not moving to the next step")
+	}
+}
+
+func ensureNewStep(t *testing.T, cs *ConsensusState) {
+	timeout := time.NewTicker(2 * time.Second)
+	select {
+	case <-timeout.C:
+		panic("We should have gone to the next step, not be stuck waiting")
+	case <-cs.NewStepCh():
+		break
 	}
 }
 

--- a/consensus/test.go
+++ b/consensus/test.go
@@ -57,7 +57,7 @@ func addVoteToFromMany(to *ConsensusState, votes []*types.Vote, froms ...*Consen
 
 func addVoteToFrom(to, from *ConsensusState, vote *types.Vote) {
 	valIndex, _ := to.Validators.GetByAddress(from.privValidator.Address)
-	added, err := to.TryAddVote(to.GetRoundState(), vote, valIndex, "")
+	added, err := to.TryAddVote(valIndex, vote, "")
 	if _, ok := err.(*types.ErrVoteConflictingSignature); ok {
 		// let it fly
 	} else if !added {

--- a/consensus/test.go
+++ b/consensus/test.go
@@ -1,12 +1,116 @@
 package consensus
 
 import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
 	bc "github.com/tendermint/tendermint/blockchain"
 	dbm "github.com/tendermint/tendermint/db"
 	mempl "github.com/tendermint/tendermint/mempool"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
 )
+
+//-------------------------------------------------------------------------------
+// utils
+
+// add vote to one cs from another
+func addVoteToFrom(t *testing.T, voteType byte, to, from *ConsensusState, hash []byte, header types.PartSetHeader) {
+	vote, err := from.signVote(voteType, hash, header)
+	if err != nil {
+		panic(fmt.Sprintln("Failed to sign vote", err))
+	}
+	fmt.Println("VOTE:", vote)
+	added, _, err := to.addVote(from.privValidator.Address, vote, "")
+	if !added {
+		panic("Failed to add vote")
+	} else if err != nil {
+		panic(fmt.Sprintln("Failed to add vote:", err))
+	}
+}
+
+func ensureNoNewStep(t *testing.T, cs *ConsensusState) {
+	timeout := time.NewTicker(2 * time.Second)
+	select {
+	case <-timeout.C:
+		break
+	case <-cs.NewStepCh():
+		t.Fatal("We should be stuck waiting for more prevotes, not moving to the next step")
+	}
+}
+
+func validatePrevote(t *testing.T, cs *ConsensusState, round int, privVal *types.PrivValidator, blockHash []byte) {
+	prevotes := cs.Votes.Prevotes(round)
+	var vote *types.Vote
+	if vote = prevotes.GetByAddress(privVal.Address); vote == nil {
+		t.Fatal("Failed to find prevote from validator")
+	}
+	if blockHash == nil {
+		if vote.BlockHash != nil {
+			t.Fatal("Expected prevote to be for nil")
+		}
+	} else {
+		if !bytes.Equal(vote.BlockHash, blockHash) {
+			t.Fatal("Expected prevote to be for proposal block")
+		}
+	}
+}
+
+func validatePrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound int, privVal *types.PrivValidator, block *types.Block) {
+	precommits := cs.Votes.Precommits(thisRound)
+	var vote *types.Vote
+	if vote = precommits.GetByAddress(privVal.Address); vote == nil {
+		panic("Failed to find precommit from validator")
+	}
+
+	if block == nil {
+		if vote.BlockHash != nil {
+			panic("Expected precommit to be for nil")
+		}
+		if cs.LockedRound != lockRound || cs.LockedBlock != nil {
+			panic("Expected to be locked on nil")
+		}
+	} else {
+		if !bytes.Equal(vote.BlockHash, block.Hash()) {
+			panic("Expected precommit to be for proposal block")
+		}
+		if cs.LockedRound != lockRound || cs.LockedBlock != block {
+			panic("Expected block to be locked")
+		}
+	}
+
+}
+
+func simpleConsensusState(nValidators int) ([]*ConsensusState, []*types.PrivValidator) {
+	// Get State
+	state, privAccs, privVals := sm.RandGenesisState(10, true, 1000, nValidators, false, 10)
+	_, _ = privAccs, privVals
+
+	fmt.Println(state.BondedValidators)
+
+	css := make([]*ConsensusState, nValidators)
+	for i := 0; i < nValidators; i++ {
+		// Get BlockStore
+		blockDB := dbm.NewMemDB()
+		blockStore := bc.NewBlockStore(blockDB)
+
+		// Make MempoolReactor
+		mempool := mempl.NewMempool(state.Copy())
+		mempoolReactor := mempl.NewMempoolReactor(mempool)
+
+		// Make ConsensusReactor
+		cs := NewConsensusState(state, blockStore, mempoolReactor)
+
+		// read off the NewHeightStep
+		<-cs.NewStepCh()
+
+		css[i] = cs
+	}
+
+	return css, privVals
+}
 
 func randConsensusState() (*ConsensusState, []*types.PrivValidator) {
 	state, _, privValidators := sm.RandGenesisState(20, false, 1000, 10, false, 1000)

--- a/consensus/test.go
+++ b/consensus/test.go
@@ -17,6 +17,44 @@ import (
 //-------------------------------------------------------------------------------
 // utils
 
+func changeProposer(t *testing.T, perspectiveOf, newProposer *ConsensusState) *types.Block {
+	_, v1 := perspectiveOf.Validators.GetByAddress(perspectiveOf.privValidator.Address)
+	v1.Accum, v1.VotingPower = 0, 0
+	if updated := perspectiveOf.Validators.Update(v1); !updated {
+		t.Fatal("failed to update validator")
+	}
+	_, v2 := perspectiveOf.Validators.GetByAddress(newProposer.privValidator.Address)
+	v2.Accum, v2.VotingPower = 100, 100
+	if updated := perspectiveOf.Validators.Update(v2); !updated {
+		t.Fatal("failed to update validator")
+	}
+
+	// make the proposal
+	propBlock, _ := newProposer.createProposalBlock()
+	if propBlock == nil {
+		t.Fatal("Failed to create proposal block with cs2")
+	}
+	return propBlock
+}
+
+func fixVotingPower(t *testing.T, cs1 *ConsensusState, addr2 []byte) {
+	_, v1 := cs1.Validators.GetByAddress(cs1.privValidator.Address)
+	_, v2 := cs1.Validators.GetByAddress(addr2)
+	v1.Accum, v1.VotingPower = v2.Accum, v2.VotingPower
+	if updated := cs1.Validators.Update(v1); !updated {
+		t.Fatal("failed to update validator")
+	}
+}
+
+func addVoteToFromMany(to *ConsensusState, votes []*types.Vote, froms ...*ConsensusState) {
+	if len(votes) != len(froms) {
+		panic("len(votes) and len(froms) must match")
+	}
+	for i, from := range froms {
+		addVoteToFrom(to, from, votes[i])
+	}
+}
+
 func addVoteToFrom(to, from *ConsensusState, vote *types.Vote) {
 	valIndex, _ := to.Validators.GetByAddress(from.privValidator.Address)
 	added, err := to.TryAddVote(to.GetRoundState(), vote, valIndex, "")
@@ -37,7 +75,22 @@ func signVote(from *ConsensusState, voteType byte, hash []byte, header types.Par
 	return vote
 }
 
+func signVoteMany(voteType byte, hash []byte, header types.PartSetHeader, css ...*ConsensusState) []*types.Vote {
+	votes := make([]*types.Vote, len(css))
+	for i, cs := range css {
+		votes[i] = signVote(cs, voteType, hash, header)
+	}
+	return votes
+}
+
 // add vote to one cs from another
+func signAddVoteToFromMany(voteType byte, to *ConsensusState, hash []byte, header types.PartSetHeader, froms ...*ConsensusState) {
+	for _, from := range froms {
+		vote := signVote(from, voteType, hash, header)
+		addVoteToFrom(to, from, vote)
+	}
+}
+
 func signAddVoteToFrom(voteType byte, to, from *ConsensusState, hash []byte, header types.PartSetHeader) *types.Vote {
 	vote := signVote(from, voteType, hash, header)
 	addVoteToFrom(to, from, vote)
@@ -81,6 +134,12 @@ func validatePrevote(t *testing.T, cs *ConsensusState, round int, privVal *types
 	}
 }
 
+func incrementRound(css ...*ConsensusState) {
+	for _, cs := range css {
+		cs.Round += 1
+	}
+}
+
 func validatePrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound int, privVal *types.PrivValidator, votedBlockHash, lockedBlockHash []byte) {
 	precommits := cs.Votes.Precommits(thisRound)
 	var vote *types.Vote
@@ -110,6 +169,20 @@ func validatePrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound in
 
 }
 
+func validatePrevoteAndPrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound int, privVal *types.PrivValidator, votedBlockHash, lockedBlockHash []byte, f func()) {
+	// verify the prevote
+	validatePrevote(t, cs, thisRound, privVal, votedBlockHash)
+	if f != nil {
+		f()
+	}
+	// wait to finish precommit
+	<-cs.NewStepCh()
+	// verify precommit
+	cs.mtx.Lock()
+	validatePrecommit(t, cs, thisRound, lockRound, privVal, votedBlockHash, lockedBlockHash)
+	cs.mtx.Unlock()
+}
+
 func simpleConsensusState(nValidators int) ([]*ConsensusState, []*types.PrivValidator) {
 	// Get State
 	state, privAccs, privVals := sm.RandGenesisState(10, true, 1000, nValidators, false, 10)
@@ -131,6 +204,7 @@ func simpleConsensusState(nValidators int) ([]*ConsensusState, []*types.PrivVali
 
 		// Make ConsensusReactor
 		cs := NewConsensusState(state, blockStore, mempoolReactor)
+		cs.SetPrivValidator(privVals[i])
 
 		// read off the NewHeightStep
 		<-cs.NewStepCh()

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -20,7 +20,6 @@ var (
 type MempoolReactor struct {
 	p2p.BaseReactor
 
-	sw      *p2p.Switch
 	Mempool *Mempool
 
 	evsw events.Fireable

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -295,7 +295,6 @@ func (sw *Switch) Broadcast(chId byte, msg interface{}) chan bool {
 		}(peer)
 	}
 	return successChan
-
 }
 
 // Returns the count of outbound/inbound and outbound-dialing peers.

--- a/rpc/core_client/ws_client.go
+++ b/rpc/core_client/ws_client.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/tendermint/tendermint/Godeps/_workspace/src/github.com/gorilla/websocket"
 	. "github.com/tendermint/tendermint/common"
-	_ "github.com/tendermint/tendermint/config/tendermint_test"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/rpc/types"
 	"github.com/tendermint/tendermint/wire"

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -85,7 +85,7 @@ func (voteSet *VoteSet) Size() int {
 // Otherwise returns err=ErrVote[UnexpectedStep|InvalidAccount|InvalidSignature|InvalidBlockHash|ConflictingSignature]
 // Duplicate votes return added=false, err=nil.
 // NOTE: vote should not be mutated after adding.
-func (voteSet *VoteSet) AddByIndex(valIndex int, vote *Vote) (added bool, index int, err error) {
+func (voteSet *VoteSet) AddByIndex(valIndex int, vote *Vote) (added bool, address []byte, err error) {
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 
@@ -109,14 +109,15 @@ func (voteSet *VoteSet) AddByAddress(address []byte, vote *Vote) (added bool, in
 	return voteSet.addVote(val, valIndex, vote)
 }
 
-func (voteSet *VoteSet) addByIndex(valIndex int, vote *Vote) (bool, int, error) {
+func (voteSet *VoteSet) addByIndex(valIndex int, vote *Vote) (added bool, address []byte, err error) {
 	// Ensure that signer is a validator.
-	_, val := voteSet.valSet.GetByIndex(valIndex)
+	address, val := voteSet.valSet.GetByIndex(valIndex)
 	if val == nil {
-		return false, 0, ErrVoteInvalidAccount
+		return false, nil, ErrVoteInvalidAccount
 	}
 
-	return voteSet.addVote(val, valIndex, vote)
+	added, _, err = voteSet.addVote(val, valIndex, vote)
+	return
 }
 
 func (voteSet *VoteSet) addVote(val *Validator, valIndex int, vote *Vote) (bool, int, error) {


### PR DESCRIPTION
- validators precommit `nil` in a round if they haven't seen a POL in that round
- timeoutChan so we can log timeouts (from propose, prevoteWait, precommitWait) and for better control in testing
- series of test suites to test the consensus state machine
- allow validators to commit once they see +2/3 precommits from a previous round (ie. the halt1 bug)