### PR TITLE
fix mempool concurrency bug between Commit and Update

### DIFF
--- a/config/tendermint/config.go
+++ b/config/tendermint/config.go
@@ -70,6 +70,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("cswal_light", false)
 
 	mapConfig.SetDefault("block_size", 10000)
+	mapConfig.SetDefault("disable_data_hash", false)
 	mapConfig.SetDefault("timeout_propose", 3000)
 	mapConfig.SetDefault("timeout_propose_delta", 500)
 	mapConfig.SetDefault("timeout_prevote", 1000)

--- a/config/tendermint/config.go
+++ b/config/tendermint/config.go
@@ -79,6 +79,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("timeout_precommit_delta", 500)
 	mapConfig.SetDefault("timeout_commit", 1000)
 	mapConfig.SetDefault("mempool_recheck", true)
+	mapConfig.SetDefault("mempool_recheck_empty", true)
 	mapConfig.SetDefault("mempool_broadcast", true)
 
 	return mapConfig

--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -97,6 +97,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("timeout_precommit_delta", 1)
 	mapConfig.SetDefault("timeout_commit", 1)
 	mapConfig.SetDefault("mempool_recheck", true)
+	mapConfig.SetDefault("mempool_recheck_empty", true)
 	mapConfig.SetDefault("mempool_broadcast", true)
 
 	return mapConfig

--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -88,6 +88,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("cswal_light", false)
 
 	mapConfig.SetDefault("block_size", 10000)
