### PR TITLE
Fix unsubscribe

### DIFF
--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -20,6 +20,6 @@ func Subscribe(wsCtx rpctypes.WSRPCContext, event string) (*ctypes.ResultSubscri
 
 func Unsubscribe(wsCtx rpctypes.WSRPCContext, event string) (*ctypes.ResultUnsubscribe, error) {
 	log.Notice("Unsubscribe to event", "remote", wsCtx.GetRemoteAddr(), "event", event)
-	wsCtx.GetEventSwitch().RemoveListener(event)
+	wsCtx.GetEventSwitch().RemoveListenerForEvent(event, wsCtx.GetRemoteAddr())
 	return &ctypes.ResultUnsubscribe{}, nil
 }


### PR DESCRIPTION
Currently unsubscribe is broken because it is using the event name instead of the listener to unsubscribe. This restores it to the functionality provided by:

https://github.com/eris-ltd/eris-db/blob/master/Godeps/_workspace/src/github.com/tendermint/tendermint/rpc/server/handlers.go#L359

As a side note the current code only allows one websocket subscription for the same remote address to the same event. This is probably a bad limitation to have. See my remark in: https://github.com/eris-ltd/eris-db/pull/235.