### PR TITLE
Fixed RPC client tests

### DIFF
--- a/rpc/test/client_test.go
+++ b/rpc/test/client_test.go
@@ -134,7 +134,7 @@ func TestURITMSPQuery(t *testing.T) {
 	k, v := sendTx()
 	time.Sleep(time.Second)
 	tmResult := new(ctypes.TMResult)
-	_, err := clientURI.Call("tmsp_query", map[string]interface{}{"query": Fmt("%X", k)}, tmResult)
+	_, err := clientURI.Call("tmsp_query", map[string]interface{}{"query": k}, tmResult)
 	if err != nil {
 		panic(err)
 	}
@@ -144,7 +144,7 @@ func TestURITMSPQuery(t *testing.T) {
 func TestJSONTMSPQuery(t *testing.T) {
 	k, v := sendTx()
 	tmResult := new(ctypes.TMResult)
-	_, err := clientJSON.Call("tmsp_query", []interface{}{Fmt("%X", k)}, tmResult)
+	_, err := clientJSON.Call("tmsp_query", []interface{}{k}, tmResult)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR updates the RPC client tests contingent on the changes in https://github.com/tendermint/go-rpc/pull/5. This change was necessary because now `go-rpc` serializes `string` and `[]byte` args into either a quoted string or `0x` hex string, rather than requiring that the consumer do that themselves.