### PR TITLE
[cli] cleanup gen_validator output

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,19 +15,22 @@ Vagrant.configure("2") do |config|
 
     wget -qO- https://get.docker.com/ | sh
     usermod -a -G docker vagrant
+    apt-get autoremove -y
 
     curl -O https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz
     tar -xvf go1.7.linux-amd64.tar.gz
-    mv go /usr/local
-    echo 'export PATH=$PATH:/usr/local/go/bin' >> /home/vagrant/.profile
+    mv -f go /usr/local
+    rm -f go1.7.linux-amd64.tar.gz
     mkdir -p /home/vagrant/go/bin
     chown -R vagrant:vagrant /home/vagrant/go
-    echo 'export GOPATH=/home/vagrant/go' >> /home/vagrant/.profile
+    echo 'export PATH=$PATH:/usr/local/go/bin:/home/vagrant/go/bin' >> /home/vagrant/.bash_profile
+    echo 'export GOPATH=/home/vagrant/go' >> /home/vagrant/.bash_profile
+
+    echo 'export LC_ALL=en_US.UTF-8' >> /home/vagrant/.bash_profile
 
     mkdir -p /home/vagrant/go/src/github.com/tendermint
     ln -s /vagrant /home/vagrant/go/src/github.com/tendermint/tendermint
 
-    su - vagrant -c 'curl https://glide.sh/get | sh'
-    su - vagrant -c 'cd /vagrant/ && make get_vendor_deps && make test'
+    su - vagrant -c 'cd /home/vagrant/go/src/github.com/tendermint/tendermint && make get_vendor_deps'
   SHELL
 end

--- a/cmd/tendermint/gen_validator.go
+++ b/cmd/tendermint/gen_validator.go
@@ -8,16 +8,8 @@ import (
 )
 
 func gen_validator() {
-
 	privValidator := types.GenPrivValidator()
 	privValidatorJSONBytes := wire.JSONBytesPretty(privValidator)
-	fmt.Printf(`Generated a new validator!
-Paste the following JSON into your %v file
-
-%v
-
-`,
-		config.GetString("priv_validator_file"),
-		string(privValidatorJSONBytes),
-	)
+	fmt.Printf(`%v
+`, string(privValidatorJSONBytes))
 }


### PR DESCRIPTION
Refs #396 

so we can pipe result to a file:

```
tendermint gen_validator > example.json
```

before this we had to cut first 3 lines:

```
tendermint gen_validator | sed 1,3d > example.json
```