### PR TITLE
Output all tendermint commands

### DIFF
--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	. "github.com/tendermint/go-common"
 	cfg "github.com/tendermint/go-config"
 	"github.com/tendermint/go-logger"
 	tmcfg "github.com/tendermint/tendermint/config/tendermint"
@@ -21,11 +20,16 @@ func main() {
 		fmt.Println(`Tendermint
 
 Commands:
-    node            Run the tendermint node
-    show_validator  Show this node's validator info
-    gen_validator   Generate new validator keypair
-    probe_upnp      Test UPnP functionality
-    version         Show version info
+    init                        Initialize tendermint
+    node                        Run the tendermint node
+    show_validator              Show this node's validator info
+    gen_validator               Generate new validator keypair
+    probe_upnp                  Test UPnP functionality
+    replay <walfile>            Replay messages from WAL
+    replay_console <walfile>    Replay messages from WAL in a console
+    unsafe_reset_all            (unsafe) Remove all the data and WAL, reset this node's validator
+    unsafe_reset_priv_validator (unsafe) Reset this node's validator
+    version                     Show version info
 `)
 		return
 	}
@@ -59,6 +63,7 @@ Commands:
 	case "version":
 		fmt.Println(version.Version)
 	default:
-		Exit(Fmt("Unknown command %v\n", args[0]))
+		fmt.Printf("Unknown command %v\n", args[0])
+		os.Exit(1)
 	}
 }

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -45,9 +45,19 @@ Commands:
 	case "node":
 		run_node(config)
 	case "replay":
-		consensus.RunReplayFile(config, args[1], false)
+		if len(args) > 1 {
+			consensus.RunReplayFile(config, args[1], false)
+		} else {
+			fmt.Println("replay requires an argument (walfile)")
+			os.Exit(1)
+		}
 	case "replay_console":
-		consensus.RunReplayFile(config, args[1], true)
+		if len(args) > 1 {
+			consensus.RunReplayFile(config, args[1], true)
+		} else {
+			fmt.Println("replay_console requires an argument (walfile)")
+			os.Exit(1)
+		}
 	case "init":
 		init_files()
 	case "show_validator":


### PR DESCRIPTION
I find it very confusing when I am going through the tutorial (https://tendermint.com/intro/getting-started/install) and **do not see `init` in the list of available commands**.

Also, now we just dump all the flags, even whose not relevant to the given command:

```
./build/tendermint replay wal --gee
unknown flag: --gee
Usage of main:
      --abci string         Specify abci transport (socket | grpc) (default "socket")
      --fast_sync           Fast blockchain syncing (default true)
      --grpc_laddr string   GRPC listen address (BroadcastTx only). Port required
      --help                Print this help message.
      --log_level string    Log level (default "notice")
      --moniker string      Node Name (default "anonymous")
      --node_laddr string   Node listen address. (0.0.0.0:0 means any interface, anyport) (default "tcp://0.0.0.0:46656")
      --pex                 Enable Peer-Exchange (dev feature)
      --proxy_app string    Proxy app address, or 'nilapp' or 'dummy' for local testing. (default "tcp://127.0.0.1:46658")
      --rpc_laddr string    RPC listen address. Port required (default "tcp://0.0.0.0:46657")
      --seeds string        Comma delimited host:port seed nodes
      --skip_upnp           Skip UPNP configuration
```

I believe most of these belong to `node`. We should probably move to something like https://github.com/spf13/cobra