### PR TITLE
go-rpc updates

### DIFF
--- a/benchmarks/simu/counter.go
+++ b/benchmarks/simu/counter.go
@@ -2,15 +2,14 @@ package main
 
 import (
 	"encoding/binary"
-	"time"
-	//"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/gorilla/websocket"
-	. "github.com/tendermint/go-common"
-	"github.com/tendermint/go-rpc/client"
-	"github.com/tendermint/go-rpc/types"
-	"github.com/tendermint/go-wire"
+	cmn "github.com/tendermint/go-common"
+	rpcclient "github.com/tendermint/go-rpc/client"
+	rpctypes "github.com/tendermint/go-rpc/types"
+	wire "github.com/tendermint/go-wire"
 	_ "github.com/tendermint/tendermint/rpc/core/types" // Register RPCResponse > Result types
 )
 
@@ -18,7 +17,7 @@ func main() {
 	ws := rpcclient.NewWSClient("127.0.0.1:46657", "/websocket")
 	_, err := ws.Start()
 	if err != nil {
-		Exit(err.Error())
+		cmn.Exit(err.Error())
 	}
 
 	// Read a bunch of responses
@@ -37,13 +36,13 @@ func main() {
 	for i := 0; ; i++ {
 		binary.BigEndian.PutUint64(buf, uint64(i))
 		//txBytes := hex.EncodeToString(buf[:n])
-		request := rpctypes.NewRPCRequest("fakeid", "broadcast_tx", Arr(buf[:8]))
+		request := rpctypes.NewRPCRequest("fakeid", "broadcast_tx", map[string]interface{}{"tx": cmn.Arr(buf[:8])})
 		reqBytes := wire.JSONBytes(request)
 		//fmt.Println("!!", string(reqBytes))
 		fmt.Print(".")
 		err := ws.WriteMessage(websocket.TextMessage, reqBytes)
 		if err != nil {
-			Exit(err.Error())
+			cmn.Exit(err.Error())
 		}
 		if i%1000 == 0 {
 			fmt.Println(i)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 41f8fec708e98b7f8c4804be46008493199fa45e89b2d5dc237fd65fe431c62f
-updated: 2017-03-06T04:01:33.319604992-05:00
+updated: 2017-03-13T14:32:05.382603276Z
 imports:
 - name: github.com/btcsuite/btcd
   version: d06c0bb181529331be8f8d9350288c420d9e60e4
@@ -12,11 +12,11 @@ imports:
   subpackages:
   - spew
 - name: github.com/ebuchman/fail-test
-  version: 13f91f14c826314205cdbed1ec8ac8bf08e03381
+  version: c1eddaa09da2b4017351245b0d43234955276798
 - name: github.com/go-stack/stack
   version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
 - name: github.com/gogo/protobuf
-  version: 909568be09de550ed094403c2bf8a261b5bb730a
+  version: 100ba4e885062801d56799d78530b73b178a78f3
   subpackages:
   - proto
 - name: github.com/golang/protobuf
@@ -24,15 +24,15 @@ imports:
   subpackages:
   - proto
 - name: github.com/golang/snappy
-  version: d9eb7a3d35ec988b8585d4a0068e462c27d28380
+  version: 7db9049039a047d955fe8c19b83c8ff5abd765c7
 - name: github.com/gorilla/websocket
   version: 3ab3a8b8831546bd18fd182c20687ca853b2bb13
 - name: github.com/jmhodges/levigo
   version: c42d9e0ca023e2198120196f842701bb4c55d7b9
 - name: github.com/mattn/go-colorable
-  version: d228849504861217f796da67fae4f6e347643f15
+  version: 5411d3eea5978e6cdc258b30de592b60df6aba96
 - name: github.com/mattn/go-isatty
-  version: 30a891c33c7cde7b02a981314b4228ec99380cca
+  version: 281032e84ae07510239465db46bf442aa44b953a
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
@@ -105,7 +105,7 @@ imports:
   subpackages:
   - upnp
 - name: github.com/tendermint/go-rpc
-  version: fcea0cda21f64889be00a0f4b6d13266b1a76ee7
+  version: b54b9b4ecc2c444f7b11077f24e5abafdcc98676
   subpackages:
   - client
   - server
@@ -123,7 +123,7 @@ imports:
   - client
   - testutil
 - name: golang.org/x/crypto
-  version: 7c6cc321c680f03b9ef0764448e780704f486b51
+  version: 453249f01cfeb54c3d549ddb75ff152ca243f9d8
   subpackages:
   - curve25519
   - nacl/box
@@ -144,7 +144,7 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  version: e24f485414aeafb646f6fca458b0bf869c0880a1
   subpackages:
   - unix
 - name: google.golang.org/grpc

--- a/rpc/client/httpclient.go
+++ b/rpc/client/httpclient.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	events "github.com/tendermint/go-events"
-	"github.com/tendermint/go-rpc/client"
+	rpcclient "github.com/tendermint/go-rpc/client"
 	wire "github.com/tendermint/go-wire"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
@@ -22,7 +22,7 @@ out the server for test code (mock).
 */
 type HTTP struct {
 	remote string
-	rpc    *rpcclient.ClientJSONRPC
+	rpc    *rpcclient.JSONRPCClient
 	*WSEvents
 }
 
@@ -30,7 +30,7 @@ type HTTP struct {
 // and the websocket path (which always seems to be "/websocket")
 func NewHTTP(remote, wsEndpoint string) *HTTP {
 	return &HTTP{
-		rpc:      rpcclient.NewClientJSONRPC(remote),
+		rpc:      rpcclient.NewJSONRPCClient(remote),
 		remote:   remote,
 		WSEvents: newWSEvents(remote, wsEndpoint),
 	}
@@ -50,7 +50,7 @@ func (c *HTTP) _assertIsEventSwitch() types.EventSwitch {
 
 func (c *HTTP) Status() (*ctypes.ResultStatus, error) {
 	tmResult := new(ctypes.TMResult)
-	_, err := c.rpc.Call("status", []interface{}{}, tmResult)
+	_, err := c.rpc.Call("status", map[string]interface{}{}, tmResult)
 	if err != nil {
 		return nil, errors.Wrap(err, "Status")
 	}
@@ -60,7 +60,7 @@ func (c *HTTP) Status() (*ctypes.ResultStatus, error) {
 
 func (c *HTTP) ABCIInfo() (*ctypes.ResultABCIInfo, error) {
 	tmResult := new(ctypes.TMResult)
-	_, err := c.rpc.Call("abci_info", []interface{}{}, tmResult)
+	_, err := c.rpc.Call("abci_info", map[string]interface{}{}, tmResult)
 	if err != nil {
 		return nil, errors.Wrap(err, "ABCIInfo")
 	}
@@ -69,7 +69,7 @@ func (c *HTTP) ABCIInfo() (*ctypes.ResultABCIInfo, error) {
 
 func (c *HTTP) ABCIQuery(path string, data []byte, prove bool) (*ctypes.ResultABCIQuery, error) {
 	tmResult := new(ctypes.TMResult)
-	_, err := c.rpc.Call("abci_query", []interface{}{path, data, prove}, tmResult)
+	_, err := c.rpc.Call("abci_query", map[string]interface{}{"path": path, "data": data, "prove": prove}, tmResult)
 	if err != nil {
 		return nil, errors.Wrap(err, "ABCIQuery")
 	}
@@ -78,7 +78,7 @@ func (c *HTTP) ABCIQuery(path string, data []byte, prove bool) (*ctypes.ResultAB
 
 func (c *HTTP) BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
 	tmResult := new(ctypes.TMResult)
-	_, err := c.rpc.Call("broadcast_tx_commit", []interface{}{tx}, tmResult)
+	_, err := c.rpc.Call("broadcast_tx_commit", map[string]interface{}{"tx": tx}, tmResult)
 	if err != nil {
 		return nil, errors.Wrap(err, "broadcast_tx_commit")
 	}
@@ -95,7 +95,7 @@ func (c *HTTP) BroadcastTxSync(tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 
 func (c *HTTP) broadcastTX(route string, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 	tmResult := new(ctypes.TMResult)
-	_, err := c.rpc.Call(route, []interface{}{tx}, tmResult)
+	_, err := c.rpc.Call(route, map[string]interface{}{"tx": tx}, tmResult)
 	if err != nil {
 		return nil, errors.Wrap(err, route)
 	}
@@ -122,7 +122,7 @@ func (c *HTTP) DumpConsensusState() (*ctypes.ResultDumpConsensusState, error) {
 
 func (c *HTTP) BlockchainInfo(minHeight, maxHeight int) (*ctypes.ResultBlockchainInfo, error) {
 	tmResult := new(ctypes.TMResult)
-	_, err := c.rpc.Call("blockchain", []interface{}{minHeight, maxHeight}, tmResult)
+	_, err := c.rpc.Call("blockchain", map[string]interface{}{"minHeight": minHeight, "maxHeight": maxHeight}, tmResult)
 	if err != nil {
 		return nil, errors.Wrap(err, "BlockchainInfo")
 	}
@@ -140,7 +140,7 @@ func (c *HTTP) Genesis() (*ctypes.ResultGenesis, error) {
 
 func (c *HTTP) Block(height int) (*ctypes.ResultBlock, error) {
 	tmResult := new(ctypes.TMResult)
-	_, err := c.rpc.Call("block", []interface{}{height}, tmResult)
+	_, err := c.rpc.Call("block", map[string]interface{}{"height": height}, tmResult)
 	if err != nil {
 		return nil, errors.Wrap(err, "Block")
 	}
@@ -149,7 +149,7 @@ func (c *HTTP) Block(height int) (*ctypes.ResultBlock, error) {
 
 func (c *HTTP) Commit(height int) (*ctypes.ResultCommit, error) {
 	tmResult := new(ctypes.TMResult)
-	_, err := c.rpc.Call("commit", []interface{}{height}, tmResult)
+	_, err := c.rpc.Call("commit", map[string]interface{}{"height": height}, tmResult)
 	if err != nil {
 		return nil, errors.Wrap(err, "Commit")
 	}

--- a/rpc/test/client_test.go
+++ b/rpc/test/client_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/abci/types"
-	. "github.com/tendermint/go-common"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -33,7 +32,7 @@ func TestURIStatus(t *testing.T) {
 
 func TestJSONStatus(t *testing.T) {
 	tmResult := new(ctypes.TMResult)
-	_, err := GetJSONClient().Call("status", []interface{}{}, tmResult)
+	_, err := GetJSONClient().Call("status", map[string]interface{}{}, tmResult)
 	require.Nil(t, err)
 	testStatus(t, tmResult)
 }
@@ -73,7 +72,7 @@ func TestJSONBroadcastTxSync(t *testing.T) {
 	defer config.Set("block_size", -1)
 	tmResult := new(ctypes.TMResult)
 	tx := randBytes(t)
-	_, err := GetJSONClient().Call("broadcast_tx_sync", []interface{}{tx}, tmResult)
+	_, err := GetJSONClient().Call("broadcast_tx_sync", map[string]interface{}{"tx": tx}, tmResult)
 	require.Nil(t, err)
 	testBroadcastTxSync(t, tmResult, tx)
 }
@@ -95,13 +94,13 @@ func testBroadcastTxSync(t *testing.T, resI interface{}, tx []byte) {
 func testTxKV(t *testing.T) ([]byte, []byte, []byte) {
 	k := randBytes(t)
 	v := randBytes(t)
-	return k, v, []byte(Fmt("%s=%s", k, v))
+	return k, v, []byte(fmt.Sprintf("%s=%s", k, v))
 }
 
 func sendTx(t *testing.T) ([]byte, []byte) {
 	tmResult := new(ctypes.TMResult)
 	k, v, tx := testTxKV(t)
-	_, err := GetJSONClient().Call("broadcast_tx_commit", []interface{}{tx}, tmResult)
+	_, err := GetJSONClient().Call("broadcast_tx_commit", map[string]interface{}{"tx": tx}, tmResult)
 	require.Nil(t, err)
 	return k, v
 }
@@ -118,7 +117,7 @@ func TestURIABCIQuery(t *testing.T) {
 func TestJSONABCIQuery(t *testing.T) {
 	k, v := sendTx(t)
 	tmResult := new(ctypes.TMResult)
-	_, err := GetJSONClient().Call("abci_query", []interface{}{"", k, false}, tmResult)
+	_, err := GetJSONClient().Call("abci_query", map[string]interface{}{"path": "", "data": k, "prove": false}, tmResult)
 	require.Nil(t, err)
 	testABCIQuery(t, tmResult, v)
 }
@@ -146,7 +145,7 @@ func TestURIBroadcastTxCommit(t *testing.T) {
 func TestJSONBroadcastTxCommit(t *testing.T) {
 	tmResult := new(ctypes.TMResult)
 	tx := randBytes(t)
-	_, err := GetJSONClient().Call("broadcast_tx_commit", []interface{}{tx}, tmResult)
+	_, err := GetJSONClient().Call("broadcast_tx_commit", map[string]interface{}{"tx": tx}, tmResult)
 	require.Nil(t, err)
 	testBroadcastTxCommit(t, tmResult, tx)
 }
@@ -240,7 +239,7 @@ func TestWSTxEvent(t *testing.T) {
 
 	// send an tx
 	tmResult := new(ctypes.TMResult)
-	_, err := GetJSONClient().Call("broadcast_tx_sync", []interface{}{tx}, tmResult)
+	_, err := GetJSONClient().Call("broadcast_tx_sync", map[string]interface{}{"tx": tx}, tmResult)
 	require.Nil(err)
 
 	waitForEvent(t, wsc, eid, true, func() {}, func(eid string, b interface{}) error {
@@ -310,7 +309,11 @@ func TestURIUnsafeSetConfig(t *testing.T) {
 func TestJSONUnsafeSetConfig(t *testing.T) {
 	for _, testCase := range testCasesUnsafeSetConfig {
 		tmResult := new(ctypes.TMResult)
-		_, err := GetJSONClient().Call("unsafe_set_config", []interface{}{testCase[0], testCase[1], testCase[2]}, tmResult)
+		_, err := GetJSONClient().Call("unsafe_set_config", map[string]interface{}{
+			"type":  testCase[0],
+			"key":   testCase[1],
+			"value": testCase[2],
+		}, tmResult)
 		require.Nil(t, err)
 	}
 	testUnsafeSetConfig(t)

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -72,15 +72,15 @@ func GetConfig() cfg.Config {
 }
 
 // GetURIClient gets a uri client pointing to the test tendermint rpc
-func GetURIClient() *client.ClientURI {
+func GetURIClient() *client.URIClient {
 	rpcAddr := GetConfig().GetString("rpc_laddr")
-	return client.NewClientURI(rpcAddr)
+	return client.NewURIClient(rpcAddr)
 }
 
 // GetJSONClient gets a http/json client pointing to the test tendermint rpc
-func GetJSONClient() *client.ClientJSONRPC {
+func GetJSONClient() *client.JSONRPCClient {
 	rpcAddr := GetConfig().GetString("rpc_laddr")
-	return client.NewClientJSONRPC(rpcAddr)
+	return client.NewJSONRPCClient(rpcAddr)
 }
 
 func GetGRPCClient() core_grpc.BroadcastAPIClient {


### PR DESCRIPTION
jsonrpc now uses the same interface as http (key-value pairs)

Refs https://github.com/tendermint/go-rpc/pull/9

rename rpc clients

See https://github.com/tendermint/go-rpc/commit/e6c083f589d93d5cada7c5e9fff1c3c05873a167

update deps