### PR TITLE
consensus: write ahead logging, recovery, replay

### DIFF
--- a/DOCKER/docker.sh
+++ b/DOCKER/docker.sh
@@ -8,11 +8,6 @@ docker build -t tmbase -f Dockerfile .
 # (config and blockchain data go in here)
 docker run --name tmdata --entrypoint /bin/echo tmbase Data-only container for tmnode
 
-# Copy files into the data-only container
-# You should stop the containers before running this
-#   cd $DATA_SRC
-#   tar cf - . | docker run -i --rm --volumes-from mintdata mint tar xvf - -C /data/tendermint
-
 # Run tendermint node
 docker run --name tmnode --volumes-from tmdata -d -p 46656:46656 -p 46657:46657 -e TMSEEDS="goldenalchemist.chaintest.net:46657" -e TMNAME="testnode" -e TMREPO="github.com/tendermint/tendermint" -e TMHEAD="origin/develop" tmbase
 

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -35,7 +35,11 @@ Commands:
 	case "node":
 		node.RunNode()
 	case "replay":
-		node.RunReplay()
+		if len(args) > 1 && args[1] == "console" {
+			node.RunReplayConsole()
+		} else {
+			node.RunReplay()
+		}
 	case "init":
 		init_files()
 	case "show_validator":

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -34,6 +34,8 @@ Commands:
 	switch args[0] {
 	case "node":
 		node.RunNode()
+	case "replay":
+		node.RunReplay()
 	case "init":
 		init_files()
 	case "show_validator":

--- a/config/tendermint/config.go
+++ b/config/tendermint/config.go
@@ -67,6 +67,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("rpc_laddr", "0.0.0.0:46657")
 	mapConfig.SetDefault("prof_laddr", "")
 	mapConfig.SetDefault("revision_file", rootDir+"/revision")
+	mapConfig.SetDefault("cs_msg_log", rootDir+"/cs_msg_log")
 	return mapConfig
 }
 

--- a/config/tendermint/config.go
+++ b/config/tendermint/config.go
@@ -67,7 +67,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("rpc_laddr", "0.0.0.0:46657")
 	mapConfig.SetDefault("prof_laddr", "")
 	mapConfig.SetDefault("revision_file", rootDir+"/revision")
-	mapConfig.SetDefault("cs_msg_log", rootDir+"/cs_msg_log")
+	mapConfig.SetDefault("cswal", rootDir+"/cswal")
 	return mapConfig
 }
 

--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -76,6 +76,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("rpc_laddr", "0.0.0.0:36657")
 	mapConfig.SetDefault("prof_laddr", "")
 	mapConfig.SetDefault("revision_file", rootDir+"/revision")
+	mapConfig.SetDefault("cs_msg_log", rootDir+"/cs_msg_log")
 	return mapConfig
 }
 

--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -75,7 +75,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("rpc_laddr", "0.0.0.0:36657")
 	mapConfig.SetDefault("prof_laddr", "")
 	mapConfig.SetDefault("revision_file", rootDir+"/revision")
-	mapConfig.SetDefault("cs_msg_log", rootDir+"/cs_msg_log")
+	mapConfig.SetDefault("cswal", rootDir+"/cswal")
 	return mapConfig
 }
 

