### PR TITLE
Protobuf + GRPC

### DIFF
--- a/cmd/tendermint/flags.go
+++ b/cmd/tendermint/flags.go
@@ -9,15 +9,16 @@ import (
 
 func parseFlags(config cfg.Config, args []string) {
 	var (
-		printHelp bool
-		moniker   string
-		nodeLaddr string
-		seeds     string
-		fastSync  bool
-		skipUPNP  bool
-		rpcLaddr  string
-		logLevel  string
-		proxyApp  string
+		printHelp     bool
+		moniker       string
+		nodeLaddr     string
+		seeds         string
+		fastSync      bool
+		skipUPNP      bool
+		rpcLaddr      string
+		logLevel      string
+		proxyApp      string
+		tmspTransport string
 	)
 
 	// Declare flags
@@ -32,6 +33,7 @@ func parseFlags(config cfg.Config, args []string) {
 	flags.StringVar(&logLevel, "log_level", config.GetString("log_level"), "Log level")
 	flags.StringVar(&proxyApp, "proxy_app", config.GetString("proxy_app"),
 		"Proxy app address, or 'nilapp' or 'dummy' for local testing.")
+	flags.StringVar(&tmspTransport, "tmsp", config.GetString("tmsp"), "Specify tmsp transport (socket | grpc)")
 	flags.Parse(args)
 	if printHelp {
 		flags.PrintDefaults()
@@ -47,4 +49,5 @@ func parseFlags(config cfg.Config, args []string) {
 	config.Set("rpc_laddr", rpcLaddr)
 	config.Set("log_level", logLevel)
 	config.Set("proxy_app", proxyApp)
+	config.Set("tmsp", tmspTransport)
 }

--- a/config/tendermint/config.go
+++ b/config/tendermint/config.go
@@ -53,6 +53,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetRequired("chain_id") // blows up if you try to use it before setting.
 	mapConfig.SetDefault("genesis_file", rootDir+"/genesis.json")
 	mapConfig.SetDefault("proxy_app", "tcp://127.0.0.1:46658")
+	mapConfig.SetDefault("tmsp", "socket")
 	mapConfig.SetDefault("moniker", "anonymous")
 	mapConfig.SetDefault("node_laddr", "0.0.0.0:46656")
 	mapConfig.SetDefault("seeds", "")

--- a/config/tendermint_test/config.go
+++ b/config/tendermint_test/config.go
@@ -68,6 +68,7 @@ func ResetConfig(localPath string) cfg.Config {
 	mapConfig.SetDefault("chain_id", "tendermint_test")
 	mapConfig.SetDefault("genesis_file", rootDir+"/genesis.json")
 	mapConfig.SetDefault("proxy_app", "dummy")
+	mapConfig.SetDefault("tmsp", "socket")
 	mapConfig.SetDefault("moniker", "anonymous")
 	mapConfig.SetDefault("node_laddr", "0.0.0.0:36656")
 	mapConfig.SetDefault("fast_sync", false)

--- a/proxy/remote_app_conn.go
+++ b/proxy/remote_app_conn.go
@@ -11,8 +11,8 @@ type remoteAppConn struct {
 	tmspcli.Client
 }
 
-func NewRemoteAppConn(addr string) (*remoteAppConn, error) {
-	client, err := tmspcli.NewClient(addr, false)
+func NewRemoteAppConn(addr, transport string) (*remoteAppConn, error) {
+	client, err := tmspcli.NewClient(addr, transport, false)
 	if err != nil {
 		return nil, err
 	}

--- a/proxy/remote_app_conn_test.go
+++ b/proxy/remote_app_conn_test.go
@@ -9,17 +9,19 @@ import (
 	"github.com/tendermint/tmsp/server"
 )
 
+var SOCKET = "socket"
+
 func TestEcho(t *testing.T) {
 	sockPath := Fmt("unix:///tmp/echo_%v.sock", RandStr(6))
 
 	// Start server
-	s, err := server.NewServer(sockPath, dummy.NewDummyApplication())
+	s, err := server.NewSocketServer(sockPath, dummy.NewDummyApplication())
 	if err != nil {
 		Exit(err.Error())
 	}
 	defer s.Stop()
 	// Start client
-	proxy, err := NewRemoteAppConn(sockPath)
+	proxy, err := NewRemoteAppConn(sockPath, SOCKET)
 	if err != nil {
 		Exit(err.Error())
 	} else {
@@ -36,13 +38,13 @@ func BenchmarkEcho(b *testing.B) {
 	b.StopTimer() // Initialize
 	sockPath := Fmt("unix:///tmp/echo_%v.sock", RandStr(6))
 	// Start server
-	s, err := server.NewServer(sockPath, dummy.NewDummyApplication())
+	s, err := server.NewSocketServer(sockPath, dummy.NewDummyApplication())
 	if err != nil {
 		Exit(err.Error())
 	}
 	defer s.Stop()
 	// Start client
-	proxy, err := NewRemoteAppConn(sockPath)
+	proxy, err := NewRemoteAppConn(sockPath, SOCKET)
 	if err != nil {
 		Exit(err.Error())
 	} else {
@@ -64,13 +66,13 @@ func BenchmarkEcho(b *testing.B) {
 func TestInfo(t *testing.T) {
 	sockPath := Fmt("unix:///tmp/echo_%v.sock", RandStr(6))
 	// Start server
-	s, err := server.NewServer(sockPath, dummy.NewDummyApplication())
+	s, err := server.NewSocketServer(sockPath, dummy.NewDummyApplication())
 	if err != nil {
 		Exit(err.Error())
 	}
 	defer s.Stop()
 	// Start client
-	proxy, err := NewRemoteAppConn(sockPath)
+	proxy, err := NewRemoteAppConn(sockPath, SOCKET)
 	if err != nil {
 		Exit(err.Error())
 	} else {

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -28,10 +28,11 @@ func BroadcastTxSync(tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 		return nil, fmt.Errorf("Error broadcasting transaction: %v", err)
 	}
 	res := <-resCh
+	r := res.GetCheckTx()
 	return &ctypes.ResultBroadcastTx{
-		Code: res.Code,
-		Data: res.Data,
-		Log:  res.Log,
+		Code: r.Code,
+		Data: r.Data,
+		Log:  r.Log,
 	}, nil
 }
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -61,16 +61,16 @@ func (s *State) execBlockOnProxyApp(evsw *events.EventSwitch, proxyAppConn proxy
 
 	// Execute transactions and get hash
 	proxyCb := func(req *tmsp.Request, res *tmsp.Response) {
-		switch res.Type {
-		case tmsp.MessageType_AppendTx:
+		switch r := res.Value.(type) {
+		case *tmsp.Response_AppendTx:
 			// TODO: make use of res.Log
 			// TODO: make use of this info
 			// Blocks may include invalid txs.
 			// reqAppendTx := req.(tmsp.RequestAppendTx)
-			if res.Code == tmsp.CodeType_OK {
+			if r.AppendTx.Code == tmsp.CodeType_OK {
 				validTxs += 1
 			} else {
-				log.Debug("Invalid tx", "code", res.Code, "log", res.Log)
+				log.Debug("Invalid tx", "code", r.AppendTx.Code, "log", r.AppendTx.Log)
 				invalidTxs += 1
 			}
 		}


### PR DESCRIPTION
- protobuf messages use oneof
- support for grpc (`tendermint node -tmsp=grpc`)

Complements https://github.com/tendermint/tmsp/pull/13