### PR TITLE
Rename docker image to tendermint

### DIFF
--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -1,24 +1,20 @@
 # Docker
 
-Tendermint uses docker for deployment of testnets via the [mintnet](github.com/tendermint/mintnet) tool. 
-
-For faster development iterations (ie. to avoid docker builds), 
-the dockerfile just sets up the OS, and tendermint is fetched/installed at runtime.
+Tendermint uses docker for deployment of testnets via the [mintnet](github.com/tendermint/mintnet) tool.
 
 For the deterministic docker builds used in testing, see the [tests directory](https://github.com/tendermint/tendermint/tree/master/test)
 
 # Build and run a docker image and container
 
-These are notes for the dev team. 
+These are notes for the dev team.
 
 ```
 # Build base Docker image
-# Make sure ./run.sh exists.
-docker build -t tendermint/tmbase -f Dockerfile .
+docker build -t "tendermint/tendermint" -t "tendermint/tendermint:0.8.0" -t "tendermint/tendermint:0.8" .
 
 # Log into dockerhub
 docker login
 
 # Push latest build to dockerhub
-docker push tendermint/tmbase
+docker push tendermint/tendermint
 ```

--- a/Makefile
+++ b/Makefile
@@ -20,18 +20,18 @@ build_race:
 dist:
 	@BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/dist.sh'"
 
-test: build
+test:
 	@echo "--> Running go test"
 	@go test $(PACKAGES)
 
-test_race: build
+test_race:
 	@echo "--> Running go test --race"
 	@go test -race $(PACKAGES)
 
 test_integrations:
 	@bash ./test/test.sh
 
-test100: build
+test100:
 	@for i in {1..100}; do make test; done
 
 draw_deps:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
     wget -qO- https://get.docker.com/ | sh
     usermod -a -G docker vagrant
 
-    curl -O https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz
+    curl -O https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz
     tar -xvf go1.7.linux-amd64.tar.gz
     mv go /usr/local
     echo 'export PATH=$PATH:/usr/local/go/bin' >> /home/vagrant/.profile
@@ -28,6 +28,6 @@ Vagrant.configure("2") do |config|
     ln -s /vagrant /home/vagrant/go/src/github.com/tendermint/tendermint
 
     su - vagrant -c 'curl https://glide.sh/get | sh'
-    su - vagrant -c 'cd /vagrant/ && glide install && make test'
+    su - vagrant -c 'cd /vagrant/ && make get_vendor_deps && make test'
   SHELL
 end

--- a/test/net/start.sh
+++ b/test/net/start.sh
@@ -17,18 +17,13 @@ if [[ "$MACH_PREFIX" == "" ]]; then
 fi
 set -u
 
-export TMHEAD=`git rev-parse --abbrev-ref HEAD`
-export TM_IMAGE="tendermint/tmbase"
-
-cd $GOPATH/src/github.com/tendermint/network_testing
+cd "$GOPATH/src/github.com/tendermint/network_testing"
 echo "... running network test $(pwd)"
-bash experiments/exp_throughput.sh $DATACENTER $VALSETSIZE $BLOCKSIZE $TX_SIZE $NTXS $MACH_PREFIX $RESULTSDIR $CLOUD_PROVIDER
+TMHEAD=$(git rev-parse --abbrev-ref HEAD) TM_IMAGE="tendermint/tendermint" bash experiments/exp_throughput.sh $DATACENTER $VALSETSIZE $BLOCKSIZE $TX_SIZE $NTXS $MACH_PREFIX $RESULTSDIR $CLOUD_PROVIDER
 
 # TODO: publish result!
 
 # cleanup
 
 echo "... destroying machines"
-mintnet destroy --machines $MACH_PREFIX[1-$VALSETSIZE] 
-
-
+mintnet destroy --machines $MACH_PREFIX[1-$VALSETSIZE]


### PR DESCRIPTION
The main reason is people usually expect docker image to have the same name as the repo. Plus, `tendermint` is cleaner than `tmbase`.

`tmbase` would make sense if we had multiple docker images within `tendermint`, but we don't.