### PR TITLE
Logging if node is validator/observer

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -775,15 +775,21 @@ func (cs *ConsensusState) enterPropose(height int, round int) {
 
 	// Nothing more to do if we're not a validator
 	if cs.privValidator == nil {
+		cs.Logger.Info("This node is not a validator")
 		return
 	}
 
 	if !bytes.Equal(cs.Validators.GetProposer().Address, cs.privValidator.GetAddress()) {
 		cs.Logger.Info("enterPropose: Not our turn to propose", "proposer", cs.Validators.GetProposer().Address, "privValidator", cs.privValidator)
+		if cs.Validators.HasAddress(cs.privValidator.GetAddress()) {
+			cs.Logger.Info("This node is a validator")
+		} else {
+			cs.Logger.Info("This node is not a validator")
+		}
 	} else {
 		cs.Logger.Info("enterPropose: Our turn to propose", "proposer", cs.Validators.GetProposer().Address, "privValidator", cs.privValidator)
+		cs.Logger.Info("This node is a validator")
 		cs.decideProposal(height, round)
-
 	}
 }
 
@@ -1141,6 +1147,7 @@ func (cs *ConsensusState) tryFinalizeCommit(height int) {
 		cs.Logger.Error("Attempt to finalize failed. We don't have the commit block.", "height", height, "proposal-block", cs.ProposalBlock.Hash(), "commit-block", blockID.Hash)
 		return
 	}
+
 	//	go
 	cs.finalizeCommit(height)
 }
@@ -1221,7 +1228,7 @@ func (cs *ConsensusState) finalizeCommit(height int) {
 	// NOTE: If we fail before firing, these events will never fire
 	//
 	// TODO: Either
-	// 	* Fire before persisting state, in ApplyBlock
+	//	* Fire before persisting state, in ApplyBlock
 	//	* Fire on start up if we haven't written any new WAL msgs
 	//   Both options mean we may fire more than once. Is that fine ?
 	types.FireEventNewBlock(cs.evsw, types.EventDataNewBlock{block})

--- a/node/node.go
+++ b/node/node.go
@@ -123,6 +123,13 @@ func NewNode(config *cfg.Config, privValidator *types.PrivValidator, clientCreat
 		}
 	}
 
+	// Log whether this node is a validator or an observer
+	if state.Validators.HasAddress(privValidator.Address) {
+		consensusLogger.Info("This node is a validator")
+	} else {
+		consensusLogger.Info("This node is not a validator")
+	}
+
 	// Make BlockchainReactor
 	bcReactor := bc.NewBlockchainReactor(state.Copy(), proxyApp.Consensus(), blockStore, fastSync)
 	bcReactor.SetLogger(logger.With("module", "blockchain"))

--- a/state/state.go
+++ b/state/state.go
@@ -151,6 +151,7 @@ func (s *State) SetBlockAndValidators(header *types.Header, blockPartsHeader typ
 		s.logger.Error("Error changing validator set", "error", err)
 		// TODO: err or carry on?
 	}
+
 	// Update validator accums and set state variables
 	nextValSet.IncrementAccum(1)
 


### PR DESCRIPTION
This PR implements #480 .

@ebuchman What's our convention for log levels? Should it be Notice?

Also, for logging when the validator changes over time I thought about putting it in state.go into SetBlockAndValidators(), but I have no access to the current node and hence can't figure out whether the current node was removed. Is there a global way to get the node that is currently running?