### PR TITLE
Validator set changes tests

### DIFF
--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -106,7 +106,7 @@ func TestValidatorSetChanges(t *testing.T) {
 	})
 
 	//---------------------------------------------------------------------------
-	// Adding one validator
+	log.Info("Testing adding one validator")
 
 	newValidatorPubKey1 := css[nVals].privValidator.(*types.PrivValidator).PubKey
 	newValidatorTx1 := dummy.MakeValSetChangeTx(newValidatorPubKey1.Bytes(), uint64(testMinPower))
@@ -132,7 +132,7 @@ func TestValidatorSetChanges(t *testing.T) {
 	waitForAndValidateBlock(t, nPeers, activeVals, eventChans, css)
 
 	//---------------------------------------------------------------------------
-	// Changing the voting power of one validator
+	log.Info("Testing changing the voting power of one validator")
 
 	updateValidatorTx1 := dummy.MakeValSetChangeTx(newValidatorPubKey1.Bytes(), 25)
 	previousTotalVotingPower := css[nVals].LastValidators.TotalVotingPower()
@@ -146,7 +146,7 @@ func TestValidatorSetChanges(t *testing.T) {
 	}
 
 	//---------------------------------------------------------------------------
-	// Adding two validators at once
+	log.Info("Testing adding two validators at once")
 
 	newValidatorPubKey2 := css[nVals+1].privValidator.(*types.PrivValidator).PubKey
 	newValidatorTx2 := dummy.MakeValSetChangeTx(newValidatorPubKey2.Bytes(), uint64(testMinPower))
@@ -162,7 +162,7 @@ func TestValidatorSetChanges(t *testing.T) {
 	waitForAndValidateBlock(t, nPeers, activeVals, eventChans, css)
 
 	//---------------------------------------------------------------------------
-	// Removing two validators at once
+	log.Info("Testing removing two validators at once")
 
 	removeValidatorTx2 := dummy.MakeValSetChangeTx(newValidatorPubKey2.Bytes(), 0)
 	removeValidatorTx3 := dummy.MakeValSetChangeTx(newValidatorPubKey3.Bytes(), 0)
@@ -215,17 +215,15 @@ func timeoutWaitGroup(t *testing.T, n int, f func(*sync.WaitGroup, int)) {
 		go f(wg, i)
 	}
 
-	// Make wait into a channel
 	done := make(chan struct{})
 	go func() {
 		wg.Wait()
 		close(done)
 	}()
 
-	tick := time.NewTicker(time.Second * 3)
 	select {
 	case <-done:
-	case <-tick.C:
+	case <-time.After(time.Second * 3):
 		t.Fatalf("Timed out waiting for all validators to commit a block")
 	}
 }


### PR DESCRIPTION
This is **failing** right now, so please do not merge!

Sometimes this test is failing with: "Timed out waiting for all validators to commit a block" (timeout was increased by 10 seconds)

Log:
```
INFO[12-23|13:02:46] Block{
  Header{
    ChainID:        tendermint_test
    Height:         11
    Time:           2016-12-23 13:02:46.052 +0000 UTC
    NumTxs:         2
    LastBlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    LastCommit:     83F202126FBA458507F7E200DCCEE7E62E4474DD
    Data:           36721760CD4AA23A7B6B5F7C5515026379272DD2
    Validators:     281D550ECD5DA99E4ADD9FE411299F6EB46B523B
    App:            65B64A51FF9F58D823C23CF034E24291FCEDD2BA
  }#75860B411898B6A27AA40C726DE119A070F40B5B
  Data{
    Tx:[118 97 108 58 48 49 51 51 68 68 55 66 48 51 54 49 70 50 69 53 65 70 65 53 52 53 52 65 50 52 56 51 55 52 68 56 57 69 53 51 49 70 53 67 54 68 52 53 70 67 66 70 65 66 52 68 67 50 67 57 51 65 53 70 50 70 67 53 70 57 47 49 48]
    Tx:[118 97 108 58 48 49 51 53 66 53 67 53 65 70 55 48 65 48 57 54 50 69 55 56 67 56 48 68 65 48 56 48 51 49 55 50 48 55 48 50 57 68 57 68 49 65 70 57 51 66 49 51 56 48 68 56 55 69 49 48 51 65 69 52 53 53 53 49 54 66 47 49 48]
  }#36721760CD4AA23A7B6B5F7C5515026379272DD2
  Commit{
    BlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    Precommits: Vote{0:2E957CF919E5 10/00/2(Precommit) B52A7701AAFA /41960BB76AFD.../}
    Vote{1:4F6BE1A4BB35 10/00/2(Precommit) B52A7701AAFA /4D2CAD15F4F1.../}
    Vote{2:531D483CB987 10/00/2(Precommit) B52A7701AAFA /F96C0ACD5514.../}
    Vote{3:C25E810EEBF0 10/00/2(Precommit) B52A7701AAFA /E88B7FCC6533.../}
    Vote{4:DFD0788E654F 10/00/2(Precommit) B52A7701AAFA /E651F413BF54.../}
  }#83F202126FBA458507F7E200DCCEE7E62E4474DD
}#75860B411898B6A27AA40C726DE119A070F40B5B module=consensus
INFO[12-23|13:02:46] Added to precommit                       module=consensus vote="Vote{1:4F6BE1A4BB35 11/00/2(Precommit) 75860B411898 /C78B5D6BAC4A.../}" precommits="VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:_X_XX} map[]}"
INFO[12-23|13:02:46] enterCommit(11/0). Current: 11/0/RoundStepPrecommit module=consensus
NOTE[12-23|13:02:46] Finalizing commit of block with 2 txs    module=consensus height=11 hash=75860B411898B6A27AA40C726DE119A070F40B5B root=65B64A51FF9F58D823C23CF034E24291FCEDD2BA
INFO[12-23|13:02:46] Block{
  Header{
    ChainID:        tendermint_test
    Height:         11
    Time:           2016-12-23 13:02:46.052 +0000 UTC
    NumTxs:         2
    LastBlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    LastCommit:     83F202126FBA458507F7E200DCCEE7E62E4474DD
    Data:           36721760CD4AA23A7B6B5F7C5515026379272DD2
    Validators:     281D550ECD5DA99E4ADD9FE411299F6EB46B523B
    App:            65B64A51FF9F58D823C23CF034E24291FCEDD2BA
  }#75860B411898B6A27AA40C726DE119A070F40B5B
  Data{
    Tx:[118 97 108 58 48 49 51 51 68 68 55 66 48 51 54 49 70 50 69 53 65 70 65 53 52 53 52 65 50 52 56 51 55 52 68 56 57 69 53 51 49 70 53 67 54 68 52 53 70 67 66 70 65 66 52 68 67 50 67 57 51 65 53 70 50 70 67 53 70 57 47 49 48]
    Tx:[118 97 108 58 48 49 51 53 66 53 67 53 65 70 55 48 65 48 57 54 50 69 55 56 67 56 48 68 65 48 56 48 51 49 55 50 48 55 48 50 57 68 57 68 49 65 70 57 51 66 49 51 56 48 68 56 55 69 49 48 51 65 69 52 53 53 53 49 54 66 47 49 48]
  }#36721760CD4AA23A7B6B5F7C5515026379272DD2
  Commit{
    BlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    Precommits: Vote{0:2E957CF919E5 10/00/2(Precommit) B52A7701AAFA /41960BB76AFD.../}
    Vote{1:4F6BE1A4BB35 10/00/2(Precommit) B52A7701AAFA /4D2CAD15F4F1.../}
    Vote{2:531D483CB987 10/00/2(Precommit) B52A7701AAFA /F96C0ACD5514.../}
    Vote{3:C25E810EEBF0 10/00/2(Precommit) B52A7701AAFA /E88B7FCC6533.../}
    Vote{4:DFD0788E654F 10/00/2(Precommit) B52A7701AAFA /E651F413BF54.../}
  }#83F202126FBA458507F7E200DCCEE7E62E4474DD
}#75860B411898B6A27AA40C726DE119A070F40B5B module=consensus
INFO[12-23|13:02:46] Executed block                           module=stateheight=11 valid txs=2 invalid txs=0
INFO[12-23|13:02:46] Update to validator set                  module=stateupdates="[{\"pub_key\":\"0133DD7B0361F2E5AFA5454A248374D89E531F5C6D45FCBFAB4DC2C93A5F2FC5F9\",\"power\":10},{\"pub_key\":\"0135B5C5AF70A0962E78C80DA080317207029D9D1AF93B1380D87E103AE455516B\",\"power\":10}]"
INFO[12-23|13:02:46] Saved state                              module=dummyroot=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
NOTE[12-23|13:02:46] Saving block                             module=dummyheight=11 root=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
INFO[12-23|13:02:46] Recheck txs                              module=mempool numtxs=0
INFO[12-23|13:02:46] Got block                                module=consensus height=11 validator=5
INFO[12-23|13:02:46] Added to precommit                       module=consensus vote="Vote{1:4F6BE1A4BB35 11/00/2(Precommit) 75860B411898 /C78B5D6BAC4A.../}" precommits="VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:_X_XX} map[]}"
INFO[12-23|13:02:46] enterCommit(11/0). Current: 11/0/RoundStepPrecommit module=consensus
NOTE[12-23|13:02:46] Finalizing commit of block with 2 txs    module=consensus height=11 hash=75860B411898B6A27AA40C726DE119A070F40B5B root=65B64A51FF9F58D823C23CF034E24291FCEDD2BA
INFO[12-23|13:02:46] Block{
  Header{
    ChainID:        tendermint_test
    Height:         11
    Time:           2016-12-23 13:02:46.052 +0000 UTC
    NumTxs:         2
    LastBlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    LastCommit:     83F202126FBA458507F7E200DCCEE7E62E4474DD
    Data:           36721760CD4AA23A7B6B5F7C5515026379272DD2
    Validators:     281D550ECD5DA99E4ADD9FE411299F6EB46B523B
    App:            65B64A51FF9F58D823C23CF034E24291FCEDD2BA
  }#75860B411898B6A27AA40C726DE119A070F40B5B
  Data{
    Tx:[118 97 108 58 48 49 51 51 68 68 55 66 48 51 54 49 70 50 69 53 65 70 65 53 52 53 52 65 50 52 56 51 55 52 68 56 57 69 53 51 49 70 53 67 54 68 52 53 70 67 66 70 65 66 52 68 67 50 67 57 51 65 53 70 50 70 67 53 70 57 47 49 48]
    Tx:[118 97 108 58 48 49 51 53 66 53 67 53 65 70 55 48 65 48 57 54 50 69 55 56 67 56 48 68 65 48 56 48 51 49 55 50 48 55 48 50 57 68 57 68 49 65 70 57 51 66 49 51 56 48 68 56 55 69 49 48 51 65 69 52 53 53 53 49 54 66 47 49 48]
  }#36721760CD4AA23A7B6B5F7C5515026379272DD2
  Commit{
    BlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    Precommits: Vote{0:2E957CF919E5 10/00/2(Precommit) B52A7701AAFA /41960BB76AFD.../}
    Vote{1:4F6BE1A4BB35 10/00/2(Precommit) B52A7701AAFA /4D2CAD15F4F1.../}
    Vote{2:531D483CB987 10/00/2(Precommit) B52A7701AAFA /F96C0ACD5514.../}
    Vote{3:C25E810EEBF0 10/00/2(Precommit) B52A7701AAFA /E88B7FCC6533.../}
    Vote{4:DFD0788E654F 10/00/2(Precommit) B52A7701AAFA /E651F413BF54.../}
  }#83F202126FBA458507F7E200DCCEE7E62E4474DD
}#75860B411898B6A27AA40C726DE119A070F40B5B module=consensus
INFO[12-23|13:02:46] Executed block                           module=stateheight=11 valid txs=2 invalid txs=0
INFO[12-23|13:02:46] Update to validator set                  module=stateupdates="[{\"pub_key\":\"0133DD7B0361F2E5AFA5454A248374D89E531F5C6D45FCBFAB4DC2C93A5F2FC5F9\",\"power\":10},{\"pub_key\":\"0135B5C5AF70A0962E78C80DA080317207029D9D1AF93B1380D87E103AE455516B\",\"power\":10}]"
INFO[12-23|13:02:46] Saved state                              module=dummyroot=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
NOTE[12-23|13:02:46] Saving block                             module=dummyheight=11 root=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
INFO[12-23|13:02:46] Recheck txs                              module=mempool numtxs=0
INFO[12-23|13:02:46] Got block                                module=consensus height=11 validator=6
INFO[12-23|13:02:46] Executed block                           module=stateheight=11 valid txs=2 invalid txs=0
INFO[12-23|13:02:46] Update to validator set                  module=stateupdates="[{\"pub_key\":\"0133DD7B0361F2E5AFA5454A248374D89E531F5C6D45FCBFAB4DC2C93A5F2FC5F9\",\"power\":10},{\"pub_key\":\"0135B5C5AF70A0962E78C80DA080317207029D9D1AF93B1380D87E103AE455516B\",\"power\":10}]"
INFO[12-23|13:02:46] Saved state                              module=dummyroot=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
NOTE[12-23|13:02:46] Saving block                             module=dummyheight=11 root=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
INFO[12-23|13:02:46] Recheck txs                              module=mempool numtxs=0
INFO[12-23|13:02:46] Got block                                module=consensus height=11 validator=3
INFO[12-23|13:02:46] Added to precommit                       module=consensus vote="Vote{3:C25E810EEBF0 11/00/2(Precommit) 75860B411898 /EA98401DCAF6.../}" precommits="VoteSet{H:11 R:0 T:2 +2/3:<nil> BA{5:__XXX} map[]}"
INFO[12-23|13:02:46] Added to precommit                       module=consensus vote="Vote{1:4F6BE1A4BB35 11/00/2(Precommit) 75860B411898 /C78B5D6BAC4A.../}" precommits="VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:_XXXX} map[]}"
INFO[12-23|13:02:46] enterCommit(11/0). Current: 11/0/RoundStepPrecommit module=consensus
NOTE[12-23|13:02:46] Finalizing commit of block with 2 txs    module=consensus height=11 hash=75860B411898B6A27AA40C726DE119A070F40B5B root=65B64A51FF9F58D823C23CF034E24291FCEDD2BA
INFO[12-23|13:02:46] Block{
  Header{
    ChainID:        tendermint_test
    Height:         11
    Time:           2016-12-23 13:02:46.052 +0000 UTC
    NumTxs:         2
    LastBlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    LastCommit:     83F202126FBA458507F7E200DCCEE7E62E4474DD
    Data:           36721760CD4AA23A7B6B5F7C5515026379272DD2
    Validators:     281D550ECD5DA99E4ADD9FE411299F6EB46B523B
    App:            65B64A51FF9F58D823C23CF034E24291FCEDD2BA
  }#75860B411898B6A27AA40C726DE119A070F40B5B
  Data{
    Tx:[118 97 108 58 48 49 51 51 68 68 55 66 48 51 54 49 70 50 69 53 65 70 65 53 52 53 52 65 50 52 56 51 55 52 68 56 57 69 53 51 49 70 53 67 54 68 52 53 70 67 66 70 65 66 52 68 67 50 67 57 51 65 53 70 50 70 67 53 70 57 47 49 48]
    Tx:[118 97 108 58 48 49 51 53 66 53 67 53 65 70 55 48 65 48 57 54 50 69 55 56 67 56 48 68 65 48 56 48 51 49 55 50 48 55 48 50 57 68 57 68 49 65 70 57 51 66 49 51 56 48 68 56 55 69 49 48 51 65 69 52 53 53 53 49 54 66 47 49 48]
  }#36721760CD4AA23A7B6B5F7C5515026379272DD2
  Commit{
    BlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    Precommits: Vote{0:2E957CF919E5 10/00/2(Precommit) B52A7701AAFA /41960BB76AFD.../}
    Vote{1:4F6BE1A4BB35 10/00/2(Precommit) B52A7701AAFA /4D2CAD15F4F1.../}
    Vote{2:531D483CB987 10/00/2(Precommit) B52A7701AAFA /F96C0ACD5514.../}
    Vote{3:C25E810EEBF0 10/00/2(Precommit) B52A7701AAFA /E88B7FCC6533.../}
    Vote{4:DFD0788E654F 10/00/2(Precommit) B52A7701AAFA /E651F413BF54.../}
  }#83F202126FBA458507F7E200DCCEE7E62E4474DD
}#75860B411898B6A27AA40C726DE119A070F40B5B module=consensus
INFO[12-23|13:02:46] Executed block                           module=stateheight=11 valid txs=2 invalid txs=0
INFO[12-23|13:02:46] Update to validator set                  module=stateupdates="[{\"pub_key\":\"0133DD7B0361F2E5AFA5454A248374D89E531F5C6D45FCBFAB4DC2C93A5F2FC5F9\",\"power\":10},{\"pub_key\":\"0135B5C5AF70A0962E78C80DA080317207029D9D1AF93B1380D87E103AE455516B\",\"power\":10}]"
INFO[12-23|13:02:46] Saved state                              module=dummyroot=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
NOTE[12-23|13:02:46] Saving block                             module=dummyheight=11 root=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
INFO[12-23|13:02:46] Recheck txs                              module=mempool numtxs=0
INFO[12-23|13:02:46] Got block                                module=consensus height=11 validator=1
INFO[12-23|13:02:46] Added to precommit                       module=consensus vote="Vote{0:2E957CF919E5 11/00/2(Precommit) 75860B411898 /B1D715AFA354.../}" precommits="VoteSet{H:11 R:0 T:2 +2/3:<nil> BA{5:X_XXX} map[]}"
INFO[12-23|13:02:46] Added to precommit                       module=consensus vote="Vote{1:4F6BE1A4BB35 11/00/2(Precommit) 75860B411898 /C78B5D6BAC4A.../}" precommits="VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:XXXXX} map[]}"
INFO[12-23|13:02:46] enterCommit(11/0). Current: 11/0/RoundStepPrecommit module=consensus
NOTE[12-23|13:02:46] Finalizing commit of block with 2 txs    module=consensus height=11 hash=75860B411898B6A27AA40C726DE119A070F40B5B root=65B64A51FF9F58D823C23CF034E24291FCEDD2BA
INFO[12-23|13:02:46] Block{
  Header{
    ChainID:        tendermint_test
    Height:         11
    Time:           2016-12-23 13:02:46.052 +0000 UTC
    NumTxs:         2
    LastBlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    LastCommit:     83F202126FBA458507F7E200DCCEE7E62E4474DD
    Data:           36721760CD4AA23A7B6B5F7C5515026379272DD2
    Validators:     281D550ECD5DA99E4ADD9FE411299F6EB46B523B
    App:            65B64A51FF9F58D823C23CF034E24291FCEDD2BA
  }#75860B411898B6A27AA40C726DE119A070F40B5B
  Data{
    Tx:[118 97 108 58 48 49 51 51 68 68 55 66 48 51 54 49 70 50 69 53 65 70 65 53 52 53 52 65 50 52 56 51 55 52 68 56 57 69 53 51 49 70 53 67 54 68 52 53 70 67 66 70 65 66 52 68 67 50 67 57 51 65 53 70 50 70 67 53 70 57 47 49 48]
    Tx:[118 97 108 58 48 49 51 53 66 53 67 53 65 70 55 48 65 48 57 54 50 69 55 56 67 56 48 68 65 48 56 48 51 49 55 50 48 55 48 50 57 68 57 68 49 65 70 57 51 66 49 51 56 48 68 56 55 69 49 48 51 65 69 52 53 53 53 49 54 66 47 49 48]
  }#36721760CD4AA23A7B6B5F7C5515026379272DD2
  Commit{
    BlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    Precommits: Vote{0:2E957CF919E5 10/00/2(Precommit) B52A7701AAFA /41960BB76AFD.../}
    Vote{1:4F6BE1A4BB35 10/00/2(Precommit) B52A7701AAFA /4D2CAD15F4F1.../}
    Vote{2:531D483CB987 10/00/2(Precommit) B52A7701AAFA /F96C0ACD5514.../}
    Vote{3:C25E810EEBF0 10/00/2(Precommit) B52A7701AAFA /E88B7FCC6533.../}
    Vote{4:DFD0788E654F 10/00/2(Precommit) B52A7701AAFA /E651F413BF54.../}
  }#83F202126FBA458507F7E200DCCEE7E62E4474DD
}#75860B411898B6A27AA40C726DE119A070F40B5B module=consensus
INFO[12-23|13:02:46] Executed block                           module=stateheight=11 valid txs=2 invalid txs=0
INFO[12-23|13:02:46] Update to validator set                  module=stateupdates="[{\"pub_key\":\"0133DD7B0361F2E5AFA5454A248374D89E531F5C6D45FCBFAB4DC2C93A5F2FC5F9\",\"power\":10},{\"pub_key\":\"0135B5C5AF70A0962E78C80DA080317207029D9D1AF93B1380D87E103AE455516B\",\"power\":10}]"
INFO[12-23|13:02:46] Saved state                              module=dummyroot=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
NOTE[12-23|13:02:46] Saving block                             module=dummyheight=11 root=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
INFO[12-23|13:02:46] Recheck txs                              module=mempool numtxs=0
INFO[12-23|13:02:46] Got block                                module=consensus height=11 validator=2
INFO[12-23|13:02:46] Added to lastPrecommits: VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:XX_XX} map[]} module=consensus
INFO[12-23|13:02:46] Added to lastPrecommits: VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:XXXXX} map[]} module=consensus
NOTE[12-23|13:02:46] enterNewRound(12/0). Current: 12/0/RoundStepNewHeightmodule=consensus
INFO[12-23|13:02:46] enterPropose(12/0). Current: 12/0/RoundStepNewRound module=consensus
INFO[12-23|13:02:46] enterPropose: Not our turn to propose    module=consensus proposer=2E957CF919E5BAFFB9CFCABE470BFD85A03531F4 privValidator="PrivValidator{19D27C755AE07DE3851E6F8076E42C2E812BAEB7 LH:0, LR:0, LS:0}"
INFO[12-23|13:02:46] Added to lastPrecommits: VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:XX_XX} map[]} module=consensus
INFO[12-23|13:02:46] Added to lastPrecommits: VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:XXXXX} map[]} module=consensus
NOTE[12-23|13:02:46] enterNewRound(12/0). Current: 12/0/RoundStepNewHeightmodule=consensus
INFO[12-23|13:02:46] enterPropose(12/0). Current: 12/0/RoundStepNewRound module=consensus
INFO[12-23|13:02:46] enterPropose: Not our turn to propose    module=consensus proposer=2E957CF919E5BAFFB9CFCABE470BFD85A03531F4 privValidator="PrivValidator{E3461FF43B6634012FBFF95DF897BF0F16FF7AD1 LH:0, LR:0, LS:0}"
INFO[12-23|13:02:46] Added to precommit                       module=consensus vote="Vote{0:2E957CF919E5 11/00/2(Precommit) 75860B411898 /B1D715AFA354.../}" precommits="VoteSet{H:11 R:0 T:2 +2/3:<nil> BA{5:X_XXX} map[]}"
INFO[12-23|13:02:46] Added to precommit                       module=consensus vote="Vote{1:4F6BE1A4BB35 11/00/2(Precommit) 75860B411898 /C78B5D6BAC4A.../}" precommits="VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:XXXXX} map[]}"
INFO[12-23|13:02:46] enterCommit(11/0). Current: 11/0/RoundStepPrecommit module=consensus
NOTE[12-23|13:02:46] Finalizing commit of block with 2 txs    module=consensus height=11 hash=75860B411898B6A27AA40C726DE119A070F40B5B root=65B64A51FF9F58D823C23CF034E24291FCEDD2BA
INFO[12-23|13:02:46] Block{
  Header{
    ChainID:        tendermint_test
    Height:         11
    Time:           2016-12-23 13:02:46.052 +0000 UTC
    NumTxs:         2
    LastBlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    LastCommit:     83F202126FBA458507F7E200DCCEE7E62E4474DD
    Data:           36721760CD4AA23A7B6B5F7C5515026379272DD2
    Validators:     281D550ECD5DA99E4ADD9FE411299F6EB46B523B
    App:            65B64A51FF9F58D823C23CF034E24291FCEDD2BA
  }#75860B411898B6A27AA40C726DE119A070F40B5B
  Data{
    Tx:[118 97 108 58 48 49 51 51 68 68 55 66 48 51 54 49 70 50 69 53 65 70 65 53 52 53 52 65 50 52 56 51 55 52 68 56 57 69 53 51 49 70 53 67 54 68 52 53 70 67 66 70 65 66 52 68 67 50 67 57 51 65 53 70 50 70 67 53 70 57 47 49 48]
    Tx:[118 97 108 58 48 49 51 53 66 53 67 53 65 70 55 48 65 48 57 54 50 69 55 56 67 56 48 68 65 48 56 48 51 49 55 50 48 55 48 50 57 68 57 68 49 65 70 57 51 66 49 51 56 48 68 56 55 69 49 48 51 65 69 52 53 53 53 49 54 66 47 49 48]
  }#36721760CD4AA23A7B6B5F7C5515026379272DD2
  Commit{
    BlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    Precommits: Vote{0:2E957CF919E5 10/00/2(Precommit) B52A7701AAFA /41960BB76AFD.../}
    Vote{1:4F6BE1A4BB35 10/00/2(Precommit) B52A7701AAFA /4D2CAD15F4F1.../}
    Vote{2:531D483CB987 10/00/2(Precommit) B52A7701AAFA /F96C0ACD5514.../}
    Vote{3:C25E810EEBF0 10/00/2(Precommit) B52A7701AAFA /E88B7FCC6533.../}
    Vote{4:DFD0788E654F 10/00/2(Precommit) B52A7701AAFA /E651F413BF54.../}
  }#83F202126FBA458507F7E200DCCEE7E62E4474DD
}#75860B411898B6A27AA40C726DE119A070F40B5B module=consensus
INFO[12-23|13:02:46] Executed block                           module=stateheight=11 valid txs=2 invalid txs=0
INFO[12-23|13:02:46] Update to validator set                  module=stateupdates="[{\"pub_key\":\"0133DD7B0361F2E5AFA5454A248374D89E531F5C6D45FCBFAB4DC2C93A5F2FC5F9\",\"power\":10},{\"pub_key\":\"0135B5C5AF70A0962E78C80DA080317207029D9D1AF93B1380D87E103AE455516B\",\"power\":10}]"
INFO[12-23|13:02:46] Saved state                              module=dummyroot=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
NOTE[12-23|13:02:46] Saving block                             module=dummyheight=11 root=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
INFO[12-23|13:02:46] Recheck txs                              module=mempool numtxs=0
INFO[12-23|13:02:46] Got block                                module=consensus height=11 validator=7
INFO[12-23|13:02:46] Added to precommit                       module=consensus vote="Vote{1:4F6BE1A4BB35 11/00/2(Precommit) 75860B411898 /C78B5D6BAC4A.../}" precommits="VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:XXXXX} map[]}"
INFO[12-23|13:02:46] enterCommit(11/0). Current: 11/0/RoundStepPrecommit module=consensus
NOTE[12-23|13:02:46] Finalizing commit of block with 2 txs    module=consensus height=11 hash=75860B411898B6A27AA40C726DE119A070F40B5B root=65B64A51FF9F58D823C23CF034E24291FCEDD2BA
INFO[12-23|13:02:46] Block{
  Header{
    ChainID:        tendermint_test
    Height:         11
    Time:           2016-12-23 13:02:46.052 +0000 UTC
    NumTxs:         2
    LastBlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    LastCommit:     83F202126FBA458507F7E200DCCEE7E62E4474DD
    Data:           36721760CD4AA23A7B6B5F7C5515026379272DD2
    Validators:     281D550ECD5DA99E4ADD9FE411299F6EB46B523B
    App:            65B64A51FF9F58D823C23CF034E24291FCEDD2BA
  }#75860B411898B6A27AA40C726DE119A070F40B5B
  Data{
    Tx:[118 97 108 58 48 49 51 51 68 68 55 66 48 51 54 49 70 50 69 53 65 70 65 53 52 53 52 65 50 52 56 51 55 52 68 56 57 69 53 51 49 70 53 67 54 68 52 53 70 67 66 70 65 66 52 68 67 50 67 57 51 65 53 70 50 70 67 53 70 57 47 49 48]
    Tx:[118 97 108 58 48 49 51 53 66 53 67 53 65 70 55 48 65 48 57 54 50 69 55 56 67 56 48 68 65 48 56 48 51 49 55 50 48 55 48 50 57 68 57 68 49 65 70 57 51 66 49 51 56 48 68 56 55 69 49 48 51 65 69 52 53 53 53 49 54 66 47 49 48]
  }#36721760CD4AA23A7B6B5F7C5515026379272DD2
  Commit{
    BlockID:    B52A7701AAFAB980B44D3C7415972FEEC8F7D942:1:E647A8FA90EA
    Precommits: Vote{0:2E957CF919E5 10/00/2(Precommit) B52A7701AAFA /41960BB76AFD.../}
    Vote{1:4F6BE1A4BB35 10/00/2(Precommit) B52A7701AAFA /4D2CAD15F4F1.../}
    Vote{2:531D483CB987 10/00/2(Precommit) B52A7701AAFA /F96C0ACD5514.../}
    Vote{3:C25E810EEBF0 10/00/2(Precommit) B52A7701AAFA /E88B7FCC6533.../}
    Vote{4:DFD0788E654F 10/00/2(Precommit) B52A7701AAFA /E651F413BF54.../}
  }#83F202126FBA458507F7E200DCCEE7E62E4474DD
}#75860B411898B6A27AA40C726DE119A070F40B5B module=consensus
INFO[12-23|13:02:46] Executed block                           module=stateheight=11 valid txs=2 invalid txs=0
INFO[12-23|13:02:46] Update to validator set                  module=stateupdates="[{\"pub_key\":\"0133DD7B0361F2E5AFA5454A248374D89E531F5C6D45FCBFAB4DC2C93A5F2FC5F9\",\"power\":10},{\"pub_key\":\"0135B5C5AF70A0962E78C80DA080317207029D9D1AF93B1380D87E103AE455516B\",\"power\":10}]"
INFO[12-23|13:02:46] Saved state                              module=dummyroot=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
NOTE[12-23|13:02:46] Saving block                             module=dummyheight=11 root=2719616B7C2585E000F5DFF1E2549061C5ED8AF1
INFO[12-23|13:02:46] Recheck txs                              module=mempool numtxs=0
INFO[12-23|13:02:46] Got block                                module=consensus height=11 validator=0
INFO[12-23|13:02:46] Added to lastPrecommits: VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:XXXXX} map[]} module=consensus
NOTE[12-23|13:02:46] enterNewRound(12/0). Current: 12/0/RoundStepNewHeightmodule=consensus
INFO[12-23|13:02:46] enterPropose(12/0). Current: 12/0/RoundStepNewRound module=consensus
INFO[12-23|13:02:46] enterPropose: Not our turn to propose    module=consensus proposer=2E957CF919E5BAFFB9CFCABE470BFD85A03531F4 privValidator="PrivValidator{531D483CB9879AE41D8A8DE7E1F7AA4DED2E3AE2 LH:11, LR:0, LS:3}"
INFO[12-23|13:02:46] Added to lastPrecommits: VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:XXXXX} map[]} module=consensus
NOTE[12-23|13:02:46] enterNewRound(12/0). Current: 12/0/RoundStepNewHeightmodule=consensus
INFO[12-23|13:02:46] enterPropose(12/0). Current: 12/0/RoundStepNewRound module=consensus
INFO[12-23|13:02:46] enterPropose: Not our turn to propose    module=consensus proposer=2E957CF919E5BAFFB9CFCABE470BFD85A03531F4 privValidator="PrivValidator{4F6BE1A4BB35859287F01F9021E1C699C5245866 LH:11, LR:0, LS:3}"
INFO[12-23|13:02:46] Added to lastPrecommits: VoteSet{H:11 R:0 T:2 +2/3:75860B411898B6A27AA40C726DE119A070F40B5B:1:F3BA2DCA105E BA{5:XXXXX} map[]} module=consensus
NOTE[12-23|13:02:46] enterNewRound(12/0). Current: 12/0/RoundStepNewHeightmodule=consensus
INFO[12-23|13:02:46] enterPropose(12/0). Current: 12/0/RoundStepNewRound module=consensus
INFO[12-23|13:02:46] enterPropose: Not our turn to propose    module=consensus proposer=2E957CF919E5BAFFB9CFCABE470BFD85A03531F4 privValidator="PrivValidator{DFD0788E654F8234A89DBA7539F75CEE1E9CA10A LH:11, LR:0, LS:3}"
--- FAIL: TestValidatorSetChanges (22.76s)
        reactor_test.go:229: Timed out waiting for all validators to commit a block
```