--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -41,9 +41,8 @@ func initTMRoot(rootDir string) {
 	if !FileExists(genesisFilePath) {
 		MustWriteFile(genesisFilePath, []byte(defaultGenesis), 0644)
 	}
-	if !FileExists(privFilePath) {
-		MustWriteFile(privFilePath, []byte(defaultPrivValidator), 0644)
-	}
+	// we always overwrite the priv val
+	MustWriteFile(privFilePath, []byte(defaultPrivValidator), 0644)
 }
 
 func GetConfig(rootDir string) cfg.Config {

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -140,7 +140,7 @@ func addVoteToFromMany(to *ConsensusState, votes []*types.Vote, froms ...*valida
 func addVoteToFrom(to *ConsensusState, from *validatorStub, vote *types.Vote) {
 	valIndex, _ := to.Validators.GetByAddress(from.PrivValidator.Address)
 
-	to.peerMsgQueue <- msgInfo{msg: &VoteMessage{valIndex, vote}}
+	to.peerMsgQueue <- msgInfo{Msg: &VoteMessage{valIndex, vote}}
 	// added, err := to.TryAddVote(valIndex, vote, "")
 	/*
 		if _, ok := err.(*types.ErrVoteConflictingSignature); ok {
@@ -344,7 +344,7 @@ func subscribeToVoter(cs *ConsensusState, addr []byte) chan interface{} {
 	go func() {
 		for {
 			v := <-voteCh0
-			vote := v.(*types.EventDataVote)
+			vote := v.(types.EventDataVote)
 			// we only fire for our own votes
 			if bytes.Equal(addr, vote.Address) {
 				voteCh <- v

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -239,8 +239,8 @@ func (conR *ConsensusReactor) registerEventCallbacks() {
 		conR.broadcastNewRoundStep(rs)
 	})
 
-	conR.evsw.AddListenerForEvent("conR", types.EventStringVote(), func(data events.EventData) {
-		edv := data.(*types.EventDataVote)
+	conR.evsw.AddListenerForEvent("conR", types.EventStringVote(), func(data types.EventData) {
+		edv := data.(types.EventDataVote)
 		conR.broadcastHasVoteMessage(edv.Vote, edv.Index)
 	})
 }

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -239,7 +239,7 @@ func (conR *ConsensusReactor) registerEventCallbacks() {
 		conR.broadcastNewRoundStep(rs)
 	})
 
-	conR.evsw.AddListenerForEvent("conR", types.EventStringVote(), func(data types.EventData) {
+	conR.evsw.AddListenerForEvent("conR", types.EventStringVote(), func(data events.EventData) {
 		edv := data.(types.EventDataVote)
 		conR.broadcastHasVoteMessage(edv.Vote, edv.Index)
 	})

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -1,0 +1,287 @@
+package consensus
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/tendermint/tendermint/Godeps/_workspace/src/github.com/tendermint/go-common"
+	"github.com/tendermint/tendermint/Godeps/_workspace/src/github.com/tendermint/go-wire"
+
+	sm "github.com/tendermint/tendermint/state"
+	"github.com/tendermint/tendermint/types"
+)
+
+//--------------------------------------------------------
+// types and functions for savings consensus messages
+
+type ConsensusLogMessage struct {
+	Msg ConsensusLogMessageInterface `json:"msg"`
+}
+
+type ConsensusLogMessageInterface interface{}
+
+var _ = wire.RegisterInterface(
+	struct{ ConsensusLogMessageInterface }{},
+	wire.ConcreteType{&types.EventDataRoundState{}, 0x01},
+	wire.ConcreteType{msgInfo{}, 0x02},
+	wire.ConcreteType{timeoutInfo{}, 0x03},
+)
+
+// called in newStep and for each pass in receiveRoutine
+func (cs *ConsensusState) saveMsg(msg ConsensusLogMessageInterface) {
+	if cs.msgLogFP != nil {
+		var n int
+		var err error
+		wire.WriteJSON(ConsensusLogMessage{msg}, cs.msgLogFP, &n, &err)
+		wire.WriteTo([]byte("\n"), cs.msgLogFP, &n, &err) // one message per line
+		if err != nil {
+			log.Error("Error writing to consensus message log file", "err", err, "msg", msg)
+		}
+	}
+}
+
+// Open file to log all consensus messages and timeouts for deterministic accountability
+func (cs *ConsensusState) OpenFileForMessageLog(file string) (err error) {
+	cs.mtx.Lock()
+	defer cs.mtx.Unlock()
+	cs.msgLogFP, err = os.OpenFile(file, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
+	return err
+}
+
+//--------------------------------------------------------
+// replay messages
+
+// Interactive playback
+func (cs ConsensusState) ReplayConsole(file string) error {
+	return cs.replay(file, true)
+}
+
+// Full playback, with tests
+func (cs ConsensusState) ReplayMessages(file string) error {
+	return cs.replay(file, false)
+}
+
+type playback struct {
+	cs           *ConsensusState
+	file         string
+	fp           *os.File
+	scanner      *bufio.Scanner
+	newStepCh    chan interface{}
+	genesisState *sm.State
+	count        int
+}
+
+func newPlayback(file string, fp *os.File, cs *ConsensusState, ch chan interface{}, genState *sm.State) *playback {
+	return &playback{
+		cs:           cs,
+		file:         file,
+		newStepCh:    ch,
+		genesisState: genState,
+		fp:           fp,
+		scanner:      bufio.NewScanner(fp),
+	}
+}
+
+func (pb *playback) replayReset(count int) error {
+
+	pb.cs.Stop()
+
+	newCs := NewConsensusState(pb.genesisState.Copy(), pb.cs.proxyAppCtx, pb.cs.blockStore, pb.cs.mempool)
+	newCs.SetEventSwitch(pb.cs.evsw)
+
+	// we ensure all new step events are regenerated as expected
+	pb.newStepCh = newCs.evsw.SubscribeToEvent("replay-test", types.EventStringNewRoundStep(), 1)
+
+	newCs.BaseService.OnStart()
+	newCs.startRoutines(0)
+
+	pb.fp.Close()
+	fp, err := os.OpenFile(pb.file, os.O_RDONLY, 0666)
+	if err != nil {
+		return err
+	}
+	pb.fp = fp
+	pb.scanner = bufio.NewScanner(fp)
+	count = pb.count - count
+	log.Notice(Fmt("Reseting from %d to %d", pb.count, count))
+	pb.count = 0
+	pb.cs = newCs
+	for i := 0; pb.scanner.Scan() && i < count; i++ {
+		if err := pb.readReplayMessage(); err != nil {
+			return err
+		}
+		pb.count += 1
+	}
+	return nil
+}
+
+func (cs *ConsensusState) replay(file string, console bool) error {
+	if cs.IsRunning() {
+		return errors.New("cs is already running, cannot replay")
+	}
+
+	cs.BaseService.OnStart()
+	cs.startRoutines(0)
+
+	if cs.msgLogFP != nil {
+		cs.msgLogFP.Close()
+		cs.msgLogFP = nil
+	}
+
+	// we ensure all new step events are regenerated as expected
+	newStepCh := cs.evsw.SubscribeToEvent("replay-test", types.EventStringNewRoundStep(), 1)
+
+	fp, err := os.OpenFile(file, os.O_RDONLY, 0666)
+	if err != nil {
+		return err
+	}
+
+	pb := newPlayback(file, fp, cs, newStepCh, cs.state.Copy())
+
+	defer pb.fp.Close()
+
+	var nextN int // apply N msgs in a row
+	for pb.scanner.Scan() {
+		if nextN == 0 && console {
+			nextN = pb.replayConsoleLoop()
+		}
+
+		if err := pb.readReplayMessage(); err != nil {
+			return err
+		}
+
+		if nextN > 0 {
+			nextN -= 1
+		}
+		pb.count += 1
+	}
+	return nil
+}
+
+func (pb *playback) replayConsoleLoop() int {
+	for {
+		fmt.Printf("> ")
+		bufReader := bufio.NewReader(os.Stdin)
+		line, more, err := bufReader.ReadLine()
+		if more {
+			Exit("input is too long")
+		} else if err != nil {
+			Exit(err.Error())
+		}
+
+		tokens := strings.Split(string(line), " ")
+		if len(tokens) == 0 {
+			continue
+		}
+
+		switch tokens[0] {
+		case "next":
+			// "next" -> replay next message
+			// "next N" -> replay next N messages
+
+			if len(tokens) == 1 {
+				return 0
+			} else {
+				i, err := strconv.Atoi(tokens[1])
+				if err != nil {
+					fmt.Println("next takes an integer argument")
+				} else {
+					return i
+				}
+			}
+
+		case "back":
+			// "back" -> go back one message
+			// "back N" -> go back N messages
+
+			// NOTE: "back" is not supported in the state machine design,
+			// so we restart to do this (expensive ...)
+
+			if len(tokens) == 1 {
+				pb.replayReset(1)
+			} else {
+				i, err := strconv.Atoi(tokens[1])
+				if err != nil {
+					fmt.Println("back takes an integer argument")
+				} else if i > pb.count {
+					fmt.Printf("argument to back must not be larger than the current count (%d)\n", pb.count)
+				} else {
+					pb.replayReset(i)
+				}
+			}
+
+		case "rs":
+			// "rs" -> print entire round state
+			// "rs short" -> print height/round/step
+			// "rs <field>" -> print another field of the round state
+
+			rs := pb.cs.RoundState
+			if len(tokens) == 1 {
+				fmt.Println(rs)
+			} else {
+				switch tokens[1] {
+				case "short":
+					fmt.Printf("%v/%v/%v\n", rs.Height, rs.Round, rs.Step)
+				case "validators":
+					fmt.Println(rs.Validators)
+				case "proposal":
+					fmt.Println(rs.Proposal)
+				case "proposal_block":
+					fmt.Printf("%v %v\n", rs.ProposalBlockParts.StringShort(), rs.ProposalBlock.StringShort())
+				case "locked_round":
+					fmt.Println(rs.LockedRound)
+				case "locked_block":
+					fmt.Printf("%v %v\n", rs.LockedBlockParts.StringShort(), rs.LockedBlock.StringShort())
+				case "votes":
+					fmt.Println(rs.Votes.StringIndented("    "))
+
+				default:
+					fmt.Println("Unknown option", tokens[1])
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func (pb *playback) readReplayMessage() error {
+	var err error
+	var msg ConsensusLogMessage
+	wire.ReadJSON(&msg, pb.scanner.Bytes(), &err)
+	if err != nil {
+		return fmt.Errorf("Error reading json data: %v", err)
+	}
+	log.Notice("Replaying message", "type", reflect.TypeOf(msg.Msg), "msg", msg.Msg)
+	switch m := msg.Msg.(type) {
+	case *types.EventDataRoundState:
+		// these are playback checks
+		ticker := time.After(time.Second * 2)
+		select {
+		case mi := <-pb.newStepCh:
+			m2 := mi.(*types.EventDataRoundState)
+			if m.Height != m2.Height || m.Round != m2.Round || m.Step != m2.Step {
+				return fmt.Errorf("RoundState mismatch. Got %v; Expected %v", m2, m)
+			}
+		case <-ticker:
+			return fmt.Errorf("Failed to read off newStepCh")
+		}
+	case msgInfo:
+		// internal or from peer
+		if m.PeerKey == "" {
+			pb.cs.internalMsgQueue <- m
+		} else {
+			pb.cs.peerMsgQueue <- m
+		}
+	case timeoutInfo:
+		pb.cs.tockChan <- m
+	default:
+		return fmt.Errorf("Unknown ConsensusLogMessage type: %v", reflect.TypeOf(msg.Msg))
+	}
+	return nil
+}

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/tendermint/tendermint/Godeps/_workspace/src/github.com/tendermint/go-common"
-	"github.com/tendermint/tendermint/Godeps/_workspace/src/github.com/tendermint/go-wire"
+	. "github.com/tendermint/go-common"
+	"github.com/tendermint/go-wire"
 
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -85,7 +84,7 @@ func (cs *ConsensusState) catchupReplay(height int) error {
 		}
 		m, ok := msg.Msg.(*types.EventDataRoundState)
 		if ok && m.Step == RoundStepNewHeight.String() {
-			r, err := f.Seek(0, 1)
+			f.Seek(0, 1)
 			// TODO: ensure the height matches
 			return true
 		}
@@ -203,7 +202,7 @@ func (pb *playback) replayReset(count int) error {
 
 	pb.cs.Stop()
 
-	newCs := NewConsensusState(pb.genesisState.Copy(), pb.cs.proxyAppCtx, pb.cs.blockStore, pb.cs.mempool)
+	newCs := NewConsensusState(pb.genesisState.Copy(), pb.cs.proxyAppConn, pb.cs.blockStore, pb.cs.mempool)
 	newCs.SetEventSwitch(pb.cs.evsw)
 
 	// ensure all new step events are regenerated as expected

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -1,0 +1,72 @@
+package consensus
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/tendermint/tendermint/types"
+)
+
+var testLog = `{"time":"2016-01-18T20:46:00.774Z","msg":[3,{"duration":982632969,"height":1,"round":0,"step":1}]}
+{"time":"2016-01-18T20:46:00.776Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPropose"}]}
+{"time":"2016-01-18T20:46:00.776Z","msg":[2,{"msg":[17,{"Proposal":{"height":1,"round":0,"block_parts_header":{"total":1,"hash":"B6227255FF20758326B0B7DFF529F20E33E58F45"},"pol_round":-1,"signature":"A1803A1364F6398C154FE45D5649A89129039F18A0FE42B211BADFDF6E81EA53F48F83D3610DDD848C3A5284D3F09BDEB26FA1D856BDF70D48C507BF2453A70E"}}],"peer_key":""}]}
+{"time":"2016-01-18T20:46:00.777Z","msg":[2,{"msg":[19,{"Height":1,"Round":0,"Part":{"index":0,"bytes":"0101010F74656E6465726D696E745F746573740101142AA030B15DDFC000000000000000000000000000000114C4B01D3810579550997AC5641E759E20D99B51C10001000100","proof":{"aunts":[]}}}],"peer_key":""}]}
+{"time":"2016-01-18T20:46:00.781Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrevote"}]}
+{"time":"2016-01-18T20:46:00.781Z","msg":[2,{"msg":[20,{"ValidatorIndex":0,"Vote":{"height":1,"round":0,"type":1,"block_hash":"E05D1DB8DEC7CDA507A42C8FF208EE4317C663F6","block_parts_header":{"total":1,"hash":"B6227255FF20758326B0B7DFF529F20E33E58F45"},"signature":"88F5708C802BEE54EFBF438967FBC6C6EAAFC41258A85D92B9B055481175BE9FA71007B1AAF2BFBC3BF3CC0542DB48A9812324B7BBA7307446CCDBF029077F07"}}],"peer_key":""}]}
+{"time":"2016-01-18T20:46:00.786Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrecommit"}]}
+{"time":"2016-01-18T20:46:00.786Z","msg":[2,{"msg":[20,{"ValidatorIndex":0,"Vote":{"height":1,"round":0,"type":2,"block_hash":"E05D1DB8DEC7CDA507A42C8FF208EE4317C663F6","block_parts_header":{"total":1,"hash":"B6227255FF20758326B0B7DFF529F20E33E58F45"},"signature":"65B0C9D2A8C9919FC9B036F82C3F1818E706E8BC066A78D99D3316E4814AB06594841E387B323AA7773F926D253C1E4D4A0930F7A8C8AE1E838CA15C673B2B02"}}],"peer_key":""}]}
+`
+
+func TestReplayCatchup(t *testing.T) {
+	// write the needed wal to file
+	f, err := ioutil.TempFile(os.TempDir(), "replay_test_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := f.Name()
+	_, err = f.WriteString(testLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	cs := fixedConsensusState()
+
+	// we've already precommitted on the first block
+	// without replay catchup we would be halted here forever
+	cs.privValidator.LastHeight = 1 // first block
+	cs.privValidator.LastStep = 3   // precommit
+
+	newBlockCh := cs.evsw.SubscribeToEvent("tester", types.EventStringNewBlock(), 0)
+
+	// start timeout and receive routines
+	cs.startRoutines(0)
+
+	// open wal and run catchup messages
+	openWAL(t, cs, name)
+	if err := cs.catchupReplay(cs.Height); err != nil {
+		t.Fatalf("Error on catchup replay %v", err)
+	}
+
+	cs.enterNewRound(cs.Height, cs.Round)
+
+	after := time.After(time.Second * 2)
+	select {
+	case <-newBlockCh:
+	case <-after:
+		t.Fatal("Timed out waiting for new block")
+	}
+
+}
+
+func openWAL(t *testing.T, cs *ConsensusState, file string) {
+	// open the wal
+	wal, err := NewWAL(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wal.exists = true
+	cs.wal = wal
+}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -277,6 +277,14 @@ func (cs *ConsensusState) OnStop() {
 	}
 }
 
+// Open file to log all consensus messages and timeouts for deterministic accountability
+func (cs *ConsensusState) OpenFileForMessageLog(file string) (err error) {
+	cs.mtx.Lock()
+	defer cs.mtx.Unlock()
+	cs.msgLogFP, err = os.OpenFile(file, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
+	return err
+}
+
 //------------------------------------------------------------
 // Public interface for passing messages into the consensus state,
 // possibly causing a state transition

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -46,7 +46,8 @@ x * TestHalt1 - if we see +2/3 precommits after timing out into new round, we sh
 
 func init() {
 	fmt.Println("")
-	timeoutPropose = 500 * time.Millisecond
+	timeoutPropose0 = 100 * time.Millisecond
+	timeoutProposeDelta = 1 * time.Millisecond
 }
 
 func TestProposerSelection0(t *testing.T) {
@@ -123,7 +124,7 @@ func TestEnterProposeNoPrivValidator(t *testing.T) {
 	startTestRound(cs, height, round)
 
 	// if we're not a validator, EnterPropose should timeout
-	ticker := time.NewTicker(timeoutPropose * 2)
+	ticker := time.NewTicker(timeoutPropose0 * 2)
 	select {
 	case <-timeoutCh:
 	case <-ticker.C:
@@ -164,7 +165,7 @@ func TestEnterProposeYesPrivValidator(t *testing.T) {
 	}
 
 	// if we're a validator, enterPropose should not timeout
-	ticker := time.NewTicker(timeoutPropose * 2)
+	ticker := time.NewTicker(timeoutPropose0 * 2)
 	select {
 	case <-timeoutCh:
 		t.Fatal("Expected EnterPropose not to timeout")

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -51,7 +51,7 @@ func init() {
 }
 
 func TestProposerSelection0(t *testing.T) {
-	cs1, vss := simpleConsensusState(4)
+	cs1, vss := randConsensusState(4)
 	height, round := cs1.Height, cs1.Round
 
 	newRoundCh := cs1.evsw.SubscribeToEvent("tester", types.EventStringNewRound(), 1)
@@ -85,7 +85,7 @@ func TestProposerSelection0(t *testing.T) {
 
 // Now let's do it all again, but starting from round 2 instead of 0
 func TestProposerSelection2(t *testing.T) {
-	cs1, vss := simpleConsensusState(4) // test needs more work for more than 3 validators
+	cs1, vss := randConsensusState(4) // test needs more work for more than 3 validators
 
 	newRoundCh := cs1.evsw.SubscribeToEvent("tester", types.EventStringNewRound(), 1)
 
@@ -114,7 +114,7 @@ func TestProposerSelection2(t *testing.T) {
 
 // a non-validator should timeout into the prevote round
 func TestEnterProposeNoPrivValidator(t *testing.T) {
-	cs, _ := simpleConsensusState(1)
+	cs, _ := randConsensusState(1)
 	cs.SetPrivValidator(nil)
 	height, round := cs.Height, cs.Round
 
@@ -139,7 +139,7 @@ func TestEnterProposeNoPrivValidator(t *testing.T) {
 
 // a validator should not timeout of the prevote round (TODO: unless the block is really big!)
 func TestEnterProposeYesPrivValidator(t *testing.T) {
-	cs, _ := simpleConsensusState(1)
+	cs, _ := randConsensusState(1)
 	height, round := cs.Height, cs.Round
 
 	// Listen for propose timeout event
@@ -175,7 +175,7 @@ func TestEnterProposeYesPrivValidator(t *testing.T) {
 }
 
 func TestBadProposal(t *testing.T) {
-	cs1, vss := simpleConsensusState(2)
+	cs1, vss := randConsensusState(2)
 	height, round := cs1.Height, cs1.Round
 	cs2 := vss[1]
 
@@ -231,7 +231,7 @@ func TestBadProposal(t *testing.T) {
 
 // propose, prevote, and precommit a block
 func TestFullRound1(t *testing.T) {
-	cs, vss := simpleConsensusState(1)
+	cs, vss := randConsensusState(1)
 	height, round := cs.Height, cs.Round
 
 	voteCh := cs.evsw.SubscribeToEvent("tester", types.EventStringVote(), 0)
@@ -259,7 +259,7 @@ func TestFullRound1(t *testing.T) {
 
 // nil is proposed, so prevote and precommit nil
 func TestFullRoundNil(t *testing.T) {
-	cs, vss := simpleConsensusState(1)
+	cs, vss := randConsensusState(1)
 	height, round := cs.Height, cs.Round
 
 	voteCh := cs.evsw.SubscribeToEvent("tester", types.EventStringVote(), 0)
@@ -277,7 +277,7 @@ func TestFullRoundNil(t *testing.T) {
 // run through propose, prevote, precommit commit with two validators
 // where the first validator has to wait for votes from the second
 func TestFullRound2(t *testing.T) {
-	cs1, vss := simpleConsensusState(2)
+	cs1, vss := randConsensusState(2)
 	cs2 := vss[1]
 	height, round := cs1.Height, cs1.Round
 
@@ -318,7 +318,7 @@ func TestFullRound2(t *testing.T) {
 // two validators, 4 rounds.
 // two vals take turns proposing. val1 locks on first one, precommits nil on everything else
 func TestLockNoPOL(t *testing.T) {
-	cs1, vss := simpleConsensusState(2)
+	cs1, vss := randConsensusState(2)
 	cs2 := vss[1]
 	height := cs1.Height
 
@@ -481,7 +481,7 @@ func TestLockNoPOL(t *testing.T) {
 
 // 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
 func TestLockPOLRelock(t *testing.T) {
-	cs1, vss := simpleConsensusState(4)
+	cs1, vss := randConsensusState(4)
 	cs2, cs3, cs4 := vss[1], vss[2], vss[3]
 
 	timeoutProposeCh := cs1.evsw.SubscribeToEvent("tester", types.EventStringTimeoutPropose(), 0)
@@ -589,7 +589,7 @@ func TestLockPOLRelock(t *testing.T) {
 
 // 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
 func TestLockPOLUnlock(t *testing.T) {
-	cs1, vss := simpleConsensusState(4)
+	cs1, vss := randConsensusState(4)
 	cs2, cs3, cs4 := vss[1], vss[2], vss[3]
 
 	proposalCh := cs1.evsw.SubscribeToEvent("tester", types.EventStringCompleteProposal(), 0)
@@ -680,7 +680,7 @@ func TestLockPOLUnlock(t *testing.T) {
 // then a polka at round 2 that we lock on
 // then we see the polka from round 1 but shouldn't unlock
 func TestLockPOLSafety1(t *testing.T) {
-	cs1, vss := simpleConsensusState(4)
+	cs1, vss := randConsensusState(4)
 	cs2, cs3, cs4 := vss[1], vss[2], vss[3]
 
 	proposalCh := cs1.evsw.SubscribeToEvent("tester", types.EventStringCompleteProposal(), 0)
@@ -799,7 +799,7 @@ func TestLockPOLSafety1(t *testing.T) {
 // What we want:
 // dont see P0, lock on P1 at R1, dont unlock using P0 at R2
 func TestLockPOLSafety2(t *testing.T) {
-	cs1, vss := simpleConsensusState(4)
+	cs1, vss := randConsensusState(4)
 	cs2, cs3, cs4 := vss[1], vss[2], vss[3]
 
 	proposalCh := cs1.evsw.SubscribeToEvent("tester", types.EventStringCompleteProposal(), 0)
@@ -889,7 +889,7 @@ func TestLockPOLSafety2(t *testing.T) {
 
 /*
 func TestSlashingPrevotes(t *testing.T) {
-	cs1, vss := simpleConsensusState(2)
+	cs1, vss := randConsensusState(2)
 	cs2 := vss[1]
 
 
@@ -924,7 +924,7 @@ func TestSlashingPrevotes(t *testing.T) {
 }
 
 func TestSlashingPrecommits(t *testing.T) {
-	cs1, vss := simpleConsensusState(2)
+	cs1, vss := randConsensusState(2)
 	cs2 := vss[1]
 
 
@@ -969,7 +969,7 @@ func TestSlashingPrecommits(t *testing.T) {
 // 4 vals.
 // we receive a final precommit after going into next round, but others might have gone to commit already!
 func TestHalt1(t *testing.T) {
-	cs1, vss := simpleConsensusState(4)
+	cs1, vss := randConsensusState(4)
 	cs2, cs3, cs4 := vss[1], vss[2], vss[3]
 
 	proposalCh := cs1.evsw.SubscribeToEvent("tester", types.EventStringCompleteProposal(), 0)

--- a/consensus/wal.go
+++ b/consensus/wal.go
@@ -1,0 +1,113 @@
+package consensus
+
+import (
+	"bufio"
+	"os"
+	"time"
+
+	. "github.com/tendermint/go-common"
+	"github.com/tendermint/go-wire"
+	"github.com/tendermint/tendermint/types"
+)
+
+//--------------------------------------------------------
+// types and functions for savings consensus messages
+
+type ConsensusLogMessage struct {
+	Time time.Time                    `json:"time"`
+	Msg  ConsensusLogMessageInterface `json:"msg"`
+}
+
+type ConsensusLogMessageInterface interface{}
+
+var _ = wire.RegisterInterface(
+	struct{ ConsensusLogMessageInterface }{},
+	wire.ConcreteType{&types.EventDataRoundState{}, 0x01},
+	wire.ConcreteType{msgInfo{}, 0x02},
+	wire.ConcreteType{timeoutInfo{}, 0x03},
+)
+
+//--------------------------------------------------------
+// Simple write-ahead logger
+
+// Write ahead logger writes msgs to disk before they are processed.
+// Can be used for crash-recovery and deterministic replay
+type WAL struct {
+	fp     *os.File
+	exists bool // if the file already existed (restarted process)
+}
+
+func NewWAL(file string) (*WAL, error) {
+	var walExists bool
+	if _, err := os.Stat(file); err == nil {
+		walExists = true
+	}
+	fp, err := os.OpenFile(file, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	return &WAL{
+		fp:     fp,
+		exists: walExists,
+	}, nil
+}
+
+// called in newStep and for each pass in receiveRoutine
+func (wal *WAL) Save(msg ConsensusLogMessageInterface) {
+	if wal != nil {
+		var n int
+		var err error
+		wire.WriteJSON(ConsensusLogMessage{time.Now(), msg}, wal.fp, &n, &err)
+		wire.WriteTo([]byte("\n"), wal.fp, &n, &err) // one message per line
+		if err != nil {
+			PanicQ(Fmt("Error writing msg to consensus wal. Error: %v \n\nMessage: %v", err, msg))
+		}
+	}
+}
+
+// Must not be called concurrently.
+func (wal *WAL) Close() {
+	if wal != nil {
+		wal.fp.Close()
+	}
+}
+
+func (wal *WAL) SeekFromEnd(found func([]byte) bool) (nLines int, err error) {
+	var current int64
+	// start at the end
+	current, err = wal.fp.Seek(0, 2)
+	if err != nil {
+		return
+	}
+
+	// backup until we find the the right line
+	for {
+		current -= 1
+		if current < 0 {
+			return
+		}
+		// backup one and read a new byte
+		if _, err = wal.fp.Seek(current, 0); err != nil {
+			return
+		}
+		b := make([]byte, 1)
+		if _, err = wal.fp.Read(b); err != nil {
+			return
+		}
+		if b[0] == '\n' || len(b) == 0 {
+			// read a full line
+			reader := bufio.NewReader(wal.fp)
+			lineBytes, _ := reader.ReadBytes('\n')
+			if len(lineBytes) == 0 {
+				continue
+			}
+
+			nLines += 1
+			if found(lineBytes) {
+				wal.fp.Seek(0, 1) // (?)
+				wal.fp.Seek(current, 0)
+				return
+			}
+		}
+	}
+}

--- a/consensus/wal_test.go
+++ b/consensus/wal_test.go
@@ -1,0 +1,76 @@
+package consensus
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+var testTxt = `{"time":"2016-01-16T04:42:00.390Z","msg":[1,{"height":28219,"round":0,"step":"RoundStepPrevote"}]}
+{"time":"2016-01-16T04:42:00.390Z","msg":[2,{"msg":[20,{"ValidatorIndex":0,"Vote":{"height":28219,"round":0,"type":1,"block_hash":"67F9689F15BEC30BF311FB4C0C80C5E661AA44E0","block_parts_header":{"total":1,"hash":"DFFD4409A1E273ED61AC27CAF975F446020D5676"},"signature":"4CC6845A128E723A299B470CCBB2A158612AA51321447F6492F3DA57D135C27FCF4124B3B19446A248252BDA45B152819C76AAA5FD35E1C07091885CE6955E05"}}],"peer_key":""}]}
+{"time":"2016-01-16T04:42:00.392Z","msg":[1,{"height":28219,"round":0,"step":"RoundStepPrecommit"}]}
+{"time":"2016-01-16T04:42:00.392Z","msg":[2,{"msg":[20,{"ValidatorIndex":0,"Vote":{"height":28219,"round":0,"type":2,"block_hash":"67F9689F15BEC30BF311FB4C0C80C5E661AA44E0","block_parts_header":{"total":1,"hash":"DFFD4409A1E273ED61AC27CAF975F446020D5676"},"signature":"1B9924E010F47E0817695DFE462C531196E5A12632434DE12180BBA3EFDAD6B3960FDB9357AFF085EB61729A7D4A6AD8408555D7569C87D9028F280192FD4E05"}}],"peer_key":""}]}
+{"time":"2016-01-16T04:42:00.393Z","msg":[1,{"height":28219,"round":0,"step":"RoundStepCommit"}]}
+{"time":"2016-01-16T04:42:00.395Z","msg":[1,{"height":28220,"round":0,"step":"RoundStepNewHeight"}]}`
+
+func TestSeek(t *testing.T) {
+	f, err := ioutil.TempFile(os.TempDir(), "seek_test_")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stat, _ := f.Stat()
+	name := stat.Name()
+
+	_, err = f.WriteString(testTxt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	wal, err := NewWAL(path.Join(os.TempDir(), name))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyWord := "Precommit"
+	n, err := wal.SeekFromEnd(func(b []byte) bool {
+		if strings.Contains(string(b), keyWord) {
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// confirm n
+	spl := strings.Split(testTxt, "\n")
+	var i int
+	var s string
+	for i, s = range spl {
+		if strings.Contains(s, keyWord) {
+			break
+		}
+	}
+	// n is lines from the end.
+	spl = spl[i:]
+	if n != len(spl) {
+		t.Fatalf("Wrong nLines. Got %d, expected %d", n, len(spl))
+	}
+
+	b, err := ioutil.ReadAll(wal.fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// first char is a \n
+	spl2 := strings.Split(strings.Trim(string(b), "\n"), "\n")
+	for i, s := range spl {
+		if s != spl2[i] {
+			t.Fatalf("Mismatch. Got %s, expected %s", spl2[i], s)
+		}
+	}
+
+}

--- a/node/node.go
+++ b/node/node.go
@@ -323,11 +323,11 @@ func newConsensusState() *consensus.ConsensusState {
 	stateDB := dbm.GetDB("state")
 	state := sm.MakeGenesisStateFromFile(stateDB, config.GetString("genesis_file"))
 
-	// Create two proxyAppCtx connections,
+	// Create two proxyAppConn connections,
 	// one for the consensus and one for the mempool.
 	proxyAddr := config.GetString("proxy_app")
-	proxyAppCtxMempool := getProxyApp(proxyAddr, state.LastAppHash)
-	proxyAppCtxConsensus := getProxyApp(proxyAddr, state.LastAppHash)
+	proxyAppConnMempool := getProxyApp(proxyAddr, state.AppHash)
+	proxyAppConnConsensus := getProxyApp(proxyAddr, state.AppHash)
 
 	// add the chainid to the global config
 	config.Set("chain_id", state.ChainID)
@@ -339,9 +339,9 @@ func newConsensusState() *consensus.ConsensusState {
 		Exit(Fmt("Failed to start event switch: %v", err))
 	}
 
-	mempool := mempl.NewMempool(proxyAppCtxMempool)
+	mempool := mempl.NewMempool(proxyAppConnMempool)
 
-	consensusState := consensus.NewConsensusState(state.Copy(), proxyAppCtxConsensus, blockStore, mempool)
+	consensusState := consensus.NewConsensusState(state.Copy(), proxyAppConnConsensus, blockStore, mempool)
 	consensusState.SetEventSwitch(eventSwitch)
 	return consensusState
 }

--- a/node/node.go
+++ b/node/node.go
@@ -311,12 +311,7 @@ func RunNode() {
 	})
 }
 
-func RunReplay() {
-	msgLogFile := config.GetString("cs_msg_log")
-	if msgLogFile == "" {
-		Exit("cs_msg_log file name not set in tendermint config")
-	}
-
+func newConsensusState() *consensus.ConsensusState {
 	// Get BlockStore
 	blockStoreDB := dbm.GetDB("blockstore")
 	blockStore := bc.NewBlockStore(blockStoreDB)
@@ -345,8 +340,31 @@ func RunReplay() {
 
 	consensusState := consensus.NewConsensusState(state.Copy(), proxyAppCtxConsensus, blockStore, mempool)
 	consensusState.SetEventSwitch(eventSwitch)
+	return consensusState
+}
 
-	if err := consensusState.ReplayMessagesFromFile(msgLogFile); err != nil {
+func RunReplayConsole() {
+	msgLogFile := config.GetString("cs_msg_log")
+	if msgLogFile == "" {
+		Exit("cs_msg_log file name not set in tendermint config")
+	}
+
+	consensusState := newConsensusState()
+
+	if err := consensusState.ReplayConsole(msgLogFile); err != nil {
+		Exit(Fmt("Error during consensus replay: %v", err))
+	}
+}
+
+func RunReplay() {
+	msgLogFile := config.GetString("cs_msg_log")
+	if msgLogFile == "" {
+		Exit("cs_msg_log file name not set in tendermint config")
+	}
+
+	consensusState := newConsensusState()
+
+	if err := consensusState.ReplayMessages(msgLogFile); err != nil {
 		Exit(Fmt("Error during consensus replay: %v", err))
 	}
 	log.Notice("Replay run successfully")

--- a/node/node.go
+++ b/node/node.go
@@ -85,7 +85,10 @@ func NewNode(privValidator *types.PrivValidator) *Node {
 	}
 
 	// deterministic accountability
-	consensusState.OpenFileForMessageLog(config.GetString("cs_msg_log"))
+	err = consensusState.OpenFileForMessageLog(config.GetString("cs_msg_log"))
+	if err != nil {
+		log.Error("Failed to open cs_msg_log", "error", err.Error())
+	}
 
 	// Make p2p network switch
 	sw := p2p.NewSwitch()

--- a/proxy/remote_app_conn.go
+++ b/proxy/remote_app_conn.go
@@ -106,7 +106,6 @@ func (app *remoteAppConn) sendRequestsRoutine() {
 				app.StopForError(err)
 				return
 			}
-			log.Debug("Sent request", "requestType", reflect.TypeOf(reqres.Request), "request", reqres.Request)
 			if _, ok := reqres.Request.(tmsp.RequestFlush); ok {
 				err = app.bufWriter.Flush()
 				if err != nil {
@@ -133,7 +132,6 @@ func (app *remoteAppConn) recvResponseRoutine() {
 		case tmsp.ResponseException:
 			app.StopForError(errors.New(res.Error))
 		default:
-			log.Debug("Received response", "responseType", reflect.TypeOf(res), "response", res)
 			err := app.didRecvResponse(res)
 			if err != nil {
 				app.StopForError(err)

--- a/types/events.go
+++ b/types/events.go
@@ -52,7 +52,7 @@ var _ = wire.RegisterInterface(
 	// wire.ConcreteType{EventDataFork{}, EventDataTypeFork },
 	wire.ConcreteType{EventDataTx{}, EventDataTypeTx},
 	wire.ConcreteType{EventDataApp{}, EventDataTypeApp},
-	wire.ConcreteType{EventDataRoundState{}, EventDataTypeRoundState},
+	wire.ConcreteType{&EventDataRoundState{}, EventDataTypeRoundState}, // a pointer because we use it internally
 	wire.ConcreteType{EventDataVote{}, EventDataTypeVote},
 )
 


### PR DESCRIPTION
This PR introduces a write ahead log (WAL) into the consensus state so that all messages received in the receiveRoutine are written to disk before they are processed, in order that consensus state is not corrupted in the event of a crash. 

TestReplayCatchup simulates a case where the node crashed after precommitting but before committing. Without being able to rerun msgs from the WAL, it would halt forever. Could potentially be saved by network input, but there are cases eg. in a 4 node net, with one node down, if another node crashed and restarted at the right point, the network could halt.

The WAL can also be used for deterministic accountability and analysis. The PR includes simple tools to rerun an entire WAL against the consensus state, and to do so interactively with commands for seeing the RoundState in between msgs. 