### PR TITLE
wire: json time in nanoseconds

### DIFF
--- a/rpc/core_client/ws_client.go
+++ b/rpc/core_client/ws_client.go
@@ -3,6 +3,7 @@ package core_client
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/tendermint/tendermint/Godeps/_workspace/src/github.com/gorilla/websocket"
 	. "github.com/tendermint/tendermint/common"
@@ -12,8 +13,12 @@ import (
 	"github.com/tendermint/tendermint/wire"
 )
 
-const wsEventsChannelCapacity = 10
-const wsResultsChannelCapacity = 10
+const (
+	wsEventsChannelCapacity  = 10
+	wsResultsChannelCapacity = 10
+
+	wsWriteTimeoutSeconds = 30 // each write times out after this
+)
 
 type WSClient struct {
 	QuitService
@@ -53,6 +58,14 @@ func (wsc *WSClient) dial() error {
 	if err != nil {
 		return err
 	}
+	// set the ping/pong handlers
+	con.SetPingHandler(func(m string) error {
+		con.WriteControl(websocket.PongMessage, []byte(m), time.Now().Add(time.Second*wsWriteTimeoutSeconds))
+		return nil
+	})
+	con.SetPongHandler(func(m string) error {
+		return nil
+	})
 	wsc.Conn = con
 	return nil
 }
@@ -65,14 +78,14 @@ func (wsc *WSClient) receiveEventsRoutine() {
 	for {
 		_, data, err := wsc.ReadMessage()
 		if err != nil {
-			log.Info(Fmt("WSClient failed to read message: %v", err))
+			log.Info("WSClient failed to read message", "error", err, "data", string(data))
 			wsc.Stop()
 			break
 		} else {
 			var response ctypes.Response
 			wire.ReadJSON(&response, data, &err)
 			if err != nil {
-				log.Info(Fmt("WSClient failed to parse message: %v", err))
+				log.Info("WSClient failed to parse message", "error", err)
 				wsc.Stop()
 				break
 			}

--- a/wire/reflect.go
+++ b/wire/reflect.go
@@ -93,7 +93,8 @@ var (
 )
 
 const (
-	rfc2822 = "Mon Jan 02 15:04:05 -0700 2006"
+	rfc2822_nano = "Mon Jan 02 15:04:05.000000000 -0700 2006" // we support nanoseconds!
+	rfc2822      = "Mon Jan 02 15:04:05 -0700 2006"
 )
 
 // NOTE: do not access typeInfos directly, but call GetTypeInfo()
@@ -731,10 +732,12 @@ func readReflectJSON(rv reflect.Value, rt reflect.Type, o interface{}, err *erro
 				return
 			}
 			log.Info(Fmt("Read time: %v", str))
-			t, err_ := time.Parse(rfc2822, str)
+			t, err_ := time.Parse(rfc2822_nano, str)
 			if err_ != nil {
-				*err = err_
-				return
+				if t, err_ = time.Parse(rfc2822, str); err_ != nil {
+					*err = err_
+					return
+				}
 			}
 			rv.Set(reflect.ValueOf(t))
 		} else {
@@ -909,7 +912,7 @@ func writeReflectJSON(rv reflect.Value, rt reflect.Type, w io.Writer, n *int64, 
 		if rt == timeType {
 			// Special case: time.Time
 			t := rv.Interface().(time.Time)
-			str := t.Format(rfc2822)
+			str := t.Format(rfc2822_nano)
 			jsonBytes, err_ := json.Marshal(str)
 			if err_ != nil {
 				*err = err_

--- a/wire/reflect_test.go
+++ b/wire/reflect_test.go
@@ -51,6 +51,7 @@ var _ = RegisterInterface(
 	ConcreteType{&Viper{}, AnimalTypeViper},
 )
 
+// TODO: add assertions here ...
 func TestAnimalInterface(t *testing.T) {
 	var foo Animal
 
@@ -93,6 +94,8 @@ type TestCase struct {
 	Validator
 }
 
+var now = time.Now()
+
 //-------------------------------------
 
 func constructBasic() interface{} {
@@ -100,7 +103,7 @@ func constructBasic() interface{} {
 		SimpleStruct{
 			String: "String",
 			Bytes:  []byte("Bytes"),
-			Time:   time.Unix(123, 0),
+			Time:   now,
 		},
 	}
 	return cat
@@ -118,8 +121,9 @@ func validateBasic(o interface{}, t *testing.T) {
 	if string(cat.Bytes) != "Bytes" {
 		t.Errorf("Expected cat.Bytes == 'Bytes', got %X", cat.Bytes)
 	}
-	if cat.Time.Unix() != 123 {
-		t.Errorf("Expected cat.Time == 'Unix(123)', got %v", cat.Time)
+	// NOTE: stricter than Unix()!
+	if cat.Time.Nanosecond() != now.Nanosecond() {
+		t.Errorf("Expected cat.Time == %v, got %v", now, cat.Time)
 	}
 }
 


### PR DESCRIPTION
json marshaling of time.Time would drop the nanoseconds (while official blocks keep them), making it impossible for eg a client to verify the block hash given the block from json. fixes https://github.com/tendermint/tendermint/issues/138