### PR TITLE
Provide means to configure a logfile

### DIFF
--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -39,7 +39,7 @@ Commands:
 	parseFlags(config, args[1:]) // Command line overrides
 
 	// set the log level
-	logger.SetLogLevel(config.GetString("log_level"))
+	logger.ResetWithLogLevel(config.GetString("log_level"), config.GetString("log_dir"))
 
 	switch args[0] {
 	case "node":

--- a/config/tendermint/config.go
+++ b/config/tendermint/config.go
@@ -75,6 +75,7 @@ func GetConfig(rootDir string) cfg.Config {
 	mapConfig.SetDefault("cs_wal_file", rootDir+"/data/cs.wal/wal")
 	mapConfig.SetDefault("cs_wal_light", false)
 	mapConfig.SetDefault("filter_peers", false)
+	mapConfig.SetDefault("log_dir", "") // don't use logfile output by default
 
 	mapConfig.SetDefault("block_size", 10000)      // max number of txs
 	mapConfig.SetDefault("block_part_size", 65536) // part size 64K


### PR DESCRIPTION
*THIS REQUIRES THE PR https://github.com/tendermint/go-logger/pull/1 FOR go-logger*

- make ResetWithLogLevel public
- new config parameter "log_dir" in config.toml
- if not-set, logging will only happen to stdout
- if set, logging will be written to a file named "node.log", located in the given dir
- logging will _always_ happen on stdout, whether a log_dir is configured or not
- tendermint will not start if the given log_dir does not exist