### PR TITLE
Fix issue with double-signing causing blockage

### DIFF
--- a/blockchain/reactor.go
+++ b/blockchain/reactor.go
@@ -223,8 +223,11 @@ FOR_LOOP:
 				firstParts := first.MakePartSet()
 				firstPartsHeader := firstParts.Header()
 				// Finally, verify the first block using the second's commit
+				// NOTE: we can probably make this more efficient, but note that calling
+				// first.Hash() doesn't verify the tx contents, so MakePartSet() is
+				// currently necessary.
 				err := bcR.state.Validators.VerifyCommit(
-					bcR.state.ChainID, first.Hash(), firstPartsHeader, first.Height, second.LastCommit)
+					bcR.state.ChainID, types.BlockID{first.Hash(), firstPartsHeader}, first.Height, second.LastCommit)
 				if err != nil {
 					log.Info("error in validation", "error", err)
 					bcR.pool.RedoRequest(first.Height)

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -71,7 +71,8 @@ func decideProposal(cs1 *ConsensusState, vs *validatorStub, height, round int) (
 	}
 
 	// Make proposal
-	proposal = types.NewProposal(height, round, blockParts.Header(), cs1.Votes.POLRound())
+	polRound, polBlockID := cs1.Votes.POLInfo()
+	proposal = types.NewProposal(height, round, blockParts.Header(), polRound, polBlockID)
 	if err := vs.SignProposal(config.GetString("chain_id"), proposal); err != nil {
 		panic(err)
 	}

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -45,8 +45,7 @@ func (vs *validatorStub) signVote(voteType byte, hash []byte, header types.PartS
 		Height:           vs.Height,
 		Round:            vs.Round,
 		Type:             voteType,
-		BlockHash:        hash,
-		BlockPartsHeader: header,
+		BlockID:          types.BlockID{hash, header},
 	}
 	err := vs.PrivValidator.SignVote(config.GetString("chain_id"), vote)
 	return vote, err
@@ -127,12 +126,12 @@ func validatePrevote(t *testing.T, cs *ConsensusState, round int, privVal *valid
 		panic("Failed to find prevote from validator")
 	}
 	if blockHash == nil {
-		if vote.BlockHash != nil {
-			panic(fmt.Sprintf("Expected prevote to be for nil, got %X", vote.BlockHash))
+		if vote.BlockID.Hash != nil {
+			panic(fmt.Sprintf("Expected prevote to be for nil, got %X", vote.BlockID.Hash))
 		}
 	} else {
-		if !bytes.Equal(vote.BlockHash, blockHash) {
-			panic(fmt.Sprintf("Expected prevote to be for %X, got %X", blockHash, vote.BlockHash))
+		if !bytes.Equal(vote.BlockID.Hash, blockHash) {
+			panic(fmt.Sprintf("Expected prevote to be for %X, got %X", blockHash, vote.BlockID.Hash))
 		}
 	}
 }
@@ -143,8 +142,8 @@ func validateLastPrecommit(t *testing.T, cs *ConsensusState, privVal *validatorS
 	if vote = votes.GetByAddress(privVal.Address); vote == nil {
 		panic("Failed to find precommit from validator")
 	}
-	if !bytes.Equal(vote.BlockHash, blockHash) {
-		panic(fmt.Sprintf("Expected precommit to be for %X, got %X", blockHash, vote.BlockHash))
+	if !bytes.Equal(vote.BlockID.Hash, blockHash) {
+		panic(fmt.Sprintf("Expected precommit to be for %X, got %X", blockHash, vote.BlockID.Hash))
 	}
 }
 
@@ -156,11 +155,11 @@ func validatePrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound in
 	}
 
 	if votedBlockHash == nil {
-		if vote.BlockHash != nil {
+		if vote.BlockID.Hash != nil {
 			panic("Expected precommit to be for nil")
 		}
 	} else {
-		if !bytes.Equal(vote.BlockHash, votedBlockHash) {
+		if !bytes.Equal(vote.BlockID.Hash, votedBlockHash) {
 			panic("Expected precommit to be for proposal block")
 		}
 	}

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -25,19 +25,23 @@ var config cfg.Config // NOTE: must be reset for each _test.go file
 var ensureTimeout = time.Duration(2)
 
 type validatorStub struct {
+	Index  int // Validator index. NOTE: we don't assume validator set changes.
 	Height int
 	Round  int
 	*types.PrivValidator
 }
 
-func NewValidatorStub(privValidator *types.PrivValidator) *validatorStub {
+func NewValidatorStub(privValidator *types.PrivValidator, valIndex int) *validatorStub {
 	return &validatorStub{
+		Index:         valIndex,
 		PrivValidator: privValidator,
 	}
 }
 
 func (vs *validatorStub) signVote(voteType byte, hash []byte, header types.PartSetHeader) (*types.Vote, error) {
 	vote := &types.Vote{
+		ValidatorIndex:   vs.Index,
+		ValidatorAddress: vs.PrivValidator.Address,
 		Height:           vs.Height,
 		Round:            vs.Round,
 		Type:             voteType,
@@ -48,7 +52,10 @@ func (vs *validatorStub) signVote(voteType byte, hash []byte, header types.PartS
 	return vote, err
 }
 
-// convenienve function for testing
+//-------------------------------------------------------------------------------
+// Convenience functions
+
+// Sign vote for type/hash/header
 func signVote(vs *validatorStub, voteType byte, hash []byte, header types.PartSetHeader) *types.Vote {
 	v, err := vs.signVote(voteType, hash, header)
 	if err != nil {
@@ -57,8 +64,8 @@ func signVote(vs *validatorStub, voteType byte, hash []byte, header types.PartSe
 	return v
 }
 
-// create proposal block from cs1 but sign it with vs
-func decideProposal(cs1 *ConsensusState, cs2 *validatorStub, height, round int) (proposal *types.Proposal, block *types.Block) {
+// Create proposal block from cs1 but sign it with vs
+func decideProposal(cs1 *ConsensusState, vs *validatorStub, height, round int) (proposal *types.Proposal, block *types.Block) {
 	block, blockParts := cs1.createProposalBlock()
 	if block == nil { // on error
 		panic("error creating proposal block")
@@ -66,90 +73,19 @@ func decideProposal(cs1 *ConsensusState, cs2 *validatorStub, height, round int) 
 
 	// Make proposal
 	proposal = types.NewProposal(height, round, blockParts.Header(), cs1.Votes.POLRound())
-	if err := cs2.SignProposal(config.GetString("chain_id"), proposal); err != nil {
+	if err := vs.SignProposal(config.GetString("chain_id"), proposal); err != nil {
 		panic(err)
 	}
 	return
 }
 
-//-------------------------------------------------------------------------------
-// utils
-
-/*
-func nilRound(t *testing.T, cs1 *ConsensusState, vss ...*validatorStub) {
-	cs1.mtx.Lock()
-	height, round := cs1.Height, cs1.Round
-	cs1.mtx.Unlock()
-
-	waitFor(t, cs1, height, round, RoundStepPrevote)
-
-	signAddVoteToFromMany(types.VoteTypePrevote, cs1, nil, cs1.ProposalBlockParts.Header(), vss...)
-
-	waitFor(t, cs1, height, round, RoundStepPrecommit)
-
-	signAddVoteToFromMany(types.VoteTypePrecommit, cs1, nil, cs1.ProposalBlockParts.Header(), vss...)
-
-	waitFor(t, cs1, height, round+1, RoundStepNewRound)
-}
-*/
-
-// NOTE: this switches the propser as far as `perspectiveOf` is concerned,
-// but for simplicity we return a block it generated.
-func changeProposer(t *testing.T, perspectiveOf *ConsensusState, newProposer *validatorStub) *types.Block {
-	_, v1 := perspectiveOf.Validators.GetByAddress(perspectiveOf.privValidator.Address)
-	v1.Accum, v1.VotingPower = 0, 0
-	if updated := perspectiveOf.Validators.Update(v1); !updated {
-		t.Fatal("failed to update validator")
-	}
-	_, v2 := perspectiveOf.Validators.GetByAddress(newProposer.Address)
-	v2.Accum, v2.VotingPower = 100, 100
-	if updated := perspectiveOf.Validators.Update(v2); !updated {
-		t.Fatal("failed to update validator")
-	}
-
-	// make the proposal
-	propBlock, _ := perspectiveOf.createProposalBlock()
-	if propBlock == nil {
-		t.Fatal("Failed to create proposal block with cs2")
-	}
-	return propBlock
-}
-
-func fixVotingPower(t *testing.T, cs1 *ConsensusState, addr2 []byte) {
-	_, v1 := cs1.Validators.GetByAddress(cs1.privValidator.Address)
-	_, v2 := cs1.Validators.GetByAddress(addr2)
-	v1.Accum, v1.VotingPower = v2.Accum, v2.VotingPower
-	if updated := cs1.Validators.Update(v1); !updated {
-		t.Fatal("failed to update validator")
+func addVotes(to *ConsensusState, votes ...*types.Vote) {
+	for _, vote := range votes {
+		to.peerMsgQueue <- msgInfo{Msg: &VoteMessage{vote}}
 	}
 }
 
-func addVoteToFromMany(to *ConsensusState, votes []*types.Vote, froms ...*validatorStub) {
-	if len(votes) != len(froms) {
-		panic("len(votes) and len(froms) must match")
-	}
-	for i, from := range froms {
-		addVoteToFrom(to, from, votes[i])
-	}
-}
-
-func addVoteToFrom(to *ConsensusState, from *validatorStub, vote *types.Vote) {
-	valIndex, _ := to.Validators.GetByAddress(from.PrivValidator.Address)
-
-	to.peerMsgQueue <- msgInfo{Msg: &VoteMessage{valIndex, vote}}
-	// added, err := to.TryAddVote(valIndex, vote, "")
-	/*
-		if _, ok := err.(*types.ErrVoteConflictingSignature); ok {
-			// let it fly
-		} else if !added {
-			fmt.Println("to, from, vote:", to.Height, from.Height, vote.Height)
-			panic(fmt.Sprintln("Failed to add vote. Err:", err))
-		} else if err != nil {
-			panic(fmt.Sprintln("Failed to add vote:", err))
-		}*/
-}
-
-func signVoteMany(voteType byte, hash []byte, header types.PartSetHeader, vss ...*validatorStub) []*types.Vote {
+func signVotes(voteType byte, hash []byte, header types.PartSetHeader, vss ...*validatorStub) []*types.Vote {
 	votes := make([]*types.Vote, len(vss))
 	for i, vs := range vss {
 		votes[i] = signVote(vs, voteType, hash, header)
@@ -157,18 +93,9 @@ func signVoteMany(voteType byte, hash []byte, header types.PartSetHeader, vss ..
 	return votes
 }
 
-// add vote to one cs from another
-func signAddVoteToFromMany(voteType byte, to *ConsensusState, hash []byte, header types.PartSetHeader, froms ...*validatorStub) {
-	for _, from := range froms {
-		vote := signVote(from, voteType, hash, header)
-		addVoteToFrom(to, from, vote)
-	}
-}
-
-func signAddVoteToFrom(voteType byte, to *ConsensusState, from *validatorStub, hash []byte, header types.PartSetHeader) *types.Vote {
-	vote := signVote(from, voteType, hash, header)
-	addVoteToFrom(to, from, vote)
-	return vote
+func signAddVotes(to *ConsensusState, voteType byte, hash []byte, header types.PartSetHeader, vss ...*validatorStub) {
+	votes := signVotes(voteType, hash, header, vss...)
+	addVotes(to, votes...)
 }
 
 func ensureNoNewStep(stepCh chan interface{}) {
@@ -180,39 +107,6 @@ func ensureNoNewStep(stepCh chan interface{}) {
 		panic("We should be stuck waiting for more votes, not moving to the next step")
 	}
 }
-
-/*
-func ensureNoNewStep(t *testing.T, cs *ConsensusState) {
-	timeout := time.NewTicker(ensureTimeout * time.Second)
-	select {
-	case <-timeout.C:
-		break
-	case <-cs.NewStepCh():
-		panic("We should be stuck waiting for more votes, not moving to the next step")
-	}
-}
-
-func ensureNewStep(t *testing.T, cs *ConsensusState) *RoundState {
-	timeout := time.NewTicker(ensureTimeout * time.Second)
-	select {
-	case <-timeout.C:
-		panic("We should have gone to the next step, not be stuck waiting")
-	case rs := <-cs.NewStepCh():
-		return rs
-	}
-}
-
-func waitFor(t *testing.T, cs *ConsensusState, height int, round int, step RoundStepType) {
-	for {
-		rs := ensureNewStep(t, cs)
-		if CompareHRS(rs.Height, rs.Round, rs.Step, height, round, step) < 0 {
-			continue
-		} else {
-			break
-		}
-	}
-}
-*/
 
 func incrementHeight(vss ...*validatorStub) {
 	for _, vs := range vss {
@@ -333,7 +227,7 @@ func randConsensusState(nValidators int) (*ConsensusState, []*validatorStub) {
 	cs := newConsensusState(state, privVals[0], counter.NewCounterApplication(true))
 
 	for i := 0; i < nValidators; i++ {
-		vss[i] = NewValidatorStub(privVals[i])
+		vss[i] = NewValidatorStub(privVals[i], i)
 	}
 	// since cs1 starts at 1
 	incrementHeight(vss[1:]...)
@@ -349,7 +243,7 @@ func subscribeToVoter(cs *ConsensusState, addr []byte) chan interface{} {
 			v := <-voteCh0
 			vote := v.(types.EventDataVote)
 			// we only fire for our own votes
-			if bytes.Equal(addr, vote.Address) {
+			if bytes.Equal(addr, vote.Vote.ValidatorAddress) {
 				voteCh <- v
 			}
 		}

--- a/consensus/height_vote_set.go
+++ b/consensus/height_vote_set.go
@@ -123,17 +123,19 @@ func (hvs *HeightVoteSet) Precommits(round int) *types.VoteSet {
 	return hvs.getVoteSet(round, types.VoteTypePrecommit)
 }
 
-// Last round that has +2/3 prevotes for a particular block or nil.
+// Last round and blockID that has +2/3 prevotes for a particular block or nil.
 // Returns -1 if no such round exists.
-func (hvs *HeightVoteSet) POLRound() int {
+func (hvs *HeightVoteSet) POLInfo() (polRound int, polBlockID types.BlockID) {
 	hvs.mtx.Lock()
 	defer hvs.mtx.Unlock()
 	for r := hvs.round; r >= 0; r-- {
-		if hvs.getVoteSet(r, types.VoteTypePrevote).HasTwoThirdsMajority() {
-			return r
+		rvs := hvs.getVoteSet(r, types.VoteTypePrevote)
+		polBlockID, ok := rvs.TwoThirdsMajority()
+		if ok {
+			return r, polBlockID
 		}
 	}
-	return -1
+	return -1, types.BlockID{}
 }
 
 func (hvs *HeightVoteSet) getVoteSet(round int, type_ byte) *types.VoteSet {

--- a/consensus/height_vote_set.go
+++ b/consensus/height_vote_set.go
@@ -93,6 +93,9 @@ func (hvs *HeightVoteSet) addRound(round int) {
 func (hvs *HeightVoteSet) AddVote(vote *types.Vote, peerKey string) (added bool, err error) {
 	hvs.mtx.Lock()
 	defer hvs.mtx.Unlock()
+	if !types.IsVoteTypeValid(vote.Type) {
+		return
+	}
 	voteSet := hvs.getVoteSet(vote.Round, vote.Type)
 	if voteSet == nil {
 		if _, ok := hvs.peerCatchupRounds[peerKey]; !ok {
@@ -183,4 +186,21 @@ func (hvs *HeightVoteSet) StringIndented(indent string) string {
 		hvs.height, hvs.round,
 		indent, strings.Join(vsStrings, "\n"+indent+"  "),
 		indent)
+}
+
+// If a peer claims that it has 2/3 majority for given blockKey, call this.
+// NOTE: if there are too many peers, or too much peer churn,
+// this can cause memory issues.
+// TODO: implement ability to remove peers too
+func (hvs *HeightVoteSet) SetPeerMaj23(round int, type_ byte, peerID string, blockID types.BlockID) {
+	hvs.mtx.Lock()
+	defer hvs.mtx.Unlock()
+	if !types.IsVoteTypeValid(type_) {
+		return
+	}
+	voteSet := hvs.getVoteSet(round, type_)
+	if voteSet == nil {
+		return
+	}
+	voteSet.SetPeerMaj23(peerID, blockID)
 }

--- a/consensus/height_vote_set.go
+++ b/consensus/height_vote_set.go
@@ -90,7 +90,7 @@ func (hvs *HeightVoteSet) addRound(round int) {
 
 // Duplicate votes return added=false, err=nil.
 // By convention, peerKey is "" if origin is self.
-func (hvs *HeightVoteSet) AddByIndex(valIndex int, vote *types.Vote, peerKey string) (added bool, address []byte, err error) {
+func (hvs *HeightVoteSet) AddVote(vote *types.Vote, peerKey string) (added bool, err error) {
 	hvs.mtx.Lock()
 	defer hvs.mtx.Unlock()
 	voteSet := hvs.getVoteSet(vote.Round, vote.Type)
@@ -107,7 +107,7 @@ func (hvs *HeightVoteSet) AddByIndex(valIndex int, vote *types.Vote, peerKey str
 			return
 		}
 	}
-	added, address, err = voteSet.AddByIndex(valIndex, vote)
+	added, err = voteSet.AddVote(vote)
 	return
 }
 

--- a/consensus/height_vote_set_test.go
+++ b/consensus/height_vote_set_test.go
@@ -16,31 +16,34 @@ func TestPeerCatchupRounds(t *testing.T) {
 
 	hvs := NewHeightVoteSet(config.GetString("chain_id"), 1, valSet)
 
-	vote999_0 := makeVoteHR(t, 1, 999, privVals[0])
-	added, _, err := hvs.AddByIndex(0, vote999_0, "peer1")
+	vote999_0 := makeVoteHR(t, 1, 999, privVals, 0)
+	added, err := hvs.AddVote(vote999_0, "peer1")
 	if !added || err != nil {
 		t.Error("Expected to successfully add vote from peer", added, err)
 	}
 
-	vote1000_0 := makeVoteHR(t, 1, 1000, privVals[0])
-	added, _, err = hvs.AddByIndex(0, vote1000_0, "peer1")
+	vote1000_0 := makeVoteHR(t, 1, 1000, privVals, 0)
+	added, err = hvs.AddVote(vote1000_0, "peer1")
 	if added {
 		t.Error("Expected to *not* add vote from peer, too many catchup rounds.")
 	}
 
-	added, _, err = hvs.AddByIndex(0, vote1000_0, "peer2")
+	added, err = hvs.AddVote(vote1000_0, "peer2")
 	if !added || err != nil {
 		t.Error("Expected to successfully add vote from another peer")
 	}
 
 }
 
-func makeVoteHR(t *testing.T, height, round int, privVal *types.PrivValidator) *types.Vote {
+func makeVoteHR(t *testing.T, height, round int, privVals []*types.PrivValidator, valIndex int) *types.Vote {
+	privVal := privVals[valIndex]
 	vote := &types.Vote{
-		Height:    height,
-		Round:     round,
-		Type:      types.VoteTypePrecommit,
-		BlockHash: []byte("fakehash"),
+		ValidatorAddress: privVal.Address,
+		ValidatorIndex:   valIndex,
+		Height:           height,
+		Round:            round,
+		Type:             types.VoteTypePrecommit,
+		BlockHash:        []byte("fakehash"),
 	}
 	chainID := config.GetString("chain_id")
 	err := privVal.SignVote(chainID, vote)

--- a/consensus/height_vote_set_test.go
+++ b/consensus/height_vote_set_test.go
@@ -43,7 +43,7 @@ func makeVoteHR(t *testing.T, height, round int, privVals []*types.PrivValidator
 		Height:           height,
 		Round:            round,
 		Type:             types.VoteTypePrecommit,
-		BlockHash:        []byte("fakehash"),
+		BlockID:          types.BlockID{[]byte("fakehash"), types.PartSetHeader{}},
 	}
 	chainID := config.GetString("chain_id")
 	err := privVal.SignVote(chainID, vote)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -637,7 +637,6 @@ OUTER_LOOP:
 
 		// Maybe send Height/CatchupCommitRound/CatchupCommit.
 		{
-			rs := conR.conS.GetRoundState()
 			prs := ps.GetRoundState()
 			if prs.CatchupCommitRound != -1 {
 				commit := conR.blockStore.LoadBlockCommit(prs.Height)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -391,13 +391,13 @@ OUTER_LOOP:
 
 		// Send Proposal && ProposalPOL BitArray?
 		if rs.Proposal != nil && !prs.Proposal {
-			// Proposal
+			// Proposal: share the proposal metadata with peer.
 			{
 				msg := &ProposalMessage{Proposal: rs.Proposal}
 				peer.Send(DataChannel, struct{ ConsensusMessage }{msg})
 				ps.SetHasProposal(rs.Proposal)
 			}
-			// ProposalPOL.
+			// ProposalPOL: lets peer know which POL votes we have so far.
 			// Peer must receive ProposalMessage first.
 			// rs.Proposal was validated, so rs.Proposal.POLRound <= rs.Round,
 			// so we definitely have rs.Votes.Prevotes(rs.Proposal.POLRound).

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -18,12 +18,14 @@ import (
 )
 
 const (
-	StateChannel = byte(0x20)
-	DataChannel  = byte(0x21)
-	VoteChannel  = byte(0x22)
+	StateChannel       = byte(0x20)
+	DataChannel        = byte(0x21)
+	VoteChannel        = byte(0x22)
+	VoteSetBitsChannel = byte(0x23)
 
-	peerGossipSleepDuration = 100 * time.Millisecond // Time to sleep if there's nothing to send.
-	maxConsensusMessageSize = 1048576                // 1MB; NOTE: keep in sync with types.PartSet sizes.
+	peerGossipSleepDuration     = 100 * time.Millisecond // Time to sleep if there's nothing to send.
+	peerQueryMaj23SleepDuration = 5 * time.Second        // Time to sleep after each VoteSetMaj23Message sent
+	maxConsensusMessageSize     = 1048576                // 1MB; NOTE: keep in sync with types.PartSet sizes.
 )
 
 //-----------------------------------------------------------------------------
@@ -102,6 +104,12 @@ func (conR *ConsensusReactor) GetChannels() []*p2p.ChannelDescriptor {
 			SendQueueCapacity:  100,
 			RecvBufferCapacity: 100 * 100,
 		},
+		&p2p.ChannelDescriptor{
+			ID:                 VoteSetBitsChannel,
+			Priority:           1,
+			SendQueueCapacity:  2,
+			RecvBufferCapacity: 1024,
+		},
 	}
 }
 
@@ -115,9 +123,11 @@ func (conR *ConsensusReactor) AddPeer(peer *p2p.Peer) {
 	peerState := NewPeerState(peer)
 	peer.Data.Set(types.PeerStateKey, peerState)
 
-	// Begin gossip routines for this peer.
+	// Begin routines for this peer.
 	go conR.gossipDataRoutine(peer, peerState)
 	go conR.gossipVotesRoutine(peer, peerState)
+	go conR.queryMaj23Routine(peer, peerState)
+	go conR.replyMaj23Routine(peer, peerState)
 
 	// Send our state to peer.
 	// If we're fast_syncing, broadcast a RoundStepMessage later upon SwitchToConsensus().
@@ -166,6 +176,15 @@ func (conR *ConsensusReactor) Receive(chID byte, src *p2p.Peer, msgBytes []byte)
 			ps.ApplyCommitStepMessage(msg)
 		case *HasVoteMessage:
 			ps.ApplyHasVoteMessage(msg)
+		case *VoteSetMaj23Message:
+			cs := conR.conS
+			cs.mtx.Lock()
+			height, votes := cs.Height, cs.Votes
+			cs.mtx.Unlock()
+			if height == msg.Height {
+				votes.SetPeerMaj23(msg.Round, msg.Type, ps.Peer.Key, msg.BlockID)
+			}
+			ps.ApplyVoteSetMaj23Message(msg)
 		default:
 			log.Warn(Fmt("Unknown message type %v", reflect.TypeOf(msg)))
 		}
@@ -209,6 +228,39 @@ func (conR *ConsensusReactor) Receive(chID byte, src *p2p.Peer, msgBytes []byte)
 			// don't punish (leave room for soft upgrades)
 			log.Warn(Fmt("Unknown message type %v", reflect.TypeOf(msg)))
 		}
+
+	case VoteSetBitsChannel:
+		if conR.fastSync {
+			log.Warn("Ignoring message received during fastSync", "msg", msg)
+			return
+		}
+		switch msg := msg.(type) {
+		case *VoteSetBitsMessage:
+			cs := conR.conS
+			cs.mtx.Lock()
+			height, votes := cs.Height, cs.Votes
+			cs.mtx.Unlock()
+
+			if height == msg.Height {
+				var ourVotes *BitArray
+				switch msg.Type {
+				case types.VoteTypePrevote:
+					ourVotes = votes.Prevotes(msg.Round).BitArrayByBlockID(msg.BlockID)
+				case types.VoteTypePrecommit:
+					ourVotes = votes.Precommits(msg.Round).BitArrayByBlockID(msg.BlockID)
+				default:
+					log.Warn("Bad VoteSetBitsMessage field Type")
+					return
+				}
+				ps.ApplyVoteSetBitsMessage(msg, ourVotes)
+			} else {
+				ps.ApplyVoteSetBitsMessage(msg, nil)
+			}
+		default:
+			// don't punish (leave room for soft upgrades)
+			log.Warn(Fmt("Unknown message type %v", reflect.TypeOf(msg)))
+		}
+
 	default:
 		log.Warn(Fmt("Unknown chId %X", chID))
 	}
@@ -516,6 +568,131 @@ OUTER_LOOP:
 	}
 }
 
+func (conR *ConsensusReactor) queryMaj23Routine(peer *p2p.Peer, ps *PeerState) {
+	log := log.New("peer", peer)
+
+OUTER_LOOP:
+	for {
+		// Manage disconnects from self or peer.
+		if !peer.IsRunning() || !conR.IsRunning() {
+			log.Notice(Fmt("Stopping queryMaj23Routine for %v.", peer))
+			return
+		}
+
+		// Maybe send Height/Round/Prevotes
+		{
+			rs := conR.conS.GetRoundState()
+			prs := ps.GetRoundState()
+			if rs.Height == prs.Height {
+				if maj23, ok := rs.Votes.Prevotes(prs.Round).TwoThirdsMajority(); ok {
+					peer.TrySend(DataChannel, struct{ ConsensusMessage }{&VoteSetMaj23Message{
+						Height:  prs.Height,
+						Round:   prs.Round,
+						Type:    types.VoteTypePrevote,
+						BlockID: maj23,
+					}})
+					time.Sleep(peerQueryMaj23SleepDuration)
+					rs = conR.conS.GetRoundState()
+					prs = ps.GetRoundState()
+				}
+			}
+		}
+
+		// Maybe send Height/Round/Precommits
+		{
+			rs := conR.conS.GetRoundState()
+			prs := ps.GetRoundState()
+			if rs.Height == prs.Height {
+				if maj23, ok := rs.Votes.Precommits(prs.Round).TwoThirdsMajority(); ok {
+					peer.TrySend(DataChannel, struct{ ConsensusMessage }{&VoteSetMaj23Message{
+						Height:  prs.Height,
+						Round:   prs.Round,
+						Type:    types.VoteTypePrecommit,
+						BlockID: maj23,
+					}})
+					time.Sleep(peerQueryMaj23SleepDuration)
+				}
+			}
+		}
+
+		// Maybe send Height/Round/ProposalPOL
+		{
+			rs := conR.conS.GetRoundState()
+			prs := ps.GetRoundState()
+			if rs.Height == prs.Height {
+				if maj23, ok := rs.Votes.Prevotes(prs.ProposalPOLRound).TwoThirdsMajority(); ok {
+					peer.TrySend(DataChannel, struct{ ConsensusMessage }{&VoteSetMaj23Message{
+						Height:  prs.Height,
+						Round:   prs.ProposalPOLRound,
+						Type:    types.VoteTypePrevote,
+						BlockID: maj23,
+					}})
+					time.Sleep(peerQueryMaj23SleepDuration)
+				}
+			}
+		}
+
+		// Little point sending LastCommitRound/LastCommit,
+		// These are fleeting and non-blocking.
+
+		// Maybe send Height/CatchupCommitRound/CatchupCommit.
+		{
+			rs := conR.conS.GetRoundState()
+			prs := ps.GetRoundState()
+			if prs.CatchupCommitRound != -1 {
+				commit := conR.blockStore.LoadBlockCommit(prs.Height)
+				peer.TrySend(DataChannel, struct{ ConsensusMessage }{&VoteSetMaj23Message{
+					Height:  prs.Height,
+					Round:   commit.Round(),
+					Type:    types.VoteTypePrecommit,
+					BlockID: commit.BlockID,
+				}})
+				time.Sleep(peerQueryMaj23SleepDuration)
+			}
+		}
+
+		continue OUTER_LOOP
+	}
+}
+
+func (conR *ConsensusReactor) replyMaj23Routine(peer *p2p.Peer, ps *PeerState) {
+	log := log.New("peer", peer)
+
+OUTER_LOOP:
+	for {
+		// Manage disconnects from self or peer.
+		if !peer.IsRunning() || !conR.IsRunning() {
+			log.Notice(Fmt("Stopping replyMaj23Routine for %v.", peer))
+			return
+		}
+		rs := conR.conS.GetRoundState()
+
+		// Process a VoteSetMaj23Message
+		msg := <-ps.Maj23Queue
+		if rs.Height == msg.Height {
+			var ourVotes *BitArray
+			switch msg.Type {
+			case types.VoteTypePrevote:
+				ourVotes = rs.Votes.Prevotes(msg.Round).BitArrayByBlockID(msg.BlockID)
+			case types.VoteTypePrecommit:
+				ourVotes = rs.Votes.Precommits(msg.Round).BitArrayByBlockID(msg.BlockID)
+			default:
+				log.Warn("Bad VoteSetBitsMessage field Type")
+				return
+			}
+			peer.TrySend(VoteSetBitsChannel, struct{ ConsensusMessage }{&VoteSetBitsMessage{
+				Height:  msg.Height,
+				Round:   msg.Round,
+				Type:    msg.Type,
+				BlockID: msg.BlockID,
+				Votes:   ourVotes,
+			}})
+		}
+
+		continue OUTER_LOOP
+	}
+}
+
 //-----------------------------------------------------------------------------
 
 // Read only when returned by PeerState.GetRoundState().
@@ -549,6 +726,7 @@ type PeerState struct {
 
 	mtx sync.Mutex
 	PeerRoundState
+	Maj23Queue chan *VoteSetMaj23Message
 }
 
 func NewPeerState(peer *p2p.Peer) *PeerState {
@@ -560,6 +738,7 @@ func NewPeerState(peer *p2p.Peer) *PeerState {
 			LastCommitRound:    -1,
 			CatchupCommitRound: -1,
 		},
+		Maj23Queue: make(chan *VoteSetMaj23Message, 2),
 	}
 }
 
@@ -650,6 +829,10 @@ func (ps *PeerState) PickVoteToSend(votes types.VoteSetReader) (vote *types.Vote
 }
 
 func (ps *PeerState) getVoteBitArray(height, round int, type_ byte) *BitArray {
+	if type_ != types.VoteTypePrevote && type_ != types.VoteTypePrecommit {
+		PanicSanity("Invalid vote type")
+	}
+
 	if ps.Height == height {
 		if ps.Round == round {
 			switch type_ {
@@ -657,8 +840,6 @@ func (ps *PeerState) getVoteBitArray(height, round int, type_ byte) *BitArray {
 				return ps.Prevotes
 			case types.VoteTypePrecommit:
 				return ps.Precommits
-			default:
-				PanicSanity(Fmt("Unexpected vote type %X", type_))
 			}
 		}
 		if ps.CatchupCommitRound == round {
@@ -667,8 +848,14 @@ func (ps *PeerState) getVoteBitArray(height, round int, type_ byte) *BitArray {
 				return nil
 			case types.VoteTypePrecommit:
 				return ps.CatchupCommit
-			default:
-				PanicSanity(Fmt("Unexpected vote type %X", type_))
+			}
+		}
+		if ps.ProposalPOLRound == round {
+			switch type_ {
+			case types.VoteTypePrevote:
+				return ps.ProposalPOL
+			case types.VoteTypePrecommit:
+				return nil
 			}
 		}
 		return nil
@@ -680,8 +867,6 @@ func (ps *PeerState) getVoteBitArray(height, round int, type_ byte) *BitArray {
 				return nil
 			case types.VoteTypePrecommit:
 				return ps.LastCommit
-			default:
-				PanicSanity(Fmt("Unexpected vote type %X", type_))
 			}
 		}
 		return nil
@@ -750,47 +935,10 @@ func (ps *PeerState) SetHasVote(vote *types.Vote) {
 
 func (ps *PeerState) setHasVote(height int, round int, type_ byte, index int) {
 	log := log.New("peer", ps.Peer, "peerRound", ps.Round, "height", height, "round", round)
-	if type_ != types.VoteTypePrevote && type_ != types.VoteTypePrecommit {
-		PanicSanity("Invalid vote type")
-	}
+	log.Info("setHasVote(LastCommit)", "lastCommit", ps.LastCommit, "index", index)
 
-	if ps.Height == height {
-		if ps.Round == round {
-			switch type_ {
-			case types.VoteTypePrevote:
-				ps.Prevotes.SetIndex(index, true)
-				log.Info("SetHasVote(round-match)", "prevotes", ps.Prevotes, "index", index)
-			case types.VoteTypePrecommit:
-				ps.Precommits.SetIndex(index, true)
-				log.Info("SetHasVote(round-match)", "precommits", ps.Precommits, "index", index)
-			}
-		} else if ps.CatchupCommitRound == round {
-			switch type_ {
-			case types.VoteTypePrevote:
-			case types.VoteTypePrecommit:
-				ps.CatchupCommit.SetIndex(index, true)
-				log.Info("SetHasVote(CatchupCommit)", "precommits", ps.Precommits, "index", index)
-			}
-		} else if ps.ProposalPOLRound == round {
-			switch type_ {
-			case types.VoteTypePrevote:
-				ps.ProposalPOL.SetIndex(index, true)
-				log.Info("SetHasVote(ProposalPOL)", "prevotes", ps.Prevotes, "index", index)
-			case types.VoteTypePrecommit:
-			}
-		}
-	} else if ps.Height == height+1 {
-		if ps.LastCommitRound == round {
-			switch type_ {
-			case types.VoteTypePrevote:
-			case types.VoteTypePrecommit:
-				ps.LastCommit.SetIndex(index, true)
-				log.Info("setHasVote(LastCommit)", "lastCommit", ps.LastCommit, "index", index)
-			}
-		}
-	} else {
-		// Does not apply.
-	}
+	// NOTE: some may be nil BitArrays -> no side effects.
+	ps.getVoteBitArray(height, round, type_).SetIndex(index, true)
 }
 
 func (ps *PeerState) ApplyNewRoundStepMessage(msg *NewRoundStepMessage) {
@@ -858,17 +1006,6 @@ func (ps *PeerState) ApplyCommitStepMessage(msg *CommitStepMessage) {
 	ps.ProposalBlockParts = msg.BlockParts
 }
 
-func (ps *PeerState) ApplyHasVoteMessage(msg *HasVoteMessage) {
-	ps.mtx.Lock()
-	defer ps.mtx.Unlock()
-
-	if ps.Height != msg.Height {
-		return
-	}
-
-	ps.setHasVote(msg.Height, msg.Round, msg.Type, msg.Index)
-}
-
 func (ps *PeerState) ApplyProposalPOLMessage(msg *ProposalPOLMessage) {
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
@@ -885,6 +1022,53 @@ func (ps *PeerState) ApplyProposalPOLMessage(msg *ProposalPOLMessage) {
 	ps.ProposalPOL = msg.ProposalPOL
 }
 
+func (ps *PeerState) ApplyHasVoteMessage(msg *HasVoteMessage) {
+	ps.mtx.Lock()
+	defer ps.mtx.Unlock()
+
+	if ps.Height != msg.Height {
+		return
+	}
+
+	ps.setHasVote(msg.Height, msg.Round, msg.Type, msg.Index)
+}
+
+// When a peer claims to have a maj23 for some BlockID at H,R,S,
+// we will try to respond with a VoteSetBitsMessage showing which
+// bits we already have (and which we don't yet have),
+// but that happens in another goroutine.
+func (ps *PeerState) ApplyVoteSetMaj23Message(msg *VoteSetMaj23Message) {
+	// ps.mtx.Lock()
+	// defer ps.mtx.Unlock()
+
+	select {
+	case ps.Maj23Queue <- msg:
+	default:
+		// Just ignore if we're already processing messages.
+	}
+}
+
+// The peer has responded with a bitarray of votes that it has
+// of the corresponding BlockID.
+// ourVotes: BitArray of votes we have for msg.BlockID
+// NOTE: if ourVotes is nil (e.g. msg.Height < rs.Height),
+// we conservatively overwrite ps's votes w/ msg.Votes.
+func (ps *PeerState) ApplyVoteSetBitsMessage(msg *VoteSetBitsMessage, ourVotes *BitArray) {
+	ps.mtx.Lock()
+	defer ps.mtx.Unlock()
+
+	votes := ps.getVoteBitArray(msg.Height, msg.Round, msg.Type)
+	if votes != nil {
+		if ourVotes == nil {
+			votes.Update(msg.Votes)
+		} else {
+			otherVotes := votes.Sub(ourVotes)
+			hasVotes := otherVotes.Or(msg.Votes)
+			votes.Update(hasVotes)
+		}
+	}
+}
+
 //-----------------------------------------------------------------------------
 // Messages
 
@@ -896,6 +1080,8 @@ const (
 	msgTypeBlockPart    = byte(0x13) // both block & POL
 	msgTypeVote         = byte(0x14)
 	msgTypeHasVote      = byte(0x15)
+	msgTypeVoteSetMaj23 = byte(0x16)
+	msgTypeVoteSetBits  = byte(0x17)
 )
 
 type ConsensusMessage interface{}
@@ -909,6 +1095,8 @@ var _ = wire.RegisterInterface(
 	wire.ConcreteType{&BlockPartMessage{}, msgTypeBlockPart},
 	wire.ConcreteType{&VoteMessage{}, msgTypeVote},
 	wire.ConcreteType{&HasVoteMessage{}, msgTypeHasVote},
+	wire.ConcreteType{&VoteSetMaj23Message{}, msgTypeVoteSetMaj23},
+	wire.ConcreteType{&VoteSetBitsMessage{}, msgTypeVoteSetBits},
 )
 
 // TODO: check for unnecessary extra bytes at the end.
@@ -1003,4 +1191,31 @@ type HasVoteMessage struct {
 
 func (m *HasVoteMessage) String() string {
 	return fmt.Sprintf("[HasVote VI:%v V:{%v/%02d/%v} VI:%v]", m.Index, m.Height, m.Round, m.Type, m.Index)
+}
+
+//-------------------------------------
+
+type VoteSetMaj23Message struct {
+	Height  int
+	Round   int
+	Type    byte
+	BlockID types.BlockID
+}
+
+func (m *VoteSetMaj23Message) String() string {
+	return fmt.Sprintf("[VSM23 %v/%02d/%v %v]", m.Height, m.Round, m.Type, m.BlockID)
+}
+
+//-------------------------------------
+
+type VoteSetBitsMessage struct {
+	Height  int
+	Round   int
+	Type    byte
+	BlockID types.BlockID
+	Votes   *BitArray
+}
+
+func (m *VoteSetBitsMessage) String() string {
+	return fmt.Sprintf("[VSB %v/%02d/%v %v %v]", m.Height, m.Round, m.Type, m.BlockID, m.Votes)
 }

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -201,7 +201,7 @@ func (conR *ConsensusReactor) Receive(chID byte, src *p2p.Peer, msgBytes []byte)
 			cs.mtx.Unlock()
 			ps.EnsureVoteBitArrays(height, valSize)
 			ps.EnsureVoteBitArrays(height-1, lastCommitSize)
-			ps.SetHasVote(msg.Vote, msg.ValidatorIndex)
+			ps.SetHasVote(msg.Vote)
 
 			conR.conS.peerMsgQueue <- msgInfo{msg, src.Key}
 
@@ -242,7 +242,7 @@ func (conR *ConsensusReactor) registerEventCallbacks() {
 
 	conR.evsw.AddListenerForEvent("conR", types.EventStringVote(), func(data events.EventData) {
 		edv := data.(types.EventDataVote)
-		conR.broadcastHasVoteMessage(edv.Vote, edv.Index)
+		conR.broadcastHasVoteMessage(edv.Vote)
 	})
 }
 
@@ -258,12 +258,12 @@ func (conR *ConsensusReactor) broadcastNewRoundStep(rs *RoundState) {
 }
 
 // Broadcasts HasVoteMessage to peers that care.
-func (conR *ConsensusReactor) broadcastHasVoteMessage(vote *types.Vote, index int) {
+func (conR *ConsensusReactor) broadcastHasVoteMessage(vote *types.Vote) {
 	msg := &HasVoteMessage{
 		Height: vote.Height,
 		Round:  vote.Round,
 		Type:   vote.Type,
-		Index:  index,
+		Index:  vote.ValidatorIndex,
 	}
 	conR.Switch.Broadcast(StateChannel, struct{ ConsensusMessage }{msg})
 	/*
@@ -613,8 +613,8 @@ func (ps *PeerState) SetHasProposalBlockPart(height int, round int, index int) {
 // Convenience function to send vote to peer.
 // Returns true if vote was sent.
 func (ps *PeerState) PickSendVote(votes types.VoteSetReader) (ok bool) {
-	if index, vote, ok := ps.PickVoteToSend(votes); ok {
-		msg := &VoteMessage{index, vote}
+	if vote, ok := ps.PickVoteToSend(votes); ok {
+		msg := &VoteMessage{vote}
 		ps.Peer.Send(VoteChannel, struct{ ConsensusMessage }{msg})
 		return true
 	}
@@ -622,12 +622,12 @@ func (ps *PeerState) PickSendVote(votes types.VoteSetReader) (ok bool) {
 }
 
 // votes: Must be the correct Size() for the Height().
-func (ps *PeerState) PickVoteToSend(votes types.VoteSetReader) (index int, vote *types.Vote, ok bool) {
+func (ps *PeerState) PickVoteToSend(votes types.VoteSetReader) (vote *types.Vote, ok bool) {
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
 
 	if votes.Size() == 0 {
-		return 0, nil, false
+		return nil, false
 	}
 
 	height, round, type_, size := votes.Height(), votes.Round(), votes.Type(), votes.Size()
@@ -640,13 +640,13 @@ func (ps *PeerState) PickVoteToSend(votes types.VoteSetReader) (index int, vote 
 
 	psVotes := ps.getVoteBitArray(height, round, type_)
 	if psVotes == nil {
-		return 0, nil, false // Not something worth sending
+		return nil, false // Not something worth sending
 	}
 	if index, ok := votes.BitArray().Sub(psVotes).PickRandom(); ok {
 		ps.setHasVote(height, round, type_, index)
-		return index, votes.GetByIndex(index), true
+		return votes.GetByIndex(index), true
 	}
-	return 0, nil, false
+	return nil, false
 }
 
 func (ps *PeerState) getVoteBitArray(height, round int, type_ byte) *BitArray {
@@ -741,11 +741,11 @@ func (ps *PeerState) ensureVoteBitArrays(height int, numValidators int) {
 	}
 }
 
-func (ps *PeerState) SetHasVote(vote *types.Vote, index int) {
+func (ps *PeerState) SetHasVote(vote *types.Vote) {
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
 
-	ps.setHasVote(vote.Height, vote.Round, vote.Type, index)
+	ps.setHasVote(vote.Height, vote.Round, vote.Type, vote.ValidatorIndex)
 }
 
 func (ps *PeerState) setHasVote(height int, round int, type_ byte, index int) {
@@ -985,12 +985,11 @@ func (m *BlockPartMessage) String() string {
 //-------------------------------------
 
 type VoteMessage struct {
-	ValidatorIndex int
-	Vote           *types.Vote
+	Vote *types.Vote
 }
 
 func (m *VoteMessage) String() string {
-	return fmt.Sprintf("[Vote VI:%v V:%v VI:%v]", m.ValidatorIndex, m.Vote, m.ValidatorIndex)
+	return fmt.Sprintf("[Vote %v]", m.Vote)
 }
 
 //-------------------------------------

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -60,7 +60,7 @@ func (cs *ConsensusState) readReplayMessage(msgBytes []byte, newStepCh chan inte
 		case *VoteMessage:
 			v := msg.Vote
 			log.Notice("Vote", "height", v.Height, "round", v.Round, "type", v.Type,
-				"hash", v.BlockHash, "header", v.BlockPartsHeader, "peer", peerKey)
+				"blockID", v.BlockID, "peer", peerKey)
 		}
 		// internal or from peer
 		if m.PeerKey == "" {

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -49,14 +49,14 @@ import (
 */
 
 var testLog = `
-{"time":"2016-08-20T00:59:04.481Z","msg":[3,{"duration":0,"height":1,"round":0,"step":1}]}
-{"time":"2016-08-20T00:59:04.483Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPropose"}]}
-{"time":"2016-08-20T00:59:04.484Z","msg":[2,{"msg":[17,{"Proposal":{"height":1,"round":0,"block_parts_header":{"total":1,"hash":"9226C78A68841731B0E853461A084D329849D73F"},"pol_round":-1,"signature":"09D241E7A02B230D06D77267979D25DE54AA67A509B07DC1023A6C6523B20B1086D83CB8E56DAC67DE7117105F57029BE84E02ACC20C1F476346C4F338803E06"}}],"peer_key":""}]}
-{"time":"2016-08-20T00:59:04.484Z","msg":[2,{"msg":[19,{"Height":1,"Round":0,"Part":{"index":0,"bytes":"0101010F74656E6465726D696E745F746573740101146C5E3164DE2C800000000000000114C4B01D3810579550997AC5641E759E20D99B51C10001000100","proof":{"aunts":[]}}}],"peer_key":""}]}
-{"time":"2016-08-20T00:59:04.485Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrevote"}]}
-{"time":"2016-08-20T00:59:04.485Z","msg":[2,{"msg":[20,{"Vote":{"validator_address":"D028C9981F7A87F3093672BF0D5B0E2A1B3ED456","validator_index":0,"height":1,"round":0,"type":1,"block_id":{"hash":"BE09462F8C590F3C32CEA0B50E4B65B04851BF41","parts":{"total":1,"hash":"9226C78A68841731B0E853461A084D329849D73F"}},"signature":"E1592D8A9C85347479DBB3C4F600196828C33C982C049A6083BC7574E4E0AB868D97E573619C23CEA470D9B1E15D89930FBD1FBCF3181CF2364B3C3155931009"}}],"peer_key":""}]}
-{"time":"2016-08-20T00:59:04.487Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrecommit"}]}
-{"time":"2016-08-20T00:59:04.487Z","msg":[2,{"msg":[20,{"Vote":{"validator_address":"D028C9981F7A87F3093672BF0D5B0E2A1B3ED456","validator_index":0,"height":1,"round":0,"type":2,"block_id":{"hash":"BE09462F8C590F3C32CEA0B50E4B65B04851BF41","parts":{"total":1,"hash":"9226C78A68841731B0E853461A084D329849D73F"}},"signature":"EA525B9570A98DF620755A96B3540B84267BF00011B496D0576413A921005C678FEDC3823010ECF096EDA9BC0D2044F61802341CA0396C3C9DD6FF53FEE9F30E"}}],"peer_key":""}]}
+{"time":"2016-08-20T22:06:16.075Z","msg":[3,{"duration":0,"height":1,"round":0,"step":1}]}
+{"time":"2016-08-20T22:06:16.077Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPropose"}]}
+{"time":"2016-08-20T22:06:16.077Z","msg":[2,{"msg":[17,{"Proposal":{"height":1,"round":0,"block_parts_header":{"total":1,"hash":"BC874710A7514C59E4F460A9621C538CF82C160A"},"pol_round":-1,"pol_block_id":{"hash":"","parts":{"total":0,"hash":""}},"signature":"E5ABDE10A4D3819184850AF85207DFD2DB8A9D3C540C4313C22DFA470AE99CDF43E5511E4FB7AAC040134E27AA8FC42869C655B4D812175ACAC32BAB7E51C906"}}],"peer_key":""}]}
+{"time":"2016-08-20T22:06:16.078Z","msg":[2,{"msg":[19,{"Height":1,"Round":0,"Part":{"index":0,"bytes":"0101010F74656E6465726D696E745F746573740101146CA357E0F5D8C00000000000000114C4B01D3810579550997AC5641E759E20D99B51C10001000100","proof":{"aunts":[]}}}],"peer_key":""}]}
+{"time":"2016-08-20T22:06:16.079Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrevote"}]}
+{"time":"2016-08-20T22:06:16.079Z","msg":[2,{"msg":[20,{"Vote":{"validator_address":"D028C9981F7A87F3093672BF0D5B0E2A1B3ED456","validator_index":0,"height":1,"round":0,"type":1,"block_id":{"hash":"D98DD4077A50690BAF670E26FD8E56AFC6ACFF4D","parts":{"total":1,"hash":"BC874710A7514C59E4F460A9621C538CF82C160A"}},"signature":"834DE6E3F530178DC695DAE92B2EEF2E31704E58256AF21A27045918A7F225CF59D24B345518C21F67E77559E0953E14DA7372863365242A22BDE2AE1BEABD04"}}],"peer_key":""}]}
+{"time":"2016-08-20T22:06:16.080Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrecommit"}]}
+{"time":"2016-08-20T22:06:16.080Z","msg":[2,{"msg":[20,{"Vote":{"validator_address":"D028C9981F7A87F3093672BF0D5B0E2A1B3ED456","validator_index":0,"height":1,"round":0,"type":2,"block_id":{"hash":"D98DD4077A50690BAF670E26FD8E56AFC6ACFF4D","parts":{"total":1,"hash":"BC874710A7514C59E4F460A9621C538CF82C160A"}},"signature":"3028C891510029A00859E4C56E4D0836C9B3E1F5A8F7CFF9E1B36D40E7727A7A64615ACACF1791C453C87E9FBFE66D978566DA92A12C6ABD7307FF5D1430A408"}}],"peer_key":""}]}
 `
 
 func TestReplayCatchup(t *testing.T) {

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -10,9 +10,12 @@ import (
 )
 
 /*
-	The easiest way to generate this data is to copy ~/.tendermint_test/somedir/* to ~/.tendermint
+	The easiest way to generate this data is to rm ~/.tendermint,
+	copy ~/.tendermint_test/somedir/* to ~/.tendermint,
+	run `tendermint unsafe_reset_all`,
+	set ~/.tendermint/config.toml to use "leveldb" (to create a cswal in data/),
+	run `make install`,
 	and to run a local node.
-	Be sure to set the db to "leveldb" to create a cswal file in ~/.tendermint/data/cswal.
 
 	If you need to change the signatures, you can use a script as follows:
 	The privBytes comes from config/tendermint_test/...
@@ -45,14 +48,15 @@ import (
 	```
 */
 
-var testLog = `{"time":"2016-07-01T21:44:23.626Z","msg":[3,{"duration":0,"height":1,"round":0,"step":1}]}
-{"time":"2016-07-01T21:44:23.631Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPropose"}]}
-{"time":"2016-07-01T21:44:23.631Z","msg":[2,{"msg":[17,{"Proposal":{"height":1,"round":0,"block_parts_header":{"total":1,"hash":"108807E7DC79BC7716CCC93217AC2B81BB8C9508"},"pol_round":-1,"signature":"1B22E998F5F4C426CB29F8AADFB012E364780B3FFDABA3B68498903EDBACECF152F45E3E3CD53A9476577E7043122E506494F4581ACDC73FE9643A791F977A07"}}],"peer_key":""}]}
-{"time":"2016-07-01T21:44:23.632Z","msg":[2,{"msg":[19,{"Height":1,"Round":0,"Part":{"index":0,"bytes":"0101010F74656E6465726D696E745F746573740101145D4921EB88A8C00000000000000114C4B01D3810579550997AC5641E759E20D99B51C10001000100","proof":{"aunts":[]}}}],"peer_key":""}]}
-{"time":"2016-07-01T21:44:23.633Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrevote"}]}
-{"time":"2016-07-01T21:44:23.633Z","msg":[2,{"msg":[20,{"Vote":{"validator_address":"D028C9981F7A87F3093672BF0D5B0E2A1B3ED456","validator_index":0,"height":1,"round":0,"type":1,"block_hash":"C421180ECD00F7FEFF8D720AE8CE891B02E85EA3","block_parts_header":{"total":1,"hash":"108807E7DC79BC7716CCC93217AC2B81BB8C9508"},"signature":"816DEAB87DB1BCA284EAEC7968B9EAE057025478D3176E174E0696C74CB2DD58EA402A3E144CA2292CCF05741097395E42EB8DA492EC73CAE8AB7C4486F99609"}}],"peer_key":""}]}
-{"time":"2016-07-01T21:44:23.636Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrecommit"}]}
-{"time":"2016-07-01T21:44:23.636Z","msg":[2,{"msg":[20,{"Vote":{"validator_address":"D028C9981F7A87F3093672BF0D5B0E2A1B3ED456","validator_index":0,"height":1,"round":0,"type":2,"block_hash":"C421180ECD00F7FEFF8D720AE8CE891B02E85EA3","block_parts_header":{"total":1,"hash":"108807E7DC79BC7716CCC93217AC2B81BB8C9508"},"signature":"BCF879FD579D03282ACF8B5C633DE9548BD93457AC7D0E69A3B13C4BF0E5581BBA20D29DF89FA20AF01F3DD39D65934AABB3B31B5E749B9EA3E4C11935E7610F"}}],"peer_key":""}]}
+var testLog = `
+{"time":"2016-08-20T00:59:04.481Z","msg":[3,{"duration":0,"height":1,"round":0,"step":1}]}
+{"time":"2016-08-20T00:59:04.483Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPropose"}]}
+{"time":"2016-08-20T00:59:04.484Z","msg":[2,{"msg":[17,{"Proposal":{"height":1,"round":0,"block_parts_header":{"total":1,"hash":"9226C78A68841731B0E853461A084D329849D73F"},"pol_round":-1,"signature":"09D241E7A02B230D06D77267979D25DE54AA67A509B07DC1023A6C6523B20B1086D83CB8E56DAC67DE7117105F57029BE84E02ACC20C1F476346C4F338803E06"}}],"peer_key":""}]}
+{"time":"2016-08-20T00:59:04.484Z","msg":[2,{"msg":[19,{"Height":1,"Round":0,"Part":{"index":0,"bytes":"0101010F74656E6465726D696E745F746573740101146C5E3164DE2C800000000000000114C4B01D3810579550997AC5641E759E20D99B51C10001000100","proof":{"aunts":[]}}}],"peer_key":""}]}
+{"time":"2016-08-20T00:59:04.485Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrevote"}]}
+{"time":"2016-08-20T00:59:04.485Z","msg":[2,{"msg":[20,{"Vote":{"validator_address":"D028C9981F7A87F3093672BF0D5B0E2A1B3ED456","validator_index":0,"height":1,"round":0,"type":1,"block_id":{"hash":"BE09462F8C590F3C32CEA0B50E4B65B04851BF41","parts":{"total":1,"hash":"9226C78A68841731B0E853461A084D329849D73F"}},"signature":"E1592D8A9C85347479DBB3C4F600196828C33C982C049A6083BC7574E4E0AB868D97E573619C23CEA470D9B1E15D89930FBD1FBCF3181CF2364B3C3155931009"}}],"peer_key":""}]}
+{"time":"2016-08-20T00:59:04.487Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrecommit"}]}
+{"time":"2016-08-20T00:59:04.487Z","msg":[2,{"msg":[20,{"Vote":{"validator_address":"D028C9981F7A87F3093672BF0D5B0E2A1B3ED456","validator_index":0,"height":1,"round":0,"type":2,"block_id":{"hash":"BE09462F8C590F3C32CEA0B50E4B65B04851BF41","parts":{"total":1,"hash":"9226C78A68841731B0E853461A084D329849D73F"}},"signature":"EA525B9570A98DF620755A96B3540B84267BF00011B496D0576413A921005C678FEDC3823010ECF096EDA9BC0D2044F61802341CA0396C3C9DD6FF53FEE9F30E"}}],"peer_key":""}]}
 `
 
 func TestReplayCatchup(t *testing.T) {

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -45,14 +45,14 @@ import (
 	```
 */
 
-var testLog = `{"time":"2016-04-03T11:23:54.387Z","msg":[3,{"duration":972835254,"height":1,"round":0,"step":1}]}
-{"time":"2016-04-03T11:23:54.388Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPropose"}]}
-{"time":"2016-04-03T11:23:54.388Z","msg":[2,{"msg":[17,{"Proposal":{"height":1,"round":0,"block_parts_header":{"total":1,"hash":"3BA1E90CB868DA6B4FD7F3589826EC461E9EB4EF"},"pol_round":-1,"signature":"3A2ECD5023B21EC144EC16CFF1B992A4321317B83EEDD8969FDFEA6EB7BF4389F38DDA3E7BB109D63A07491C16277A197B241CF1F05F5E485C59882ECACD9E07"}}],"peer_key":""}]}
-{"time":"2016-04-03T11:23:54.389Z","msg":[2,{"msg":[19,{"Height":1,"Round":0,"Part":{"index":0,"bytes":"0101010F74656E6465726D696E745F7465737401011441D59F4B718AC00000000000000114C4B01D3810579550997AC5641E759E20D99B51C10001000100","proof":{"aunts":[]}}}],"peer_key":""}]}
-{"time":"2016-04-03T11:23:54.390Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrevote"}]}
-{"time":"2016-04-03T11:23:54.390Z","msg":[2,{"msg":[20,{"ValidatorIndex":0,"Vote":{"height":1,"round":0,"type":1,"block_hash":"4291966B8A9DFBA00AEC7C700F2718E61DF4331D","block_parts_header":{"total":1,"hash":"3BA1E90CB868DA6B4FD7F3589826EC461E9EB4EF"},"signature":"47D2A75A4E2F15DB1F0D1B656AC0637AF9AADDFEB6A156874F6553C73895E5D5DC948DBAEF15E61276C5342D0E638DFCB77C971CD282096EA8735A564A90F008"}}],"peer_key":""}]}
-{"time":"2016-04-03T11:23:54.392Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrecommit"}]}
-{"time":"2016-04-03T11:23:54.392Z","msg":[2,{"msg":[20,{"ValidatorIndex":0,"Vote":{"height":1,"round":0,"type":2,"block_hash":"4291966B8A9DFBA00AEC7C700F2718E61DF4331D","block_parts_header":{"total":1,"hash":"3BA1E90CB868DA6B4FD7F3589826EC461E9EB4EF"},"signature":"39147DA595F08B73CF8C899967C8403B5872FD9042FFA4E239159E0B6C5D9665C9CA81D766EACA2AE658872F94C2FCD1E34BF51859CD5B274DA8512BACE4B50D"}}],"peer_key":""}]}
+var testLog = `{"time":"2016-07-01T21:44:23.626Z","msg":[3,{"duration":0,"height":1,"round":0,"step":1}]}
+{"time":"2016-07-01T21:44:23.631Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPropose"}]}
+{"time":"2016-07-01T21:44:23.631Z","msg":[2,{"msg":[17,{"Proposal":{"height":1,"round":0,"block_parts_header":{"total":1,"hash":"108807E7DC79BC7716CCC93217AC2B81BB8C9508"},"pol_round":-1,"signature":"1B22E998F5F4C426CB29F8AADFB012E364780B3FFDABA3B68498903EDBACECF152F45E3E3CD53A9476577E7043122E506494F4581ACDC73FE9643A791F977A07"}}],"peer_key":""}]}
+{"time":"2016-07-01T21:44:23.632Z","msg":[2,{"msg":[19,{"Height":1,"Round":0,"Part":{"index":0,"bytes":"0101010F74656E6465726D696E745F746573740101145D4921EB88A8C00000000000000114C4B01D3810579550997AC5641E759E20D99B51C10001000100","proof":{"aunts":[]}}}],"peer_key":""}]}
+{"time":"2016-07-01T21:44:23.633Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrevote"}]}
+{"time":"2016-07-01T21:44:23.633Z","msg":[2,{"msg":[20,{"Vote":{"validator_address":"D028C9981F7A87F3093672BF0D5B0E2A1B3ED456","validator_index":0,"height":1,"round":0,"type":1,"block_hash":"C421180ECD00F7FEFF8D720AE8CE891B02E85EA3","block_parts_header":{"total":1,"hash":"108807E7DC79BC7716CCC93217AC2B81BB8C9508"},"signature":"816DEAB87DB1BCA284EAEC7968B9EAE057025478D3176E174E0696C74CB2DD58EA402A3E144CA2292CCF05741097395E42EB8DA492EC73CAE8AB7C4486F99609"}}],"peer_key":""}]}
+{"time":"2016-07-01T21:44:23.636Z","msg":[1,{"height":1,"round":0,"step":"RoundStepPrecommit"}]}
+{"time":"2016-07-01T21:44:23.636Z","msg":[2,{"msg":[20,{"Vote":{"validator_address":"D028C9981F7A87F3093672BF0D5B0E2A1B3ED456","validator_index":0,"height":1,"round":0,"type":2,"block_hash":"C421180ECD00F7FEFF8D720AE8CE891B02E85EA3","block_parts_header":{"total":1,"hash":"108807E7DC79BC7716CCC93217AC2B81BB8C9508"},"signature":"BCF879FD579D03282ACF8B5C633DE9548BD93457AC7D0E69A3B13C4BF0E5581BBA20D29DF89FA20AF01F3DD39D65934AABB3B31B5E749B9EA3E4C11935E7610F"}}],"peer_key":""}]}
 `
 
 func TestReplayCatchup(t *testing.T) {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -345,15 +345,15 @@ func (cs *ConsensusState) OpenWAL(file string) (err error) {
 // TODO: should these return anything or let callers just use events?
 
 // May block on send if queue is full.
-func (cs *ConsensusState) AddVote(valIndex int, vote *types.Vote, peerKey string) (added bool, address []byte, err error) {
+func (cs *ConsensusState) AddVote(vote *types.Vote, peerKey string) (added bool, err error) {
 	if peerKey == "" {
-		cs.internalMsgQueue <- msgInfo{&VoteMessage{valIndex, vote}, ""}
+		cs.internalMsgQueue <- msgInfo{&VoteMessage{vote}, ""}
 	} else {
-		cs.peerMsgQueue <- msgInfo{&VoteMessage{valIndex, vote}, peerKey}
+		cs.peerMsgQueue <- msgInfo{&VoteMessage{vote}, peerKey}
 	}
 
 	// TODO: wait for event?!
-	return false, nil, nil
+	return false, nil
 }
 
 // May block on send if queue is full.
@@ -443,11 +443,13 @@ func (cs *ConsensusState) reconstructLastCommit(state *sm.State) {
 	}
 	seenCommit := cs.blockStore.LoadSeenCommit(state.LastBlockHeight)
 	lastPrecommits := types.NewVoteSet(cs.config.GetString("chain_id"), state.LastBlockHeight, seenCommit.Round(), types.VoteTypePrecommit, state.LastValidators)
-	for idx, precommit := range seenCommit.Precommits {
+	for _, precommit := range seenCommit.Precommits {
 		if precommit == nil {
 			continue
 		}
-		added, _, err := lastPrecommits.AddByIndex(idx, precommit)
+		// XXXX reconstruct Vote from precommit after changing precommit to simpler
+		// structure.
+		added, err := lastPrecommits.AddVote(precommit)
 		if !added || err != nil {
 			PanicCrisis(Fmt("Failed to reconstruct LastCommit: %v", err))
 		}
@@ -665,7 +667,7 @@ func (cs *ConsensusState) handleMsg(mi msgInfo, rs RoundState) {
 	case *VoteMessage:
 		// attempt to add the vote and dupeout the validator if its a duplicate signature
 		// if the vote gives us a 2/3-any or 2/3-one, we transition
-		err := cs.tryAddVote(msg.ValidatorIndex, msg.Vote, peerKey)
+		err := cs.tryAddVote(msg.Vote, peerKey)
 		if err == ErrAddingVote {
 			// TODO: punish peer
 		}
@@ -1354,8 +1356,8 @@ func (cs *ConsensusState) addProposalBlockPart(height int, part *types.Part, ver
 }
 
 // Attempt to add the vote. if its a duplicate signature, dupeout the validator
-func (cs *ConsensusState) tryAddVote(valIndex int, vote *types.Vote, peerKey string) error {
-	_, _, err := cs.addVote(valIndex, vote, peerKey)
+func (cs *ConsensusState) tryAddVote(vote *types.Vote, peerKey string) error {
+	_, err := cs.addVote(vote, peerKey)
 	if err != nil {
 		// If the vote height is off, we'll just ignore it,
 		// But if it's a conflicting sig, broadcast evidence tx for slashing.
@@ -1388,7 +1390,7 @@ func (cs *ConsensusState) tryAddVote(valIndex int, vote *types.Vote, peerKey str
 
 //-----------------------------------------------------------------------------
 
-func (cs *ConsensusState) addVote(valIndex int, vote *types.Vote, peerKey string) (added bool, address []byte, err error) {
+func (cs *ConsensusState) addVote(vote *types.Vote, peerKey string) (added bool, err error) {
 	log.Debug("addVote", "voteHeight", vote.Height, "voteType", vote.Type, "csHeight", cs.Height)
 
 	// A precommit for the previous height?
@@ -1396,12 +1398,12 @@ func (cs *ConsensusState) addVote(valIndex int, vote *types.Vote, peerKey string
 		if !(cs.Step == RoundStepNewHeight && vote.Type == types.VoteTypePrecommit) {
 			// TODO: give the reason ..
 			// fmt.Errorf("tryAddVote: Wrong height, not a LastCommit straggler commit.")
-			return added, nil, ErrVoteHeightMismatch
+			return added, ErrVoteHeightMismatch
 		}
-		added, address, err = cs.LastCommit.AddByIndex(valIndex, vote)
+		added, err = cs.LastCommit.AddVote(vote)
 		if added {
 			log.Info(Fmt("Added to lastPrecommits: %v", cs.LastCommit.StringShort()))
-			cs.evsw.FireEvent(types.EventStringVote(), types.EventDataVote{valIndex, address, vote})
+			cs.evsw.FireEvent(types.EventStringVote(), types.EventDataVote{vote})
 
 		}
 		return
@@ -1410,9 +1412,9 @@ func (cs *ConsensusState) addVote(valIndex int, vote *types.Vote, peerKey string
 	// A prevote/precommit for this height?
 	if vote.Height == cs.Height {
 		height := cs.Height
-		added, address, err = cs.Votes.AddByIndex(valIndex, vote, peerKey)
+		added, err = cs.Votes.AddVote(vote, peerKey)
 		if added {
-			cs.evsw.FireEvent(types.EventStringVote(), types.EventDataVote{valIndex, address, vote})
+			cs.evsw.FireEvent(types.EventStringVote(), types.EventDataVote{vote})
 
 			switch vote.Type {
 			case types.VoteTypePrevote:
@@ -1482,7 +1484,11 @@ func (cs *ConsensusState) addVote(valIndex int, vote *types.Vote, peerKey string
 }
 
 func (cs *ConsensusState) signVote(type_ byte, hash []byte, header types.PartSetHeader) (*types.Vote, error) {
+	// TODO: store our index in the cs so we don't have to do this every time
+	valIndex, _ := cs.Validators.GetByAddress(cs.privValidator.Address)
 	vote := &types.Vote{
+		ValidatorAddress: cs.privValidator.Address,
+		ValidatorIndex:   valIndex,
 		Height:           cs.Height,
 		Round:            cs.Round,
 		Type:             type_,
@@ -1500,9 +1506,7 @@ func (cs *ConsensusState) signAddVote(type_ byte, hash []byte, header types.Part
 	}
 	vote, err := cs.signVote(type_, hash, header)
 	if err == nil {
-		// TODO: store our index in the cs so we don't have to do this every time
-		valIndex, _ := cs.Validators.GetByAddress(cs.privValidator.Address)
-		cs.sendInternalMessage(msgInfo{&VoteMessage{valIndex, vote}, ""})
+		cs.sendInternalMessage(msgInfo{&VoteMessage{vote}, ""})
 		log.Info("Signed and pushed vote", "height", cs.Height, "round", cs.Round, "vote", vote, "error", err)
 		return vote
 	} else {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -447,8 +447,6 @@ func (cs *ConsensusState) reconstructLastCommit(state *sm.State) {
 		if precommit == nil {
 			continue
 		}
-		// XXX reconstruct Vote from precommit after changing precommit to simpler
-		// structure.
 		added, err := lastPrecommits.AddVote(precommit)
 		if !added || err != nil {
 			PanicCrisis(Fmt("Failed to reconstruct LastCommit: %v", err))

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -447,7 +447,7 @@ func (cs *ConsensusState) reconstructLastCommit(state *sm.State) {
 		if precommit == nil {
 			continue
 		}
-		// XXXX reconstruct Vote from precommit after changing precommit to simpler
+		// XXX reconstruct Vote from precommit after changing precommit to simpler
 		// structure.
 		added, err := lastPrecommits.AddVote(precommit)
 		if !added || err != nil {
@@ -891,8 +891,7 @@ func (cs *ConsensusState) createProposalBlock() (block *types.Block, blockParts 
 			Height:         cs.Height,
 			Time:           time.Now(),
 			NumTxs:         len(txs),
-			LastBlockHash:  cs.state.LastBlockHash,
-			LastBlockParts: cs.state.LastBlockParts,
+			LastBlockID:    cs.state.LastBlockID,
 			ValidatorsHash: cs.state.Validators.Hash(),
 			AppHash:        cs.state.AppHash, // state merkle root of txs from the previous block.
 		},
@@ -1017,7 +1016,7 @@ func (cs *ConsensusState) enterPrecommit(height int, round int) {
 		cs.newStep()
 	}()
 
-	hash, partsHeader, ok := cs.Votes.Prevotes(round).TwoThirdsMajority()
+	blockID, ok := cs.Votes.Prevotes(round).TwoThirdsMajority()
 
 	// If we don't have a polka, we must precommit nil
 	if !ok {
@@ -1039,7 +1038,7 @@ func (cs *ConsensusState) enterPrecommit(height int, round int) {
 	}
 
 	// +2/3 prevoted nil. Unlock and precommit nil.
-	if len(hash) == 0 {
+	if len(blockID.Hash) == 0 {
 		if cs.LockedBlock == nil {
 			log.Notice("enterPrecommit: +2/3 prevoted for nil.")
 		} else {
@@ -1056,17 +1055,17 @@ func (cs *ConsensusState) enterPrecommit(height int, round int) {
 	// At this point, +2/3 prevoted for a particular block.
 
 	// If we're already locked on that block, precommit it, and update the LockedRound
-	if cs.LockedBlock.HashesTo(hash) {
+	if cs.LockedBlock.HashesTo(blockID.Hash) {
 		log.Notice("enterPrecommit: +2/3 prevoted locked block. Relocking")
 		cs.LockedRound = round
 		cs.evsw.FireEvent(types.EventStringRelock(), cs.RoundStateEvent())
-		cs.signAddVote(types.VoteTypePrecommit, hash, partsHeader)
+		cs.signAddVote(types.VoteTypePrecommit, blockID.Hash, blockID.PartsHeader)
 		return
 	}
 
 	// If +2/3 prevoted for proposal block, stage and precommit it
-	if cs.ProposalBlock.HashesTo(hash) {
-		log.Notice("enterPrecommit: +2/3 prevoted proposal block. Locking", "hash", hash)
+	if cs.ProposalBlock.HashesTo(blockID.Hash) {
+		log.Notice("enterPrecommit: +2/3 prevoted proposal block. Locking", "hash", blockID.Hash)
 		// Validate the block.
 		if err := cs.state.ValidateBlock(cs.ProposalBlock); err != nil {
 			PanicConsensus(Fmt("enterPrecommit: +2/3 prevoted for an invalid block: %v", err))
@@ -1075,7 +1074,7 @@ func (cs *ConsensusState) enterPrecommit(height int, round int) {
 		cs.LockedBlock = cs.ProposalBlock
 		cs.LockedBlockParts = cs.ProposalBlockParts
 		cs.evsw.FireEvent(types.EventStringLock(), cs.RoundStateEvent())
-		cs.signAddVote(types.VoteTypePrecommit, hash, partsHeader)
+		cs.signAddVote(types.VoteTypePrecommit, blockID.Hash, blockID.PartsHeader)
 		return
 	}
 
@@ -1086,9 +1085,9 @@ func (cs *ConsensusState) enterPrecommit(height int, round int) {
 	cs.LockedRound = 0
 	cs.LockedBlock = nil
 	cs.LockedBlockParts = nil
-	if !cs.ProposalBlockParts.HasHeader(partsHeader) {
+	if !cs.ProposalBlockParts.HasHeader(blockID.PartsHeader) {
 		cs.ProposalBlock = nil
-		cs.ProposalBlockParts = types.NewPartSetFromHeader(partsHeader)
+		cs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartsHeader)
 	}
 	cs.evsw.FireEvent(types.EventStringUnlock(), cs.RoundStateEvent())
 	cs.signAddVote(types.VoteTypePrecommit, nil, types.PartSetHeader{})
@@ -1136,7 +1135,7 @@ func (cs *ConsensusState) enterCommit(height int, commitRound int) {
 		cs.tryFinalizeCommit(height)
 	}()
 
-	hash, partsHeader, ok := cs.Votes.Precommits(commitRound).TwoThirdsMajority()
+	blockID, ok := cs.Votes.Precommits(commitRound).TwoThirdsMajority()
 	if !ok {
 		PanicSanity("RunActionCommit() expects +2/3 precommits")
 	}
@@ -1144,18 +1143,18 @@ func (cs *ConsensusState) enterCommit(height int, commitRound int) {
 	// The Locked* fields no longer matter.
 	// Move them over to ProposalBlock if they match the commit hash,
 	// otherwise they'll be cleared in updateToState.
-	if cs.LockedBlock.HashesTo(hash) {
+	if cs.LockedBlock.HashesTo(blockID.Hash) {
 		cs.ProposalBlock = cs.LockedBlock
 		cs.ProposalBlockParts = cs.LockedBlockParts
 	}
 
 	// If we don't have the block being committed, set up to get it.
-	if !cs.ProposalBlock.HashesTo(hash) {
-		if !cs.ProposalBlockParts.HasHeader(partsHeader) {
+	if !cs.ProposalBlock.HashesTo(blockID.Hash) {
+		if !cs.ProposalBlockParts.HasHeader(blockID.PartsHeader) {
 			// We're getting the wrong block.
 			// Set up ProposalBlockParts and keep waiting.
 			cs.ProposalBlock = nil
-			cs.ProposalBlockParts = types.NewPartSetFromHeader(partsHeader)
+			cs.ProposalBlockParts = types.NewPartSetFromHeader(blockID.PartsHeader)
 		} else {
 			// We just need to keep waiting.
 		}
@@ -1168,12 +1167,12 @@ func (cs *ConsensusState) tryFinalizeCommit(height int) {
 		PanicSanity(Fmt("tryFinalizeCommit() cs.Height: %v vs height: %v", cs.Height, height))
 	}
 
-	hash, _, ok := cs.Votes.Precommits(cs.CommitRound).TwoThirdsMajority()
-	if !ok || len(hash) == 0 {
+	blockID, ok := cs.Votes.Precommits(cs.CommitRound).TwoThirdsMajority()
+	if !ok || len(blockID.Hash) == 0 {
 		log.Warn("Attempt to finalize failed. There was no +2/3 majority, or +2/3 was for <nil>.")
 		return
 	}
-	if !cs.ProposalBlock.HashesTo(hash) {
+	if !cs.ProposalBlock.HashesTo(blockID.Hash) {
 		// TODO: this happens every time if we're not a validator (ugly logs)
 		log.Warn("Attempt to finalize failed. We don't have the commit block.")
 		return
@@ -1189,16 +1188,16 @@ func (cs *ConsensusState) finalizeCommit(height int) {
 		return
 	}
 
-	hash, header, ok := cs.Votes.Precommits(cs.CommitRound).TwoThirdsMajority()
+	blockID, ok := cs.Votes.Precommits(cs.CommitRound).TwoThirdsMajority()
 	block, blockParts := cs.ProposalBlock, cs.ProposalBlockParts
 
 	if !ok {
 		PanicSanity(Fmt("Cannot finalizeCommit, commit does not have two thirds majority"))
 	}
-	if !blockParts.HasHeader(header) {
+	if !blockParts.HasHeader(blockID.PartsHeader) {
 		PanicSanity(Fmt("Expected ProposalBlockParts header to be commit header"))
 	}
-	if !block.HashesTo(hash) {
+	if !block.HashesTo(blockID.Hash) {
 		PanicSanity(Fmt("Cannot finalizeCommit, ProposalBlock does not hash to commit hash"))
 	}
 	if err := cs.state.ValidateBlock(block); err != nil {
@@ -1426,8 +1425,8 @@ func (cs *ConsensusState) addVote(vote *types.Vote, peerKey string) (added bool,
 				// we'll still enterNewRound(H,vote.R) and enterPrecommit(H,vote.R) to process it
 				// there.
 				if (cs.LockedBlock != nil) && (cs.LockedRound < vote.Round) && (vote.Round <= cs.Round) {
-					hash, _, ok := prevotes.TwoThirdsMajority()
-					if ok && !cs.LockedBlock.HashesTo(hash) {
+					blockID, ok := prevotes.TwoThirdsMajority()
+					if ok && !cs.LockedBlock.HashesTo(blockID.Hash) {
 						log.Notice("Unlocking because of POL.", "lockedRound", cs.LockedRound, "POLRound", vote.Round)
 						cs.LockedRound = 0
 						cs.LockedBlock = nil
@@ -1453,9 +1452,9 @@ func (cs *ConsensusState) addVote(vote *types.Vote, peerKey string) (added bool,
 			case types.VoteTypePrecommit:
 				precommits := cs.Votes.Precommits(vote.Round)
 				log.Info("Added to precommit", "vote", vote, "precommits", precommits.StringShort())
-				hash, _, ok := precommits.TwoThirdsMajority()
+				blockID, ok := precommits.TwoThirdsMajority()
 				if ok {
-					if len(hash) == 0 {
+					if len(blockID.Hash) == 0 {
 						cs.enterNewRound(height, vote.Round+1)
 					} else {
 						cs.enterNewRound(height, vote.Round)
@@ -1492,8 +1491,7 @@ func (cs *ConsensusState) signVote(type_ byte, hash []byte, header types.PartSet
 		Height:           cs.Height,
 		Round:            cs.Round,
 		Type:             type_,
-		BlockHash:        hash,
-		BlockPartsHeader: header,
+		BlockID:          types.BlockID{hash, header},
 	}
 	err := cs.privValidator.SignVote(cs.state.ChainID, vote)
 	return vote, err

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1364,7 +1364,7 @@ func (cs *ConsensusState) tryAddVote(vote *types.Vote, peerKey string) error {
 		// If it's otherwise invalid, punish peer.
 		if err == ErrVoteHeightMismatch {
 			return err
-		} else if _, ok := err.(*types.ErrVoteConflictingSignature); ok {
+		} else if _, ok := err.(*types.ErrVoteConflictingVotes); ok {
 			if peerKey == "" {
 				log.Warn("Found conflicting vote from ourselves. Did you unsafe_reset a validator?", "height", vote.Height, "round", vote.Round, "type", vote.Type)
 				return err

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -824,7 +824,8 @@ func (cs *ConsensusState) decideProposal(height, round int) {
 	}
 
 	// Make proposal
-	proposal := types.NewProposal(height, round, blockParts.Header(), cs.Votes.POLRound())
+	polRound, polBlockID := cs.Votes.POLInfo()
+	proposal := types.NewProposal(height, round, blockParts.Header(), polRound, polBlockID)
 	err := cs.privValidator.SignProposal(cs.state.ChainID, proposal)
 	if err == nil {
 		// Set fields
@@ -1033,8 +1034,9 @@ func (cs *ConsensusState) enterPrecommit(height int, round int) {
 	cs.evsw.FireEvent(types.EventStringPolka(), cs.RoundStateEvent())
 
 	// the latest POLRound should be this round
-	if cs.Votes.POLRound() < round {
-		PanicSanity(Fmt("This POLRound should be %v but got %", round, cs.Votes.POLRound()))
+	polRound, _ := cs.Votes.POLInfo()
+	if polRound < round {
+		PanicSanity(Fmt("This POLRound should be %v but got %", round, polRound))
 	}
 
 	// +2/3 prevoted nil. Unlock and precommit nil.

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -74,7 +74,7 @@ func TestProposerSelection0(t *testing.T) {
 	<-proposalCh
 
 	rs := cs1.GetRoundState()
-	signAddVoteToFromMany(types.VoteTypePrecommit, cs1, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), vss[1:]...)
+	signAddVotes(cs1, types.VoteTypePrecommit, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), vss[1:]...)
 
 	// wait for new round so next validator is set
 	<-newRoundCh
@@ -106,7 +106,7 @@ func TestProposerSelection2(t *testing.T) {
 		}
 
 		rs := cs1.GetRoundState()
-		signAddVoteToFromMany(types.VoteTypePrecommit, cs1, nil, rs.ProposalBlockParts.Header(), vss[1:]...)
+		signAddVotes(cs1, types.VoteTypePrecommit, nil, rs.ProposalBlockParts.Header(), vss[1:]...)
 		<-newRoundCh // wait for the new round event each round
 
 		incrementRound(vss[1:]...)
@@ -179,12 +179,12 @@ func TestEnterProposeYesPrivValidator(t *testing.T) {
 func TestBadProposal(t *testing.T) {
 	cs1, vss := randConsensusState(2)
 	height, round := cs1.Height, cs1.Round
-	cs2 := vss[1]
+	vs2 := vss[1]
 
 	proposalCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringCompleteProposal(), 1)
 	voteCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringVote(), 1)
 
-	propBlock, _ := cs1.createProposalBlock() //changeProposer(t, cs1, cs2)
+	propBlock, _ := cs1.createProposalBlock() //changeProposer(t, cs1, vs2)
 
 	// make the second validator the proposer by incrementing round
 	round = round + 1
@@ -198,8 +198,8 @@ func TestBadProposal(t *testing.T) {
 	stateHash[0] = byte((stateHash[0] + 1) % 255)
 	propBlock.AppHash = stateHash
 	propBlockParts := propBlock.MakePartSet()
-	proposal := types.NewProposal(cs2.Height, round, propBlockParts.Header(), -1)
-	if err := cs2.SignProposal(config.GetString("chain_id"), proposal); err != nil {
+	proposal := types.NewProposal(vs2.Height, round, propBlockParts.Header(), -1)
+	if err := vs2.SignProposal(config.GetString("chain_id"), proposal); err != nil {
 		t.Fatal("failed to sign bad proposal", err)
 	}
 
@@ -217,15 +217,15 @@ func TestBadProposal(t *testing.T) {
 
 	validatePrevote(t, cs1, round, vss[0], nil)
 
-	// add bad prevote from cs2 and wait for it
-	signAddVoteToFrom(types.VoteTypePrevote, cs1, cs2, propBlock.Hash(), propBlock.MakePartSet().Header())
+	// add bad prevote from vs2 and wait for it
+	signAddVotes(cs1, types.VoteTypePrevote, propBlock.Hash(), propBlock.MakePartSet().Header(), vs2)
 	<-voteCh
 
 	// wait for precommit
 	<-voteCh
 
 	validatePrecommit(t, cs1, round, 0, vss[0], nil, nil)
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs2, propBlock.Hash(), propBlock.MakePartSet().Header())
+	signAddVotes(cs1, types.VoteTypePrecommit, propBlock.Hash(), propBlock.MakePartSet().Header(), vs2)
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -280,7 +280,7 @@ func TestFullRoundNil(t *testing.T) {
 // where the first validator has to wait for votes from the second
 func TestFullRound2(t *testing.T) {
 	cs1, vss := randConsensusState(2)
-	cs2 := vss[1]
+	vs2 := vss[1]
 	height, round := cs1.Height, cs1.Round
 
 	voteCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringVote(), 1)
@@ -295,8 +295,8 @@ func TestFullRound2(t *testing.T) {
 
 	propBlockHash, propPartsHeader := cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header()
 
-	// prevote arrives from cs2:
-	signAddVoteToFrom(types.VoteTypePrevote, cs1, cs2, propBlockHash, propPartsHeader)
+	// prevote arrives from vs2:
+	signAddVotes(cs1, types.VoteTypePrevote, propBlockHash, propPartsHeader, vs2)
 	<-voteCh
 
 	<-voteCh //precommit
@@ -306,8 +306,8 @@ func TestFullRound2(t *testing.T) {
 
 	// we should be stuck in limbo waiting for more precommits
 
-	// precommit arrives from cs2:
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs2, propBlockHash, propPartsHeader)
+	// precommit arrives from vs2:
+	signAddVotes(cs1, types.VoteTypePrecommit, propBlockHash, propPartsHeader, vs2)
 	<-voteCh
 
 	// wait to finish commit, propose in next height
@@ -321,7 +321,7 @@ func TestFullRound2(t *testing.T) {
 // two vals take turns proposing. val1 locks on first one, precommits nil on everything else
 func TestLockNoPOL(t *testing.T) {
 	cs1, vss := randConsensusState(2)
-	cs2 := vss[1]
+	vs2 := vss[1]
 	height := cs1.Height
 
 	timeoutProposeCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringTimeoutPropose(), 1)
@@ -345,8 +345,8 @@ func TestLockNoPOL(t *testing.T) {
 	<-voteCh // prevote
 
 	// we should now be stuck in limbo forever, waiting for more prevotes
-	// prevote arrives from cs2:
-	signAddVoteToFrom(types.VoteTypePrevote, cs1, cs2, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header())
+	// prevote arrives from vs2:
+	signAddVotes(cs1, types.VoteTypePrevote, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header(), vs2)
 	<-voteCh // prevote
 
 	<-voteCh // precommit
@@ -360,7 +360,7 @@ func TestLockNoPOL(t *testing.T) {
 	hash := make([]byte, len(theBlockHash))
 	copy(hash, theBlockHash)
 	hash[0] = byte((hash[0] + 1) % 255)
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs2, hash, rs.ProposalBlock.MakePartSet().Header())
+	signAddVotes(cs1, types.VoteTypePrecommit, hash, rs.ProposalBlock.MakePartSet().Header(), vs2)
 	<-voteCh // precommit
 
 	// (note we're entering precommit for a second time this round)
@@ -375,7 +375,7 @@ func TestLockNoPOL(t *testing.T) {
 		Round2 (cs1, B) // B B2
 	*/
 
-	incrementRound(cs2)
+	incrementRound(vs2)
 
 	// now we're on a new round and not the proposer, so wait for timeout
 	re = <-timeoutProposeCh
@@ -392,7 +392,7 @@ func TestLockNoPOL(t *testing.T) {
 	validatePrevote(t, cs1, 1, vss[0], rs.LockedBlock.Hash())
 
 	// add a conflicting prevote from the other validator
-	signAddVoteToFrom(types.VoteTypePrevote, cs1, cs2, hash, rs.ProposalBlock.MakePartSet().Header())
+	signAddVotes(cs1, types.VoteTypePrevote, hash, rs.ProposalBlock.MakePartSet().Header(), vs2)
 	<-voteCh
 
 	// now we're going to enter prevote again, but with invalid args
@@ -405,9 +405,9 @@ func TestLockNoPOL(t *testing.T) {
 	// we should precommit nil and be locked on the proposal
 	validatePrecommit(t, cs1, 1, 0, vss[0], nil, theBlockHash)
 
-	// add conflicting precommit from cs2
+	// add conflicting precommit from vs2
 	// NOTE: in practice we should never get to a point where there are precommits for different blocks at the same round
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs2, hash, rs.ProposalBlock.MakePartSet().Header())
+	signAddVotes(cs1, types.VoteTypePrecommit, hash, rs.ProposalBlock.MakePartSet().Header(), vs2)
 	<-voteCh
 
 	// (note we're entering precommit for a second time this round, but with invalid args
@@ -417,10 +417,10 @@ func TestLockNoPOL(t *testing.T) {
 	<-newRoundCh
 	log.Notice("#### ONTO ROUND 2")
 	/*
-		Round3 (cs2, _) // B, B2
+		Round3 (vs2, _) // B, B2
 	*/
 
-	incrementRound(cs2)
+	incrementRound(vs2)
 
 	re = <-proposalCh
 	rs = re.(types.EventDataRoundState).RoundState.(*RoundState)
@@ -434,30 +434,31 @@ func TestLockNoPOL(t *testing.T) {
 
 	validatePrevote(t, cs1, 2, vss[0], rs.LockedBlock.Hash())
 
-	signAddVoteToFrom(types.VoteTypePrevote, cs1, cs2, hash, rs.ProposalBlock.MakePartSet().Header())
+	signAddVotes(cs1, types.VoteTypePrevote, hash, rs.ProposalBlock.MakePartSet().Header(), vs2)
 	<-voteCh
 
 	<-timeoutWaitCh // prevote wait
 	<-voteCh        // precommit
 
-	validatePrecommit(t, cs1, 2, 0, vss[0], nil, theBlockHash)                                          // precommit nil but be locked on proposal
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs2, hash, rs.ProposalBlock.MakePartSet().Header()) // NOTE: conflicting precommits at same height
+	validatePrecommit(t, cs1, 2, 0, vss[0], nil, theBlockHash) // precommit nil but be locked on proposal
+
+	signAddVotes(cs1, types.VoteTypePrecommit, hash, rs.ProposalBlock.MakePartSet().Header(), vs2) // NOTE: conflicting precommits at same height
 	<-voteCh
 
 	<-timeoutWaitCh
 
 	// before we time out into new round, set next proposal block
-	prop, propBlock := decideProposal(cs1, cs2, cs2.Height, cs2.Round+1)
+	prop, propBlock := decideProposal(cs1, vs2, vs2.Height, vs2.Round+1)
 	if prop == nil || propBlock == nil {
-		t.Fatal("Failed to create proposal block with cs2")
+		t.Fatal("Failed to create proposal block with vs2")
 	}
 
-	incrementRound(cs2)
+	incrementRound(vs2)
 
 	<-newRoundCh
 	log.Notice("#### ONTO ROUND 3")
 	/*
-		Round4 (cs2, C) // B C // B C
+		Round4 (vs2, C) // B C // B C
 	*/
 
 	// now we're on a new round and not the proposer
@@ -470,21 +471,22 @@ func TestLockNoPOL(t *testing.T) {
 	// prevote for locked block (not proposal)
 	validatePrevote(t, cs1, 0, vss[0], cs1.LockedBlock.Hash())
 
-	signAddVoteToFrom(types.VoteTypePrevote, cs1, cs2, propBlock.Hash(), propBlock.MakePartSet().Header())
+	signAddVotes(cs1, types.VoteTypePrevote, propBlock.Hash(), propBlock.MakePartSet().Header(), vs2)
 	<-voteCh
 
 	<-timeoutWaitCh
 	<-voteCh
 
-	validatePrecommit(t, cs1, 2, 0, vss[0], nil, theBlockHash)                                               // precommit nil but locked on proposal
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs2, propBlock.Hash(), propBlock.MakePartSet().Header()) // NOTE: conflicting precommits at same height
+	validatePrecommit(t, cs1, 2, 0, vss[0], nil, theBlockHash) // precommit nil but locked on proposal
+
+	signAddVotes(cs1, types.VoteTypePrecommit, propBlock.Hash(), propBlock.MakePartSet().Header(), vs2) // NOTE: conflicting precommits at same height
 	<-voteCh
 }
 
 // 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
 func TestLockPOLRelock(t *testing.T) {
 	cs1, vss := randConsensusState(4)
-	cs2, cs3, cs4 := vss[1], vss[2], vss[3]
+	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 
 	timeoutProposeCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringTimeoutPropose(), 1)
 	timeoutWaitCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringTimeoutWait(), 1)
@@ -493,14 +495,14 @@ func TestLockPOLRelock(t *testing.T) {
 	newRoundCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringNewRound(), 1)
 	newBlockCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringNewBlockHeader(), 1)
 
-	log.Debug("cs2 last round", "lr", cs2.PrivValidator.LastRound)
+	log.Debug("vs2 last round", "lr", vs2.PrivValidator.LastRound)
 
 	// everything done from perspective of cs1
 
 	/*
 		Round1 (cs1, B) // B B B B// B nil B nil
 
-		eg. cs2 and cs4 didn't see the 2/3 prevotes
+		eg. vs2 and vs4 didn't see the 2/3 prevotes
 	*/
 
 	// start round and wait for propose and prevote
@@ -513,7 +515,7 @@ func TestLockPOLRelock(t *testing.T) {
 
 	<-voteCh // prevote
 
-	signAddVoteToFromMany(types.VoteTypePrevote, cs1, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header(), cs2, cs3, cs4)
+	signAddVotes(cs1, types.VoteTypePrevote, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header(), vs2, vs3, vs4)
 	_, _, _ = <-voteCh, <-voteCh, <-voteCh // prevotes
 
 	<-voteCh // our precommit
@@ -521,16 +523,16 @@ func TestLockPOLRelock(t *testing.T) {
 	validatePrecommit(t, cs1, 0, 0, vss[0], theBlockHash, theBlockHash)
 
 	// add precommits from the rest
-	signAddVoteToFromMany(types.VoteTypePrecommit, cs1, nil, types.PartSetHeader{}, cs2, cs4)
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs3, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header())
+	signAddVotes(cs1, types.VoteTypePrecommit, nil, types.PartSetHeader{}, vs2, vs4)
+	signAddVotes(cs1, types.VoteTypePrecommit, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header(), vs3)
 	_, _, _ = <-voteCh, <-voteCh, <-voteCh // precommits
 
 	// before we timeout to the new round set the new proposal
-	prop, propBlock := decideProposal(cs1, cs2, cs2.Height, cs2.Round+1)
+	prop, propBlock := decideProposal(cs1, vs2, vs2.Height, vs2.Round+1)
 	propBlockParts := propBlock.MakePartSet()
 	propBlockHash := propBlock.Hash()
 
-	incrementRound(cs2, cs3, cs4)
+	incrementRound(vs2, vs3, vs4)
 
 	// timeout to new round
 	<-timeoutWaitCh
@@ -542,7 +544,7 @@ func TestLockPOLRelock(t *testing.T) {
 	log.Notice("### ONTO ROUND 1")
 
 	/*
-		Round2 (cs2, C) // B C C C // C C C _)
+		Round2 (vs2, C) // B C C C // C C C _)
 
 		cs1 changes lock!
 	*/
@@ -560,7 +562,7 @@ func TestLockPOLRelock(t *testing.T) {
 	validatePrevote(t, cs1, 0, vss[0], theBlockHash)
 
 	// now lets add prevotes from everyone else for the new block
-	signAddVoteToFromMany(types.VoteTypePrevote, cs1, propBlockHash, propBlockParts.Header(), cs2, cs3, cs4)
+	signAddVotes(cs1, types.VoteTypePrevote, propBlockHash, propBlockParts.Header(), vs2, vs3, vs4)
 	_, _, _ = <-voteCh, <-voteCh, <-voteCh // prevotes
 
 	// now either we go to PrevoteWait or Precommit
@@ -573,7 +575,7 @@ func TestLockPOLRelock(t *testing.T) {
 	// we should have unlocked and locked on the new block
 	validatePrecommit(t, cs1, 1, 1, vss[0], propBlockHash, propBlockHash)
 
-	signAddVoteToFromMany(types.VoteTypePrecommit, cs1, propBlockHash, propBlockParts.Header(), cs2, cs3)
+	signAddVotes(cs1, types.VoteTypePrecommit, propBlockHash, propBlockParts.Header(), vs2, vs3)
 	_, _ = <-voteCh, <-voteCh
 
 	be := <-newBlockCh
@@ -592,7 +594,7 @@ func TestLockPOLRelock(t *testing.T) {
 // 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
 func TestLockPOLUnlock(t *testing.T) {
 	cs1, vss := randConsensusState(4)
-	cs2, cs3, cs4 := vss[1], vss[2], vss[3]
+	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 
 	proposalCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringCompleteProposal(), 1)
 	timeoutProposeCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringTimeoutPropose(), 1)
@@ -618,7 +620,7 @@ func TestLockPOLUnlock(t *testing.T) {
 
 	<-voteCh // prevote
 
-	signAddVoteToFromMany(types.VoteTypePrevote, cs1, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header(), cs2, cs3, cs4)
+	signAddVotes(cs1, types.VoteTypePrevote, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header(), vs2, vs3, vs4)
 
 	<-voteCh //precommit
 
@@ -626,14 +628,14 @@ func TestLockPOLUnlock(t *testing.T) {
 	validatePrecommit(t, cs1, 0, 0, vss[0], theBlockHash, theBlockHash)
 
 	// add precommits from the rest
-	signAddVoteToFromMany(types.VoteTypePrecommit, cs1, nil, types.PartSetHeader{}, cs2, cs4)
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs3, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header())
+	signAddVotes(cs1, types.VoteTypePrecommit, nil, types.PartSetHeader{}, vs2, vs4)
+	signAddVotes(cs1, types.VoteTypePrecommit, cs1.ProposalBlock.Hash(), cs1.ProposalBlockParts.Header(), vs3)
 
 	// before we time out into new round, set next proposal block
-	prop, propBlock := decideProposal(cs1, cs2, cs2.Height, cs2.Round+1)
+	prop, propBlock := decideProposal(cs1, vs2, vs2.Height, vs2.Round+1)
 	propBlockParts := propBlock.MakePartSet()
 
-	incrementRound(cs2, cs3, cs4)
+	incrementRound(vs2, vs3, vs4)
 
 	// timeout to new round
 	re = <-timeoutWaitCh
@@ -646,7 +648,7 @@ func TestLockPOLUnlock(t *testing.T) {
 	<-newRoundCh
 	log.Notice("#### ONTO ROUND 1")
 	/*
-		Round2 (cs2, C) // B nil nil nil // nil nil nil _
+		Round2 (vs2, C) // B nil nil nil // nil nil nil _
 
 		cs1 unlocks!
 	*/
@@ -663,7 +665,7 @@ func TestLockPOLUnlock(t *testing.T) {
 	<-voteCh
 	validatePrevote(t, cs1, 0, vss[0], lockedBlockHash)
 	// now lets add prevotes from everyone else for nil (a polka!)
-	signAddVoteToFromMany(types.VoteTypePrevote, cs1, nil, types.PartSetHeader{}, cs2, cs3, cs4)
+	signAddVotes(cs1, types.VoteTypePrevote, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
 	// the polka makes us unlock and precommit nil
 	<-unlockCh
@@ -673,7 +675,7 @@ func TestLockPOLUnlock(t *testing.T) {
 	// NOTE: since we don't relock on nil, the lock round is 0
 	validatePrecommit(t, cs1, 1, 0, vss[0], nil, nil)
 
-	signAddVoteToFromMany(types.VoteTypePrecommit, cs1, nil, types.PartSetHeader{}, cs2, cs3)
+	signAddVotes(cs1, types.VoteTypePrecommit, nil, types.PartSetHeader{}, vs2, vs3)
 	<-newRoundCh
 }
 
@@ -683,7 +685,7 @@ func TestLockPOLUnlock(t *testing.T) {
 // then we see the polka from round 1 but shouldn't unlock
 func TestLockPOLSafety1(t *testing.T) {
 	cs1, vss := randConsensusState(4)
-	cs2, cs3, cs4 := vss[1], vss[2], vss[3]
+	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 
 	proposalCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringCompleteProposal(), 1)
 	timeoutProposeCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringTimeoutPropose(), 1)
@@ -703,7 +705,7 @@ func TestLockPOLSafety1(t *testing.T) {
 	validatePrevote(t, cs1, 0, vss[0], propBlock.Hash())
 
 	// the others sign a polka but we don't see it
-	prevotes := signVoteMany(types.VoteTypePrevote, propBlock.Hash(), propBlock.MakePartSet().Header(), cs2, cs3, cs4)
+	prevotes := signVotes(types.VoteTypePrevote, propBlock.Hash(), propBlock.MakePartSet().Header(), vs2, vs3, vs4)
 
 	// before we time out into new round, set next proposer
 	// and next proposal block
@@ -717,13 +719,13 @@ func TestLockPOLSafety1(t *testing.T) {
 	log.Warn("old prop", "hash", fmt.Sprintf("%X", propBlock.Hash()))
 
 	// we do see them precommit nil
-	signAddVoteToFromMany(types.VoteTypePrecommit, cs1, nil, types.PartSetHeader{}, cs2, cs3, cs4)
+	signAddVotes(cs1, types.VoteTypePrecommit, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
-	prop, propBlock := decideProposal(cs1, cs2, cs2.Height, cs2.Round+1)
+	prop, propBlock := decideProposal(cs1, vs2, vs2.Height, vs2.Round+1)
 	propBlockHash := propBlock.Hash()
 	propBlockParts := propBlock.MakePartSet()
 
-	incrementRound(cs2, cs3, cs4)
+	incrementRound(vs2, vs3, vs4)
 
 	//XXX: this isnt gauranteed to get there before the timeoutPropose ...
 	cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer")
@@ -754,18 +756,18 @@ func TestLockPOLSafety1(t *testing.T) {
 	validatePrevote(t, cs1, 1, vss[0], propBlockHash)
 
 	// now we see the others prevote for it, so we should lock on it
-	signAddVoteToFromMany(types.VoteTypePrevote, cs1, propBlockHash, propBlockParts.Header(), cs2, cs3, cs4)
+	signAddVotes(cs1, types.VoteTypePrevote, propBlockHash, propBlockParts.Header(), vs2, vs3, vs4)
 
 	<-voteCh // precommit
 
 	// we should have precommitted
 	validatePrecommit(t, cs1, 1, 1, vss[0], propBlockHash, propBlockHash)
 
-	signAddVoteToFromMany(types.VoteTypePrecommit, cs1, nil, types.PartSetHeader{}, cs2, cs3)
+	signAddVotes(cs1, types.VoteTypePrecommit, nil, types.PartSetHeader{}, vs2, vs3)
 
 	<-timeoutWaitCh
 
-	incrementRound(cs2, cs3, cs4)
+	incrementRound(vs2, vs3, vs4)
 
 	<-newRoundCh
 
@@ -786,7 +788,7 @@ func TestLockPOLSafety1(t *testing.T) {
 	newStepCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringNewRoundStep(), 1)
 
 	// add prevotes from the earlier round
-	addVoteToFromMany(cs1, prevotes, cs2, cs3, cs4)
+	addVotes(cs1, prevotes...)
 
 	log.Warn("Done adding prevotes!")
 
@@ -802,7 +804,7 @@ func TestLockPOLSafety1(t *testing.T) {
 // dont see P0, lock on P1 at R1, dont unlock using P0 at R2
 func TestLockPOLSafety2(t *testing.T) {
 	cs1, vss := randConsensusState(4)
-	cs2, cs3, cs4 := vss[1], vss[2], vss[3]
+	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 
 	proposalCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringCompleteProposal(), 1)
 	timeoutProposeCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringTimeoutPropose(), 1)
@@ -818,14 +820,14 @@ func TestLockPOLSafety2(t *testing.T) {
 	propBlockParts0 := propBlock0.MakePartSet()
 
 	// the others sign a polka but we don't see it
-	prevotes := signVoteMany(types.VoteTypePrevote, propBlockHash0, propBlockParts0.Header(), cs2, cs3, cs4)
+	prevotes := signVotes(types.VoteTypePrevote, propBlockHash0, propBlockParts0.Header(), vs2, vs3, vs4)
 
 	// the block for round 1
-	prop1, propBlock1 := decideProposal(cs1, cs2, cs2.Height, cs2.Round+1)
+	prop1, propBlock1 := decideProposal(cs1, vs2, vs2.Height, vs2.Round+1)
 	propBlockHash1 := propBlock1.Hash()
 	propBlockParts1 := propBlock1.MakePartSet()
 
-	incrementRound(cs2, cs3, cs4)
+	incrementRound(vs2, vs3, vs4)
 
 	cs1.updateRoundStep(0, RoundStepPrecommitWait)
 
@@ -840,28 +842,30 @@ func TestLockPOLSafety2(t *testing.T) {
 
 	<-voteCh // prevote
 
-	signAddVoteToFromMany(types.VoteTypePrevote, cs1, propBlockHash1, propBlockParts1.Header(), cs2, cs3, cs4)
+	signAddVotes(cs1, types.VoteTypePrevote, propBlockHash1, propBlockParts1.Header(), vs2, vs3, vs4)
 
 	<-voteCh // precommit
 	// the proposed block should now be locked and our precommit added
 	validatePrecommit(t, cs1, 1, 1, vss[0], propBlockHash1, propBlockHash1)
 
 	// add precommits from the rest
-	signAddVoteToFromMany(types.VoteTypePrecommit, cs1, nil, types.PartSetHeader{}, cs2, cs4)
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs3, propBlockHash1, propBlockParts1.Header())
+	signAddVotes(cs1, types.VoteTypePrecommit, nil, types.PartSetHeader{}, vs2, vs4)
+	signAddVotes(cs1, types.VoteTypePrecommit, propBlockHash1, propBlockParts1.Header(), vs3)
 
-	incrementRound(cs2, cs3, cs4)
+	incrementRound(vs2, vs3, vs4)
 
 	// timeout of precommit wait to new round
 	<-timeoutWaitCh
 
 	// in round 2 we see the polkad block from round 0
 	newProp := types.NewProposal(height, 2, propBlockParts0.Header(), 0)
-	if err := cs3.SignProposal(config.GetString("chain_id"), newProp); err != nil {
+	if err := vs3.SignProposal(config.GetString("chain_id"), newProp); err != nil {
 		t.Fatal(err)
 	}
 	cs1.SetProposalAndBlock(newProp, propBlock0, propBlockParts0, "some peer")
-	addVoteToFromMany(cs1, prevotes, cs2, cs3, cs4) // add the pol votes
+
+	// Add the pol votes
+	addVotes(cs1, prevotes...)
 
 	<-newRoundCh
 	log.Notice("### ONTO Round 2")
@@ -892,7 +896,7 @@ func TestLockPOLSafety2(t *testing.T) {
 /*
 func TestSlashingPrevotes(t *testing.T) {
 	cs1, vss := randConsensusState(2)
-	cs2 := vss[1]
+	vs2 := vss[1]
 
 
 	proposalCh := subscribeToEvent(cs1.evsw,"tester",types.EventStringCompleteProposal() , 1)
@@ -912,7 +916,7 @@ func TestSlashingPrevotes(t *testing.T) {
 	// add one for a different block should cause us to go into prevote wait
 	hash := cs1.ProposalBlock.Hash()
 	hash[0] = byte(hash[0]+1) % 255
-	signAddVoteToFrom(types.VoteTypePrevote, cs1, cs2, hash, rs.ProposalBlockParts.Header())
+	signAddVotes(cs1, types.VoteTypePrevote, hash, rs.ProposalBlockParts.Header(), vs2)
 
 	<-timeoutWaitCh
 
@@ -920,14 +924,14 @@ func TestSlashingPrevotes(t *testing.T) {
 	// away and ignore more prevotes (and thus fail to slash!)
 
 	// add the conflicting vote
-	signAddVoteToFrom(types.VoteTypePrevote, cs1, cs2, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header())
+	signAddVotes(cs1, types.VoteTypePrevote, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), vs2)
 
 	// XXX: Check for existence of Dupeout info
 }
 
 func TestSlashingPrecommits(t *testing.T) {
 	cs1, vss := randConsensusState(2)
-	cs2 := vss[1]
+	vs2 := vss[1]
 
 
 	proposalCh := subscribeToEvent(cs1.evsw,"tester",types.EventStringCompleteProposal() , 1)
@@ -941,8 +945,8 @@ func TestSlashingPrecommits(t *testing.T) {
 	re := <-proposalCh
 	<-voteCh // prevote
 
-	// add prevote from cs2
-	signAddVoteToFrom(types.VoteTypePrevote, cs1, cs2, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header())
+	// add prevote from vs2
+	signAddVotes(cs1, types.VoteTypePrevote, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), vs2)
 
 	<-voteCh // precommit
 
@@ -950,13 +954,13 @@ func TestSlashingPrecommits(t *testing.T) {
 	// add one for a different block should cause us to go into prevote wait
 	hash := rs.ProposalBlock.Hash()
 	hash[0] = byte(hash[0]+1) % 255
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs2, hash, rs.ProposalBlockParts.Header())
+	signAddVotes(cs1, types.VoteTypePrecommit, hash, rs.ProposalBlockParts.Header(), vs2)
 
 	// NOTE: we have to send the vote for different block first so we don't just go into precommit round right
 	// away and ignore more prevotes (and thus fail to slash!)
 
-	// add precommit from cs2
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs2, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header())
+	// add precommit from vs2
+	signAddVotes(cs1, types.VoteTypePrecommit, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), vs2)
 
 	// XXX: Check for existence of Dupeout info
 }
@@ -972,7 +976,7 @@ func TestSlashingPrecommits(t *testing.T) {
 // we receive a final precommit after going into next round, but others might have gone to commit already!
 func TestHalt1(t *testing.T) {
 	cs1, vss := randConsensusState(4)
-	cs2, cs3, cs4 := vss[1], vss[2], vss[3]
+	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 
 	proposalCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringCompleteProposal(), 1)
 	timeoutWaitCh := subscribeToEvent(cs1.evsw, "tester", types.EventStringTimeoutWait(), 1)
@@ -990,19 +994,19 @@ func TestHalt1(t *testing.T) {
 
 	<-voteCh // prevote
 
-	signAddVoteToFromMany(types.VoteTypePrevote, cs1, propBlock.Hash(), propBlockParts.Header(), cs3, cs4)
+	signAddVotes(cs1, types.VoteTypePrevote, propBlock.Hash(), propBlockParts.Header(), vs3, vs4)
 	<-voteCh // precommit
 
 	// the proposed block should now be locked and our precommit added
 	validatePrecommit(t, cs1, 0, 0, vss[0], propBlock.Hash(), propBlock.Hash())
 
 	// add precommits from the rest
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs2, nil, types.PartSetHeader{}) // didnt receive proposal
-	signAddVoteToFrom(types.VoteTypePrecommit, cs1, cs3, propBlock.Hash(), propBlockParts.Header())
-	// we receive this later, but cs3 might receive it earlier and with ours will go to commit!
-	precommit4 := signVote(cs4, types.VoteTypePrecommit, propBlock.Hash(), propBlockParts.Header())
+	signAddVotes(cs1, types.VoteTypePrecommit, nil, types.PartSetHeader{}, vs2) // didnt receive proposal
+	signAddVotes(cs1, types.VoteTypePrecommit, propBlock.Hash(), propBlockParts.Header(), vs3)
+	// we receive this later, but vs3 might receive it earlier and with ours will go to commit!
+	precommit4 := signVote(vs4, types.VoteTypePrecommit, propBlock.Hash(), propBlockParts.Header())
 
-	incrementRound(cs2, cs3, cs4)
+	incrementRound(vs2, vs3, vs4)
 
 	// timeout to new round
 	<-timeoutWaitCh
@@ -1020,7 +1024,7 @@ func TestHalt1(t *testing.T) {
 	validatePrevote(t, cs1, 0, vss[0], rs.LockedBlock.Hash())
 
 	// now we receive the precommit from the previous round
-	addVoteToFrom(cs1, cs4, precommit4)
+	addVotes(cs1, precommit4)
 
 	// receiving that precommit should take us straight to commit
 	<-newBlockCh

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -198,7 +198,7 @@ func TestBadProposal(t *testing.T) {
 	stateHash[0] = byte((stateHash[0] + 1) % 255)
 	propBlock.AppHash = stateHash
 	propBlockParts := propBlock.MakePartSet()
-	proposal := types.NewProposal(vs2.Height, round, propBlockParts.Header(), -1)
+	proposal := types.NewProposal(vs2.Height, round, propBlockParts.Header(), -1, types.BlockID{})
 	if err := vs2.SignProposal(config.GetString("chain_id"), proposal); err != nil {
 		t.Fatal("failed to sign bad proposal", err)
 	}
@@ -826,6 +826,7 @@ func TestLockPOLSafety2(t *testing.T) {
 	prop1, propBlock1 := decideProposal(cs1, vs2, vs2.Height, vs2.Round+1)
 	propBlockHash1 := propBlock1.Hash()
 	propBlockParts1 := propBlock1.MakePartSet()
+	propBlockID1 := types.BlockID{propBlockHash1, propBlockParts1.Header()}
 
 	incrementRound(vs2, vs3, vs4)
 
@@ -858,7 +859,7 @@ func TestLockPOLSafety2(t *testing.T) {
 	<-timeoutWaitCh
 
 	// in round 2 we see the polkad block from round 0
-	newProp := types.NewProposal(height, 2, propBlockParts0.Header(), 0)
+	newProp := types.NewProposal(height, 2, propBlockParts0.Header(), 0, propBlockID1)
 	if err := vs3.SignProposal(config.GetString("chain_id"), newProp); err != nil {
 		t.Fatal(err)
 	}

--- a/state/execution.go
+++ b/state/execution.go
@@ -44,8 +44,7 @@ func (s *State) ExecBlock(evsw *events.EventSwitch, proxyAppConn proxy.AppConn, 
 	// All good!
 	nextValSet.IncrementAccum(1)
 	s.LastBlockHeight = block.Height
-	s.LastBlockHash = block.Hash()
-	s.LastBlockParts = blockPartsHeader
+	s.LastBlockID = types.BlockID{block.Hash(), blockPartsHeader}
 	s.LastBlockTime = block.Time
 	s.Validators = nextValSet
 	s.LastValidators = valSet
@@ -100,7 +99,7 @@ func (s *State) execBlockOnProxyApp(evsw *events.EventSwitch, proxyAppConn proxy
 
 func (s *State) validateBlock(block *types.Block) error {
 	// Basic block validation.
-	err := block.ValidateBasic(s.ChainID, s.LastBlockHeight, s.LastBlockHash, s.LastBlockParts, s.LastBlockTime, s.AppHash)
+	err := block.ValidateBasic(s.ChainID, s.LastBlockHeight, s.LastBlockID, s.LastBlockTime, s.AppHash)
 	if err != nil {
 		return err
 	}
@@ -116,7 +115,7 @@ func (s *State) validateBlock(block *types.Block) error {
 				s.LastValidators.Size(), len(block.LastCommit.Precommits))
 		}
 		err := s.LastValidators.VerifyCommit(
-			s.ChainID, s.LastBlockHash, s.LastBlockParts, block.Height-1, block.LastCommit)
+			s.ChainID, s.LastBlockID, block.Height-1, block.LastCommit)
 		if err != nil {
 			return err
 		}

--- a/state/state.go
+++ b/state/state.go
@@ -25,8 +25,7 @@ type State struct {
 	GenesisDoc      *types.GenesisDoc
 	ChainID         string
 	LastBlockHeight int // Genesis state has this set to 0.  So, Block(H=0) does not exist.
-	LastBlockHash   []byte
-	LastBlockParts  types.PartSetHeader
+	LastBlockID     types.BlockID
 	LastBlockTime   time.Time
 	Validators      *types.ValidatorSet
 	LastValidators  *types.ValidatorSet
@@ -56,8 +55,7 @@ func (s *State) Copy() *State {
 		GenesisDoc:      s.GenesisDoc,
 		ChainID:         s.ChainID,
 		LastBlockHeight: s.LastBlockHeight,
-		LastBlockHash:   s.LastBlockHash,
-		LastBlockParts:  s.LastBlockParts,
+		LastBlockID:     s.LastBlockID,
 		LastBlockTime:   s.LastBlockTime,
 		Validators:      s.Validators.Copy(),
 		LastValidators:  s.LastValidators.Copy(),
@@ -117,8 +115,7 @@ func MakeGenesisState(db dbm.DB, genDoc *types.GenesisDoc) *State {
 		GenesisDoc:      genDoc,
 		ChainID:         genDoc.ChainID,
 		LastBlockHeight: 0,
-		LastBlockHash:   nil,
-		LastBlockParts:  types.PartSetHeader{},
+		LastBlockID:     types.BlockID{},
 		LastBlockTime:   genDoc.GenesisTime,
 		Validators:      types.NewValidatorSet(validators),
 		LastValidators:  types.NewValidatorSet(nil),

--- a/types/block.go
+++ b/types/block.go
@@ -376,9 +376,13 @@ func (blockID BlockID) Key() string {
 }
 
 func (blockID BlockID) WriteSignBytes(w io.Writer, n *int, err *error) {
-	wire.WriteTo([]byte(Fmt(`{"hash":"%X","parts":`, blockID.Hash)), w, n, err)
-	blockID.PartsHeader.WriteSignBytes(w, n, err)
-	wire.WriteTo([]byte("}"), w, n, err)
+	if blockID.IsZero() {
+		wire.WriteTo([]byte("null"), w, n, err)
+	} else {
+		wire.WriteTo([]byte(Fmt(`{"hash":"%X","parts":`, blockID.Hash)), w, n, err)
+		blockID.PartsHeader.WriteSignBytes(w, n, err)
+		wire.WriteTo([]byte("}"), w, n, err)
+	}
 }
 
 func (blockID BlockID) String() string {

--- a/types/block.go
+++ b/types/block.go
@@ -191,6 +191,7 @@ type Commit struct {
 	// NOTE: The Precommits are in order of address to preserve the bonded ValidatorSet order.
 	// Any peer with a block can gossip precommits by index with a peer without recalculating the
 	// active ValidatorSet.
+	BlockID    BlockID `json:"blockID"`
 	Precommits []*Vote `json:"precommits"`
 
 	// Volatile
@@ -262,6 +263,9 @@ func (commit *Commit) IsCommit() bool {
 }
 
 func (commit *Commit) ValidateBasic() error {
+	if commit.BlockID.IsZero() {
+		return errors.New("Commit cannot be for nil block")
+	}
 	if len(commit.Precommits) == 0 {
 		return errors.New("No precommits in commit")
 	}
@@ -310,8 +314,10 @@ func (commit *Commit) StringIndented(indent string) string {
 		precommitStrings[i] = precommit.String()
 	}
 	return fmt.Sprintf(`Commit{
+%s  BlockID:    %v
 %s  Precommits: %v
 %s}#%X`,
+		indent, commit.BlockID,
 		indent, strings.Join(precommitStrings, "\n"+indent+"  "),
 		indent, commit.hash)
 }

--- a/types/events.go
+++ b/types/events.go
@@ -87,9 +87,7 @@ type EventDataRoundState struct {
 }
 
 type EventDataVote struct {
-	Index   int
-	Address []byte
-	Vote    *Vote
+	Vote *Vote
 }
 
 func (_ EventDataNewBlock) AssertIsTMEventData()       {}

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -66,7 +66,7 @@ type PartSetHeader struct {
 }
 
 func (psh PartSetHeader) String() string {
-	return fmt.Sprintf("PartSet{T:%v %X}", psh.Total, Fingerprint(psh.Hash))
+	return fmt.Sprintf("%v:%X", psh.Total, Fingerprint(psh.Hash))
 }
 
 func (psh PartSetHeader) IsZero() bool {

--- a/types/proposal.go
+++ b/types/proposal.go
@@ -19,29 +19,33 @@ type Proposal struct {
 	Height           int                     `json:"height"`
 	Round            int                     `json:"round"`
 	BlockPartsHeader PartSetHeader           `json:"block_parts_header"`
-	POLRound         int                     `json:"pol_round"` // -1 if null.
+	POLRound         int                     `json:"pol_round"`    // -1 if null.
+	POLBlockID       BlockID                 `json:"pol_block_id"` // zero if null.
 	Signature        crypto.SignatureEd25519 `json:"signature"`
 }
 
 // polRound: -1 if no polRound.
-func NewProposal(height int, round int, blockPartsHeader PartSetHeader, polRound int) *Proposal {
+func NewProposal(height int, round int, blockPartsHeader PartSetHeader, polRound int, polBlockID BlockID) *Proposal {
 	return &Proposal{
 		Height:           height,
 		Round:            round,
 		BlockPartsHeader: blockPartsHeader,
 		POLRound:         polRound,
+		POLBlockID:       polBlockID,
 	}
 }
 
 func (p *Proposal) String() string {
-	return fmt.Sprintf("Proposal{%v/%v %v %v %v}", p.Height, p.Round,
-		p.BlockPartsHeader, p.POLRound, p.Signature)
+	return fmt.Sprintf("Proposal{%v/%v %v (%v,%v) %v}", p.Height, p.Round,
+		p.BlockPartsHeader, p.POLRound, p.POLBlockID, p.Signature)
 }
 
 func (p *Proposal) WriteSignBytes(chainID string, w io.Writer, n *int, err *error) {
 	wire.WriteTo([]byte(Fmt(`{"chain_id":"%s"`, chainID)), w, n, err)
 	wire.WriteTo([]byte(`,"proposal":{"block_parts_header":`), w, n, err)
 	p.BlockPartsHeader.WriteSignBytes(w, n, err)
-	wire.WriteTo([]byte(Fmt(`,"height":%v,"pol_round":%v`, p.Height, p.POLRound)), w, n, err)
+	wire.WriteTo([]byte(Fmt(`,"height":%v,"pol_block_id":`, p.Height)), w, n, err)
+	p.POLBlockID.WriteSignBytes(w, n, err)
+	wire.WriteTo([]byte(Fmt(`,"pol_round":%v`, p.POLRound)), w, n, err)
 	wire.WriteTo([]byte(Fmt(`,"round":%v}}`, p.Round)), w, n, err)
 }

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -14,8 +14,8 @@ func TestProposalSignable(t *testing.T) {
 	signBytes := SignBytes("test_chain_id", proposal)
 	signStr := string(signBytes)
 
-	expected := `{"chain_id":"test_chain_id","proposal":{"block_parts_header":{"hash":"626C6F636B7061727473","total":111},"height":12345,"pol_round":-1,"round":23456}}`
+	expected := `{"chain_id":"test_chain_id","proposal":{"block_parts_header":{"hash":"626C6F636B7061727473","total":111},"height":12345,"pol_block_id":null,"pol_round":-1,"round":23456}}`
 	if signStr != expected {
-		t.Errorf("Got unexpected sign string for SendTx. Expected:\n%v\nGot:\n%v", expected, signStr)
+		t.Errorf("Got unexpected sign string for Proposal. Expected:\n%v\nGot:\n%v", expected, signStr)
 	}
 }

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -313,6 +313,7 @@ func (ac accumComparable) Less(o interface{}) bool {
 //----------------------------------------
 // For testing
 
+// NOTE: PrivValidator are in order.
 func RandValidatorSet(numValidators int, votingPower int64) (*ValidatorSet, []*PrivValidator) {
 	vals := make([]*Validator, numValidators)
 	privValidators := make([]*PrivValidator, numValidators)

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -206,8 +206,7 @@ func (valSet *ValidatorSet) Iterate(fn func(index int, val *Validator) bool) {
 }
 
 // Verify that +2/3 of the set had signed the given signBytes
-func (valSet *ValidatorSet) VerifyCommit(chainID string,
-	hash []byte, parts PartSetHeader, height int, commit *Commit) error {
+func (valSet *ValidatorSet) VerifyCommit(chainID string, blockID BlockID, height int, commit *Commit) error {
 	if valSet.Size() != len(commit.Precommits) {
 		return fmt.Errorf("Invalid commit -- wrong set size: %v vs %v", valSet.Size(), len(commit.Precommits))
 	}
@@ -238,10 +237,7 @@ func (valSet *ValidatorSet) VerifyCommit(chainID string,
 		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {
 			return fmt.Errorf("Invalid commit -- invalid signature: %v", precommit)
 		}
-		if !bytes.Equal(precommit.BlockHash, hash) {
-			continue // Not an error, but doesn't count
-		}
-		if !parts.Equals(precommit.BlockPartsHeader) {
+		if !blockID.Equals(precommit.BlockID) {
 			continue // Not an error, but doesn't count
 		}
 		// Good precommit!

--- a/types/vote.go
+++ b/types/vote.go
@@ -27,6 +27,24 @@ func (err *ErrVoteConflictingVotes) Error() string {
 	return "Conflicting votes"
 }
 
+// Types of votes
+// TODO Make a new type "VoteType"
+const (
+	VoteTypePrevote   = byte(0x01)
+	VoteTypePrecommit = byte(0x02)
+)
+
+func IsVoteTypeValid(type_ byte) bool {
+	switch type_ {
+	case VoteTypePrevote:
+		return true
+	case VoteTypePrecommit:
+		return true
+	default:
+		return false
+	}
+}
+
 // Represents a prevote, precommit, or commit vote from validators for consensus.
 type Vote struct {
 	ValidatorAddress []byte                  `json:"validator_address"`
@@ -37,12 +55,6 @@ type Vote struct {
 	BlockID          BlockID                 `json:"block_id"` // zero if vote is nil.
 	Signature        crypto.SignatureEd25519 `json:"signature"`
 }
-
-// Types of votes
-const (
-	VoteTypePrevote   = byte(0x01)
-	VoteTypePrecommit = byte(0x02)
-)
 
 func (vote *Vote) WriteSignBytes(chainID string, w io.Writer, n *int, err *error) {
 	wire.WriteTo([]byte(Fmt(`{"chain_id":"%s"`, chainID)), w, n, err)

--- a/types/vote.go
+++ b/types/vote.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -18,13 +19,13 @@ var (
 	ErrVoteInvalidBlockHash        = errors.New("Invalid block hash")
 )
 
-type ErrVoteConflictingSignature struct {
+type ErrVoteConflictingVotes struct {
 	VoteA *Vote
 	VoteB *Vote
 }
 
-func (err *ErrVoteConflictingSignature) Error() string {
-	return "Conflicting round vote signature"
+func (err *ErrVoteConflictingVotes) Error() string {
+	return "Conflicting votes"
 }
 
 // Represents a prevote, precommit, or commit vote from validators for consensus.
@@ -74,4 +75,11 @@ func (vote *Vote) String() string {
 		vote.ValidatorIndex, Fingerprint(vote.ValidatorAddress),
 		vote.Height, vote.Round, vote.Type, typeString,
 		Fingerprint(vote.BlockHash), vote.Signature)
+}
+
+// Does not check signature, but checks for equality of block
+// NOTE: May be from different validators, and signature may be incorrect.
+func (vote *Vote) SameBlockAs(other *Vote) bool {
+	return bytes.Equal(vote.BlockHash, other.BlockHash) &&
+		vote.BlockPartsHeader.Equals(other.BlockPartsHeader)
 }

--- a/types/vote.go
+++ b/types/vote.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	ErrVoteUnexpectedStep   = errors.New("Unexpected step")
-	ErrVoteInvalidAccount   = errors.New("Invalid round vote account")
-	ErrVoteInvalidSignature = errors.New("Invalid round vote signature")
-	ErrVoteInvalidBlockHash = errors.New("Invalid block hash")
+	ErrVoteUnexpectedStep          = errors.New("Unexpected step")
+	ErrVoteInvalidValidatorIndex   = errors.New("Invalid round vote validator index")
+	ErrVoteInvalidValidatorAddress = errors.New("Invalid round vote validator address")
+	ErrVoteInvalidSignature        = errors.New("Invalid round vote signature")
+	ErrVoteInvalidBlockHash        = errors.New("Invalid block hash")
 )
 
 type ErrVoteConflictingSignature struct {
@@ -28,6 +29,8 @@ func (err *ErrVoteConflictingSignature) Error() string {
 
 // Represents a prevote, precommit, or commit vote from validators for consensus.
 type Vote struct {
+	ValidatorAddress []byte                  `json:"validator_address"`
+	ValidatorIndex   int                     `json:"validator_index"`
 	Height           int                     `json:"height"`
 	Round            int                     `json:"round"`
 	Type             byte                    `json:"type"`
@@ -67,5 +70,8 @@ func (vote *Vote) String() string {
 		PanicSanity("Unknown vote type")
 	}
 
-	return fmt.Sprintf("Vote{%v/%02d/%v(%v) %X#%v %v}", vote.Height, vote.Round, vote.Type, typeString, Fingerprint(vote.BlockHash), vote.BlockPartsHeader, vote.Signature)
+	return fmt.Sprintf("Vote{%v:%X %v/%02d/%v(%v) %X %v}",
+		vote.ValidatorIndex, Fingerprint(vote.ValidatorAddress),
+		vote.Height, vote.Round, vote.Type, typeString,
+		Fingerprint(vote.BlockHash), vote.Signature)
 }

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -140,7 +140,7 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 		panic("Validator index or address was not set in vote.")
 	}
 
-	// Make sure the step matches. (or that vote is commit && round < voteSet.round)
+	// Make sure the step matches.
 	if (vote.Height != voteSet.height) ||
 		(vote.Round != voteSet.round) ||
 		(vote.Type != voteSet.type_) {
@@ -330,7 +330,7 @@ func (voteSet *VoteSet) BitArrayByBlockID(blockID BlockID) *BitArray {
 	return nil
 }
 
-// NOTE: if validator has conflicting votes, picks random.
+// NOTE: if validator has conflicting votes, returns "canonical" vote
 func (voteSet *VoteSet) GetByIndex(valIndex int) *Vote {
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -10,26 +10,54 @@ import (
 	"github.com/tendermint/go-wire"
 )
 
-// VoteSet helps collect signatures from validators at each height+round
-// for a predefined vote type.
-// Note that there three kinds of votes: prevotes, precommits, and commits.
-// A commit of prior rounds can be added added in lieu of votes/precommits.
-// NOTE: Assumes that the sum total of voting power does not exceed MaxUInt64.
+/*
+	VoteSet helps collect signatures from validators at each height+round for a
+	predefined vote type.
+
+	We need VoteSet to be able to keep track of conflicting votes when validators
+	double-sign.  Yet, we can't keep track of *all* the votes seen, as that could
+	be a DoS attack vector.
+
+	There are two storage areas for votes.
+	1. voteSet.votes
+	2. voteSet.votesByBlock
+
+	`.votes` is the "canonical" list of votes.  It always has at least one vote,
+	if a vote from a validator had been seen at all.  Usually it keeps track of
+	the first vote seen, but when a 2/3 majority is found, votes for that get
+	priority and are copied over from `.votesByBlock`.
+
+	`.votesByBlock` keeps track of a list of votes for a particular block.  There
+	are two ways a &blockVotes{} gets created in `.votesByBlock`.
+	1. the first vote seen by a validator was for the particular block.
+	2. a peer claims to have seen 2/3 majority for the particular block.
+
+	Since the first vote from a validator will always get added in `.votesByBlock`
+	, all votes in `.votes` will have a corresponding entry in `.votesByBlock`.
+
+	When a &blockVotes{} in `.votesByBlock` reaches a 2/3 majority quorum, its
+	votes are copied into `.votes`.
+
+	All this is memory bounded because conflicting votes only get added if a peer
+	told us to track that block, each peer only gets to tell us 1 such block, and,
+	there's only a limited number of peers.
+
+	NOTE: Assumes that the sum total of voting power does not exceed MaxUInt64.
+*/
 type VoteSet struct {
 	chainID string
 	height  int
 	round   int
 	type_   byte
 
-	mtx              sync.Mutex
-	valSet           *ValidatorSet
-	votes            []*Vote          // validator index -> vote
-	votesBitArray    *BitArray        // validator index -> has vote?
-	votesByBlock     map[string]int64 // string(blockHash)+string(blockParts) -> vote sum.
-	totalVotes       int64
-	maj23Hash        []byte
-	maj23PartsHeader PartSetHeader
-	maj23Exists      bool
+	mtx           sync.Mutex
+	valSet        *ValidatorSet
+	votesBitArray *BitArray
+	votes         []*Vote                // Primary votes to share
+	sum           int64                  // Sum of voting power for seen votes, discounting conflicts
+	maj23         *blockInfo             // First 2/3 majority seen
+	votesByBlock  map[string]*blockVotes // string(blockHash|blockParts) -> blockVotes
+	peerMaj23s    map[string]*blockInfo  // Maj23 for each peer
 }
 
 // Constructs a new VoteSet struct used to accumulate votes for given height/round.
@@ -43,10 +71,12 @@ func NewVoteSet(chainID string, height int, round int, type_ byte, valSet *Valid
 		round:         round,
 		type_:         type_,
 		valSet:        valSet,
-		votes:         make([]*Vote, valSet.Size()),
 		votesBitArray: NewBitArray(valSet.Size()),
-		votesByBlock:  make(map[string]int64),
-		totalVotes:    0,
+		votes:         make([]*Vote, valSet.Size()),
+		sum:           0,
+		maj23:         nil,
+		votesByBlock:  make(map[string]*blockVotes, valSet.Size()),
+		peerMaj23s:    make(map[string]*blockInfo),
 	}
 }
 
@@ -86,9 +116,12 @@ func (voteSet *VoteSet) Size() int {
 	}
 }
 
-// Returns added=true
-// Otherwise returns err=ErrVote[UnexpectedStep|InvalidIndex|InvalidAddress|InvalidSignature|InvalidBlockHash|ConflictingSignature]
+// Returns added=true if vote is valid and new.
+// Otherwise returns err=ErrVote[
+//		UnexpectedStep | InvalidIndex | InvalidAddress |
+//		InvalidSignature | InvalidBlockHash | ConflictingVotes ]
 // Duplicate votes return added=false, err=nil.
+// Conflicting votes return added=*, err=ErrVoteConflictingVotes.
 // NOTE: vote should not be mutated after adding.
 func (voteSet *VoteSet) AddVote(vote *Vote) (added bool, err error) {
 	voteSet.mtx.Lock()
@@ -97,11 +130,13 @@ func (voteSet *VoteSet) AddVote(vote *Vote) (added bool, err error) {
 	return voteSet.addVote(vote)
 }
 
+// NOTE: Validates as much as possible before attempting to verify the signature.
 func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 	valIndex := vote.ValidatorIndex
 	valAddr := vote.ValidatorAddress
+	blockKey := getBlockKey(vote)
 
-	// Ensure thta validator index was set
+	// Ensure that validator index was set
 	if valIndex < 0 || len(valAddr) == 0 {
 		panic("Validator index or address was not set in vote.")
 	}
@@ -124,20 +159,12 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 		return false, ErrVoteInvalidValidatorAddress
 	}
 
-	// If vote already exists, return false.
-	if existingVote := voteSet.votes[valIndex]; existingVote != nil {
-		if bytes.Equal(existingVote.BlockHash, vote.BlockHash) {
-			return false, nil
+	// If we already know of this vote, return false.
+	if existing, ok := voteSet.getVote(valIndex, blockKey); ok {
+		if existing.Signature.Equals(vote.Signature) {
+			return false, nil // duplicate
 		} else {
-			// Check signature.
-			if !val.PubKey.VerifyBytes(SignBytes(voteSet.chainID, vote), vote.Signature) {
-				// Bad signature.
-				return false, ErrVoteInvalidSignature
-			}
-			return false, &ErrVoteConflictingSignature{
-				VoteA: existingVote,
-				VoteB: vote,
-			}
+			return false, ErrVoteInvalidSignature // NOTE: assumes deterministic signatures
 		}
 	}
 
@@ -147,23 +174,139 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 		return false, ErrVoteInvalidSignature
 	}
 
-	// Add vote.
-	voteSet.votes[valIndex] = vote
-	voteSet.votesBitArray.SetIndex(valIndex, true)
-	blockKey := string(vote.BlockHash) + string(wire.BinaryBytes(vote.BlockPartsHeader))
-	totalBlockHashVotes := voteSet.votesByBlock[blockKey] + val.VotingPower
-	voteSet.votesByBlock[blockKey] = totalBlockHashVotes
-	voteSet.totalVotes += val.VotingPower
-
-	// If we just nudged it up to two thirds majority, add it.
-	if totalBlockHashVotes > voteSet.valSet.TotalVotingPower()*2/3 &&
-		(totalBlockHashVotes-val.VotingPower) <= voteSet.valSet.TotalVotingPower()*2/3 {
-		voteSet.maj23Hash = vote.BlockHash
-		voteSet.maj23PartsHeader = vote.BlockPartsHeader
-		voteSet.maj23Exists = true
+	// Add vote and get conflicting vote if any
+	added, conflicting := voteSet.addVerifiedVote(vote, blockKey, val.VotingPower)
+	if conflicting != nil {
+		return added, &ErrVoteConflictingVotes{
+			VoteA: conflicting,
+			VoteB: vote,
+		}
+	} else {
+		if !added {
+			PanicSanity("Expected to add non-conflicting vote")
+		}
+		return added, nil
 	}
 
-	return true, nil
+}
+
+// Returns (vote, true) if vote exists for valIndex and blockKey
+func (voteSet *VoteSet) getVote(valIndex int, blockKey string) (vote *Vote, ok bool) {
+	if existing := voteSet.votes[valIndex]; existing != nil && getBlockKey(existing) == blockKey {
+		return existing, true
+	}
+	if existing := voteSet.votesByBlock[blockKey].getByIndex(valIndex); existing != nil {
+		return existing, true
+	}
+	return nil, false
+}
+
+// Assumes signature is valid.
+// If conflicting vote exists, returns it.
+func (voteSet *VoteSet) addVerifiedVote(vote *Vote, blockKey string, votingPower int64) (added bool, conflicting *Vote) {
+	valIndex := vote.ValidatorIndex
+
+	// Already exists in voteSet.votes?
+	if existing := voteSet.votes[valIndex]; existing != nil {
+		if existing.SameBlockAs(vote) {
+			PanicSanity("addVerifiedVote does not expect duplicate votes")
+		} else {
+			conflicting = existing
+		}
+		// Replace vote if blockKey matches voteSet.maj23.
+		if voteSet.maj23 != nil && voteSet.maj23.BlockKey() == blockKey {
+			voteSet.votes[valIndex] = vote
+			voteSet.votesBitArray.SetIndex(valIndex, true)
+		}
+		// Otherwise don't add it to voteSet.votes
+	} else {
+		// Add to voteSet.votes and incr .sum
+		voteSet.votes[valIndex] = vote
+		voteSet.votesBitArray.SetIndex(valIndex, true)
+		voteSet.sum += votingPower
+	}
+
+	votesByBlock, ok := voteSet.votesByBlock[blockKey]
+	if ok {
+		if conflicting != nil && !votesByBlock.peerMaj23 {
+			// There's a conflict and no peer claims that this block is special.
+			return false, conflicting
+		}
+		// We'll add the vote in a bit.
+	} else {
+		// .votesByBlock doesn't exist...
+		if conflicting != nil {
+			// ... and there's a conflicting vote.
+			// We're not even tracking this blockKey, so just forget it.
+			return false, conflicting
+		} else {
+			// ... and there's no conflicting vote.
+			// Start tracking this blockKey
+			votesByBlock = newBlockVotes(false, voteSet.valSet.Size())
+			voteSet.votesByBlock[blockKey] = votesByBlock
+			// We'll add the vote in a bit.
+		}
+	}
+
+	// Before adding to votesByBlock, see if we'll exceed quorum
+	origSum := votesByBlock.sum
+	quorum := voteSet.valSet.TotalVotingPower()*2/3 + 1
+
+	// Add vote to votesByBlock
+	votesByBlock.addVerifiedVote(vote, votingPower)
+
+	// If we just crossed the quorum threshold and have 2/3 majority...
+	if origSum < quorum && quorum <= votesByBlock.sum {
+		// Only consider the first quorum reached
+		if voteSet.maj23 == nil {
+			voteSet.maj23 = getBlockInfo(vote)
+			// And also copy votes over to voteSet.votes
+			for i, vote := range votesByBlock.votes {
+				if vote != nil {
+					voteSet.votes[i] = vote
+				}
+			}
+		}
+	}
+
+	return true, conflicting
+}
+
+// If a peer claims that it has 2/3 majority for given blockKey, call this.
+// NOTE: if there are too many peers, or too much peer churn,
+// this can cause memory issues.
+// TODO: implement ability to remove peers too
+func (voteSet *VoteSet) SetPeerMaj23(peerID string, blockHash []byte, blockPartsHeader PartSetHeader) {
+	voteSet.mtx.Lock()
+	defer voteSet.mtx.Unlock()
+
+	blockInfo := &blockInfo{blockHash, blockPartsHeader}
+	blockKey := blockInfo.BlockKey()
+
+	// Make sure peer hasn't already told us something.
+	if existing, ok := voteSet.peerMaj23s[peerID]; ok {
+		if existing.Equals(blockInfo) {
+			return // Nothing to do
+		} else {
+			return // TODO bad peer!
+		}
+	}
+	voteSet.peerMaj23s[peerID] = blockInfo
+
+	// Create .votesByBlock entry if needed.
+	votesByBlock, ok := voteSet.votesByBlock[blockKey]
+	if ok {
+		if votesByBlock.peerMaj23 {
+			return // Nothing to do
+		} else {
+			votesByBlock.peerMaj23 = true
+			// No need to copy votes, already there.
+		}
+	} else {
+		votesByBlock = newBlockVotes(true, voteSet.valSet.Size())
+		voteSet.votesByBlock[blockKey] = votesByBlock
+		// No need to copy votes, no votes to copy over.
+	}
 }
 
 func (voteSet *VoteSet) BitArray() *BitArray {
@@ -175,6 +318,7 @@ func (voteSet *VoteSet) BitArray() *BitArray {
 	return voteSet.votesBitArray.Copy()
 }
 
+// NOTE: if validator has conflicting votes, picks random.
 func (voteSet *VoteSet) GetByIndex(valIndex int) *Vote {
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
@@ -197,7 +341,7 @@ func (voteSet *VoteSet) HasTwoThirdsMajority() bool {
 	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
-	return voteSet.maj23Exists
+	return voteSet.maj23 != nil
 }
 
 func (voteSet *VoteSet) IsCommit() bool {
@@ -209,7 +353,7 @@ func (voteSet *VoteSet) IsCommit() bool {
 	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
-	return len(voteSet.maj23Hash) > 0
+	return voteSet.maj23 != nil
 }
 
 func (voteSet *VoteSet) HasTwoThirdsAny() bool {
@@ -218,16 +362,16 @@ func (voteSet *VoteSet) HasTwoThirdsAny() bool {
 	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
-	return voteSet.totalVotes > voteSet.valSet.TotalVotingPower()*2/3
+	return voteSet.sum > voteSet.valSet.TotalVotingPower()*2/3
 }
 
 // Returns either a blockhash (or nil) that received +2/3 majority.
-// If there exists no such majority, returns (nil, false).
+// If there exists no such majority, returns (nil, PartSetHeader{}, false).
 func (voteSet *VoteSet) TwoThirdsMajority() (hash []byte, parts PartSetHeader, ok bool) {
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
-	if voteSet.maj23Exists {
-		return voteSet.maj23Hash, voteSet.maj23PartsHeader, true
+	if voteSet.maj23 != nil {
+		return voteSet.maj23.hash, voteSet.maj23.partsHeader, true
 	} else {
 		return nil, PartSetHeader{}, false
 	}
@@ -267,7 +411,7 @@ func (voteSet *VoteSet) StringShort() string {
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 	return fmt.Sprintf(`VoteSet{H:%v R:%v T:%v +2/3:%v %v}`,
-		voteSet.height, voteSet.round, voteSet.type_, voteSet.maj23Exists, voteSet.votesBitArray)
+		voteSet.height, voteSet.round, voteSet.type_, voteSet.maj23, voteSet.votesBitArray)
 }
 
 //--------------------------------------------------------------------------------
@@ -279,30 +423,61 @@ func (voteSet *VoteSet) MakeCommit() *Commit {
 	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
-	if len(voteSet.maj23Hash) == 0 {
+
+	// Make sure we have a 2/3 majority
+	if voteSet.maj23 == nil {
 		PanicSanity("Cannot MakeCommit() unless a blockhash has +2/3")
 	}
-	precommits := make([]*Vote, voteSet.valSet.Size())
-	voteSet.valSet.Iterate(func(valIndex int, val *Validator) bool {
-		vote := voteSet.votes[valIndex]
-		if vote == nil {
-			return false
-		}
-		if !bytes.Equal(vote.BlockHash, voteSet.maj23Hash) {
-			return false
-		}
-		if !vote.BlockPartsHeader.Equals(voteSet.maj23PartsHeader) {
-			return false
-		}
-		precommits[valIndex] = vote
-		return false
-	})
+
+	// For every validator, get the precommit
+	maj23Votes := voteSet.votesByBlock[voteSet.maj23.BlockKey()]
 	return &Commit{
-		Precommits: precommits,
+		Precommits: maj23Votes.votes,
 	}
 }
 
-//----------------------------------------
+//--------------------------------------------------------------------------------
+
+/*
+	Votes for a particular block
+	There are two ways a *blockVotes gets created for a blockKey.
+	1. first (non-conflicting) vote of a validator w/ blockKey (peerMaj23=false)
+	2. A peer claims to have a 2/3 majority w/ blockKey (peerMaj23=true)
+*/
+type blockVotes struct {
+	peerMaj23 bool      // peer claims to have maj23
+	bitArray  *BitArray // valIndex -> hasVote?
+	votes     []*Vote   // valIndex -> *Vote
+	sum       int64     // vote sum
+}
+
+func newBlockVotes(peerMaj23 bool, numValidators int) *blockVotes {
+	return &blockVotes{
+		peerMaj23: peerMaj23,
+		bitArray:  NewBitArray(numValidators),
+		votes:     make([]*Vote, numValidators),
+		sum:       0,
+	}
+}
+
+func (vs *blockVotes) addVerifiedVote(vote *Vote, votingPower int64) {
+	valIndex := vote.ValidatorIndex
+	if existing := vs.votes[valIndex]; existing == nil {
+		vs.bitArray.SetIndex(valIndex, true)
+		vs.votes[valIndex] = vote
+		vs.sum += votingPower
+	}
+}
+
+func (vs *blockVotes) getByIndex(index int) *Vote {
+	if vs == nil {
+		return nil
+	}
+	return vs.votes[index]
+}
+
+//--------------------------------------------------------------------------------
+
 // Common interface between *consensus.VoteSet and types.Commit
 type VoteSetReader interface {
 	Height() int
@@ -312,4 +487,28 @@ type VoteSetReader interface {
 	BitArray() *BitArray
 	GetByIndex(int) *Vote
 	IsCommit() bool
+}
+
+//--------------------------------------------------------------------------------
+
+type blockInfo struct {
+	hash        []byte
+	partsHeader PartSetHeader
+}
+
+func (bInfo *blockInfo) Equals(other *blockInfo) bool {
+	return bytes.Equal(bInfo.hash, other.hash) &&
+		bInfo.partsHeader.Equals(other.partsHeader)
+}
+
+func (bInfo *blockInfo) BlockKey() string {
+	return string(bInfo.hash) + string(wire.BinaryBytes(bInfo.partsHeader))
+}
+
+func getBlockInfo(vote *Vote) *blockInfo {
+	return &blockInfo{vote.BlockHash, vote.BlockPartsHeader}
+}
+
+func getBlockKey(vote *Vote) string {
+	return string(vote.BlockHash) + string(wire.BinaryBytes(vote.BlockPartsHeader))
 }

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -49,14 +49,14 @@ func withType(vote *Vote, type_ byte) *Vote {
 // Convenience: Return new vote with different blockHash
 func withBlockHash(vote *Vote, blockHash []byte) *Vote {
 	vote = vote.Copy()
-	vote.BlockHash = blockHash
+	vote.BlockID.Hash = blockHash
 	return vote
 }
 
 // Convenience: Return new vote with different blockParts
 func withBlockPartsHeader(vote *Vote, blockPartsHeader PartSetHeader) *Vote {
 	vote = vote.Copy()
-	vote.BlockPartsHeader = blockPartsHeader
+	vote.BlockID.PartsHeader = blockPartsHeader
 	return vote
 }
 
@@ -79,8 +79,8 @@ func TestAddVote(t *testing.T) {
 	if voteSet.BitArray().GetIndex(0) {
 		t.Errorf("Expected BitArray.GetIndex(0) to be false")
 	}
-	hash, header, ok := voteSet.TwoThirdsMajority()
-	if hash != nil || !header.IsZero() || ok {
+	blockID, ok := voteSet.TwoThirdsMajority()
+	if ok || !blockID.IsZero() {
 		t.Errorf("There should be no 2/3 majority")
 	}
 
@@ -90,7 +90,7 @@ func TestAddVote(t *testing.T) {
 		Height:           height,
 		Round:            round,
 		Type:             VoteTypePrevote,
-		BlockHash:        nil,
+		BlockID:          BlockID{nil, PartSetHeader{}},
 	}
 	signAddVote(val0, vote, voteSet)
 
@@ -100,8 +100,8 @@ func TestAddVote(t *testing.T) {
 	if !voteSet.BitArray().GetIndex(0) {
 		t.Errorf("Expected BitArray.GetIndex(0) to be true")
 	}
-	hash, header, ok = voteSet.TwoThirdsMajority()
-	if hash != nil || !header.IsZero() || ok {
+	blockID, ok = voteSet.TwoThirdsMajority()
+	if ok || !blockID.IsZero() {
 		t.Errorf("There should be no 2/3 majority")
 	}
 }
@@ -116,15 +116,15 @@ func Test2_3Majority(t *testing.T) {
 		Height:           height,
 		Round:            round,
 		Type:             VoteTypePrevote,
-		BlockHash:        nil,
+		BlockID:          BlockID{nil, PartSetHeader{}},
 	}
 	// 6 out of 10 voted for nil.
 	for i := 0; i < 6; i++ {
 		vote := withValidator(voteProto, privValidators[i].Address, i)
 		signAddVote(privValidators[i], vote, voteSet)
 	}
-	hash, header, ok := voteSet.TwoThirdsMajority()
-	if hash != nil || !header.IsZero() || ok {
+	blockID, ok := voteSet.TwoThirdsMajority()
+	if ok || !blockID.IsZero() {
 		t.Errorf("There should be no 2/3 majority")
 	}
 
@@ -132,8 +132,8 @@ func Test2_3Majority(t *testing.T) {
 	{
 		vote := withValidator(voteProto, privValidators[6].Address, 6)
 		signAddVote(privValidators[6], withBlockHash(vote, RandBytes(32)), voteSet)
-		hash, header, ok = voteSet.TwoThirdsMajority()
-		if hash != nil || !header.IsZero() || ok {
+		blockID, ok = voteSet.TwoThirdsMajority()
+		if ok || !blockID.IsZero() {
 			t.Errorf("There should be no 2/3 majority")
 		}
 	}
@@ -142,8 +142,8 @@ func Test2_3Majority(t *testing.T) {
 	{
 		vote := withValidator(voteProto, privValidators[7].Address, 7)
 		signAddVote(privValidators[7], vote, voteSet)
-		hash, header, ok = voteSet.TwoThirdsMajority()
-		if hash != nil || !header.IsZero() || !ok {
+		blockID, ok = voteSet.TwoThirdsMajority()
+		if !ok || !blockID.IsZero() {
 			t.Errorf("There should be 2/3 majority for nil")
 		}
 	}
@@ -163,8 +163,7 @@ func Test2_3MajorityRedux(t *testing.T) {
 		Height:           height,
 		Round:            round,
 		Type:             VoteTypePrevote,
-		BlockHash:        blockHash,
-		BlockPartsHeader: blockPartsHeader,
+		BlockID:          BlockID{blockHash, blockPartsHeader},
 	}
 
 	// 66 out of 100 voted for nil.
@@ -172,8 +171,8 @@ func Test2_3MajorityRedux(t *testing.T) {
 		vote := withValidator(voteProto, privValidators[i].Address, i)
 		signAddVote(privValidators[i], vote, voteSet)
 	}
-	hash, header, ok := voteSet.TwoThirdsMajority()
-	if hash != nil || !header.IsZero() || ok {
+	blockID, ok := voteSet.TwoThirdsMajority()
+	if ok || !blockID.IsZero() {
 		t.Errorf("There should be no 2/3 majority")
 	}
 
@@ -181,8 +180,8 @@ func Test2_3MajorityRedux(t *testing.T) {
 	{
 		vote := withValidator(voteProto, privValidators[66].Address, 66)
 		signAddVote(privValidators[66], withBlockHash(vote, nil), voteSet)
-		hash, header, ok = voteSet.TwoThirdsMajority()
-		if hash != nil || !header.IsZero() || ok {
+		blockID, ok = voteSet.TwoThirdsMajority()
+		if ok || !blockID.IsZero() {
 			t.Errorf("There should be no 2/3 majority: last vote added was nil")
 		}
 	}
@@ -192,8 +191,8 @@ func Test2_3MajorityRedux(t *testing.T) {
 		vote := withValidator(voteProto, privValidators[67].Address, 67)
 		blockPartsHeader := PartSetHeader{blockPartsTotal, crypto.CRandBytes(32)}
 		signAddVote(privValidators[67], withBlockPartsHeader(vote, blockPartsHeader), voteSet)
-		hash, header, ok = voteSet.TwoThirdsMajority()
-		if hash != nil || !header.IsZero() || ok {
+		blockID, ok = voteSet.TwoThirdsMajority()
+		if ok || !blockID.IsZero() {
 			t.Errorf("There should be no 2/3 majority: last vote added had different PartSetHeader Hash")
 		}
 	}
@@ -203,8 +202,8 @@ func Test2_3MajorityRedux(t *testing.T) {
 		vote := withValidator(voteProto, privValidators[68].Address, 68)
 		blockPartsHeader := PartSetHeader{blockPartsTotal + 1, blockPartsHeader.Hash}
 		signAddVote(privValidators[68], withBlockPartsHeader(vote, blockPartsHeader), voteSet)
-		hash, header, ok = voteSet.TwoThirdsMajority()
-		if hash != nil || !header.IsZero() || ok {
+		blockID, ok = voteSet.TwoThirdsMajority()
+		if ok || !blockID.IsZero() {
 			t.Errorf("There should be no 2/3 majority: last vote added had different PartSetHeader Total")
 		}
 	}
@@ -213,8 +212,8 @@ func Test2_3MajorityRedux(t *testing.T) {
 	{
 		vote := withValidator(voteProto, privValidators[69].Address, 69)
 		signAddVote(privValidators[69], withBlockHash(vote, RandBytes(32)), voteSet)
-		hash, header, ok = voteSet.TwoThirdsMajority()
-		if hash != nil || !header.IsZero() || ok {
+		blockID, ok = voteSet.TwoThirdsMajority()
+		if ok || !blockID.IsZero() {
 			t.Errorf("There should be no 2/3 majority: last vote added had different BlockHash")
 		}
 	}
@@ -223,8 +222,8 @@ func Test2_3MajorityRedux(t *testing.T) {
 	{
 		vote := withValidator(voteProto, privValidators[70].Address, 70)
 		signAddVote(privValidators[70], vote, voteSet)
-		hash, header, ok = voteSet.TwoThirdsMajority()
-		if !bytes.Equal(hash, blockHash) || !header.Equals(blockPartsHeader) || !ok {
+		blockID, ok = voteSet.TwoThirdsMajority()
+		if !ok || !blockID.Equals(BlockID{blockHash, blockPartsHeader}) {
 			t.Errorf("There should be 2/3 majority")
 		}
 	}
@@ -240,7 +239,7 @@ func TestBadVotes(t *testing.T) {
 		Height:           height,
 		Round:            round,
 		Type:             VoteTypePrevote,
-		BlockHash:        nil,
+		BlockID:          BlockID{nil, PartSetHeader{}},
 	}
 
 	// val0 votes for nil.
@@ -301,7 +300,7 @@ func TestConflicts(t *testing.T) {
 		Height:           height,
 		Round:            round,
 		Type:             VoteTypePrevote,
-		BlockHash:        nil,
+		BlockID:          BlockID{nil, PartSetHeader{}},
 	}
 
 	// val0 votes for nil.
@@ -326,7 +325,7 @@ func TestConflicts(t *testing.T) {
 	}
 
 	// start tracking blockHash1
-	voteSet.SetPeerMaj23("peerA", blockHash1, PartSetHeader{})
+	voteSet.SetPeerMaj23("peerA", BlockID{blockHash1, PartSetHeader{}})
 
 	// val0 votes again for blockHash1.
 	{
@@ -341,7 +340,7 @@ func TestConflicts(t *testing.T) {
 	}
 
 	// attempt tracking blockHash2, should fail because already set for peerA.
-	voteSet.SetPeerMaj23("peerA", blockHash2, PartSetHeader{})
+	voteSet.SetPeerMaj23("peerA", BlockID{blockHash2, PartSetHeader{}})
 
 	// val0 votes again for blockHash1.
 	{
@@ -390,7 +389,7 @@ func TestConflicts(t *testing.T) {
 	}
 
 	// now attempt tracking blockHash1
-	voteSet.SetPeerMaj23("peerB", blockHash1, PartSetHeader{})
+	voteSet.SetPeerMaj23("peerB", BlockID{blockHash1, PartSetHeader{}})
 
 	// val2 votes for blockHash1.
 	{
@@ -408,8 +407,8 @@ func TestConflicts(t *testing.T) {
 	if !voteSet.HasTwoThirdsMajority() {
 		t.Errorf("We should have 2/3 majority for blockHash1")
 	}
-	blockHash23maj, _, _ := voteSet.TwoThirdsMajority()
-	if !bytes.Equal(blockHash23maj, blockHash1) {
+	blockIDMaj23, _ := voteSet.TwoThirdsMajority()
+	if !bytes.Equal(blockIDMaj23.Hash, blockHash1) {
 		t.Errorf("Got the wrong 2/3 majority blockhash")
 	}
 	if !voteSet.HasTwoThirdsAny() {
@@ -429,8 +428,7 @@ func TestMakeCommit(t *testing.T) {
 		Height:           height,
 		Round:            round,
 		Type:             VoteTypePrecommit,
-		BlockHash:        blockHash,
-		BlockPartsHeader: blockPartsHeader,
+		BlockID:          BlockID{blockHash, blockPartsHeader},
 	}
 
 	// 6 out of 10 voted for some block.

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestVoteSignable(t *testing.T) {
+	vote := &Vote{
+		ValidatorAddress: []byte("addr"),
+		ValidatorIndex:   56789,
+		Height:           12345,
+		Round:            23456,
+		Type:             byte(2),
+		BlockID: BlockID{
+			Hash: []byte("hash"),
+			PartsHeader: PartSetHeader{
+				Total: 1000000,
+				Hash:  []byte("parts_hash"),
+			},
+		},
+	}
+	signBytes := SignBytes("test_chain_id", vote)
+	signStr := string(signBytes)
+
+	expected := `{"chain_id":"test_chain_id","vote":{"block_id":{"hash":"68617368","parts":{"hash":"70617274735F68617368","total":1000000}},"height":12345,"round":23456,"type":2}}`
+	if signStr != expected {
+		// NOTE: when this fails, you probably want to fix up consensus/replay_test too
+		t.Errorf("Got unexpected sign string for Vote. Expected:\n%v\nGot:\n%v", expected, signStr)
+	}
+}


### PR DESCRIPTION
This is not complete, but I'll document the thinking process while working on it.

The problem is that, the way things are, due to the way peers communicate to each other which votes it has, if a validator double-signs for a given height/round/step, then it can prevent its own other double-votes from propagating correct, e.g. "occluding".

The case in which this was discovered to be an issue was during a BFT fuzz test, where it halted the blockchain with less than 1/3 of Byzantine validators, due to the Commit being occluded.

What are all the issues related to double-signing occlusion?
- 2/3 Precommits, or a Commit, from being broadcast and letting the network progress in height
- 2/3 Prevotes, or a POL, from being broadcast and letting validators unlock to let consensus progress

What about when there are more than 1 2/3 majority for a prevote or precommit step, due to 1/3+ being Byzantine?  Currently we don't have logic to automatically broadcast this issue.  This would be a good time to implement that logic, so we fix BFT as well as the first step in identifying an attack.  This isn't the same as Tendermint V2, where a Commit is fully justified, but, it would be ideal to work toward that, while we fix this issue.

So, we want to:
- prevent occlusion when < 1/3 have double-signed
- ensure broadcasting of double-signing by each validator
- ensure broadcasting of 2 conflicting 2/3 precommits (forks)
- maybe, ensure broadcasting of 2 conflicting 2/3 prevotes

I don't have the whole solution yet, but the first step might be to refactor the VoteSet structure to allow tracking of double-signing.  But we need to make sure this is done in such a way that double-signers can't sign a million votes and make nodes run out of memory, or cause some other issue.

The general solution I have in mind is to do the following:
- By default, allow VoteSet to keep track of up to 2 conflicting votes for each validator
- Implement a method on VoteSet to allow, for each unique peer, one 2/3-majority blockhash to be tracked as extra, beyond the 2 maximum conflicting votes.  So even though we have votes from ByzVal1 for BlockA and BlockB, if Peer1 says it has a 2/3-majority blockhash for BlockC, then we allow this VoteSet to also remember a third vote for ByzVal1 for BlockC.
- It is the responsibility of the consensus reactor to manage calling the above method, as well as any cleanup methods, upon peer connection and disconnection, and communicate 2/3-majority blockhash announcements as necessary.

As I implement these features in VoteSet, I'll make sure the functionality is reusable for Tendermint V2, so that justifications can be requested for (H,R,S) as necessary.
