### PR TITLE
allow app to be restarted

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -73,6 +73,14 @@ func (mem *Mempool) TxsFrontWait() *clist.CElement {
 	return mem.txs.FrontWait()
 }
 
+func (mem *Mempool) ResetProxyApp(proxyApp proxy.AppConn, wg *sync.WaitGroup, done chan struct{}) {
+	mem.proxyMtx.Lock()
+	defer mem.proxyMtx.Unlock()
+	mem.proxyAppConn = proxyApp
+	wg.Done()
+	<-done
+}
+
 // Try a new transaction in the mempool.
 // Potentially blocking if we're blocking on Update() or Reap().
 func (mem *Mempool) CheckTx(tx types.Tx) (err error) {

--- a/proxy/app_conn.go
+++ b/proxy/app_conn.go
@@ -7,6 +7,8 @@ import (
 type Callback func(tmsp.Request, tmsp.Response)
 
 type AppConn interface {
+	Stop() bool
+	IsRunning() bool
 	SetResponseCallback(Callback)
 	Error() error
 

--- a/proxy/local_app_conn.go
+++ b/proxy/local_app_conn.go
@@ -18,6 +18,14 @@ func NewLocalAppConn(mtx *sync.Mutex, app tmsp.Application) *localAppConn {
 	}
 }
 
+func (app *localAppConn) IsRunning() bool {
+	return true
+}
+
+func (app *localAppConn) Stop() bool {
+	return false
+}
+
 func (app *localAppConn) SetResponseCallback(cb Callback) {
 	app.mtx.Lock()
 	defer app.mtx.Unlock()


### PR DESCRIPTION
Fix and new feature:
- fixes a bug wherein everything would hang when the app connection fails.
- allows app to be reconnected by pinging the endpoint until success, and then resetting the proxyAppCtx on all services that use it
- resetting the proxyAppCtx is done atomically across services