### PR TITLE
contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing guidelines
+
+**Thanks for considering making contributions to Tendermint!**
+
+Please follow standard github best practices: fork the repo, **branch from the
+tip of develop**, make some commits, test your code changes with `make test`,
+and submit a pull request to develop.
+
+See the [open issues](https://github.com/tendermint/tendermint/issues) for
+things we need help with!
+
+Please make sure to use `gofmt` before every commit - the easiest way to do
+this is have your editor run it for you upon saving a file.
+
+You can read the full guide [on our
+site](https://tendermint.com/docs/guides/contributing).


### PR DESCRIPTION
One primary reason behind this: Github shows this a the top of the page when someone wants to create a PR - https://github.com/blog/1184-contributing-guidelines. Often, I see people creating PR against `master` branch with the changes, which are already present in develop.

![68747470733a2f2f6769746875622d696d616765732e73332e616d617a6f6e6177732e636f6d2f736b697463682f6973737565732d32303132303931332d3136323533392e6a7067](https://cloud.githubusercontent.com/assets/1282182/22585478/6bc8d486-ea11-11e6-9be0-b93ca1596a33.jpeg)
