### PR TITLE
`make dist` for creating binaries and packaging them for distribution

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+
+[*.sh]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ remote_dump
 vendor
 .vagrant
 test/p2p/data/
+.glide

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ build:
 build_race:
 	go build -race -o build/tendermint ./cmd/tendermint
 
+# dist builds binaries for all platforms and packages them for distribution
+dist:
+	@BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/dist.sh'"
+
 test: build
 	@echo "--> Running go test"
 	@go test $(PACKAGES)

--- a/Makefile
+++ b/Makefile
@@ -1,59 +1,65 @@
-.PHONY: get_deps build all list_deps install
+GOTOOLS = \
+					github.com/mitchellh/gox \
+					github.com/Masterminds/glide
+PACKAGES=$(shell go list ./... | grep -v '/vendor/')
+BUILD_TAGS?=tendermint
+TMROOT = $${TMROOT:-$$HOME/.tendermint}
 
 all: get_deps install test
 
-TMROOT = $${TMROOT:-$$HOME/.tendermint}
-define NEWLINE
-
-
-endef
-NOVENDOR = go list github.com/tendermint/tendermint/... | grep -v /vendor/
-
 install: get_deps
-	go install github.com/tendermint/tendermint/cmd/tendermint
+	@go install ./cmd/tendermint
 
 build:
-	go build -o build/tendermint github.com/tendermint/tendermint/cmd/tendermint
+	go build -o build/tendermint ./cmd/tendermint
 
 build_race:
-	go build -race -o build/tendermint github.com/tendermint/tendermint/cmd/tendermint
+	go build -race -o build/tendermint ./cmd/tendermint
 
 test: build
-	go test `${NOVENDOR}`
+	@echo "--> Running go test"
+	@go test $(PACKAGES)
 
 test_race: build
-	go test -race `${NOVENDOR}`
+	@echo "--> Running go test --race"
+	@go test -race $(PACKAGES)
 
 test_integrations:
-	bash ./test/test.sh
+	@bash ./test/test.sh
 
 test100: build
-	for i in {1..100}; do make test; done
+	@for i in {1..100}; do make test; done
 
 draw_deps:
 	# requires brew install graphviz
 	go get github.com/hirokidaichi/goviz
-	goviz -i github.com/tendermint/tendermint/cmd/tendermint | dot -Tpng -o huge.png
+	goviz -i ./cmd/tendermint | dot -Tpng -o huge.png
 
 list_deps:
-	go list -f '{{join .Deps "\n"}}' github.com/tendermint/tendermint/... | \
+	@go list -f '{{join .Deps "\n"}}' ./... | \
 		grep -v /vendor/ | sort | uniq | \
-	  xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}'
+		xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}'
 
 get_deps:
-	go get -d `${NOVENDOR}`
-	go list -f '{{join .TestImports "\n"}}' github.com/tendermint/tendermint/... | \
+	@go get -d $(PACKAGES)
+	@go list -f '{{join .TestImports "\n"}}' ./... | \
 		grep -v /vendor/ | sort | uniq | \
 		xargs go get
 
-get_vendor_deps:
-	go get github.com/Masterminds/glide
-	rm -rf vendor/
-	glide install
+get_vendor_deps: tools
+	@rm -rf vendor/
+	@echo "--> Running glide install"
+	@glide install
 
 update_deps:
-	go get -d -u github.com/tendermint/tendermint/...
+	@echo "--> Updating dependencies"
+	@go get -d -u ./...
 
 revision:
 	-echo `git rev-parse --verify HEAD` > $(TMROOT)/revision
 	-echo `git rev-parse --verify HEAD` >> $(TMROOT)/revision_history
