### PR TITLE
PEX issues #335

### DIFF
--- a/blockchain/pool.go
+++ b/blockchain/pool.go
@@ -26,7 +26,7 @@ var peerTimeoutSeconds = time.Duration(15) // not const so we can override with 
 	in sequence from peers that reported higher heights than ours.
 	Every so often we ask peers what height they're on so we can keep going.
 
-	Requests are continuously made for blocks of heigher heights until
+	Requests are continuously made for blocks of higher heights until
 	the limits. If most of the requests have no available peers, and we
 	are not at peer limits, we can probably switch to consensus reactor
 */

--- a/test/p2p/fast_sync/test_peer.sh
+++ b/test/p2p/fast_sync/test_peer.sh
@@ -27,7 +27,7 @@ SEEDS="$(test/p2p/ip.sh 1):46656"
 for j in `seq 2 $N`; do
 	SEEDS="$SEEDS,$(test/p2p/ip.sh $j):46656"
 done
-bash test/p2p/peer.sh $DOCKER_IMAGE $NETWORK_NAME $ID $PROXY_APP $SEEDS
+bash test/p2p/peer.sh $DOCKER_IMAGE $NETWORK_NAME $ID $PROXY_APP "--seeds $SEEDS"
 
 # wait for peer to sync and check the app hash
 bash test/p2p/client.sh $DOCKER_IMAGE $NETWORK_NAME fs_$ID "test/p2p/fast_sync/check_peer.sh $ID"

--- a/test/p2p/local_testnet_start.sh
+++ b/test/p2p/local_testnet_start.sh
@@ -18,5 +18,5 @@ done
 echo "Seeds: $seeds"
 
 for i in `seq 1 $N`; do
-	bash test/p2p/peer.sh $DOCKER_IMAGE $NETWORK_NAME $i $APP_PROXY $seeds
+	bash test/p2p/peer.sh $DOCKER_IMAGE $NETWORK_NAME $i $APP_PROXY "--seeds $seeds --pex"
 done

--- a/test/p2p/peer.sh
+++ b/test/p2p/peer.sh
@@ -7,11 +7,8 @@ ID=$3
 APP_PROXY=$4
 
 set +u
-SEEDS=$5
+NODE_FLAGS=$5
 set -u
-if [[ "$SEEDS" != "" ]]; then
-	SEEDS=" --seeds $SEEDS "
-fi
 
 echo "starting tendermint peer ID=$ID"
 # start tendermint container on the network
@@ -21,4 +18,4 @@ docker run -d \
   --name local_testnet_$ID \
   --entrypoint tendermint \
   -e TMROOT=/go/src/github.com/tendermint/tendermint/test/p2p/data/mach$ID/core \
-  $DOCKER_IMAGE node $SEEDS --proxy_app=$APP_PROXY
+  $DOCKER_IMAGE node $NODE_FLAGS --proxy_app=$APP_PROXY

--- a/test/p2p/pex/check_peer.sh
+++ b/test/p2p/pex/check_peer.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+set -u
+
+ID=$1
+N=$2
+
+addr=$(test/p2p/ip.sh "$ID"):46657
+
+echo "2. wait until peer $ID connects to other nodes using pex reactor"
+peers_count="0"
+while [[ "$peers_count" -lt "$((N-1))" ]]; do
+  sleep 1
+  peers_count=$(curl -s "$addr/net_info" | jq ".result[1].peers | length")
+  echo "... peers count = $peers_count, expected = $((N-1))"
+done
+
+echo "... successful"

--- a/test/p2p/pex/test.sh
+++ b/test/p2p/pex/test.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+set -eu
+
+DOCKER_IMAGE=$1
+NETWORK_NAME=$2
+N=$3
+PROXY_APP=$4
+
+ID=1
+
+echo "----------------------------------------------------------------------"
+echo "Testing pex creates the addrbook and uses it if seeds are not provided"
+echo "(assuming peers are started with pex enabled)"
+
+echo "1. restart peer $ID"
+docker stop "local_testnet_$ID"
+# preserce addrbook.json
+docker cp "local_testnet_$ID:/go/src/github.com/tendermint/tendermint/test/p2p/data/mach1/core/addrbook.json" "/tmp/addrbook.json"
+docker rm -vf "local_testnet_$ID"
+
+# NOTE that we do not provide seeds this time
+bash test/p2p/peer.sh "$DOCKER_IMAGE" "$NETWORK_NAME" "$ID" "$PROXY_APP" "--pex"
+docker cp "/tmp/addrbook.json" "local_testnet_$ID:/go/src/github.com/tendermint/tendermint/test/p2p/data/mach1/core/addrbook.json"
+echo "with the following addrbook:"
+docker exec "local_testnet_$ID" cat "/go/src/github.com/tendermint/tendermint/test/p2p/data/mach1/core/addrbook.json"
+echo ""
+
+# if the client runs forever, it means addrbook wasn't saved or was empty
+bash test/p2p/client.sh "$DOCKER_IMAGE" "$NETWORK_NAME" "pex_$ID" "test/p2p/pex/check_peer.sh $ID $N"
+
+echo ""
+echo "PASS"
+echo ""

--- a/test/p2p/test.sh
+++ b/test/p2p/test.sh
@@ -29,5 +29,8 @@ bash test/p2p/client.sh $DOCKER_IMAGE $NETWORK_NAME ab "test/p2p/atomic_broadcas
 # for each node, kill it and readd via fast sync
 bash test/p2p/fast_sync/test.sh $DOCKER_IMAGE $NETWORK_NAME $N $PROXY_APP
 
-# test killing all peers
+# test killing all peers 3 times
 bash test/p2p/kill_all/test.sh $DOCKER_IMAGE $NETWORK_NAME $N 3
+
+# test pex
+bash test/p2p/pex/test.sh $DOCKER_IMAGE $NETWORK_NAME $N $PROXY_APP


### PR DESCRIPTION
This is a 2 PR change fixing #335

2nd PR: https://github.com/tendermint/go-p2p/pull/12

In this PR:
- test p2p pex reactor
- save seeds when they are provided to avoid losing them.

Saving seeds while starting the node might look like a hack, but while I was exploring the options, this was the best possible solution I could think of. If you think different, please let me know.