+	mapConfig.SetDefault("disable_data_hash", false)
 	mapConfig.SetDefault("timeout_propose", 100)
 	mapConfig.SetDefault("timeout_propose_delta", 1)
 	mapConfig.SetDefault("timeout_prevote", 1)

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -1,0 +1,110 @@
+package consensus
+
+import (
+	"encoding/binary"
+	//	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/tendermint/tendermint/config/tendermint_test"
+	"github.com/tendermint/tendermint/types"
+	tmsp "github.com/tendermint/tmsp/types"
+
+	. "github.com/tendermint/go-common"
+)
+
+func init() {
+	tendermint_test.ResetConfig("consensus_mempool_test")
+}
+
+func TestTxConcurrentWithCommit(t *testing.T) {
+
+	state, privVals := randGenesisState(1, false, 10)
+	cs := newConsensusState(state, privVals[0], NewCounterApplication())
+	height, round := cs.Height, cs.Round
+	newBlockCh := subscribeToEvent(cs.evsw, "tester", types.EventStringNewBlock(), 1)
+
+	appendTxsRange := func(start, end int) {
+		// Append some txs.
+		for i := start; i < end; i++ {
+			txBytes := make([]byte, 8)
+			binary.BigEndian.PutUint64(txBytes, uint64(i))
+			err := cs.mempool.CheckTx(txBytes, nil)
+			if err != nil {
+				t.Fatal("Error after CheckTx: %v", err)
+			}
+			//	time.Sleep(time.Microsecond * time.Duration(rand.Int63n(3000)))
+		}
+	}
+
+	NTxs := 10000
+	go appendTxsRange(0, NTxs)
+
+	startTestRound(cs, height, round)
+	ticker := time.NewTicker(time.Second * 5)
+	for nTxs := 0; nTxs < NTxs; {
+		select {
+		case b := <-newBlockCh:
+			nTxs += b.(types.EventDataNewBlock).Block.Header.NumTxs
+		case <-ticker.C:
+			t.Fatal("Timed out waiting to commit blocks with transactions")
+		}
+	}
+}
+
+// CounterApplication that maintains a mempool state and resets it upon commit
+type CounterApplication struct {
+	txCount        int
+	mempoolTxCount int
+}
+
+func NewCounterApplication() *CounterApplication {
+	return &CounterApplication{}
+}
+
+func (app *CounterApplication) Info() string {
+	return Fmt("txs:%v", app.txCount)
+}
+
+func (app *CounterApplication) SetOption(key string, value string) (log string) {
+	return ""
+}
+
+func (app *CounterApplication) AppendTx(tx []byte) tmsp.Result {
+	return runTx(tx, &app.txCount)
+}
+
+func (app *CounterApplication) CheckTx(tx []byte) tmsp.Result {
+	return runTx(tx, &app.mempoolTxCount)
+}
+
+func runTx(tx []byte, countPtr *int) tmsp.Result {
+	count := *countPtr
+	tx8 := make([]byte, 8)
+	copy(tx8[len(tx8)-len(tx):], tx)
+	txValue := binary.BigEndian.Uint64(tx8)
+	if txValue != uint64(count) {
+		return tmsp.Result{
+			Code: tmsp.CodeType_BadNonce,
+			Data: nil,
+			Log:  Fmt("Invalid nonce. Expected %v, got %v", count, txValue),
+		}
+	}
+	*countPtr += 1
+	return tmsp.OK
+}
+
+func (app *CounterApplication) Commit() tmsp.Result {
+	app.mempoolTxCount = app.txCount
+	if app.txCount == 0 {
+		return tmsp.OK
+	} else {
+		hash := make([]byte, 8)
+		binary.BigEndian.PutUint64(hash, uint64(app.txCount))
+		return tmsp.NewResultOK(hash, "")
+	}
+}
+
+func (app *CounterApplication) Query(query []byte) tmsp.Result {
+	return tmsp.NewResultOK(nil, Fmt("Query is not supported"))
+}

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -91,9 +91,9 @@ func (conR *ConsensusReactor) GetChannels() []*p2p.ChannelDescriptor {
 			SendQueueCapacity: 100,
 		},
 		&p2p.ChannelDescriptor{
-			ID:                 DataChannel,
-			Priority:           2,
-			SendQueueCapacity:  50,
+			ID:                 DataChannel, // maybe split between gossiping current block and catchup stuff
+			Priority:           200,         // once we gossip the whole block there's nothing left to send until next height or round
+			SendQueueCapacity:  100,
 			RecvBufferCapacity: 50 * 4096,
 		},
 		&p2p.ChannelDescriptor{

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -80,19 +80,20 @@ func TestReplayCatchup(t *testing.T) {
 	// start timeout and receive routines
 	cs.startRoutines(0)
 
+	// 	cs.scheduleRound0(cs.Height)
+
 	// open wal and run catchup messages
 	openWAL(t, cs, name)
 	if err := cs.catchupReplay(cs.Height); err != nil {
 		t.Fatalf("Error on catchup replay %v", err)
 	}
 
-	after := time.After(time.Second * 2)
+	after := time.After(time.Second * 15)
 	select {
 	case <-newBlockCh:
 	case <-after:
 		t.Fatal("Timed out waiting for new block")
 	}
-
 }
 
 func openWAL(t *testing.T, cs *ConsensusState, file string) {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1258,6 +1258,9 @@ func (cs *ConsensusState) commitStateUpdateMempool(s *sm.State, block *types.Blo
 	cs.mempool.Lock()
 	defer cs.mempool.Unlock()
 
+	// flush out any CheckTx that have already started
+	cs.proxyAppConn.FlushSync()
+
 	// Commit block, get hash back
 	res := cs.proxyAppConn.CommitSync()
 	if res.IsErr() {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -655,7 +655,7 @@ func (cs *ConsensusState) handleMsg(mi msgInfo, rs RoundState) {
 		err = cs.setProposal(msg.Proposal)
 	case *BlockPartMessage:
 		// if the proposal is complete, we'll enterPrevote or tryFinalizeCommit
-		_, err = cs.addProposalBlockPart(msg.Height, msg.Part)
+		_, err = cs.addProposalBlockPart(msg.Height, msg.Part, peerKey != "")
 		if err != nil && msg.Round != cs.Round {
 			err = nil
 		}
@@ -1291,7 +1291,7 @@ func (cs *ConsensusState) setProposal(proposal *types.Proposal) error {
 
 // NOTE: block is not necessarily valid.
 // Asynchronously triggers either enterPrevote (before we timeout of propose) or tryFinalizeCommit, once we have the full block.
-func (cs *ConsensusState) addProposalBlockPart(height int, part *types.Part) (added bool, err error) {
+func (cs *ConsensusState) addProposalBlockPart(height int, part *types.Part, verify bool) (added bool, err error) {
 	// Blocks might be reused, so round mismatch is OK
 	if cs.Height != height {
 		return false, nil
@@ -1302,7 +1302,7 @@ func (cs *ConsensusState) addProposalBlockPart(height int, part *types.Part) (ad
 		return false, nil // TODO: bad peer? Return error?
 	}
 
-	added, err = cs.ProposalBlockParts.AddPart(part)
+	added, err = cs.ProposalBlockParts.AddPart(part, verify)
 	if err != nil {
 		return added, err
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1205,7 +1205,8 @@ func (cs *ConsensusState) finalizeCommit(height int) {
 
 	// Fire off event for new block.
 	// TODO: Handle app failure.  See #177
-	cs.evsw.FireEvent(types.EventStringNewBlock(), types.EventDataNewBlock{&types.BlockHeader{block.Header}})
+	cs.evsw.FireEvent(types.EventStringNewBlock(), types.EventDataNewBlock{block})
+	cs.evsw.FireEvent(types.EventStringNewBlockHeader(), types.EventDataNewBlockHeader{block.Header})
 
 	// Create a copy of the state for staging
 	stateCopy := cs.state.Copy()

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -835,8 +835,8 @@ func (cs *ConsensusState) decideProposal(height, round int) {
 			part := blockParts.GetPart(i)
 			cs.sendInternalMessage(msgInfo{&BlockPartMessage{cs.Height, cs.Round, part}, ""})
 		}
-		log.Info("Signed and sent proposal", "height", height, "round", round, "proposal", proposal)
-		log.Debug(Fmt("Signed and sent proposal block: %v", block))
+		log.Info("Signed proposal", "height", height, "round", round, "proposal", proposal)
+		log.Debug(Fmt("Signed proposal block: %v", block))
 	} else {
 		log.Warn("enterPropose: Error signing proposal", "height", height, "round", round, "error", err)
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1205,7 +1205,7 @@ func (cs *ConsensusState) finalizeCommit(height int) {
 
 	// Fire off event for new block.
 	// TODO: Handle app failure.  See #177
-	cs.evsw.FireEvent(types.EventStringNewBlock(), types.EventDataNewBlock{block})
+	cs.evsw.FireEvent(types.EventStringNewBlock(), types.EventDataNewBlock{&types.BlockHeader{block.Header}})
 
 	// Create a copy of the state for staging
 	stateCopy := cs.state.Copy()

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -584,7 +584,7 @@ func TestLockPOLRelock(t *testing.T) {
 		t.Fatal("Expected height to increment")
 	}
 
-	if !bytes.Equal(b.Block.Hash(), propBlockHash) {
+	if !bytes.Equal(b.Block.Header.Hash(), propBlockHash) {
 		t.Fatal("Expected new block to be proposal block")
 	}
 }

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -491,7 +491,7 @@ func TestLockPOLRelock(t *testing.T) {
 	proposalCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringCompleteProposal(), 1)
 	voteCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringVote(), 1)
 	newRoundCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringNewRound(), 1)
-	newBlockCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringNewBlock(), 1)
+	newBlockCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringNewBlockHeader(), 1)
 
 	log.Debug("cs2 last round", "lr", cs2.PrivValidator.LastRound)
 
@@ -577,14 +577,14 @@ func TestLockPOLRelock(t *testing.T) {
 	_, _ = <-voteCh, <-voteCh
 
 	be := <-newBlockCh
-	b := be.(types.EventDataNewBlock)
+	b := be.(types.EventDataNewBlockHeader)
 	re = <-newRoundCh
 	rs = re.(types.EventDataRoundState).RoundState.(*RoundState)
 	if rs.Height != 2 {
 		t.Fatal("Expected height to increment")
 	}
 
-	if !bytes.Equal(b.Block.Header.Hash(), propBlockHash) {
+	if !bytes.Equal(b.Header.Hash(), propBlockHash) {
 		t.Fatal("Expected new block to be proposal block")
 	}
 }

--- a/consensus/version.go
+++ b/consensus/version.go
@@ -1,0 +1,13 @@
+package consensus
+
+import (
+	. "github.com/tendermint/go-common"
+)
+
+// kind of arbitrary
+var Spec = "1"     // async
+var Major = "0"    //
+var Minor = "2"    // replay refactor
+var Revision = "1" // round state fix
+
+var Version = Fmt("v%s/%s.%s.%s", Spec, Major, Minor, Revision)

--- a/consensus/wal.go
+++ b/consensus/wal.go
@@ -64,9 +64,12 @@ func NewWAL(file string, light bool) (*WAL, error) {
 func (wal *WAL) Save(clm ConsensusLogMessageInterface) {
 	if wal != nil {
 		if wal.light {
-			// in light mode we only write new steps and timeouts (no votes, proposals, block parts)
-			if _, ok := clm.(msgInfo); ok {
-				return
+			// in light mode we only write new steps, timeouts, and our own votes (no proposals, block parts)
+			if mi, ok := clm.(msgInfo); ok {
+				_ = mi
+				if mi.PeerKey != "" {
+					return
+				}
 			}
 		}
 		var n int

--- a/glide.lock
+++ b/glide.lock
@@ -1,20 +1,20 @@
 hash: f3eab3f91c9d2c07574e8ec6f2f5d56bd946af1b061533a0baf9db8765f97a51
-updated: 2016-03-24T16:39:27.330201414-04:00
+updated: 2016-04-11T19:42:00.993267284-04:00
 imports:
 - name: github.com/gogo/protobuf
-  version: 4168943e65a2802828518e95310aeeed6d84c4e5
+  version: 74b6e9deaff6ba6da1389ec97351d337f0d08b06
   subpackages:
   - proto
 - name: github.com/golang/protobuf
-  version: 8d92cf5fc15a4382f8964b08e1f42a75c0591aa3
+  version: dda510ac0fd43b39770f22ac6260eb91d377bce3
   subpackages:
   - proto
 - name: github.com/golang/snappy
-  version: 5f1c01d9f64b941dd9582c638279d046eda6ca31
+  version: ef80b33e873821cff33038ae16c444717218cdb1
 - name: github.com/gorilla/websocket
   version: e2e3d8414d0fbae04004f151979f4e27c6747fe7
 - name: github.com/inconshreveable/log15
-  version: 210d6fdc4d979ef6579778f1b6ed84571454abb4
+  version: 57a084d014d4150152b19e4e531399a7145d1540
   subpackages:
   - stack
   - term
@@ -31,9 +31,9 @@ imports:
 - name: github.com/sfreiberg/gotwilio
   version: f024bbefe80fdb7bcc8c43b6add05dae97744e0e
 - name: github.com/spf13/pflag
-  version: 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7
+  version: 1f296710f879815ad9e6d39d947c828c3e4b4c3d
 - name: github.com/syndtr/goleveldb
-  version: 917f41c560270110ceb73c5b38be2a9127387071
+  version: 93fc893f2dadb96ffde441c7546cc67ea290a3a8
   subpackages:
   - leveldb
   - leveldb/errors
@@ -75,7 +75,7 @@ imports:
 - name: github.com/tendermint/go-merkle
   version: 05042c6ab9cad51d12e4cecf717ae68e3b1409a8
 - name: github.com/tendermint/go-p2p
-  version: 10619248c665dee6b8f81455f7f27ab93d5ec366
+  version: 78c9d526c31d5ae06d5793b865d25a9407b635dc
   subpackages:
   - upnp
 - name: github.com/tendermint/go-rpc
@@ -85,18 +85,18 @@ imports:
   - types
   - server
 - name: github.com/tendermint/go-wire
-  version: 7a15dd53dfdecc0f967676edcd6b335c59344c83
+  version: 3b0adbc86ed8425eaed98516165b6788d9f4de7a
 - name: github.com/tendermint/log15
   version: 6e460758f10ef42a4724b8e4a82fee59aaa0e41d
 - name: github.com/tendermint/tmsp
-  version: 1dfc6950dddf47ff397e670a67d405d25da138ea
+  version: 82a411fca58b3b1e2ac8fc3a6784a17579012d68
   subpackages:
   - types
   - client
   - example/dummy
   - example/nil
 - name: golang.org/x/crypto
-  version: c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6
+  version: 3fbbcd23f1cb824e69491a5930cfeff09b12f4d2
   subpackages:
   - ripemd160
   - nacl/box
@@ -107,7 +107,7 @@ imports:
   - poly1305
   - openpgp/errors
 - name: golang.org/x/sys
-  version: afce3de5756ca82699128ebae46ac95ad59d6297
+  version: 9eef40adf05b951699605195b829612bd7b69952
   subpackages:
   - unix
 devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,18 @@
 hash: f3eab3f91c9d2c07574e8ec6f2f5d56bd946af1b061533a0baf9db8765f97a51
-updated: 2016-03-05T17:20:40.721925401-05:00
+updated: 2016-03-12T13:07:06.8783023-05:00
 imports:
 - name: github.com/gogo/protobuf
-  version: f4cc07910fc38f5b6b8d6e75d7457cf504157b6c
+  version: 5dbe2a9482b48e988cadb27b8e06448688fc2f25
   subpackages:
   - proto
 - name: github.com/golang/protobuf
-  version: c75fbf01dc6cb73649c4cd4326182c3e44aa9dbb
+  version: 0fd8c908d872c921af513ef5091964bbd2e0d904
   subpackages:
   - proto
 - name: github.com/golang/snappy
   version: 5f1c01d9f64b941dd9582c638279d046eda6ca31
 - name: github.com/gorilla/websocket
-  version: c45a635370221f34fea2d5163fd156fcb4e38e8a
+  version: a622679ebd7a3b813862379232f645f8e690e43f
 - name: github.com/inconshreveable/log15
   version: 210d6fdc4d979ef6579778f1b6ed84571454abb4
   subpackages:
@@ -33,7 +33,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7
 - name: github.com/syndtr/goleveldb
-  version: ad0d8b2ab58a55ed5c58073aa46451d5e1ca1280
+  version: 917f41c560270110ceb73c5b38be2a9127387071
   subpackages:
   - leveldb
   - leveldb/errors
@@ -61,7 +61,7 @@ imports:
 - name: github.com/tendermint/go-common
   version: 1559ae1ac90c88b1373ff114c409399c5a1cedac
 - name: github.com/tendermint/go-config
-  version: c077af2c1ecf584fb797fd1956758545b25d952b
+  version: c47b67203b070d8bea835a928d50cb739972c48a
 - name: github.com/tendermint/go-crypto
   version: 76ba23e4c0c627b8c66d1f97b6a18dc77f4f0297
 - name: github.com/tendermint/go-db
@@ -69,13 +69,13 @@ imports:
 - name: github.com/tendermint/go-events
   version: 7b75ca7bb55aa25e9ef765eb8c0b69486b227357
 - name: github.com/tendermint/go-logger
-  version: 4901b71ade2b834ca0f4c2ca69edb96792dca05b
+  version: 84391b36d3f5960e691c688d06b768708f0fa2f3
 - name: github.com/tendermint/go-logio
   version: 04f3aa0a3b38d06dcadefbafd988c8b85e499225
 - name: github.com/tendermint/go-merkle
-  version: 67b535ce9633be7df575dc3a7833fa2301020c25
+  version: 05042c6ab9cad51d12e4cecf717ae68e3b1409a8
 - name: github.com/tendermint/go-p2p
-  version: 7f6aad20fbad6ef1a132d5a8bebd18f3521fff1a
+  version: dda17bf1f666ea692fa5ead79a5d35ce06daea9c
   subpackages:
   - upnp
 - name: github.com/tendermint/go-rpc
@@ -85,18 +85,18 @@ imports:
   - types
   - server
 - name: github.com/tendermint/go-wire
-  version: 9acb294893c790427e2b9abf2877e69690cd5b6c
+  version: d9da1ad5fe838fbf89e64aabc68e5cf97007c02d
 - name: github.com/tendermint/log15
   version: 6e460758f10ef42a4724b8e4a82fee59aaa0e41d
 - name: github.com/tendermint/tmsp
-  version: 72540f9cac4840989cb05b147cc89be8cd91f043
+  version: 61c34ade0d480b8f23d6cdcd8fe7fea0dfec3279
   subpackages:
   - types
   - example/dummy
   - example/nil
   - client
 - name: golang.org/x/crypto
-  version: 5dc8cb4b8a8eb076cbb5a06bc3b8682c15bdbbd3
+  version: de93d05161db39bcbd84d3da2e54c4a18f37f0b1
   subpackages:
   - ripemd160
   - nacl/box

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: f3eab3f91c9d2c07574e8ec6f2f5d56bd946af1b061533a0baf9db8765f97a51
-updated: 2016-03-18T02:38:49.170573737-04:00
+updated: 2016-03-24T16:39:27.330201414-04:00
 imports:
 - name: github.com/gogo/protobuf
-  version: d5d4941acc4490628827091cafee2168f8c4bc67
+  version: 4168943e65a2802828518e95310aeeed6d84c4e5
   subpackages:
   - proto
 - name: github.com/golang/protobuf
-  version: 62e4364d64b32762febb61f2c88c0a29bc49a225
+  version: 8d92cf5fc15a4382f8964b08e1f42a75c0591aa3
   subpackages:
   - proto
 - name: github.com/golang/snappy
@@ -63,7 +63,7 @@ imports:
 - name: github.com/tendermint/go-config
   version: c47b67203b070d8bea835a928d50cb739972c48a
 - name: github.com/tendermint/go-crypto
-  version: 8152c18c355bb17e38292d9473e71d7998a72a43
+  version: 3f0d9b3f29f30e5d0cbc2cef04fa45e5a606c622
 - name: github.com/tendermint/go-db
   version: a7878f1d0d8eaebf15f87bc2df15f7a1088cce7f
 - name: github.com/tendermint/go-events
@@ -75,7 +75,7 @@ imports:
 - name: github.com/tendermint/go-merkle
   version: 05042c6ab9cad51d12e4cecf717ae68e3b1409a8
 - name: github.com/tendermint/go-p2p
-  version: 69c7ae5e3fd5fb9a3bf26d4b93f9ea8d6b921b44
+  version: 10619248c665dee6b8f81455f7f27ab93d5ec366
   subpackages:
   - upnp
 - name: github.com/tendermint/go-rpc
@@ -85,18 +85,18 @@ imports:
   - types
   - server
 - name: github.com/tendermint/go-wire
-  version: 39ed90899108c7bdd66482447f40a1e72f88a9da
+  version: 7a15dd53dfdecc0f967676edcd6b335c59344c83
 - name: github.com/tendermint/log15
   version: 6e460758f10ef42a4724b8e4a82fee59aaa0e41d
 - name: github.com/tendermint/tmsp
-  version: 29a6d511b48e5c2dc3feff0c57237062baa83f33
+  version: 1dfc6950dddf47ff397e670a67d405d25da138ea
   subpackages:
   - types
+  - client
   - example/dummy
   - example/nil
-  - client
 - name: golang.org/x/crypto
-  version: 6025851c7c2bf210daf74d22300c699b16541847
+  version: c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6
   subpackages:
   - ripemd160
   - nacl/box
@@ -107,7 +107,7 @@ imports:
   - poly1305
   - openpgp/errors
 - name: golang.org/x/sys
-  version: 9d4e42a20653790449273b3c85e67d6d8bae6e2e
+  version: afce3de5756ca82699128ebae46ac95ad59d6297
   subpackages:
   - unix
 devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,18 @@
 hash: f3eab3f91c9d2c07574e8ec6f2f5d56bd946af1b061533a0baf9db8765f97a51
-updated: 2016-03-12T13:07:06.8783023-05:00
+updated: 2016-03-18T02:38:49.170573737-04:00
 imports:
 - name: github.com/gogo/protobuf
-  version: 5dbe2a9482b48e988cadb27b8e06448688fc2f25
+  version: d5d4941acc4490628827091cafee2168f8c4bc67
   subpackages:
   - proto
 - name: github.com/golang/protobuf
-  version: 0fd8c908d872c921af513ef5091964bbd2e0d904
+  version: 62e4364d64b32762febb61f2c88c0a29bc49a225
   subpackages:
   - proto
 - name: github.com/golang/snappy
   version: 5f1c01d9f64b941dd9582c638279d046eda6ca31
 - name: github.com/gorilla/websocket
-  version: a622679ebd7a3b813862379232f645f8e690e43f
+  version: e2e3d8414d0fbae04004f151979f4e27c6747fe7
 - name: github.com/inconshreveable/log15
   version: 210d6fdc4d979ef6579778f1b6ed84571454abb4
   subpackages:
@@ -59,11 +59,11 @@ imports:
 - name: github.com/tendermint/go-clist
   version: 634527f5b60fd7c71ca811262493df2ad65ee0ca
 - name: github.com/tendermint/go-common
-  version: 1559ae1ac90c88b1373ff114c409399c5a1cedac
+  version: dcfa46af1341d03b80d32e4901019d1668b978b9
 - name: github.com/tendermint/go-config
   version: c47b67203b070d8bea835a928d50cb739972c48a
 - name: github.com/tendermint/go-crypto
-  version: 76ba23e4c0c627b8c66d1f97b6a18dc77f4f0297
+  version: 8152c18c355bb17e38292d9473e71d7998a72a43
 - name: github.com/tendermint/go-db
   version: a7878f1d0d8eaebf15f87bc2df15f7a1088cce7f
 - name: github.com/tendermint/go-events
@@ -75,7 +75,7 @@ imports:
 - name: github.com/tendermint/go-merkle
   version: 05042c6ab9cad51d12e4cecf717ae68e3b1409a8
 - name: github.com/tendermint/go-p2p
-  version: dda17bf1f666ea692fa5ead79a5d35ce06daea9c
+  version: 69c7ae5e3fd5fb9a3bf26d4b93f9ea8d6b921b44
   subpackages:
   - upnp
 - name: github.com/tendermint/go-rpc
@@ -85,27 +85,29 @@ imports:
   - types
   - server
 - name: github.com/tendermint/go-wire
-  version: d9da1ad5fe838fbf89e64aabc68e5cf97007c02d
+  version: 39ed90899108c7bdd66482447f40a1e72f88a9da
 - name: github.com/tendermint/log15
   version: 6e460758f10ef42a4724b8e4a82fee59aaa0e41d
 - name: github.com/tendermint/tmsp
-  version: 61c34ade0d480b8f23d6cdcd8fe7fea0dfec3279
+  version: 29a6d511b48e5c2dc3feff0c57237062baa83f33
   subpackages:
   - types
   - example/dummy
   - example/nil
   - client
 - name: golang.org/x/crypto
-  version: de93d05161db39bcbd84d3da2e54c4a18f37f0b1
+  version: 6025851c7c2bf210daf74d22300c699b16541847
   subpackages:
   - ripemd160
   - nacl/box
   - nacl/secretbox
+  - openpgp/armor
   - curve25519
   - salsa20/salsa
   - poly1305
+  - openpgp/errors
 - name: golang.org/x/sys
-  version: 7a56174f0086b32866ebd746a794417edbc678a1
+  version: 9d4e42a20653790449273b3c85e67d6d8bae6e2e
   subpackages:
   - unix
 devImports: []

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -157,6 +157,7 @@ func (mem *Mempool) resCbNormal(req *tmsp.Request, res *tmsp.Response) {
 			}
 			mem.txs.PushBack(memTx)
 		} else {
+			log.Info("Bad Transaction", "res", res)
 			// ignore bad transaction
 			// TODO: handle other retcodes
 		}
@@ -188,6 +189,7 @@ func (mem *Mempool) resCbRecheck(req *tmsp.Request, res *tmsp.Response) {
 		if mem.recheckCursor == nil {
 			// Done!
 			atomic.StoreInt32(&mem.rechecking, 0)
+			log.Info("Done rechecking txs")
 		}
 	default:
 		// ignore other messages
@@ -245,6 +247,7 @@ func (mem *Mempool) Update(height int, txs []types.Tx) {
 	goodTxs := mem.filterTxs(txsMap)
 	// Recheck mempool txs
 	if config.GetBool("mempool_recheck") {
+		log.Info("Recheck txs", "numtxs", len(goodTxs))
 		mem.recheckTxs(goodTxs)
 		// At this point, mem.txs are being rechecked.
 		// mem.recheckCursor re-scans mem.txs and possibly removes some txs.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -77,6 +77,10 @@ func NewMempool(proxyAppConn proxy.AppConn) *Mempool {
 	return mempool
 }
 
+func (mem *Mempool) Size() int {
+	return mem.txs.Len()
+}
+
 // Return the first element of mem.txs for peer goroutines to call .NextWait() on.
 // Blocks until txs has elements.
 func (mem *Mempool) TxsFrontWait() *clist.CElement {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -245,8 +245,11 @@ func (mem *Mempool) Update(height int, txs []types.Tx) {
 	mem.height = height
 	// Remove transactions that are already in txs.
 	goodTxs := mem.filterTxs(txsMap)
-	// Recheck mempool txs
-	if config.GetBool("mempool_recheck") {
+	// Recheck mempool txs if any txs were committed in the block
+	// NOTE/XXX: in some apps a tx could be invalidated due to EndBlock,
+	//	so we really still do need to recheck, but this is for debugging
+	if config.GetBool("mempool_recheck") &&
+		(config.GetBool("mempool_recheck_empty") || len(txs) > 0) {
 		log.Info("Recheck txs", "numtxs", len(goodTxs))
 		mem.recheckTxs(goodTxs)
 		// At this point, mem.txs are being rechecked.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -77,6 +77,14 @@ func NewMempool(proxyAppConn proxy.AppConn) *Mempool {
 	return mempool
 }
 
+func (mem *Mempool) Lock() {
+	mem.proxyMtx.Lock()
+}
+
+func (mem *Mempool) Unlock() {
+	mem.proxyMtx.Unlock()
+}
+
 func (mem *Mempool) Size() int {
 	return mem.txs.Len()
 }
@@ -219,9 +227,10 @@ func (mem *Mempool) collectTxs(maxTxs int) []types.Tx {
 // Tell mempool that these txs were committed.
 // Mempool will discard these txs.
 // NOTE: this should be called *after* block is committed by consensus.
+// NOTE: unsafe; Lock/Unlock must be managed by caller
 func (mem *Mempool) Update(height int, txs []types.Tx) {
-	mem.proxyMtx.Lock()
-	defer mem.proxyMtx.Unlock()
+	//	mem.proxyMtx.Lock()
+	//	defer mem.proxyMtx.Unlock()
 	mem.proxyAppConn.FlushSync() // To flush async resCb calls e.g. from CheckTx
 
 	// First, create a lookup map of txns in new txs.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -201,10 +201,12 @@ func (mem *Mempool) Reap(maxTxs int) []types.Tx {
 	return txs
 }
 
-// maxTxs: 0 means uncapped
+// maxTxs: 0 means uncapped, -1 means none
 func (mem *Mempool) collectTxs(maxTxs int) []types.Tx {
 	if maxTxs == 0 {
 		maxTxs = mem.txs.Len()
+	} else if maxTxs < 0 {
+		return []types.Tx{}
 	}
 	txs := make([]types.Tx, 0, MinInt(mem.txs.Len(), maxTxs))
 	for e := mem.txs.Front(); e != nil && len(txs) < maxTxs; e = e.Next() {

--- a/node/node.go
+++ b/node/node.go
@@ -224,6 +224,7 @@ func makeNodeInfo(sw *p2p.Switch, privKey crypto.PrivKeyEd25519) *p2p.NodeInfo {
 		Other: []string{
 			Fmt("wire_version=%v", wire.Version),
 			Fmt("p2p_version=%v", p2p.Version),
+			Fmt("consensus_version=%v", consensus.Version),
 			Fmt("rpc_version=%v/%v", rpc.Version, rpccore.Version),
 		},
 	}

--- a/rpc/core/dev.go
+++ b/rpc/core/dev.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"strconv"
+
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+)
+
+func UnsafeSetConfig(typ, key, value string) (*ctypes.ResultUnsafeSetConfig, error) {
+	switch typ {
+	case "string":
+		config.Set(key, value)
+	case "int":
+		val, err := strconv.Atoi(value)
+		if err != nil {
+			return nil, fmt.Errorf("non-integer value found. key:%s; value:%s; err:%v", key, value, err)
+		}
+		config.Set(key, val)
+	case "bool":
+		switch value {
+		case "true":
+			config.Set(key, true)
+		case "false":
+			config.Set(key, false)
+		default:
+			return nil, fmt.Errorf("bool value must be true or false. got %s", value)
+		}
+	default:
+		return nil, fmt.Errorf("Unknown type %s", typ)
+	}
+	return &ctypes.ResultUnsafeSetConfig{}, nil
+}
+
+var profFile *os.File
+
+func UnsafeStartCPUProfiler(filename string) (*ctypes.ResultUnsafeCPUProfiler, error) {
+	var err error
+	profFile, err = os.Create(filename)
+	if err != nil {
+		return nil, err
+	}
+	err = pprof.StartCPUProfile(profFile)
+	if err != nil {
+		return nil, err
+	}
+	return &ctypes.ResultUnsafeCPUProfiler{}, nil
+}
+
+func UnsafeStopCPUProfiler() (*ctypes.ResultUnsafeCPUProfiler, error) {
+	pprof.StopCPUProfile()
+	profFile.Close()
+	return &ctypes.ResultUnsafeCPUProfiler{}, nil
+}

--- a/rpc/core/dev.go
+++ b/rpc/core/dev.go
@@ -36,7 +36,7 @@ func UnsafeSetConfig(typ, key, value string) (*ctypes.ResultUnsafeSetConfig, err
 
 var profFile *os.File
 
-func UnsafeStartCPUProfiler(filename string) (*ctypes.ResultUnsafeCPUProfiler, error) {
+func UnsafeStartCPUProfiler(filename string) (*ctypes.ResultUnsafeProfile, error) {
 	var err error
 	profFile, err = os.Create(filename)
 	if err != nil {
@@ -46,11 +46,22 @@ func UnsafeStartCPUProfiler(filename string) (*ctypes.ResultUnsafeCPUProfiler, e
 	if err != nil {
 		return nil, err
 	}
-	return &ctypes.ResultUnsafeCPUProfiler{}, nil
+	return &ctypes.ResultUnsafeProfile{}, nil
 }
 
-func UnsafeStopCPUProfiler() (*ctypes.ResultUnsafeCPUProfiler, error) {
+func UnsafeStopCPUProfiler() (*ctypes.ResultUnsafeProfile, error) {
 	pprof.StopCPUProfile()
 	profFile.Close()
-	return &ctypes.ResultUnsafeCPUProfiler{}, nil
+	return &ctypes.ResultUnsafeProfile{}, nil
+}
+
+func UnsafeWriteHeapProfile(filename string) (*ctypes.ResultUnsafeProfile, error) {
+	memProfFile, err := os.Create(filename)
+	if err != nil {
+		return nil, err
+	}
+	pprof.WriteHeapProfile(memProfFile)
+	memProfFile.Close()
+
+	return &ctypes.ResultUnsafeProfile{}, nil
 }

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -39,3 +39,8 @@ func UnconfirmedTxs() (*ctypes.ResultUnconfirmedTxs, error) {
 	txs := mempoolReactor.Mempool.Reap(0)
 	return &ctypes.ResultUnconfirmedTxs{len(txs), txs}, nil
 }
+
+func NumUnconfirmedTxs() (*ctypes.ResultUnconfirmedTxs, error) {
+	txs := mempoolReactor.Mempool.Reap()
+	return &ctypes.ResultUnconfirmedTxs{len(txs), txs[:0]}, nil
+}

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -41,6 +41,5 @@ func UnconfirmedTxs() (*ctypes.ResultUnconfirmedTxs, error) {
 }
 
 func NumUnconfirmedTxs() (*ctypes.ResultUnconfirmedTxs, error) {
-	txs := mempoolReactor.Mempool.Reap()
-	return &ctypes.ResultUnconfirmedTxs{len(txs), txs[:0]}, nil
+	return &ctypes.ResultUnconfirmedTxs{N: mempoolReactor.Mempool.Size()}, nil
 }

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -22,6 +22,7 @@ var Routes = map[string]*rpc.RPCFunc{
 	"broadcast_tx_sync":    rpc.NewRPCFunc(BroadcastTxSyncResult, "tx"),
 	"broadcast_tx_async":   rpc.NewRPCFunc(BroadcastTxAsyncResult, "tx"),
 	"unconfirmed_txs":      rpc.NewRPCFunc(UnconfirmedTxsResult, ""),
+	"num_unconfirmed_txs":  rpc.NewRPCFunc(NumUnconfirmedTxsResult, ""),
 
 	"unsafe_set_config": rpc.NewRPCFunc(UnsafeSetConfigResult, "type,key,value"),
 }
@@ -108,6 +109,14 @@ func DumpConsensusStateResult() (ctypes.TMResult, error) {
 
 func UnconfirmedTxsResult() (ctypes.TMResult, error) {
 	if r, err := UnconfirmedTxs(); err != nil {
+		return nil, err
+	} else {
+		return r, nil
+	}
+}
+
+func NumUnconfirmedTxsResult() (ctypes.TMResult, error) {
+	if r, err := NumUnconfirmedTxs(); err != nil {
 		return nil, err
 	} else {
 		return r, nil

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -24,7 +24,9 @@ var Routes = map[string]*rpc.RPCFunc{
 	"unconfirmed_txs":      rpc.NewRPCFunc(UnconfirmedTxsResult, ""),
 	"num_unconfirmed_txs":  rpc.NewRPCFunc(NumUnconfirmedTxsResult, ""),
 
-	"unsafe_set_config": rpc.NewRPCFunc(UnsafeSetConfigResult, "type,key,value"),
+	"unsafe_set_config":         rpc.NewRPCFunc(UnsafeSetConfigResult, "type,key,value"),
+	"unsafe_start_cpu_profiler": rpc.NewRPCFunc(UnsafeStartCPUProfilerResult, "filename"),
+	"unsafe_stop_cpu_profiler":  rpc.NewRPCFunc(UnsafeStopCPUProfilerResult, ""),
 }
 
 func SubscribeResult(wsCtx rpctypes.WSRPCContext, event string) (ctypes.TMResult, error) {
@@ -141,6 +143,22 @@ func BroadcastTxAsyncResult(tx []byte) (ctypes.TMResult, error) {
 
 func UnsafeSetConfigResult(typ, key, value string) (ctypes.TMResult, error) {
 	if r, err := UnsafeSetConfig(typ, key, value); err != nil {
+		return nil, err
+	} else {
+		return r, nil
+	}
+}
+
+func UnsafeStartCPUProfilerResult(filename string) (ctypes.TMResult, error) {
+	if r, err := UnsafeStartCPUProfiler(filename); err != nil {
+		return nil, err
+	} else {
+		return r, nil
+	}
+}
+
+func UnsafeStopCPUProfilerResult() (ctypes.TMResult, error) {
+	if r, err := UnsafeStopCPUProfiler(); err != nil {
 		return nil, err
 	} else {
 		return r, nil

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -27,6 +27,7 @@ var Routes = map[string]*rpc.RPCFunc{
 	"unsafe_set_config":         rpc.NewRPCFunc(UnsafeSetConfigResult, "type,key,value"),
 	"unsafe_start_cpu_profiler": rpc.NewRPCFunc(UnsafeStartCPUProfilerResult, "filename"),
 	"unsafe_stop_cpu_profiler":  rpc.NewRPCFunc(UnsafeStopCPUProfilerResult, ""),
+	"unsafe_write_heap_profile": rpc.NewRPCFunc(UnsafeWriteHeapProfileResult, "filename"),
 }
 
 func SubscribeResult(wsCtx rpctypes.WSRPCContext, event string) (ctypes.TMResult, error) {
@@ -159,6 +160,14 @@ func UnsafeStartCPUProfilerResult(filename string) (ctypes.TMResult, error) {
 
 func UnsafeStopCPUProfilerResult() (ctypes.TMResult, error) {
 	if r, err := UnsafeStopCPUProfiler(); err != nil {
+		return nil, err
+	} else {
+		return r, nil
+	}
+}
+
+func UnsafeWriteHeapProfileResult(filename string) (ctypes.TMResult, error) {
+	if r, err := UnsafeWriteHeapProfile(filename); err != nil {
 		return nil, err
 	} else {
 		return r, nil

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -1,9 +1,6 @@
 package core
 
 import (
-	"fmt"
-	"strconv"
-
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -30,29 +27,4 @@ func Status() (*ctypes.ResultStatus, error) {
 		LatestAppHash:     latestAppHash,
 		LatestBlockHeight: latestHeight,
 		LatestBlockTime:   latestBlockTime}, nil
-}
-
-func UnsafeSetConfig(typ, key, value string) (*ctypes.ResultUnsafeSetConfig, error) {
-	switch typ {
-	case "string":
-		config.Set(key, value)
-	case "int":
-		val, err := strconv.Atoi(value)
-		if err != nil {
-			return nil, fmt.Errorf("non-integer value found. key:%s; value:%s; err:%v", key, value, err)
-		}
-		config.Set(key, val)
-	case "bool":
-		switch value {
-		case "true":
-			config.Set(key, true)
-		case "false":
-			config.Set(key, false)
-		default:
-			return nil, fmt.Errorf("bool value must be true or false. got %s", value)
-		}
-	default:
-		return nil, fmt.Errorf("Unknown type %s", typ)
-	}
-	return &ctypes.ResultUnsafeSetConfig{}, nil
 }

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -70,6 +70,8 @@ type ResultUnconfirmedTxs struct {
 
 type ResultUnsafeSetConfig struct{}
 
+type ResultUnsafeCPUProfiler struct{}
+
 type ResultSubscribe struct {
 }
 
@@ -109,7 +111,9 @@ const (
 	ResultTypeEvent       = byte(0x82)
 
 	// 0xa bytes for testing
-	ResultTypeUnsafeSetConfig = byte(0xa0)
+	ResultTypeUnsafeSetConfig        = byte(0xa0)
+	ResultTypeUnsafeStartCPUProfiler = byte(0xa1)
+	ResultTypeUnsafeStopCPUProfiler  = byte(0xa2)
 )
 
 type TMResult interface {
@@ -133,4 +137,6 @@ var _ = wire.RegisterInterface(
 	wire.ConcreteType{&ResultUnsubscribe{}, ResultTypeUnsubscribe},
 	wire.ConcreteType{&ResultEvent{}, ResultTypeEvent},
 	wire.ConcreteType{&ResultUnsafeSetConfig{}, ResultTypeUnsafeSetConfig},
+	wire.ConcreteType{&ResultUnsafeCPUProfiler{}, ResultTypeUnsafeStartCPUProfiler},
+	wire.ConcreteType{&ResultUnsafeCPUProfiler{}, ResultTypeUnsafeStopCPUProfiler},
 )

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -70,7 +70,7 @@ type ResultUnconfirmedTxs struct {
 
 type ResultUnsafeSetConfig struct{}
 
-type ResultUnsafeCPUProfiler struct{}
+type ResultUnsafeProfile struct{}
 
 type ResultSubscribe struct {
 }
@@ -114,6 +114,7 @@ const (
 	ResultTypeUnsafeSetConfig        = byte(0xa0)
 	ResultTypeUnsafeStartCPUProfiler = byte(0xa1)
 	ResultTypeUnsafeStopCPUProfiler  = byte(0xa2)
+	ResultTypeUnsafeWriteHeapProfile = byte(0xa3)
 )
 
 type TMResult interface {
@@ -137,6 +138,7 @@ var _ = wire.RegisterInterface(
 	wire.ConcreteType{&ResultUnsubscribe{}, ResultTypeUnsubscribe},
 	wire.ConcreteType{&ResultEvent{}, ResultTypeEvent},
 	wire.ConcreteType{&ResultUnsafeSetConfig{}, ResultTypeUnsafeSetConfig},
-	wire.ConcreteType{&ResultUnsafeCPUProfiler{}, ResultTypeUnsafeStartCPUProfiler},
-	wire.ConcreteType{&ResultUnsafeCPUProfiler{}, ResultTypeUnsafeStopCPUProfiler},
+	wire.ConcreteType{&ResultUnsafeProfile{}, ResultTypeUnsafeStartCPUProfiler},
+	wire.ConcreteType{&ResultUnsafeProfile{}, ResultTypeUnsafeStopCPUProfiler},
+	wire.ConcreteType{&ResultUnsafeProfile{}, ResultTypeUnsafeWriteHeapProfile},
 )

--- a/rpc/core/version.go
+++ b/rpc/core/version.go
@@ -2,4 +2,4 @@ package core
 
 // a single integer is sufficient here
 
-const Version = "2" // add DialSeeds; re-organize type bytes
+const Version = "3" // rpc routes for profiling, setting config

--- a/state/execution.go
+++ b/state/execution.go
@@ -94,20 +94,7 @@ func (s *State) execBlockOnProxyApp(evsw *events.EventSwitch, proxyAppConn proxy
 	// TODO: Do something with changedValidators
 	log.Info("TODO: Do something with changedValidators", changedValidators)
 
-	// Commit block, get hash back
-	res := proxyAppConn.CommitSync()
-	if res.IsErr() {
-		log.Warn("Error in proxyAppConn.CommitSync", "error", res)
-		return res
-	}
-	if res.Log != "" {
-		log.Debug("Commit.Log: " + res.Log)
-	}
 	log.Info(Fmt("ExecBlock got %v valid txs and %v invalid txs", validTxs, invalidTxs))
-
-	// Set the state's new AppHash
-	s.AppHash = res.Data
-
 	return nil
 }
 

--- a/types/block.go
+++ b/types/block.go
@@ -337,6 +337,7 @@ type Data struct {
 
 func (data *Data) Hash() []byte {
 	if config.GetBool("disable_data_hash") {
+		// we could use the part_set hash instead
 		data.hash = []byte{}
 		return data.hash
 	}

--- a/types/block.go
+++ b/types/block.go
@@ -336,6 +336,10 @@ type Data struct {
 }
 
 func (data *Data) Hash() []byte {
+	if config.GetBool("disable_data_hash") {
+		data.hash = []byte{}
+		return data.hash
+	}
 	if data.hash == nil {
 		txs := make([]interface{}, len(data.Txs))
 		for i, tx := range data.Txs {

--- a/types/block.go
+++ b/types/block.go
@@ -329,7 +329,7 @@ type Data struct {
 	// Txs that will be applied by state @ block.Height+1.
 	// NOTE: not all txs here are valid.  We're just agreeing on the order first.
 	// This means that block.AppHash does not include these txs.
-	Txs []Tx `json:"txs"`
+	Txs Txs `json:"txs"`
 
 	// Volatile
 	hash []byte
@@ -342,11 +342,7 @@ func (data *Data) Hash() []byte {
 		return data.hash
 	}
 	if data.hash == nil {
-		txs := make([]interface{}, len(data.Txs))
-		for i, tx := range data.Txs {
-			txs[i] = tx
-		}
-		data.hash = merkle.SimpleHashFromBinaries(txs) // NOTE: leaves are TxIDs.
+		data.hash = data.Txs.Hash() // NOTE: leaves of merkle tree are TxIDs
 	}
 	return data.hash
 }

--- a/types/events.go
+++ b/types/events.go
@@ -57,7 +57,11 @@ var _ = wire.RegisterInterface(
 // but some (an input to a call tx or a receive) are more exotic
 
 type EventDataNewBlock struct {
-	Block *Block `json:"block"`
+	// we drop block data but keep the form the same
+	Block *BlockHeader `json:"block"`
+}
+type BlockHeader struct {
+	Header *Header `json:"header"`
 }
 
 // All txs fire EventDataTx

--- a/types/events.go
+++ b/types/events.go
@@ -16,6 +16,7 @@ func EventStringDupeout() string { return "Dupeout" }
 func EventStringFork() string    { return "Fork" }
 
 func EventStringNewBlock() string         { return "NewBlock" }
+func EventStringNewBlockHeader() string   { return "NewBlockHeader" }
 func EventStringNewRound() string         { return "NewRound" }
 func EventStringNewRoundStep() string     { return "NewRoundStep" }
 func EventStringTimeoutPropose() string   { return "TimeoutPropose" }
@@ -36,9 +37,10 @@ type TMEventData interface {
 }
 
 const (
-	EventDataTypeNewBlock = byte(0x01)
-	EventDataTypeFork     = byte(0x02)
-	EventDataTypeTx       = byte(0x03)
+	EventDataTypeNewBlock       = byte(0x01)
+	EventDataTypeFork           = byte(0x02)
+	EventDataTypeTx             = byte(0x03)
+	EventDataTypeNewBlockHeader = byte(0x04)
 
 	EventDataTypeRoundState = byte(0x11)
 	EventDataTypeVote       = byte(0x12)
@@ -47,6 +49,7 @@ const (
 var _ = wire.RegisterInterface(
 	struct{ TMEventData }{},
 	wire.ConcreteType{EventDataNewBlock{}, EventDataTypeNewBlock},
+	wire.ConcreteType{EventDataNewBlockHeader{}, EventDataTypeNewBlockHeader},
 	// wire.ConcreteType{EventDataFork{}, EventDataTypeFork },
 	wire.ConcreteType{EventDataTx{}, EventDataTypeTx},
 	wire.ConcreteType{EventDataRoundState{}, EventDataTypeRoundState},
@@ -57,10 +60,11 @@ var _ = wire.RegisterInterface(
 // but some (an input to a call tx or a receive) are more exotic
 
 type EventDataNewBlock struct {
-	// we drop block data but keep the form the same
-	Block *BlockHeader `json:"block"`
+	Block *Block `json:"block"`
 }
-type BlockHeader struct {
+
+// light weight event for benchmarking
+type EventDataNewBlockHeader struct {
 	Header *Header `json:"header"`
 }
 
@@ -88,7 +92,8 @@ type EventDataVote struct {
 	Vote    *Vote
 }
 
-func (_ EventDataNewBlock) AssertIsTMEventData()   {}
-func (_ EventDataTx) AssertIsTMEventData()         {}
-func (_ EventDataRoundState) AssertIsTMEventData() {}
-func (_ EventDataVote) AssertIsTMEventData()       {}
+func (_ EventDataNewBlock) AssertIsTMEventData()       {}
+func (_ EventDataNewBlockHeader) AssertIsTMEventData() {}
+func (_ EventDataTx) AssertIsTMEventData()             {}
+func (_ EventDataRoundState) AssertIsTMEventData()     {}
+func (_ EventDataVote) AssertIsTMEventData()           {}

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -268,7 +268,7 @@ func (psr *PartSetReader) Read(p []byte) (n int, err error) {
 
 	psr.i += 1
 	if psr.i >= len(psr.parts) {
-		return 0, fmt.Errorf("Attempt to read from PartSet but no parts left")
+		return 0, io.EOF
 	}
 	psr.reader = bytes.NewReader(psr.parts[psr.i].Bytes)
 	return psr.Read(p)

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -188,7 +188,7 @@ func (ps *PartSet) Total() int {
 	return ps.total
 }
 
-func (ps *PartSet) AddPart(part *Part) (bool, error) {
+func (ps *PartSet) AddPart(part *Part, verify bool) (bool, error) {
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
 
@@ -203,9 +203,10 @@ func (ps *PartSet) AddPart(part *Part) (bool, error) {
 	}
 
 	// Check hash proof
-	// TODO: minor gains for not checking part sets we made
-	if !part.Proof.Verify(part.Index, ps.total, part.Hash(), ps.Hash()) {
-		return false, ErrPartSetInvalidProof
+	if verify {
+		if !part.Proof.Verify(part.Index, ps.total, part.Hash(), ps.Hash()) {
+			return false, ErrPartSetInvalidProof
+		}
 	}
 
 	// Add part

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	partSize = 4096 // 4KB
+	partSize = 65536 // 64KB ...  4096 // 4KB
 )
 
 var (
@@ -203,6 +203,7 @@ func (ps *PartSet) AddPart(part *Part) (bool, error) {
 	}
 
 	// Check hash proof
+	// TODO: minor gains for not checking part sets we made
 	if !part.Proof.Verify(part.Index, ps.total, part.Hash(), ps.Hash()) {
 		return false, ErrPartSetInvalidProof
 	}

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -30,7 +30,7 @@ func TestBasicPartSet(t *testing.T) {
 	for i := 0; i < partSet.Total(); i++ {
 		part := partSet.GetPart(i)
 		//t.Logf("\n%v", part)
-		added, err := partSet2.AddPart(part)
+		added, err := partSet2.AddPart(part, true)
 		if !added || err != nil {
 			t.Errorf("Failed to add part %v, error: %v", i, err)
 		}
@@ -70,7 +70,7 @@ func TestWrongProof(t *testing.T) {
 	// Test adding a part with wrong trail.
 	part := partSet.GetPart(0)
 	part.Proof.Aunts[0][0] += byte(0x01)
-	added, err := partSet2.AddPart(part)
+	added, err := partSet2.AddPart(part, true)
 	if added || err == nil {
 		t.Errorf("Expected to fail adding a part with bad trail.")
 	}
@@ -78,7 +78,7 @@ func TestWrongProof(t *testing.T) {
 	// Test adding a part with wrong bytes.
 	part = partSet.GetPart(1)
 	part.Bytes[0] += byte(0x01)
-	added, err = partSet2.AddPart(part)
+	added, err = partSet2.AddPart(part, true)
 	if added || err == nil {
 		t.Errorf("Expected to fail adding a part with bad bytes.")
 	}

--- a/types/tx.go
+++ b/types/tx.go
@@ -1,3 +1,24 @@
 package types
 
+import (
+	"github.com/tendermint/go-merkle"
+)
+
 type Tx []byte
+
+type Txs []Tx
+
+func (txs Txs) Hash() []byte {
+	// Recursive impl.
+	// Copied from go-merkle to avoid allocations
+	switch len(txs) {
+	case 0:
+		return nil
+	case 1:
+		return txs[0]
+	default:
+		left := Txs(txs[:(len(txs)+1)/2]).Hash()
+		right := Txs(txs[(len(txs)+1)/2:]).Hash()
+		return merkle.SimpleHashFromTwoHashes(left, right)
+	}
+}

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -128,22 +128,27 @@ func (voteSet *VoteSet) addVote(val *Validator, valIndex int, vote *Vote) (bool,
 		return false, 0, ErrVoteUnexpectedStep
 	}
 
-	// Check signature.
-	if !val.PubKey.VerifyBytes(SignBytes(config.GetString("chain_id"), vote), vote.Signature) {
-		// Bad signature.
-		return false, 0, ErrVoteInvalidSignature
-	}
-
 	// If vote already exists, return false.
 	if existingVote := voteSet.votes[valIndex]; existingVote != nil {
 		if bytes.Equal(existingVote.BlockHash, vote.BlockHash) {
 			return false, valIndex, nil
 		} else {
+			// Check signature.
+			if !val.PubKey.VerifyBytes(SignBytes(config.GetString("chain_id"), vote), vote.Signature) {
+				// Bad signature.
+				return false, 0, ErrVoteInvalidSignature
+			}
 			return false, valIndex, &ErrVoteConflictingSignature{
 				VoteA: existingVote,
 				VoteB: vote,
 			}
 		}
+	}
+
+	// Check signature.
+	if !val.PubKey.VerifyBytes(SignBytes(config.GetString("chain_id"), vote), vote.Signature) {
+		// Bad signature.
+		return false, 0, ErrVoteInvalidSignature
 	}
 
 	// Add vote.


### PR DESCRIPTION
Includes https://github.com/tendermint/tendermint/pull/205

Fixes bug where application maintains mempool state that resets after commit, causing new txs to be rejected before old txs get replayed against latest committed state. Commit and Update must be called atomically. Includes test.