### PR TITLE
Abci proof (formerly tmsp proof)

### DIFF
--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -165,6 +165,6 @@ func (app *CounterApplication) Query(query []byte) abci.Result {
 	return abci.NewResultOK(nil, Fmt("Query is not supported"))
 }
 
-func (app *CounterApplication) Proof(key []byte, blockHeight int64) abci.Result {
+func (app *CounterApplication) Proof(key []byte, blockHeight uint64) abci.Result {
 	return abci.NewResultOK(nil, Fmt("Proof is not supported"))
 }

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/tendermint/config/tendermint_test"
 	"github.com/tendermint/tendermint/types"
-	abci "github.com/tendermint/abci/types"
 
 	. "github.com/tendermint/go-common"
 )
@@ -163,4 +163,8 @@ func (app *CounterApplication) Commit() abci.Result {
 
 func (app *CounterApplication) Query(query []byte) abci.Result {
 	return abci.NewResultOK(nil, Fmt("Query is not supported"))
+}
+
+func (app *CounterApplication) Proof(key []byte, blockHeight int64) abci.Result {
+	return abci.NewResultOK(nil, Fmt("Proof is not supported"))
 }

--- a/glide.lock
+++ b/glide.lock
@@ -54,7 +54,7 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: github.com/tendermint/abci
-  version: e0309007ad431ddd126e2ec0d36bd2adbede1aed
+  version: fdc047ae7af0f0189dd9f21b932eb92ce455ffa5
   subpackages:
   - client
   - example/counter

--- a/glide.lock
+++ b/glide.lock
@@ -49,7 +49,7 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: github.com/tendermint/abci
-  version: 6526ab2137fadd0f4d2e25002bbfc1784b4f3c27
+  version: e0309007ad431ddd126e2ec0d36bd2adbede1aed
   subpackages:
   - client
   - example/counter

--- a/glide.lock
+++ b/glide.lock
@@ -33,6 +33,11 @@ imports:
   version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
 - name: github.com/spf13/pflag
   version: 25f8b5b07aece3207895bf19f7ab517eb3b22a40
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert
+  - require
 - name: github.com/syndtr/goleveldb
   version: 6ae1797c0b42b9323fc27ff7dcf568df88f2f33d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,11 @@
 package: github.com/tendermint/tendermint
 import:
+- package: github.com/gogo/protobuf
+  subpackages:
+  - proto
+- package: github.com/gorilla/websocket
+- package: github.com/spf13/pflag
+- package: github.com/tendermint/ed25519
 - package: github.com/tendermint/go-autofile
   version: develop
 - package: github.com/tendermint/go-clist
@@ -25,7 +31,7 @@ import:
 - package: github.com/tendermint/go-wire
   version: develop
 - package: github.com/tendermint/abci
-  version: develop
+  version: abci_proof
 - package: github.com/tendermint/go-flowrate
 - package: github.com/tendermint/log15
 - package: github.com/tendermint/ed25519

--- a/glide.yaml
+++ b/glide.yaml
@@ -43,3 +43,8 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - ripemd160
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - assert
+  - require

--- a/proxy/app_conn.go
+++ b/proxy/app_conn.go
@@ -36,7 +36,7 @@ type AppConnQuery interface {
 	EchoSync(string) (res types.Result)
 	InfoSync() (types.ResponseInfo, error)
 	QuerySync(tx []byte) (res types.Result)
-	ProofSync(key []byte, blockHeight int64) (res types.Result)
+	ProofSync(key []byte, blockHeight uint64) (res types.Result)
 
 	//	SetOptionSync(key string, value string) (res types.Result)
 }
@@ -144,6 +144,6 @@ func (app *appConnQuery) QuerySync(tx []byte) (res types.Result) {
 	return app.appConn.QuerySync(tx)
 }
 
-func (app *appConnQuery) ProofSync(key []byte, blockHeight int64) (res types.Result) {
+func (app *appConnQuery) ProofSync(key []byte, blockHeight uint64) (res types.Result) {
 	return app.appConn.ProofSync(key, blockHeight)
 }

--- a/proxy/app_conn.go
+++ b/proxy/app_conn.go
@@ -36,6 +36,7 @@ type AppConnQuery interface {
 	EchoSync(string) (res types.Result)
 	InfoSync() (types.ResponseInfo, error)
 	QuerySync(tx []byte) (res types.Result)
+	ProofSync(key []byte, blockHeight int64) (res types.Result)
 
 	//	SetOptionSync(key string, value string) (res types.Result)
 }
@@ -141,4 +142,8 @@ func (app *appConnQuery) InfoSync() (types.ResponseInfo, error) {
 
 func (app *appConnQuery) QuerySync(tx []byte) (res types.Result) {
 	return app.appConn.QuerySync(tx)
+}
+
+func (app *appConnQuery) ProofSync(key []byte, blockHeight int64) (res types.Result) {
+	return app.appConn.ProofSync(key, blockHeight)
 }

--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -11,6 +11,11 @@ func ABCIQuery(query []byte) (*ctypes.ResultABCIQuery, error) {
 	return &ctypes.ResultABCIQuery{res}, nil
 }
 
+func ABCIProof(key []byte, height int64) (*ctypes.ResultABCIProof, error) {
+	res := proxyAppQuery.ProofSync(key, height)
+	return &ctypes.ResultABCIProof{res}, nil
+}
+
 func ABCIInfo() (*ctypes.ResultABCIInfo, error) {
 	res, err := proxyAppQuery.InfoSync()
 	if err != nil {

--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -11,7 +11,7 @@ func ABCIQuery(query []byte) (*ctypes.ResultABCIQuery, error) {
 	return &ctypes.ResultABCIQuery{res}, nil
 }
 
-func ABCIProof(key []byte, height int64) (*ctypes.ResultABCIProof, error) {
+func ABCIProof(key []byte, height uint64) (*ctypes.ResultABCIProof, error) {
 	res := proxyAppQuery.ProofSync(key, height)
 	return &ctypes.ResultABCIProof{res}, nil
 }

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -172,7 +172,7 @@ func ABCIQueryResult(query []byte) (ctypes.TMResult, error) {
 	}
 }
 
-func ABCIProofResult(key []byte, height int64) (ctypes.TMResult, error) {
+func ABCIProofResult(key []byte, height uint64) (ctypes.TMResult, error) {
 	if r, err := ABCIProof(key, height); err != nil {
 		return nil, err
 	} else {

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -30,6 +30,7 @@ var Routes = map[string]*rpc.RPCFunc{
 
 	// abci API
 	"abci_query": rpc.NewRPCFunc(ABCIQueryResult, "query"),
+	"abci_proof": rpc.NewRPCFunc(ABCIProofResult, "key,height"),
 	"abci_info":  rpc.NewRPCFunc(ABCIInfoResult, ""),
 
 	// control API
@@ -165,6 +166,14 @@ func BroadcastTxAsyncResult(tx []byte) (ctypes.TMResult, error) {
 
 func ABCIQueryResult(query []byte) (ctypes.TMResult, error) {
 	if r, err := ABCIQuery(query); err != nil {
+		return nil, err
+	} else {
+		return r, nil
+	}
+}
+
+func ABCIProofResult(key []byte, height int64) (ctypes.TMResult, error) {
+	if r, err := ABCIProof(key, height); err != nil {
 		return nil, err
 	} else {
 		return r, nil

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -1,12 +1,12 @@
 package core_types
 
 import (
+	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/go-crypto"
 	"github.com/tendermint/go-p2p"
 	"github.com/tendermint/go-rpc/types"
 	"github.com/tendermint/go-wire"
 	"github.com/tendermint/tendermint/types"
-	abci "github.com/tendermint/abci/types"
 )
 
 type ResultBlockchainInfo struct {
@@ -64,7 +64,7 @@ type ResultBroadcastTx struct {
 }
 
 type ResultBroadcastTxCommit struct {
-	CheckTx  *abci.ResponseCheckTx  `json:"check_tx"`
+	CheckTx   *abci.ResponseCheckTx   `json:"check_tx"`
 	DeliverTx *abci.ResponseDeliverTx `json:"deliver_tx"`
 }
 
@@ -82,6 +82,10 @@ type ResultABCIInfo struct {
 
 type ResultABCIQuery struct {
 	Result abci.Result `json:"result"`
+}
+
+type ResultABCIProof struct {
+	Result abci.Result `json:"proof"`
 }
 
 type ResultUnsafeFlushMempool struct{}

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -131,6 +131,7 @@ const (
 	// 0x7 bytes are for querying the application
 	ResultTypeABCIQuery = byte(0x70)
 	ResultTypeABCIInfo  = byte(0x71)
+	ResultTypeABCIProof = byte(0x72)
 
 	// 0x8 bytes are for events
 	ResultTypeSubscribe   = byte(0x80)
@@ -172,5 +173,6 @@ var _ = wire.RegisterInterface(
 	wire.ConcreteType{&ResultUnsafeProfile{}, ResultTypeUnsafeWriteHeapProfile},
 	wire.ConcreteType{&ResultUnsafeFlushMempool{}, ResultTypeUnsafeFlushMempool},
 	wire.ConcreteType{&ResultABCIQuery{}, ResultTypeABCIQuery},
+	wire.ConcreteType{&ResultABCIProof{}, ResultTypeABCIProof},
 	wire.ConcreteType{&ResultABCIInfo{}, ResultTypeABCIInfo},
 )

--- a/rpc/test/client_test.go
+++ b/rpc/test/client_test.go
@@ -8,12 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/abci/example/dummy"
+	abci "github.com/tendermint/abci/types"
 	. "github.com/tendermint/go-common"
+	merkle "github.com/tendermint/go-merkle"
 	"github.com/tendermint/go-wire"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
-	"github.com/tendermint/abci/example/dummy"
-	abci "github.com/tendermint/abci/types"
 )
 
 //--------------------------------------------------------------------------------
@@ -124,9 +127,7 @@ func sendTx() ([]byte, []byte) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("SENT TX", tx)
 	fmt.Printf("SENT TX %X\n", tx)
-	fmt.Printf("k %X; v %X", k, v)
 	return k, v
 }
 
@@ -166,6 +167,44 @@ func testABCIQuery(t *testing.T, statusI interface{}, value []byte) {
 	if qResult.Exists != true {
 		panic(Fmt("Query error. Expected to find 'exists=true'. Got: %v", qResult))
 	}
+}
+
+// Proof -----
+
+func TestURITMSPProof(t *testing.T) {
+	k, v := sendTx()
+	time.Sleep(time.Second)
+	tmResult := new(ctypes.TMResult)
+	_, err := clientURI.Call("abci_proof", map[string]interface{}{"key": k, "height": 0}, tmResult)
+	if err != nil {
+		panic(err)
+	}
+	testTMSPProof(t, tmResult, k, v)
+}
+
+func TestJSONTMSPProof(t *testing.T) {
+	k, v := sendTx()
+	time.Sleep(time.Second)
+	tmResult := new(ctypes.TMResult)
+	_, err := clientJSON.Call("abci_proof", []interface{}{Fmt("%X", k), 0}, tmResult)
+	if err != nil {
+		panic(err)
+	}
+	testTMSPProof(t, tmResult, k, v)
+}
+
+func testTMSPProof(t *testing.T, statusI interface{}, key, value []byte) {
+	tmRes := statusI.(*ctypes.TMResult)
+	proof := (*tmRes).(*ctypes.ResultABCIProof)
+	if proof.Result.IsErr() {
+		panic(Fmt("Proof returned an err: %v", proof))
+	}
+
+	p, err := merkle.LoadProof(proof.Result.Data)
+	require.Nil(t, err)
+	require.True(t, p.Valid())
+	assert.Equal(t, []byte(key), p.Key())
+	assert.Equal(t, []byte(value), p.Value())
 }
 
 //--------------------------------------------------------------------------------

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/tendermint/go-common"
 	cfg "github.com/tendermint/go-config"
+	logger "github.com/tendermint/go-logger"
 	"github.com/tendermint/go-p2p"
 	"github.com/tendermint/go-wire"
 
@@ -31,9 +32,12 @@ var (
 	clientGRPC        core_grpc.BroadcastAPIClient
 )
 
+const tmLogLevel = "error"
+
 // initialize config and create new node
 func init() {
 	config = tendermint_test.ResetConfig("rpc_test_client_test")
+	logger.SetLogLevel(tmLogLevel)
 	chainID = config.GetString("chain_id")
 	rpcAddr = config.GetString("rpc_laddr")
 	grpcAddr = config.GetString("grpc_laddr")


### PR DESCRIPTION
This is an update of PR #356 please take a look there for the conversation and some interesting discussion on tmsp in general.

Anyway, this exposed the proof command from an abci app through the tendermint rpc layer, in a similar way as how query is handled. We can discuss best practices for now, but this branch is good to use for building demos with proofs for now.