### PR TITLE
blockpool: fix removePeer bug

### DIFF
--- a/blockchain/pool.go
+++ b/blockchain/pool.go
@@ -240,7 +240,9 @@ func (pool *BlockPool) RemovePeer(peerID string) {
 func (pool *BlockPool) removePeer(peerID string) {
 	for _, requester := range pool.requesters {
 		if requester.getPeerID() == peerID {
-			pool.numPending++
+			if requester.getBlock() != nil {
+				pool.numPending++
+			}
 			go requester.redo() // pick another peer and ...
 		}
 	}


### PR DESCRIPTION
On removePeer, we were incrementing numPending for every requester associated with that peer (even those that weren't pending), causing us to exceed the MaxNumPending and stop making progress. Now we only increment for blocks that weren't already pending (ie. blocks we had received from the peer).

Question: should we really reset a requester and re-request a block just because the peer disconnected ? 