+
+tools:
+	go get -u -v $(GOTOOLS)
+
+.PHONY: install build build_race dist test test_race test_integrations test100 draw_deps list_deps get_deps get_vendor_deps update_deps revision tools

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+# Get the version from the environment, or try to figure it out.
+if [ -z $VERSION ]; then
+	VERSION=$(awk -F\" '/Version =/ { print $2; exit }' < version/version.go)
+fi
 if [ -z "$VERSION" ]; then
     echo "Please specify a version."
     exit 1

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -z "$VERSION" ]; then
+    echo "Please specify a version."
+    exit 1
+fi
+echo "==> Building version $VERSION..."
+
+# Get the parent directory of where this script is.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+
+# Change into that dir because we expect that.
+cd "$DIR"
+
+# Generate the tag.
+if [ -z "$NOTAG" ]; then
+  echo "==> Tagging..."
+  git commit --allow-empty -a -m "Release v$VERSION"
+  git tag -a -m "Version $VERSION" "v${VERSION}" master
+fi
+
+# Do a hermetic build inside a Docker container.
+docker build -t tendermint/tendermint-builder scripts/tendermint-builder/
+docker run --rm -e "BUILD_TAGS=$BUILD_TAGS" -v "$(pwd)":/go/src/github.com/tendermint/tendermint tendermint/tendermint-builder ./scripts/dist_build.sh
+
+# Add "tendermint" and $VERSION prefix to package name.
+for FILENAME in $(find ./build/dist -mindepth 1 -maxdepth 1 -type f); do
+  FILENAME=$(basename "$FILENAME")
+  mv "./build/dist/${FILENAME}" "./build/dist/tendermint_${VERSION}_${FILENAME}"
+done
+
+# Make the checksums.
+pushd ./build/dist
+shasum -a256 ./* > "./tendermint_${VERSION}_SHA256SUMS"
+popd
+
+# Done
+echo
+echo "==> Results:"
+ls -hl ./build/dist
+
+exit 0

--- a/scripts/dist_build.sh
+++ b/scripts/dist_build.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -e
+
+# Get the parent directory of where this script is.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+
+# Change into that dir because we expect that.
+cd "$DIR"
+
+# Get the git commit
+GIT_COMMIT="$(git rev-parse --short HEAD)"
+GIT_DESCRIBE="$(git describe --tags --always)"
+GIT_IMPORT="github.com/tendermint/tendermint/version"
+
+# Determine the arch/os combos we're building for
+XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
+XC_OS=${XC_OS:-"solaris darwin freebsd linux windows"}
+
+# Delete the old dir
+echo "==> Removing old directory..."
+rm -rf build/dist/*
+mkdir -p build/dist
+
+# Make sure build tools are available.
+make tools
+
+# Get VENDORED dependencies
+make get_vendor_deps
+
+# Build!
+echo "==> Building..."
+"$(which gox)" \
+		-os="${XC_OS}" \
+		-arch="${XC_ARCH}" \
+		-osarch="!darwin/arm !solaris/amd64 !freebsd/amd64" \
+		-ldflags "-X ${GIT_IMPORT}.GitCommit='${GIT_COMMIT}' -X ${GIT_IMPORT}.GitDescribe='${GIT_DESCRIBE}'" \
+		-output "build/dist/{{.OS}}_{{.Arch}}/tendermint" \
+		-tags="${BUILD_TAGS}" \
+		github.com/tendermint/tendermint/cmd/tendermint
+
+# Zip all the files.
+echo "==> Packaging..."
+for PLATFORM in $(find ./build/dist -mindepth 1 -maxdepth 1 -type d); do
+		OSARCH=$(basename "${PLATFORM}")
+		echo "--> ${OSARCH}"
+
+		pushd "$PLATFORM" >/dev/null 2>&1
+		zip "../${OSARCH}.zip" ./*
+		popd >/dev/null 2>&1
+done
+
+# Remove build/dist/{{.OS}}_{{.Arch}} directories.
+rm -rf build/dist/*/
+
+exit 0

