### PR TITLE
make sure to run "removeTxFromCacheMap" in separate go routines 

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -196,7 +196,7 @@ func (mem *Mempool) resCbNormal(req *tmsp.Request, res *tmsp.Response) {
 			// remove from cache (it might be good later)
 			// note this is an async callback,
 			// so we need to grab the lock in removeTxFromCacheMap
-			mem.removeTxFromCacheMap(req.GetCheckTx().Tx)
+			go mem.removeTxFromCacheMap(req.GetCheckTx().Tx)
 
 			// TODO: handle other retcodes
 		}
@@ -221,7 +221,7 @@ func (mem *Mempool) resCbRecheck(req *tmsp.Request, res *tmsp.Response) {
 			mem.recheckCursor.DetachPrev()
 
 			// remove from cache (it might be good later)
-			mem.removeTxFromCacheMap(req.GetCheckTx().Tx)
+			go mem.removeTxFromCacheMap(req.GetCheckTx().Tx)
 		}
 		if mem.recheckCursor == mem.recheckEnd {
 			mem.recheckCursor = nil


### PR DESCRIPTION
to avoid deadlocks

 - fix is not fully understood by me
 - reference: https://tendermint.slack.com/archives/support/p1475625676000526