### PR TITLE
more config options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,5 @@ gen_client:
 	go generate rpc/core_client/*.go
 
 revision:
-	-echo `git rev-parse --verify HEAD` >> $(TMROOT)/revisions
+	-echo `git rev-parse --verify HEAD` > $(TMROOT)/revision
+	-echo `git rev-parse --verify HEAD` >> $(TMROOT)/revision_history

--- a/config/tendermint/config.go
+++ b/config/tendermint/config.go
@@ -54,6 +54,9 @@ func GetConfig(rootDir string) cfg.Config {
 	if mapConfig.IsSet("chain_id") {
 		Exit("Cannot set 'chain_id' via config.toml")
 	}
+	if mapConfig.IsSet("revisions_file") {
+		Exit("Cannot set 'revisions_file' via config.toml. It must match what's in the Makefile")
+	}
 	mapConfig.SetDefault("chain_id", "tendermint_testnet_10")
 	mapConfig.SetDefault("genesis_file", rootDir+"/genesis.json")
 	mapConfig.SetDefault("moniker", "anonymous")
@@ -65,9 +68,12 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("priv_validator_file", rootDir+"/priv_validator.json")
 	mapConfig.SetDefault("db_backend", "leveldb")
 	mapConfig.SetDefault("db_dir", rootDir+"/data")
+	mapConfig.SetDefault("vm_log", true)
 	mapConfig.SetDefault("log_level", "info")
 	mapConfig.SetDefault("rpc_laddr", "0.0.0.0:46657")
-	mapConfig.SetDefault("revisions_file", rootDir+"/revisions")
+	mapConfig.SetDefault("prof_laddr", "")
+	mapConfig.SetDefault("revisions_file", rootDir+"/revision")
+	mapConfig.SetDefault("local_routing", false)
 	return mapConfig
 }
 

--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -70,8 +70,11 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("db_backend", "memdb")
 	mapConfig.SetDefault("db_dir", rootDir+"/data")
 	mapConfig.SetDefault("log_level", "debug")
+	mapConfig.SetDefault("vm_log", true)
 	mapConfig.SetDefault("rpc_laddr", "0.0.0.0:36657")
-	mapConfig.SetDefault("revisions_file", rootDir+"/revisions")
+	mapConfig.SetDefault("prof_laddr", "")
+	mapConfig.SetDefault("revisions_file", rootDir+"/revision")
+	mapConfig.SetDefault("local_routing", false)
 	return mapConfig
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -24,6 +24,7 @@ import (
 	sm "github.com/tendermint/tendermint/state"
 	stypes "github.com/tendermint/tendermint/state/types"
 	"github.com/tendermint/tendermint/types"
+	"github.com/tendermint/tendermint/vm"
 	"github.com/tendermint/tendermint/wire"
 )
 
@@ -126,6 +127,17 @@ func NewNode() *Node {
 	// add the event switch to all services
 	// they should all satisfy events.Eventable
 	SetFireable(eventSwitch, pexReactor, bcReactor, mempoolReactor, consensusReactor)
+
+	// run the profile server
+	profileHost := config.GetString("prof_laddr")
+	if profileHost != "" {
+		go func() {
+			log.Warn("Profile server", "error", http.ListenAndServe(profileHost, nil))
+		}()
+	}
+
+	// set vm log level
+	vm.SetDebug(config.GetBool("vm_log"))
 
 	return &Node{
 		sw:               sw,

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -110,6 +110,10 @@ func (na *NetAddress) DialTimeout(timeout time.Duration) (net.Conn, error) {
 }
 
 func (na *NetAddress) Routable() bool {
+	if config.GetBool("local_routing") {
+		return na.Valid()
+	}
+
 	// TODO(oga) bitcoind doesn't include RFC3849 here, but should we?
 	return na.Valid() && !(na.RFC1918() || na.RFC3927() || na.RFC4862() ||
 		na.RFC4193() || na.RFC4843() || na.Local())

--- a/vm/config.go
+++ b/vm/config.go
@@ -1,0 +1,13 @@
+package vm
+
+import (
+	cfg "github.com/tendermint/tendermint/config"
+)
+
+var config cfg.Config = nil
+
+func init() {
+	cfg.OnConfig(func(newConfig cfg.Config) {
+		config = newConfig
+	})
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -36,14 +36,19 @@ func (err ErrPermission) Error() string {
 	return fmt.Sprintf("Contract does not have permission to %s", err.typ)
 }
 
+const (
+	dataStackCapacity = 1024
+	callStackCapacity = 100         // TODO ensure usage.
+	memoryCapacity    = 1024 * 1024 // 1 MB
+)
+
 type Debug bool
 
-const (
-	dataStackCapacity       = 1024
-	callStackCapacity       = 100         // TODO ensure usage.
-	memoryCapacity          = 1024 * 1024 // 1 MB
-	dbg               Debug = true
-)
+var dbg Debug
+
+func SetDebug(d bool) {
+	dbg = Debug(d)
+}
 
 func (d Debug) Printf(s string, a ...interface{}) {
 	if d {


### PR DESCRIPTION
- one commit hash per revision file, but also keep a revision_history
- enable profile server from config
- toggle vm output from config
- enable local routing from config (for running multiple nodes from one machine, for debugging)