--- a/scripts/tendermint-builder/Dockerfile
+++ b/scripts/tendermint-builder/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.7.4
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		zip \
+	&& rm -rf /var/lib/apt/lists/*
+
+# We want to ensure that release builds never have any cgo dependencies so we
+# switch that off at the highest level.
+ENV CGO_ENABLED 0
+
+RUN mkdir -p $GOPATH/src/github.com/tendermint/tendermint
+WORKDIR $GOPATH/src/github.com/tendermint/tendermint

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const Maj = "0"
-const Min = "8" // validator set changes, tmsp->abci, app persistence/recovery, BFT-liveness fix
-const Fix = "0" //
+const Min = "8"
+const Fix = "0"
 
-const Version = Maj + "." + Min + "." + Fix
+const Version = "0.8.0"


### PR DESCRIPTION
Preface: if we want to engage more people (not just hardcore devs), I believe we must provide statically compiled binaries for each release. Besides, this could be easily done with Golang. 

Story: as a dev, if I just want to try Tendermint (or I am planning to write my app in Java), I don't want to install Golang, I just want `brew install tendermint` or similar (btw, what do you think about adding Tendermint to `brew`).

This will fix many issues (https://tendermint.com/intro/getting-started/install):

1. user don't have to install Golang
2. user don't have to learn Golang tools (go get)
3. user won't be having any problems with updated dependencies

Usage
=====

```
$ make dist
```
will create binaries for almost all platforms and will package them for distribution. It will also create a tag (e.g. "v0.8.0").

If you've already created a tag, set `NOTAG` env variable to true:
```
$ NOTAG=1 make dist
```

RELEASE could be set explicitly via env variable. Otherwise, the script will try to fetch it from `version/version.go`

Broken builds
==========

Our code currently does not compile for freebsd/amd64:

```
--> freebsd/amd64 error: exit status 2
Stderr: # github.com/tendermint/tendermint/vendor/github.com/spf13/pflag
vendor/github.com/spf13/pflag/uint16.go:89: illegal NUL byte
vendor/github.com/spf13/pflag/uint16.go:89: syntax error: illegal character U+0000
```

and solaris/amd64:

```
--> solaris/amd64 error: exit status 1
Stderr: vendor/github.com/tendermint/log15/root.go:7:2: no buildable Go source filesin /go/src/github.com/tendermint/tendermint/vendor/github.com/tendermint/log15/term
```

Example output
===========

```
==> Results:
total 49M
-rw-r--r-- 1 vagrant vagrant 5.4M Jan 23 11:12 tendermint_0.8.0_darwin_386.zip
-rw-r--r-- 1 vagrant vagrant 5.7M Jan 23 11:12 tendermint_0.8.0_darwin_amd64.zip
-rw-r--r-- 1 vagrant vagrant 6.1K Jan 23 10:51 tendermint_0.8.0_.DS_Store
-rw-r--r-- 1 vagrant vagrant 5.4M Jan 23 11:12 tendermint_0.8.0_freebsd_386.zip
-rw-r--r-- 1 vagrant vagrant 5.2M Jan 23 11:12 tendermint_0.8.0_freebsd_arm.zip
-rw-r--r-- 1 vagrant vagrant 5.4M Jan 23 11:12 tendermint_0.8.0_linux_386.zip
-rw-r--r-- 1 vagrant vagrant 5.6M Jan 23 11:12 tendermint_0.8.0_linux_amd64.zip
-rw-r--r-- 1 vagrant vagrant 5.2M Jan 23 11:12 tendermint_0.8.0_linux_arm.zip
-rw-r--r-- 1 vagrant vagrant 1002 Jan 23 11:12 tendermint_0.8.0_SHA256SUMS
-rw-r--r-- 1 vagrant vagrant 5.4M Jan 23 11:12 tendermint_0.8.0_windows_386.zip
-rw-r--r-- 1 vagrant vagrant 5.6M Jan 23 11:12 tendermint_0.8.0_windows_amd64.zip
```

What could be done
===============

1. sign tag with GPG signature **(easily done)**
2. sign tendermint_VERSION_SHA256SUMS with GPG signature **(easily done)**
3. figure out why our code does not compile for freebsd and solaris, and fix it

Inspiration: https://www.hashicorp.com/security.html