### PR TITLE
more versioning

### DIFF
--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -48,7 +48,7 @@ Commands:
 	case "unsafe_reset_priv_validator":
 		reset_priv_validator()
 	case "version":
-		fmt.Println(config.GetString("version"))
+		fmt.Println(node.Version)
 	default:
 		fmt.Printf("Unknown command %v\n", args[0])
 	}

--- a/config/tendermint/config.go
+++ b/config/tendermint/config.go
@@ -54,14 +54,7 @@ func GetConfig(rootDir string) cfg.Config {
 	if mapConfig.IsSet("chain_id") {
 		Exit("Cannot set 'chain_id' via config.toml")
 	}
-	if mapConfig.IsSet("version") {
-		Exit("Cannot set 'version' via config.toml")
-	}
 	mapConfig.SetDefault("chain_id", "tendermint_testnet_10")
-	// Major: alpha
-	// Minor: encrypted p2p!
-	// Revision: ripemd for NewContractAddress
-	mapConfig.SetDefault("version", "0.5.1")
 	mapConfig.SetDefault("genesis_file", rootDir+"/genesis.json")
 	mapConfig.SetDefault("moniker", "anonymous")
 	mapConfig.SetDefault("node_laddr", "0.0.0.0:46656")

--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -59,11 +59,7 @@ func GetConfig(rootDir string) cfg.Config {
 	if mapConfig.IsSet("chain_id") {
 		Exit("Cannot set 'chain_id' via config.toml")
 	}
-	if mapConfig.IsSet("version") {
-		Exit("Cannot set 'version' via config.toml")
-	}
 	mapConfig.SetDefault("chain_id", "tendermint_test")
-	mapConfig.SetDefault("version", "0.5.0")
 	mapConfig.SetDefault("genesis_file", rootDir+"/genesis.json")
 	mapConfig.SetDefault("moniker", "anonymous")
 	mapConfig.SetDefault("node_laddr", "0.0.0.0:36656")

--- a/node/node.go
+++ b/node/node.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tendermint/tendermint/events"
 	mempl "github.com/tendermint/tendermint/mempool"
 	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/rpc"
 	"github.com/tendermint/tendermint/rpc/core"
 	"github.com/tendermint/tendermint/rpc/server"
 	sm "github.com/tendermint/tendermint/state"
@@ -246,12 +247,17 @@ func makeNodeInfo(sw *p2p.Switch, privKey acm.PrivKeyEd25519) *types.NodeInfo {
 		PubKey:  privKey.PubKey().(acm.PubKeyEd25519),
 		Moniker: config.GetString("moniker"),
 		ChainID: config.GetString("chain_id"),
-		Version: config.GetString("version"),
+		Version: types.Versions{
+			Tendermint: Version,
+			P2P:        p2p.Version,
+			RPC:        rpc.Version,
+			Wire:       wire.Version,
+		},
 	}
 
 	// include git hash in the nodeInfo if available
 	if rev, err := ReadFile(config.GetString("revisions_file")); err == nil {
-		nodeInfo.Revision = string(rev)
+		nodeInfo.Version.Revision = string(rev)
 	}
 
 	if !sw.IsListening() {

--- a/node/version.go
+++ b/node/version.go
@@ -1,0 +1,6 @@
+package node
+
+// Major: alpha
+// Minor: encrypted p2p!
+// Patch: New block pool logic
+const Version = "0.5.2"

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -81,7 +81,7 @@ func makeSwitchPair(t testing.TB, initSwitch func(*Switch) *Switch) (*Switch, *S
 		PubKey:  s1PrivKey.PubKey().(acm.PubKeyEd25519),
 		Moniker: "switch1",
 		ChainID: "testing",
-		Version: "123.123.123",
+		Version: types.Versions{Tendermint: "123.123.123"},
 	})
 	s1.SetNodePrivKey(s1PrivKey)
 	s2 := initSwitch(NewSwitch())
@@ -89,7 +89,7 @@ func makeSwitchPair(t testing.TB, initSwitch func(*Switch) *Switch) (*Switch, *S
 		PubKey:  s2PrivKey.PubKey().(acm.PubKeyEd25519),
 		Moniker: "switch2",
 		ChainID: "testing",
-		Version: "123.123.123",
+		Version: types.Versions{Tendermint: "123.123.123"},
 	})
 	s2.SetNodePrivKey(s2PrivKey)
 

--- a/p2p/version.go
+++ b/p2p/version.go
@@ -1,0 +1,3 @@
+package p2p
+
+const Version = "0.3.0"

--- a/rpc/version.go
+++ b/rpc/version.go
@@ -1,0 +1,3 @@
+package rpc
+
+const Version = "0.4.0"

--- a/types/node.go
+++ b/types/node.go
@@ -7,19 +7,28 @@ import (
 )
 
 type NodeInfo struct {
-	PubKey   acm.PubKeyEd25519 `json:"pub_key"`
-	Moniker  string            `json:"moniker"`
-	ChainID  string            `json:"chain_id"`
-	Version  string            `json:"version"`
-	Revision string            `json:"revision"`
-	Host     string            `json:"host"`
-	P2PPort  uint16            `json:"p2p_port"`
-	RPCPort  uint16            `json:"rpc_port"`
+	PubKey  acm.PubKeyEd25519 `json:"pub_key"`
+	Moniker string            `json:"moniker"`
+	ChainID string            `json:"chain_id"`
+	Host    string            `json:"host"`
+	P2PPort uint16            `json:"p2p_port"`
+	RPCPort uint16            `json:"rpc_port"`
+
+	Version Versions `json:"versions"`
 }
 
+type Versions struct {
+	Revision   string `json:"revision"`
+	Tendermint string `json:"tendermint"`
+	P2P        string `json:"p2p"`
+	RPC        string `json:"rpc"`
+	Wire       string `json:"wire"`
+}
+
+// CONTRACT: two nodes with the same Tendermint major and minor version and with the same ChainID are compatible
 func (ni *NodeInfo) CompatibleWith(no *NodeInfo) error {
-	iM, im, _, ie := splitVersion(ni.Version)
-	oM, om, _, oe := splitVersion(no.Version)
+	iM, im, _, ie := splitVersion(ni.Version.Tendermint)
+	oM, om, _, oe := splitVersion(no.Version.Tendermint)
 
 	// if our own version number is not formatted right, we messed up
 	if ie != nil {

--- a/wire/version.go
+++ b/wire/version.go
@@ -1,0 +1,3 @@
+package wire
+
+const Version = "0.5.0"


### PR DESCRIPTION
Add versions to the p2p, rpc, and wire. This is mostly for sake of other consumers/clients. The main tendermint version encapsulates state/consensus/blockchain.