### PR TITLE
Fire proper EventData object on append transaction

### DIFF
--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -52,9 +52,9 @@ func BroadcastTxSync(tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 func BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 
 	// subscribe to tx being committed in block
-	appendTxResCh := make(chan *tmsp.Response, 1)
+	appendTxResCh := make(chan types.EventDataTx, 1)
 	eventSwitch.AddListenerForEvent("rpc", types.EventStringTx(tx), func(data events.EventData) {
-		appendTxResCh <- data.(*tmsp.Response)
+		appendTxResCh <- data.(types.EventDataTx)
 	})
 
 	// broadcast the tx and register checktx callback
@@ -84,11 +84,10 @@ func BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 		// The tx was included in a block.
 		// NOTE we don't return an error regardless of the AppendTx code;
 		// 	clients must check this to see if they need to send a new tx!
-		r := appendTxRes.GetAppendTx()
 		return &ctypes.ResultBroadcastTx{
-			Code: r.Code,
-			Data: r.Data,
-			Log:  r.Log,
+			Code: appendTxRes.Code,
+			Data: appendTxRes.Result,
+			Log:  appendTxRes.Log,
 		}, nil
 	case <-timer.C:
 		r := checkTxR

--- a/types/events.go
+++ b/types/events.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/tendermint/go-common"
 	"github.com/tendermint/go-events"
 	"github.com/tendermint/go-wire"
+	tmsp "github.com/tendermint/tmsp/types"
 )
 
 // Functions to generate eventId strings
@@ -72,10 +73,11 @@ type EventDataNewBlockHeader struct {
 
 // All txs fire EventDataTx
 type EventDataTx struct {
-	Tx     Tx     `json:"tx"`
-	Result []byte `json:"result"`
-	Log    string `json:"log"`
-	Error  string `json:"error"`
+	Tx     Tx            `json:"tx"`
+	Result []byte        `json:"result"`
+	Log    string        `json:"log"`
+	Code   tmsp.CodeType `json:"code"`
+	Error  string        `json:"error"`
 }
 
 // NOTE: This goes into the replay WAL


### PR DESCRIPTION
Fixed issue #285 

Please validate.  And it's probably best to return the same type from CheckTx as well for consistency? (look in mempool.go).