### PR TITLE
Bft fix

### DIFF
--- a/config/tendermint/config.go
+++ b/config/tendermint/config.go
@@ -79,6 +79,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("timeout_precommit_delta", 500)
 	mapConfig.SetDefault("timeout_commit", 1000)
 	mapConfig.SetDefault("mempool_recheck", true)
+	mapConfig.SetDefault("mempool_recheck_empty", true)
 	mapConfig.SetDefault("mempool_broadcast", true)
 
 	return mapConfig

--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -97,6 +97,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("timeout_precommit_delta", 1)
 	mapConfig.SetDefault("timeout_commit", 1)
 	mapConfig.SetDefault("mempool_recheck", true)
+	mapConfig.SetDefault("mempool_recheck_empty", true)
 	mapConfig.SetDefault("mempool_broadcast", true)
 
 	return mapConfig

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -1,0 +1,110 @@
+package consensus
+
+import (
+	"encoding/binary"
+	//	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/tendermint/tendermint/config/tendermint_test"
+	"github.com/tendermint/tendermint/types"
+	tmsp "github.com/tendermint/tmsp/types"
+
+	. "github.com/tendermint/go-common"
+)
+
+func init() {
+	tendermint_test.ResetConfig("consensus_mempool_test")
+}
+
+func TestTxConcurrentWithCommit(t *testing.T) {
+
+	state, privVals := randGenesisState(1, false, 10)
+	cs := newConsensusState(state, privVals[0], NewCounterApplication())
+	height, round := cs.Height, cs.Round
+	newBlockCh := subscribeToEvent(cs.evsw, "tester", types.EventStringNewBlock(), 1)
+
+	appendTxsRange := func(start, end int) {
+		// Append some txs.
+		for i := start; i < end; i++ {
+			txBytes := make([]byte, 8)
+			binary.BigEndian.PutUint64(txBytes, uint64(i))
+			err := cs.mempool.CheckTx(txBytes, nil)
+			if err != nil {
+				t.Fatal("Error after CheckTx: %v", err)
+			}
+			//	time.Sleep(time.Microsecond * time.Duration(rand.Int63n(3000)))
+		}
+	}
+
+	NTxs := 10000
+	go appendTxsRange(0, NTxs)
+
+	startTestRound(cs, height, round)
+	ticker := time.NewTicker(time.Second * 5)
+	for nTxs := 0; nTxs < NTxs; {
+		select {
+		case b := <-newBlockCh:
+			nTxs += b.(types.EventDataNewBlock).Block.Header.NumTxs
+		case <-ticker.C:
+			t.Fatal("Timed out waiting to commit blocks with transactions")
+		}
+	}
+}
+
+// CounterApplication that maintains a mempool state and resets it upon commit
+type CounterApplication struct {
+	txCount        int
+	mempoolTxCount int
+}
+
+func NewCounterApplication() *CounterApplication {
+	return &CounterApplication{}
+}
+
+func (app *CounterApplication) Info() string {
+	return Fmt("txs:%v", app.txCount)
+}
+
+func (app *CounterApplication) SetOption(key string, value string) (log string) {
+	return ""
+}
+
+func (app *CounterApplication) AppendTx(tx []byte) tmsp.Result {
+	return runTx(tx, &app.txCount)
+}
+
+func (app *CounterApplication) CheckTx(tx []byte) tmsp.Result {
+	return runTx(tx, &app.mempoolTxCount)
+}
+
+func runTx(tx []byte, countPtr *int) tmsp.Result {
+	count := *countPtr
+	tx8 := make([]byte, 8)
+	copy(tx8[len(tx8)-len(tx):], tx)
+	txValue := binary.BigEndian.Uint64(tx8)
+	if txValue != uint64(count) {
+		return tmsp.Result{
+			Code: tmsp.CodeType_BadNonce,
+			Data: nil,
+			Log:  Fmt("Invalid nonce. Expected %v, got %v", count, txValue),
+		}
+	}
+	*countPtr += 1
+	return tmsp.OK
+}
+
+func (app *CounterApplication) Commit() tmsp.Result {
+	app.mempoolTxCount = app.txCount
+	if app.txCount == 0 {
+		return tmsp.OK
+	} else {
+		hash := make([]byte, 8)
+		binary.BigEndian.PutUint64(hash, uint64(app.txCount))
+		return tmsp.NewResultOK(hash, "")
+	}
+}
+
+func (app *CounterApplication) Query(query []byte) tmsp.Result {
+	return tmsp.NewResultOK(nil, Fmt("Query is not supported"))
+}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1258,6 +1258,9 @@ func (cs *ConsensusState) commitStateUpdateMempool(s *sm.State, block *types.Blo
 	cs.mempool.Lock()
 	defer cs.mempool.Unlock()
 
+	// flush out any CheckTx that have already started
+	cs.proxyAppConn.FlushSync()
+
 	// Commit block, get hash back
 	res := cs.proxyAppConn.CommitSync()
 	if res.IsErr() {

--- a/glide.lock
+++ b/glide.lock
@@ -1,20 +1,20 @@
 hash: f3eab3f91c9d2c07574e8ec6f2f5d56bd946af1b061533a0baf9db8765f97a51
-updated: 2016-03-24T16:39:27.330201414-04:00
+updated: 2016-04-11T19:42:00.993267284-04:00
 imports:
 - name: github.com/gogo/protobuf
-  version: 4168943e65a2802828518e95310aeeed6d84c4e5
+  version: 74b6e9deaff6ba6da1389ec97351d337f0d08b06
   subpackages:
   - proto
 - name: github.com/golang/protobuf
-  version: 8d92cf5fc15a4382f8964b08e1f42a75c0591aa3
+  version: dda510ac0fd43b39770f22ac6260eb91d377bce3
   subpackages:
   - proto
 - name: github.com/golang/snappy
-  version: 5f1c01d9f64b941dd9582c638279d046eda6ca31
+  version: ef80b33e873821cff33038ae16c444717218cdb1
 - name: github.com/gorilla/websocket
   version: e2e3d8414d0fbae04004f151979f4e27c6747fe7
 - name: github.com/inconshreveable/log15
-  version: 210d6fdc4d979ef6579778f1b6ed84571454abb4
+  version: 57a084d014d4150152b19e4e531399a7145d1540
   subpackages:
   - stack
   - term
@@ -31,9 +31,9 @@ imports:
 - name: github.com/sfreiberg/gotwilio
   version: f024bbefe80fdb7bcc8c43b6add05dae97744e0e
 - name: github.com/spf13/pflag
-  version: 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7
+  version: 1f296710f879815ad9e6d39d947c828c3e4b4c3d
 - name: github.com/syndtr/goleveldb
-  version: 917f41c560270110ceb73c5b38be2a9127387071
+  version: 93fc893f2dadb96ffde441c7546cc67ea290a3a8
   subpackages:
   - leveldb
   - leveldb/errors
@@ -75,7 +75,7 @@ imports:
 - name: github.com/tendermint/go-merkle
   version: 05042c6ab9cad51d12e4cecf717ae68e3b1409a8
 - name: github.com/tendermint/go-p2p
-  version: 10619248c665dee6b8f81455f7f27ab93d5ec366
+  version: 78c9d526c31d5ae06d5793b865d25a9407b635dc
   subpackages:
   - upnp
 - name: github.com/tendermint/go-rpc
@@ -85,18 +85,18 @@ imports:
   - types
   - server
 - name: github.com/tendermint/go-wire
-  version: 7a15dd53dfdecc0f967676edcd6b335c59344c83
+  version: 3b0adbc86ed8425eaed98516165b6788d9f4de7a
 - name: github.com/tendermint/log15
   version: 6e460758f10ef42a4724b8e4a82fee59aaa0e41d
 - name: github.com/tendermint/tmsp
-  version: 1dfc6950dddf47ff397e670a67d405d25da138ea
+  version: 82a411fca58b3b1e2ac8fc3a6784a17579012d68
   subpackages:
   - types
   - client
   - example/dummy
   - example/nil
 - name: golang.org/x/crypto
-  version: c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6
+  version: 3fbbcd23f1cb824e69491a5930cfeff09b12f4d2
   subpackages:
   - ripemd160
   - nacl/box
@@ -107,7 +107,7 @@ imports:
   - poly1305
   - openpgp/errors
 - name: golang.org/x/sys
-  version: afce3de5756ca82699128ebae46ac95ad59d6297
+  version: 9eef40adf05b951699605195b829612bd7b69952
   subpackages:
   - unix
 devImports: []

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -157,6 +157,7 @@ func (mem *Mempool) resCbNormal(req *tmsp.Request, res *tmsp.Response) {
 			}
 			mem.txs.PushBack(memTx)
 		} else {
+			log.Info("Bad Transaction", "res", res)
 			// ignore bad transaction
 			// TODO: handle other retcodes
 		}
@@ -188,6 +189,7 @@ func (mem *Mempool) resCbRecheck(req *tmsp.Request, res *tmsp.Response) {
 		if mem.recheckCursor == nil {
 			// Done!
 			atomic.StoreInt32(&mem.rechecking, 0)
+			log.Info("Done rechecking txs")
 		}
 	default:
 		// ignore other messages
@@ -245,6 +247,7 @@ func (mem *Mempool) Update(height int, txs []types.Tx) {
 	goodTxs := mem.filterTxs(txsMap)
 	// Recheck mempool txs
 	if config.GetBool("mempool_recheck") {
+		log.Info("Recheck txs", "numtxs", len(goodTxs))
 		mem.recheckTxs(goodTxs)
 		// At this point, mem.txs are being rechecked.
 		// mem.recheckCursor re-scans mem.txs and possibly removes some txs.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -245,8 +245,11 @@ func (mem *Mempool) Update(height int, txs []types.Tx) {
 	mem.height = height
 	// Remove transactions that are already in txs.
 	goodTxs := mem.filterTxs(txsMap)
-	// Recheck mempool txs
-	if config.GetBool("mempool_recheck") {
+	// Recheck mempool txs if any txs were committed in the block
+	// NOTE/XXX: in some apps a tx could be invalidated due to EndBlock,
+	//	so we really still do need to recheck, but this is for debugging
+	if config.GetBool("mempool_recheck") &&
+		(config.GetBool("mempool_recheck_empty") || len(txs) > 0) {
 		log.Info("Recheck txs", "numtxs", len(goodTxs))
 		mem.recheckTxs(goodTxs)
 		// At this point, mem.txs are being rechecked.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -77,6 +77,14 @@ func NewMempool(proxyAppConn proxy.AppConn) *Mempool {
 	return mempool
 }
 
+func (mem *Mempool) Lock() {
+	mem.proxyMtx.Lock()
+}
+
+func (mem *Mempool) Unlock() {
+	mem.proxyMtx.Unlock()
+}
+
 func (mem *Mempool) Size() int {
 	return mem.txs.Len()
 }
@@ -219,9 +227,10 @@ func (mem *Mempool) collectTxs(maxTxs int) []types.Tx {
 // Tell mempool that these txs were committed.
 // Mempool will discard these txs.
 // NOTE: this should be called *after* block is committed by consensus.
+// NOTE: unsafe; Lock/Unlock must be managed by caller
 func (mem *Mempool) Update(height int, txs []types.Tx) {
-	mem.proxyMtx.Lock()
-	defer mem.proxyMtx.Unlock()
+	//	mem.proxyMtx.Lock()
+	//	defer mem.proxyMtx.Unlock()
 	mem.proxyAppConn.FlushSync() // To flush async resCb calls e.g. from CheckTx
 
 	// First, create a lookup map of txns in new txs.

--- a/state/execution.go
+++ b/state/execution.go
@@ -94,20 +94,7 @@ func (s *State) execBlockOnProxyApp(evsw *events.EventSwitch, proxyAppConn proxy
 	// TODO: Do something with changedValidators
 	log.Info("TODO: Do something with changedValidators", changedValidators)
 
-	// Commit block, get hash back
-	res := proxyAppConn.CommitSync()
-	if res.IsErr() {
-		log.Warn("Error in proxyAppConn.CommitSync", "error", res)
-		return res
-	}
-	if res.Log != "" {
-		log.Debug("Commit.Log: " + res.Log)
-	}
 	log.Info(Fmt("ExecBlock got %v valid txs and %v invalid txs", validTxs, invalidTxs))
-
-	// Set the state's new AppHash
-	s.AppHash = res.Data
-
 	return nil
 }
 

--- a/types/block.go
+++ b/types/block.go
@@ -75,7 +75,6 @@ func (b *Block) FillHeader() {
 // Computes and returns the block hash.
 // If the block is incomplete, block hash is nil for safety.
 func (b *Block) Hash() []byte {
-	fmt.Println(">>", b.Data)
 	if b.Header == nil || b.Data == nil || b.LastCommit == nil {
 		return nil
 	}


### PR DESCRIPTION
Fix bug where consensus may halt if there is a byzantine voter. 
Since we only keep a bit array of our peer's votes, if a validator publishes two conflicting votes,
peers might only see one, while there's supposed to be consensus on the other. 
The fix here is naiive: if the peer has votes from all validators but isn't moving to the next round, send a random vote.
A more involved solution would be to track the actual block hash each peer has received votes for, and use that to send the missing vote in the gossip routine.

This bug was uncovered by implementing byzantine behaviour, as seen in https://github.com/tendermint/tendermint/commit/94e591ee1cdddd925838db91b42fa93fc9a701bc (branch https://github.com/tendermint/tendermint/tree/byzantine)