### PR TITLE
allow app to fail and restart

### DIFF
--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -317,7 +317,6 @@ func fixedConsensusState() *ConsensusState {
 	privValidatorFile := config.GetString("priv_validator_file")
 	privValidator := types.LoadOrGenPrivValidator(privValidatorFile)
 	return newConsensusState(state, privValidator, counter.NewCounterApplication(true))
-
 }
 
 func newConsensusState(state *sm.State, pv *types.PrivValidator, app tmsp.Application) *ConsensusState {

--- a/consensus/reconnect_test.go
+++ b/consensus/reconnect_test.go
@@ -1,0 +1,142 @@
+package consensus
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/tendermint/go-common"
+	"github.com/tendermint/tendermint/types"
+	"github.com/tendermint/tmsp/example/dummy"
+	"github.com/tendermint/tmsp/server"
+)
+
+func TestAppRestart1(t *testing.T) {
+
+	state, privVal := fixedState()
+
+	proxyAddr := "tcp://localhost:36658"
+	transport := config.GetString("tmsp")
+
+	var tmspServer Service
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		var err error
+		tmspServer, err = server.NewServer(proxyAddr, transport, dummy.NewDummyApplication())
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+	cs, err := newConsensusStateProxyApp(state, privVal, proxyAddr, transport)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureDir(config.GetString("db_dir"), 0700) // incase we use memdb, cswal still gets written here
+
+	newBlockCh := subscribeToEvent(cs.evsw, "tester", types.EventStringNewBlock(), 0)
+	voteCh := subscribeToEvent(cs.evsw, "tester", types.EventStringVote(), 0)
+
+	// start timeout and receive routines
+	cs.Start()
+
+	_, _, _ = <-voteCh, <-voteCh, <-newBlockCh
+
+	log.Warn("Stopping tmsp server before hitting proxy app. Consensus state should not stop")
+	tmspServer.Stop()
+	tmspServer.Reset()
+
+	_, _ = <-voteCh, <-voteCh
+
+	timer := time.NewTimer(time.Second * 3)
+	select {
+	case <-newBlockCh:
+		t.Fatal("expected no new block as app crashed")
+	case <-timer.C:
+	}
+
+	time.Sleep(time.Second * 3)
+	log.Warn("Restart tmsp server")
+	if _, err := tmspServer.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	timer = time.NewTimer(time.Second * 10)
+	select {
+	case <-newBlockCh:
+	case <-timer.C:
+		t.Fatal("expected new block after app restart")
+	}
+}
+
+func TestAppRestart2(t *testing.T) {
+
+	state, privVal := fixedState()
+
+	proxyAddr := "tcp://localhost:36658"
+	transport := config.GetString("tmsp")
+
+	var tmspServer Service
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		var err error
+		tmspServer, err = server.NewServer(proxyAddr, transport, dummy.NewDummyApplication())
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+	cs, err := newConsensusStateProxyApp(state, privVal, proxyAddr, transport)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureDir(config.GetString("db_dir"), 0700) // incase we use memdb, cswal still gets written here
+
+	newBlockCh := subscribeToEvent(cs.evsw, "tester", types.EventStringNewBlock(), 0)
+	voteCh := subscribeToEvent(cs.evsw, "tester", types.EventStringVote(), 0)
+
+	// start timeout and receive routines
+	cs.Start()
+
+	_, _, _ = <-voteCh, <-voteCh, <-newBlockCh
+
+	<-voteCh
+
+	log.Warn("Stopping tmsp server to hit proxy app. Consensus state should stop")
+	tmspServer.Stop()
+	tmspServer.Reset()
+
+	<-voteCh
+
+	timer := time.NewTimer(time.Second * 3)
+	select {
+	case <-newBlockCh:
+		t.Fatal("expected no new block as app crashed")
+	case <-timer.C:
+	}
+
+	time.Sleep(time.Second * 3)
+	log.Warn("Restart tmsp server")
+	if _, err := tmspServer.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// the two votes should be replayed
+	_, _ = <-voteCh, <-voteCh
+
+	timer = time.NewTimer(time.Second * 10)
+	select {
+	case <-newBlockCh:
+	case <-timer.C:
+		t.Fatal("expected new block after app restart")
+	}
+
+}

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -80,11 +80,11 @@ func (cs *ConsensusState) readReplayMessage(msgBytes []byte, newStepCh chan inte
 // replay only those messages since the last block
 func (cs *ConsensusState) catchupReplay(height int) error {
 	if cs.wal == nil {
-		log.Warn("consensus msg log is nil")
+		log.Warn("WAL is nil")
 		return nil
 	}
 	if !cs.wal.exists {
-		// new wal, nothing to catchup on
+		log.Warn("New WAL, nothing to catchup on")
 		return nil
 	}
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -20,6 +20,17 @@ import (
 )
 
 //-----------------------------------------------------------------------------
+// Errors
+
+type ErrProxyApp struct {
+	err error
+}
+
+func (err ErrProxyApp) Error() string {
+	return err.err.Error()
+}
+
+//-----------------------------------------------------------------------------
 // Timeout Parameters
 
 // All in milliseconds
@@ -298,8 +309,14 @@ func (cs *ConsensusState) SetPrivValidator(priv *types.PrivValidator) {
 func (cs *ConsensusState) OnStart() error {
 	cs.QuitService.OnStart()
 
+	err := cs.OpenWAL(cs.config.GetString("cswal"))
+	if err != nil {
+		return err
+	}
+
 	// start timeout and receive routines
-	cs.startRoutines(0)
+	// cs.startRoutines(0)
+	go cs.receiveRoutine(0)
 
 	// we may have lost some votes if the process crashed
 	// reload from consensus log to catchup
@@ -307,6 +324,8 @@ func (cs *ConsensusState) OnStart() error {
 		log.Error("Error on catchup replay", "error", err.Error())
 		// let's go for it anyways, maybe we're fine
 	}
+
+	go cs.timeoutRoutine()
 
 	// schedule the first round!
 	cs.scheduleRound0(cs.Height)
@@ -324,7 +343,7 @@ func (cs *ConsensusState) startRoutines(maxSteps int) {
 func (cs *ConsensusState) OnStop() {
 	cs.QuitService.OnStop()
 
-	if cs.wal != nil && cs.IsRunning() {
+	if cs.IsRunning() {
 		cs.wal.Wait()
 	}
 }
@@ -332,6 +351,9 @@ func (cs *ConsensusState) OnStop() {
 // Allow it to be Reset
 func (cs *ConsensusState) OnReset() error {
 	log.Notice("Resetting consensus state base service")
+	cs.mtx.Lock()
+	defer cs.mtx.Unlock()
+	cs.resetRoundState(cs.Height, cs.state)
 	return nil
 }
 
@@ -489,8 +511,17 @@ func (cs *ConsensusState) updateToState(state *sm.State) {
 	}
 
 	// Reset fields based on state.
-	validators := state.Validators
 	height := state.LastBlockHeight + 1 // Next desired block height
+
+	cs.resetRoundState(height, state)
+
+	cs.state = state
+
+	// Finally, broadcast RoundState
+	cs.newStep()
+}
+
+func (cs *ConsensusState) lastPrecommits() *types.VoteSet {
 	lastPrecommits := (*types.VoteSet)(nil)
 	if cs.CommitRound > -1 && cs.Votes != nil {
 		if !cs.Votes.Precommits(cs.CommitRound).HasTwoThirdsMajority() {
@@ -498,6 +529,12 @@ func (cs *ConsensusState) updateToState(state *sm.State) {
 		}
 		lastPrecommits = cs.Votes.Precommits(cs.CommitRound)
 	}
+	return lastPrecommits
+}
+
+func (cs *ConsensusState) resetRoundState(height int, state *sm.State) {
+	lastPrecommits := cs.lastPrecommits()
+	validators := state.Validators
 
 	// RoundState fields
 	cs.updateHeight(height)
@@ -512,23 +549,20 @@ func (cs *ConsensusState) updateToState(state *sm.State) {
 	} else {
 		cs.StartTime = cs.timeoutParams.Commit(cs.CommitTime)
 	}
-	cs.CommitTime = time.Time{}
-	cs.Validators = validators
+
 	cs.Proposal = nil
 	cs.ProposalBlock = nil
 	cs.ProposalBlockParts = nil
 	cs.LockedRound = 0
 	cs.LockedBlock = nil
 	cs.LockedBlockParts = nil
-	cs.Votes = NewHeightVoteSet(cs.config.GetString("chain_id"), height, validators)
 	cs.CommitRound = -1
+
+	cs.CommitTime = time.Time{}
+	cs.Validators = validators
+	cs.Votes = NewHeightVoteSet(cs.config.GetString("chain_id"), height, validators)
 	cs.LastCommit = lastPrecommits
 	cs.LastValidators = state.LastValidators
-
-	cs.state = state
-
-	// Finally, broadcast RoundState
-	cs.newStep()
 }
 
 func (cs *ConsensusState) newStep() {
@@ -613,17 +647,18 @@ func (cs *ConsensusState) receiveRoutine(maxSteps int) {
 		}
 		rs := cs.RoundState
 		var mi msgInfo
+		var err error
 
 		select {
 		case mi = <-cs.peerMsgQueue:
 			cs.wal.Save(mi)
 			// handles proposals, block parts, votes
 			// may generate internal events (votes, complete proposals, 2/3 majorities)
-			cs.handleMsg(mi, rs)
+			err = cs.handleMsg(mi, rs)
 		case mi = <-cs.internalMsgQueue:
 			cs.wal.Save(mi)
 			// handles proposals, block parts, votes
-			cs.handleMsg(mi, rs)
+			err = cs.handleMsg(mi, rs)
 		case ti := <-cs.tockChan:
 			cs.wal.Save(ti)
 			// if the timeout is relevant to the rs
@@ -644,16 +679,23 @@ func (cs *ConsensusState) receiveRoutine(maxSteps int) {
 			}
 
 			// close wal now that we're done writing to it
-			if cs.wal != nil {
-				cs.wal.Close()
-			}
+			cs.wal.Close()
 			return
+		}
+
+		if _, ok := err.(ErrProxyApp); ok {
+			// Proxy app failed
+			cs.Stop()
+			_, err := cs.Reset() // allow it to be restart when the app comes back online
+			if err != nil {
+				PanicSanity(err)
+			}
 		}
 	}
 }
 
 // state transitions on complete-proposal, 2/3-any, 2/3-one
-func (cs *ConsensusState) handleMsg(mi msgInfo, rs RoundState) {
+func (cs *ConsensusState) handleMsg(mi msgInfo, rs RoundState) error {
 	cs.mtx.Lock()
 	defer cs.mtx.Unlock()
 
@@ -673,7 +715,7 @@ func (cs *ConsensusState) handleMsg(mi msgInfo, rs RoundState) {
 	case *VoteMessage:
 		// attempt to add the vote and dupeout the validator if its a duplicate signature
 		// if the vote gives us a 2/3-any or 2/3-one, we transition
-		err := cs.tryAddVote(msg.ValidatorIndex, msg.Vote, peerKey)
+		err = cs.tryAddVote(msg.ValidatorIndex, msg.Vote, peerKey)
 		if err == ErrAddingVote {
 			// TODO: punish peer
 		}
@@ -687,9 +729,12 @@ func (cs *ConsensusState) handleMsg(mi msgInfo, rs RoundState) {
 	default:
 		log.Warn("Unknown msg type", reflect.TypeOf(msg))
 	}
-	if err != nil {
+	if _, ok := err.(ErrProxyApp); ok {
+		// ...
+	} else if err != nil {
 		log.Error("Error with msg", "type", reflect.TypeOf(msg), "peer", peerKey, "error", err, "msg", msg)
 	}
+	return err
 }
 
 func (cs *ConsensusState) handleTimeout(ti timeoutInfo, rs RoundState) {
@@ -1124,7 +1169,7 @@ func (cs *ConsensusState) enterPrecommitWait(height int, round int) {
 }
 
 // Enter: +2/3 precommits for block
-func (cs *ConsensusState) enterCommit(height int, commitRound int) {
+func (cs *ConsensusState) enterCommit(height int, commitRound int) (err error) {
 	if cs.Height != height || RoundStepCommit <= cs.Step {
 		log.Debug(Fmt("enterCommit(%v/%v): Invalid args. Current step: %v/%v/%v", height, commitRound, cs.Height, cs.Round, cs.Step))
 		return
@@ -1139,7 +1184,7 @@ func (cs *ConsensusState) enterCommit(height int, commitRound int) {
 		cs.newStep()
 
 		// Maybe finalize immediately.
-		cs.tryFinalizeCommit(height)
+		err = cs.tryFinalizeCommit(height)
 	}()
 
 	hash, partsHeader, ok := cs.Votes.Precommits(commitRound).TwoThirdsMajority()
@@ -1166,10 +1211,11 @@ func (cs *ConsensusState) enterCommit(height int, commitRound int) {
 			// We just need to keep waiting.
 		}
 	}
+	return
 }
 
 // If we have the block AND +2/3 commits for it, finalize.
-func (cs *ConsensusState) tryFinalizeCommit(height int) {
+func (cs *ConsensusState) tryFinalizeCommit(height int) error {
 	if cs.Height != height {
 		PanicSanity(Fmt("tryFinalizeCommit() cs.Height: %v vs height: %v", cs.Height, height))
 	}
@@ -1177,22 +1223,21 @@ func (cs *ConsensusState) tryFinalizeCommit(height int) {
 	hash, _, ok := cs.Votes.Precommits(cs.CommitRound).TwoThirdsMajority()
 	if !ok || len(hash) == 0 {
 		log.Warn("Attempt to finalize failed. There was no +2/3 majority, or +2/3 was for <nil>.")
-		return
+		return nil
 	}
 	if !cs.ProposalBlock.HashesTo(hash) {
 		// TODO: this happens every time if we're not a validator (ugly logs)
 		log.Warn("Attempt to finalize failed. We don't have the commit block.")
-		return
+		return nil
 	}
-	//	go
-	cs.finalizeCommit(height)
+	return cs.finalizeCommit(height)
 }
 
 // Increment height and goto RoundStepNewHeight
-func (cs *ConsensusState) finalizeCommit(height int) {
+func (cs *ConsensusState) finalizeCommit(height int) error {
 	if cs.Height != height || cs.Step != RoundStepCommit {
 		log.Debug(Fmt("finalizeCommit(%v): Invalid args. Current step: %v/%v/%v", height, cs.Height, cs.Round, cs.Step))
-		return
+		return nil
 	}
 
 	hash, header, ok := cs.Votes.Precommits(cs.CommitRound).TwoThirdsMajority()
@@ -1214,11 +1259,6 @@ func (cs *ConsensusState) finalizeCommit(height int) {
 	log.Notice(Fmt("Finalizing commit of block with %d txs", block.NumTxs), "height", block.Height, "hash", block.Hash())
 	log.Info(Fmt("%v", block))
 
-	// Fire off event for new block.
-	// TODO: Handle app failure.  See #177
-	cs.evsw.FireEvent(types.EventStringNewBlock(), types.EventDataNewBlock{block})
-	cs.evsw.FireEvent(types.EventStringNewBlockHeader(), types.EventDataNewBlockHeader{block.Header})
-
 	// Create a copy of the state for staging
 	stateCopy := cs.state.Copy()
 
@@ -1231,18 +1271,22 @@ func (cs *ConsensusState) finalizeCommit(height int) {
 	err := stateCopy.ExecBlock(eventCache, cs.proxyAppConn, block, blockParts.Header())
 	if err != nil {
 		// stop the consensus state and let it be restarted
-		log.Warn(Fmt("Exec failed for application: %v", err))
-		cs.Stop()
-		cs.Reset() // allow it to be restart when the app comes back online
-		return
+		log.Error("Exec failed for application", "error", err)
+		return ErrProxyApp{err}
 	}
 
 	// lock mempool, commit state, update mempoool
 	err = cs.commitStateUpdateMempool(stateCopy, block)
 	if err != nil {
-		// TODO: handle this gracefully.
-		PanicQ(Fmt("Commit failed for application: %v", err))
+		// stop the consensus state and let it be restarted
+		log.Error("Commit failed for application", "error", err)
+		return ErrProxyApp{err}
 	}
+
+	// Fire off event for new block.
+	// TODO: Handle app failure.  See #177
+	cs.evsw.FireEvent(types.EventStringNewBlock(), types.EventDataNewBlock{block})
+	cs.evsw.FireEvent(types.EventStringNewBlockHeader(), types.EventDataNewBlockHeader{block.Header})
 
 	// txs committed, bad ones removed from mepool; fire events
 	// NOTE: the block.AppHash wont reflect these txs until the next block
@@ -1269,7 +1313,7 @@ func (cs *ConsensusState) finalizeCommit(height int) {
 	// * cs.Height has been increment to height+1
 	// * cs.Step is now RoundStepNewHeight
 	// * cs.StartTime is set to when we will start round0.
-	return
+	return nil
 }
 
 // mempool must be locked during commit and update
@@ -1280,6 +1324,7 @@ func (cs *ConsensusState) commitStateUpdateMempool(s *sm.State, block *types.Blo
 	defer cs.mempool.Unlock()
 
 	// flush out any CheckTx that have already started
+	// XXX: ? (there should be no CheckTx on this conn)
 	cs.proxyAppConn.FlushSync()
 
 	// Commit block, get hash back
@@ -1364,7 +1409,7 @@ func (cs *ConsensusState) addProposalBlockPart(height int, part *types.Part, ver
 			cs.enterPrevote(height, cs.Round)
 		} else if cs.Step == RoundStepCommit {
 			// If we're waiting on the proposal block...
-			cs.tryFinalizeCommit(height)
+			err = cs.tryFinalizeCommit(height)
 		}
 		return true, err
 	}
@@ -1394,6 +1439,8 @@ func (cs *ConsensusState) tryAddVote(valIndex int, vote *types.Vote, peerKey str
 			}
 			cs.mempool.BroadcastTx(struct{???}{evidenceTx}) // shouldn't need to check returned err
 			*/
+			return err
+		} else if _, ok := err.(ErrProxyApp); ok {
 			return err
 		} else {
 			// Probably an invalid signature. Bad peer.
@@ -1476,7 +1523,7 @@ func (cs *ConsensusState) addVote(valIndex int, vote *types.Vote, peerKey string
 					} else {
 						cs.enterNewRound(height, vote.Round)
 						cs.enterPrecommit(height, vote.Round)
-						cs.enterCommit(height, vote.Round)
+						err = cs.enterCommit(height, vote.Round)
 					}
 				} else if cs.Round <= vote.Round && precommits.HasTwoThirdsAny() {
 					cs.enterNewRound(height, vote.Round)
@@ -1488,7 +1535,8 @@ func (cs *ConsensusState) addVote(valIndex int, vote *types.Vote, peerKey string
 				PanicSanity(Fmt("Unexpected vote type %X", vote.Type)) // Should not happen.
 			}
 		}
-		// Either duplicate, or error upon cs.Votes.AddByIndex()
+		// Either duplicate, error upon cs.Votes.AddByIndex(),
+		// or ErrProxyApp from failed enterCommit
 		return
 	} else {
 		err = ErrVoteHeightMismatch

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -3,6 +3,8 @@ package mempool
 import (
 	"bytes"
 	"container/list"
+	"fmt"
+	"io"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -46,6 +48,8 @@ TODO: Better handle tmsp client errors. (make it automatically handle connection
 const cacheSize = 100000
 
 type Mempool struct {
+	QuitService
+
 	config cfg.Config
 
 	proxyMtx      sync.Mutex
@@ -79,7 +83,14 @@ func NewMempool(config cfg.Config, proxyAppConn proxy.AppConn) *Mempool {
 		cacheList: list.New(),
 	}
 	proxyAppConn.SetResponseCallback(mempool.resCb)
+	mempool.QuitService = *NewQuitService(log, "Mempool", mempool)
 	return mempool
+}
+
+// Allow mempool to be restarted
+func (mem *Mempool) OnReset() error {
+	mem.Flush()
+	return nil
 }
 
 // consensus must be able to hold lock to safely update
@@ -121,9 +132,12 @@ func (mem *Mempool) TxsFrontWait() *clist.CElement {
 // cb: A callback from the CheckTx command.
 //     It gets called from another goroutine.
 // CONTRACT: Either cb will get called, or err returned.
-// TODO: write-ahead log
-// TODO: buffer transactions received while the proxyApp is down and replay when its back up
+// TODO: write-ahead log. it should also record txs received while the proxyApp is down
 func (mem *Mempool) CheckTx(tx types.Tx, cb func(*tmsp.Response)) (err error) {
+	if !mem.IsRunning() {
+		return fmt.Errorf("Mempool is not running")
+	}
+
 	mem.proxyMtx.Lock()
 	defer mem.proxyMtx.Unlock()
 
@@ -156,6 +170,10 @@ func (mem *Mempool) CheckTx(tx types.Tx, cb func(*tmsp.Response)) (err error) {
 	// NOTE: proxyAppConn may error if tx buffer is full
 	// or if the connection died
 	if err = mem.proxyAppConn.Error(); err != nil {
+		if err == io.EOF {
+			mem.Stop()
+			mem.Reset()
+		}
 		return err
 	}
 	reqRes := mem.proxyAppConn.CheckTxAsync(tx)

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -40,6 +40,20 @@ func NewMempoolReactor(config cfg.Config, mempool *Mempool) *MempoolReactor {
 	return memR
 }
 
+func (memR *MempoolReactor) OnStart() error {
+	memR.BaseReactor.OnStart()
+	_, err := memR.Mempool.Start()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (memR *MempoolReactor) OnStop() {
+	memR.BaseReactor.OnStop()
+	memR.Mempool.Stop()
+}
+
 // Implements Reactor
 func (memR *MempoolReactor) GetChannels() []*p2p.ChannelDescriptor {
 	return []*p2p.ChannelDescriptor{
@@ -74,7 +88,7 @@ func (memR *MempoolReactor) Receive(chID byte, src *p2p.Peer, msgBytes []byte) {
 		err := memR.Mempool.CheckTx(msg.Tx, nil)
 		if err != nil {
 			// Bad, seen, or conflicting tx.
-			log.Info("Could not add tx", "tx", msg.Tx)
+			log.Info("Could not add tx", "err", err, "tx", msg.Tx)
 			return
 		} else {
 			log.Info("Added valid tx", "tx", msg.Tx)

--- a/node/node.go
+++ b/node/node.go
@@ -110,12 +110,6 @@ func NewNode(config cfg.Config, privValidator *types.PrivValidator, getProxyApp 
 	setConnectCallback(proxyAppConnConsensus, consensusState)
 	setConnectCallback(proxyAppConnMempool, mempool)
 
-	// deterministic accountability
-	err = consensusState.OpenWAL(config.GetString("cswal"))
-	if err != nil {
-		log.Error("Failed to open cswal", "error", err.Error())
-	}
-
 	// Make p2p network switch
 	sw := p2p.NewSwitch(config.GetConfig("p2p"))
 	sw.AddReactor("MEMPOOL", mempoolReactor)

--- a/proxy/remote_app_conn.go
+++ b/proxy/remote_app_conn.go
@@ -12,7 +12,8 @@ type remoteAppConn struct {
 }
 
 func NewRemoteAppConn(addr, transport string) (*remoteAppConn, error) {
-	client, err := tmspcli.NewClient(addr, transport, false)
+	mustConnect := false // force reconnect attempts
+	client, err := tmspcli.NewClient(addr, transport, mustConnect)
 	if err != nil {
 		return nil, err
 	}

--- a/state/execution.go
+++ b/state/execution.go
@@ -82,6 +82,7 @@ func (s *State) execBlockOnProxyApp(eventCache events.Fireable, proxyAppConn pro
 
 	// TODO: BeginBlock
 
+	log.Info(Fmt("AppendTx (%d)", len(block.Txs)))
 	// Run txs of block
 	for _, tx := range block.Txs {
 		proxyAppConn.AppendTxAsync(tx)
@@ -90,10 +91,11 @@ func (s *State) execBlockOnProxyApp(eventCache events.Fireable, proxyAppConn pro
 		}
 	}
 
+	log.Info("EndBlock")
 	// End block
 	changedValidators, err := proxyAppConn.EndBlockSync(uint64(block.Height))
 	if err != nil {
-		log.Warn("Error in proxyAppConn.EndBlock", "error", err)
+		log.Error("Error in proxyAppConn.EndBlock", "error", err)
 		return err
 	}
 	// TODO: Do something with changedValidators


### PR DESCRIPTION
See details/outline in https://github.com/tendermint/tendermint/issues/243
- use `OnReset` from https://github.com/tendermint/go-common/pull/2 to allow ConsensusState to be restarted
- use `SetConnectCallback` from https://github.com/tendermint/tmsp/pull/26 to restart the consensus state when the tmsp client reconnects
- if ExecBlock fails during consensus, stop and reset the consensus state.
- Replay/WAL magic handles the rest.
