### PR TITLE
fixes to changelog, config, default logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ BREAKING CHANGES:
   - Remove config/tendermint and config/tendermint_test. Defaults are handled by viper and `DefaultConfig() / `TestConfig()` functions
   - Tests do not read config from file
 - New logger (`github.com/tendermint/tmlibs/log`)
-  - Reduced to three levels: Error, Info, Debug
+  - Reduced to three levels: `error`, `info`, and `debug`
+  - NOTE: The default in previous versions was `notice`, which is no longer valid. Please change it in the `config.toml`
   - Per-module log levels
+  - The new default is `state:info,*:error`, which means the `state` package logs at `info` level, and everything else logs at `error` level
   - No global loggers (loggers are passed into constructors, or preferably set with a `SetLogger` method)
 - RPC serialization cleanup:
   - Lowercase json names for ValidatorSet fields
@@ -46,7 +48,7 @@ IMPROVEMENTS:
   - `go-data -> go-wire/data`
   - All other `go-*` libs, except `go-crypto` and `go-wire`, merged under `tmlibs`
 - Return HTTP status codes with errors for RPC responses
-- Use `.Wrap()` and `.Unwarp()` instead of eg. `PubKeyS` for `go-crypto` types
+- Use `.Wrap()` and `.Unwrap()` instead of eg. `PubKeyS` for `go-crypto` types
 - Color code different instances of the consensus for tests 
 - RPC JSON responses use pretty printing (via `json.MarshalIndent`)
 

--- a/cmd/tendermint/commands/flags/log_level.go
+++ b/cmd/tendermint/commands/flags/log_level.go
@@ -76,7 +76,7 @@ func ParseLogLevel(lvl string, logger log.Logger) (log.Logger, error) {
 
 	// if "*" is not provided, set default global level
 	if !isDefaultLogLevelSet {
-		option, err = log.AllowLevel(cfg.DefaultBaseConfig().LogLevel)
+		option, err = log.AllowLevel(cfg.DefaultLogLevel())
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -30,15 +30,14 @@ func init() {
 	runNodeCmd.Flags().String("abci", config.ABCI, "Specify abci transport (socket | grpc)")
 
 	// rpc flags
-	runNodeCmd.Flags().String("rpc_laddr", config.RPCListenAddress, "RPC listen address. Port required")
-	runNodeCmd.Flags().String("grpc_laddr", config.GRPCListenAddress, "GRPC listen address (BroadcastTx only). Port required")
+	runNodeCmd.Flags().String("rpc.laddr", config.RPC.ListenAddress, "RPC listen address. Port required")
+	runNodeCmd.Flags().String("rpc.grpc_laddr", config.RPC.GRPCListenAddress, "GRPC listen address (BroadcastTx only). Port required")
+	runNodeCmd.Flags().Bool("rpc.unsafe", config.RPC.Unsafe, "Enabled unsafe rpc methods")
 
 	// p2p flags
 	runNodeCmd.Flags().String("p2p.laddr", config.P2P.ListenAddress, "Node listen address. (0.0.0.0:0 means any interface, any port)")
 	runNodeCmd.Flags().String("p2p.seeds", config.P2P.Seeds, "Comma delimited host:port seed nodes")
 	runNodeCmd.Flags().Bool("p2p.skip_upnp", config.P2P.SkipUPNP, "Skip UPNP configuration")
-
-	// feature flags
 	runNodeCmd.Flags().Bool("p2p.pex", config.P2P.PexReactor, "Enable Peer-Exchange (dev feature)")
 
 	RootCmd.AddCommand(runNodeCmd)

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -108,7 +109,7 @@ func DefaultBaseConfig() BaseConfig {
 		Moniker:           "anonymous",
 		ProxyApp:          "tcp://127.0.0.1:46658",
 		ABCI:              "socket",
-		LogLevel:          "state:info,*:error",
+		LogLevel:          DefaultPackageLogLevels(),
 		ProfListenAddress: "",
 		FastSync:          true,
 		FilterPeers:       false,
@@ -137,6 +138,14 @@ func (b BaseConfig) PrivValidatorFile() string {
 
 func (b BaseConfig) DBDir() string {
 	return rootify(b.DBPath, b.RootDir)
+}
+
+func DefaultLogLevel() string {
+	return "error"
+}
+
+func DefaultPackageLogLevels() string {
+	return fmt.Sprintf("state:info,*:%s", DefaultLogLevel())
 }
 
 //-----------------------------------------------------------------------------

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	BaseConfig `mapstructure:",squash"`
 
 	// Options for services
+	RPC       *RPCConfig       `mapstructure:"rpc"`
 	P2P       *P2PConfig       `mapstructure:"p2p"`
 	Mempool   *MempoolConfig   `mapstructure:"mempool"`
 	Consensus *ConsensusConfig `mapstructure:"consensus"`
@@ -20,6 +21,7 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		BaseConfig: DefaultBaseConfig(),
+		RPC:        DefaultRPCConfig(),
 		P2P:        DefaultP2PConfig(),
 		Mempool:    DefaultMempoolConfig(),
 		Consensus:  DefaultConsensusConfig(),
@@ -29,6 +31,7 @@ func DefaultConfig() *Config {
 func TestConfig() *Config {
 	return &Config{
 		BaseConfig: TestBaseConfig(),
+		RPC:        TestRPCConfig(),
 		P2P:        TestP2PConfig(),
 		Mempool:    DefaultMempoolConfig(),
 		Consensus:  TestConsensusConfig(),
@@ -38,11 +41,15 @@ func TestConfig() *Config {
 // Set the RootDir for all Config structs
 func (cfg *Config) SetRoot(root string) *Config {
 	cfg.BaseConfig.RootDir = root
+	cfg.RPC.RootDir = root
 	cfg.P2P.RootDir = root
 	cfg.Mempool.RootDir = root
 	cfg.Consensus.RootDir = root
 	return cfg
 }
+
+//-----------------------------------------------------------------------------
+// BaseConfig
 
 // BaseConfig struct for a Tendermint node
 type BaseConfig struct {
@@ -92,13 +99,6 @@ type BaseConfig struct {
 
 	// Database directory
 	DBPath string `mapstructure:"db_dir"`
-
-	// TCP or UNIX socket address for the RPC server to listen on
-	RPCListenAddress string `mapstructure:"rpc_laddr"`
-
-	// TCP or UNIX socket address for the gRPC server to listen on
-	// NOTE: This server only supports /broadcast_tx_commit
-	GRPCListenAddress string `mapstructure:"grpc_laddr"`
 }
 
 func DefaultBaseConfig() BaseConfig {
@@ -108,15 +108,13 @@ func DefaultBaseConfig() BaseConfig {
 		Moniker:           "anonymous",
 		ProxyApp:          "tcp://127.0.0.1:46658",
 		ABCI:              "socket",
-		LogLevel:          "info",
+		LogLevel:          "state:info,*:error",
 		ProfListenAddress: "",
 		FastSync:          true,
 		FilterPeers:       false,
 		TxIndex:           "kv",
 		DBBackend:         "leveldb",
 		DBPath:            "data",
-		RPCListenAddress:  "tcp://0.0.0.0:46657",
-		GRPCListenAddress: "",
 	}
 }
 
@@ -126,8 +124,6 @@ func TestBaseConfig() BaseConfig {
 	conf.ProxyApp = "dummy"
 	conf.FastSync = false
 	conf.DBBackend = "memdb"
-	conf.RPCListenAddress = "tcp://0.0.0.0:36657"
-	conf.GRPCListenAddress = "tcp://0.0.0.0:36658"
 	return conf
 }
 
@@ -142,6 +138,42 @@ func (b BaseConfig) PrivValidatorFile() string {
 func (b BaseConfig) DBDir() string {
 	return rootify(b.DBPath, b.RootDir)
 }
+
+//-----------------------------------------------------------------------------
+// RPCConfig
+
+type RPCConfig struct {
+	RootDir string `mapstructure:"home"`
+
+	// TCP or UNIX socket address for the RPC server to listen on
+	ListenAddress string `mapstructure:"laddr"`
+
+	// TCP or UNIX socket address for the gRPC server to listen on
+	// NOTE: This server only supports /broadcast_tx_commit
+	GRPCListenAddress string `mapstructure:"grpc_laddr"`
+
+	// Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
+	Unsafe bool `mapstructure:"unsafe"`
+}
+
+func DefaultRPCConfig() *RPCConfig {
+	return &RPCConfig{
+		ListenAddress:     "tcp://0.0.0.0:46657",
+		GRPCListenAddress: "",
+		Unsafe:            false,
+	}
+}
+
+func TestRPCConfig() *RPCConfig {
+	conf := DefaultRPCConfig()
+	conf.ListenAddress = "tcp://0.0.0.0:36657"
+	conf.GRPCListenAddress = "tcp://0.0.0.0:36658"
+	conf.Unsafe = true
+	return conf
+}
+
+//-----------------------------------------------------------------------------
+// P2PConfig
 
 type P2PConfig struct {
 	RootDir        string `mapstructure:"home"`
@@ -174,6 +206,9 @@ func (p *P2PConfig) AddrBookFile() string {
 	return rootify(p.AddrBook, p.RootDir)
 }
 
+//-----------------------------------------------------------------------------
+// MempoolConfig
+
 type MempoolConfig struct {
 	RootDir      string `mapstructure:"home"`
 	Recheck      bool   `mapstructure:"recheck"`
@@ -194,6 +229,9 @@ func DefaultMempoolConfig() *MempoolConfig {
 func (m *MempoolConfig) WalDir() string {
 	return rootify(m.WalPath, m.RootDir)
 }
+
+//-----------------------------------------------------------------------------
+// ConsensusConfig
 
 // ConsensusConfig holds timeouts and details about the WAL, the block structure,
 // and timeouts in the consensus protocol.
@@ -285,6 +323,9 @@ func (c *ConsensusConfig) WalFile() string {
 func (c *ConsensusConfig) SetWalFile(walFile string) {
 	c.walFile = walFile
 }
+
+//-----------------------------------------------------------------------------
+// Utils
 
 // helper function to make config creation independent of root dir
 func rootify(path, root string) string {

--- a/config/toml.go
+++ b/config/toml.go
@@ -32,8 +32,10 @@ proxy_app = "tcp://127.0.0.1:46658"
 moniker = "__MONIKER__"
 fast_sync = true
 db_backend = "leveldb"
-log_level = "info"
-rpc_laddr = "tcp://0.0.0.0:46657"
+log_level = "state:info,*:error"
+
+[rpc]
+laddr = "tcp://0.0.0.0:46657"
 
 [p2p]
 laddr = "tcp://0.0.0.0:46656"
@@ -94,7 +96,9 @@ moniker = "__MONIKER__"
 fast_sync = false
 db_backend = "memdb"
 log_level = "info"
-rpc_laddr = "tcp://0.0.0.0:36657"
+
+[rpc]
+laddr = "tcp://0.0.0.0:36657"
 
 [p2p]
 laddr = "tcp://0.0.0.0:36656"

--- a/config/toml.go
+++ b/config/toml.go
@@ -30,17 +30,18 @@ var defaultConfigTmpl = `# This is a TOML config file.
 
 proxy_app = "tcp://127.0.0.1:46658"
 moniker = "__MONIKER__"
-node_laddr = "tcp://0.0.0.0:46656"
-seeds = ""
 fast_sync = true
 db_backend = "leveldb"
 log_level = "info"
 rpc_laddr = "tcp://0.0.0.0:46657"
+
+[p2p]
+laddr = "tcp://0.0.0.0:46656"
+seeds = ""
 `
 
-func defaultConfig(moniker string) (defaultConfig string) {
-	defaultConfig = strings.Replace(defaultConfigTmpl, "__MONIKER__", moniker, -1)
-	return
+func defaultConfig(moniker string) string {
+	return strings.Replace(defaultConfigTmpl, "__MONIKER__", moniker, -1)
 }
 
 /****** these are for test settings ***********/
@@ -90,12 +91,14 @@ var testConfigTmpl = `# This is a TOML config file.
 
 proxy_app = "dummy"
 moniker = "__MONIKER__"
-node_laddr = "tcp://0.0.0.0:36656"
-seeds = ""
 fast_sync = false
 db_backend = "memdb"
 log_level = "info"
 rpc_laddr = "tcp://0.0.0.0:36657"
+
+[p2p]
+laddr = "tcp://0.0.0.0:36656"
+seeds = ""
 `
 
 func testConfig(moniker string) (testConfig string) {

--- a/node/node.go
+++ b/node/node.go
@@ -322,6 +322,10 @@ func (n *Node) startRPC() ([]net.Listener, error) {
 	n.ConfigureRPC()
 	listenAddrs := strings.Split(n.config.RPC.ListenAddress, ",")
 
+	if n.config.RPC.Unsafe {
+		rpccore.AddUnsafeRoutes()
+	}
+
 	// we may expose the rpc over both a unix and tcp socket
 	listeners := make([]net.Listener, len(listenAddrs))
 	for i, listenAddr := range listenAddrs {

--- a/node/node.go
+++ b/node/node.go
@@ -255,7 +255,7 @@ func (n *Node) OnStart() error {
 	}
 
 	// Run the RPC server
-	if n.config.RPCListenAddress != "" {
+	if n.config.RPC.ListenAddress != "" {
 		listeners, err := n.startRPC()
 		if err != nil {
 			return err
@@ -320,7 +320,7 @@ func (n *Node) ConfigureRPC() {
 
 func (n *Node) startRPC() ([]net.Listener, error) {
 	n.ConfigureRPC()
-	listenAddrs := strings.Split(n.config.RPCListenAddress, ",")
+	listenAddrs := strings.Split(n.config.RPC.ListenAddress, ",")
 
 	// we may expose the rpc over both a unix and tcp socket
 	listeners := make([]net.Listener, len(listenAddrs))
@@ -339,7 +339,7 @@ func (n *Node) startRPC() ([]net.Listener, error) {
 	}
 
 	// we expose a simplified api over grpc for convenience to app devs
-	grpcListenAddr := n.config.GRPCListenAddress
+	grpcListenAddr := n.config.RPC.GRPCListenAddress
 	if grpcListenAddr != "" {
 		listener, err := grpccore.StartGRPCServer(grpcListenAddr)
 		if err != nil {
@@ -421,7 +421,7 @@ func (n *Node) makeNodeInfo() *p2p.NodeInfo {
 	p2pListener := n.sw.Listeners()[0]
 	p2pHost := p2pListener.ExternalAddress().IP.String()
 	p2pPort := p2pListener.ExternalAddress().Port
-	rpcListenAddr := n.config.RPCListenAddress
+	rpcListenAddr := n.config.RPC.ListenAddress
 
 	// We assume that the rpcListener has the same ExternalAddress.
 	// This is probably true because both P2P and RPC listeners use UPnP,

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func getHTTPClient() *client.HTTP {
-	rpcAddr := rpctest.GetConfig().RPCListenAddress
+	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
 	return client.NewHTTP(rpcAddr, "/websocket")
 }
 

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -10,7 +10,7 @@ import (
 
 //-----------------------------------------------------------------------------
 
-// TODO: limit/permission on (max - min)
+// Returns at most 20 blocks
 func BlockchainInfo(minHeight, maxHeight int) (*ctypes.ResultBlockchainInfo, error) {
 	if maxHeight == 0 {
 		maxHeight = blockStore.Height()
@@ -19,7 +19,10 @@ func BlockchainInfo(minHeight, maxHeight int) (*ctypes.ResultBlockchainInfo, err
 	}
 	if minHeight == 0 {
 		minHeight = MaxInt(1, maxHeight-20)
+	} else {
+		minHeight = MaxInt(minHeight, maxHeight-20)
 	}
+
 	logger.Debug("BlockchainInfoHandler", "maxHeight", maxHeight, "minHeight", minHeight)
 
 	blockMetas := []*types.BlockMeta{}

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -31,13 +31,15 @@ var Routes = map[string]*rpc.RPCFunc{
 	// abci API
 	"abci_query": rpc.NewRPCFunc(ABCIQuery, "path,data,prove"),
 	"abci_info":  rpc.NewRPCFunc(ABCIInfo, ""),
+}
 
+func AddUnsafeRoutes() {
 	// control API
-	"dial_seeds":           rpc.NewRPCFunc(UnsafeDialSeeds, "seeds"),
-	"unsafe_flush_mempool": rpc.NewRPCFunc(UnsafeFlushMempool, ""),
+	Routes["dial_seeds"] = rpc.NewRPCFunc(UnsafeDialSeeds, "seeds")
+	Routes["unsafe_flush_mempool"] = rpc.NewRPCFunc(UnsafeFlushMempool, "")
 
 	// profiler API
-	"unsafe_start_cpu_profiler": rpc.NewRPCFunc(UnsafeStartCPUProfiler, "filename"),
-	"unsafe_stop_cpu_profiler":  rpc.NewRPCFunc(UnsafeStopCPUProfiler, ""),
-	"unsafe_write_heap_profile": rpc.NewRPCFunc(UnsafeWriteHeapProfile, "filename"),
+	Routes["unsafe_start_cpu_profiler"] = rpc.NewRPCFunc(UnsafeStartCPUProfiler, "filename")
+	Routes["unsafe_stop_cpu_profiler"] = rpc.NewRPCFunc(UnsafeStopCPUProfiler, "")
+	Routes["unsafe_write_heap_profile"] = rpc.NewRPCFunc(UnsafeWriteHeapProfile, "filename")
 }

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -59,31 +59,31 @@ func GetConfig() *cfg.Config {
 		// and we use random ports to run in parallel
 		tm, rpc, grpc := makeAddrs()
 		config.P2P.ListenAddress = tm
-		config.RPCListenAddress = rpc
-		config.GRPCListenAddress = grpc
+		config.RPC.ListenAddress = rpc
+		config.RPC.GRPCListenAddress = grpc
 	}
 	return config
 }
 
 // GetURIClient gets a uri client pointing to the test tendermint rpc
 func GetURIClient() *client.URIClient {
-	rpcAddr := GetConfig().RPCListenAddress
+	rpcAddr := GetConfig().RPC.ListenAddress
 	return client.NewURIClient(rpcAddr)
 }
 
 // GetJSONClient gets a http/json client pointing to the test tendermint rpc
 func GetJSONClient() *client.JSONRPCClient {
-	rpcAddr := GetConfig().RPCListenAddress
+	rpcAddr := GetConfig().RPC.ListenAddress
 	return client.NewJSONRPCClient(rpcAddr)
 }
 
 func GetGRPCClient() core_grpc.BroadcastAPIClient {
-	grpcAddr := config.GRPCListenAddress
+	grpcAddr := config.RPC.GRPCListenAddress
 	return core_grpc.StartGRPCClient(grpcAddr)
 }
 
 func GetWSClient() *client.WSClient {
-	rpcAddr := GetConfig().RPCListenAddress
+	rpcAddr := GetConfig().RPC.ListenAddress
 	wsc := client.NewWSClient(rpcAddr, "/websocket")
 	if _, err := wsc.Start(); err != nil {
 		panic(err)

--- a/state/execution.go
+++ b/state/execution.go
@@ -259,7 +259,8 @@ func (s *State) CommitStateUpdateMempool(proxyAppConn proxy.AppConnConsensus, bl
 		s.logger.Debug("Commit.Log: " + res.Log)
 	}
 
-	s.logger.Info("Committed state", "hash", res.Data)
+	s.logger.Info("Committed state", "height", block.Height, "hash", res.Data)
+
 	// Set the state's new AppHash
 	s.AppHash = res.Data
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -259,7 +259,7 @@ func (s *State) CommitStateUpdateMempool(proxyAppConn proxy.AppConnConsensus, bl
 		s.logger.Debug("Commit.Log: " + res.Log)
 	}
 
-	s.logger.Info("Committed state", "height", block.Height, "hash", res.Data)
+	s.logger.Info("Committed state", "height", block.Height, "txs", block.NumTxs, "hash", res.Data)
 
 	// Set the state's new AppHash
 	s.AppHash = res.Data

--- a/test/app/test.sh
+++ b/test/app/test.sh
@@ -85,7 +85,7 @@ function counter_over_grpc_grpc() {
 	pid_counter=$!
 	sleep 1
 	GRPC_PORT=36656
-	tendermint node --abci grpc --grpc_laddr tcp://localhost:$GRPC_PORT > tendermint.log &
+	tendermint node --abci grpc --rpc.grpc_laddr tcp://localhost:$GRPC_PORT > tendermint.log &
 	pid_tendermint=$!
 	sleep 5
 

--- a/test/p2p/data/core/init.sh
+++ b/test/p2p/data/core/init.sh
@@ -17,4 +17,4 @@ git fetch origin $BRANCH
 git checkout $BRANCH
 make install
 
-tendermint node --p2p.seeds="$TMSEEDS" --moniker="$TMNAME" --proxy_app="$PROXYAPP"
+tendermint node --p2p.seeds="$TMSEEDS" --moniker="$TMNAME" --proxy_app="$PROXYAPP" --rpc.unsafe

--- a/test/p2p/fast_sync/test_peer.sh
+++ b/test/p2p/fast_sync/test_peer.sh
@@ -27,7 +27,7 @@ SEEDS="$(test/p2p/ip.sh 1):46656"
 for j in `seq 2 $N`; do
 	SEEDS="$SEEDS,$(test/p2p/ip.sh $j):46656"
 done
-bash test/p2p/peer.sh $DOCKER_IMAGE $NETWORK_NAME $ID $PROXY_APP "--p2p.seeds $SEEDS --p2p.pex"
+bash test/p2p/peer.sh $DOCKER_IMAGE $NETWORK_NAME $ID $PROXY_APP "--p2p.seeds $SEEDS --p2p.pex --rpc.unsafe"
 
 # wait for peer to sync and check the app hash
 bash test/p2p/client.sh $DOCKER_IMAGE $NETWORK_NAME fs_$ID "test/p2p/fast_sync/check_peer.sh $ID"

--- a/test/p2p/local_testnet_start.sh
+++ b/test/p2p/local_testnet_start.sh
@@ -20,5 +20,5 @@ cd "$GOPATH/src/github.com/tendermint/tendermint"
 docker network create --driver bridge --subnet 172.57.0.0/16 "$NETWORK_NAME"
 
 for i in $(seq 1 "$N"); do
-	bash test/p2p/peer.sh "$DOCKER_IMAGE" "$NETWORK_NAME" "$i" "$APP_PROXY" "$SEEDS --p2p.pex"
+	bash test/p2p/peer.sh "$DOCKER_IMAGE" "$NETWORK_NAME" "$i" "$APP_PROXY" "$SEEDS --p2p.pex --rpc.unsafe"
 done

--- a/test/p2p/pex/test_addrbook.sh
+++ b/test/p2p/pex/test_addrbook.sh
@@ -23,7 +23,7 @@ docker rm -vf "local_testnet_$ID"
 set -e
 
 # NOTE that we do not provide seeds
-bash test/p2p/peer.sh "$DOCKER_IMAGE" "$NETWORK_NAME" "$ID" "$PROXY_APP" "--p2p.pex"
+bash test/p2p/peer.sh "$DOCKER_IMAGE" "$NETWORK_NAME" "$ID" "$PROXY_APP" "--p2p.pex --rpc.unsafe"
 docker cp "/tmp/addrbook.json" "local_testnet_$ID:/go/src/github.com/tendermint/tendermint/test/p2p/data/mach1/core/addrbook.json"
 echo "with the following addrbook:"
 cat /tmp/addrbook.json
@@ -47,7 +47,7 @@ docker rm -vf "local_testnet_$ID"
 set -e 
 
 # NOTE that we do not provide seeds
-bash test/p2p/peer.sh "$DOCKER_IMAGE" "$NETWORK_NAME" "$ID" "$PROXY_APP" "--p2p.pex"
+bash test/p2p/peer.sh "$DOCKER_IMAGE" "$NETWORK_NAME" "$ID" "$PROXY_APP" "--p2p.pex --rpc.unsafe"
 
 # if the client runs forever, it means other peers have removed us from their books (which should not happen)
 bash test/p2p/client.sh "$DOCKER_IMAGE" "$NETWORK_NAME" "$CLIENT_NAME" "test/p2p/pex/check_peer.sh $ID $N"

--- a/test/persist/test_failure_indices.sh
+++ b/test/persist/test_failure_indices.sh
@@ -8,7 +8,7 @@ tendermint init
 # use a unix socket so we can remove it
 RPC_ADDR="$(pwd)/rpc.sock"
 
-TM_CMD="tendermint node --log_level=debug --rpc_laddr=unix://$RPC_ADDR" # &> tendermint_${name}.log"
+TM_CMD="tendermint node --log_level=debug --rpc.laddr=unix://$RPC_ADDR" # &> tendermint_${name}.log"
 DUMMY_CMD="dummy --persist $TMHOME/dummy" # &> dummy_${name}.log"
 
 

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ const Fix = "0"
 
 var (
 	// The full version string
-	Version = "0.10.0-rc1"
+	Version = "0.10.0-rc2"
 
 	// GitCommit is set with --ldflags "-X main.gitCommit=$(git rev-parse HEAD)"
 	GitCommit string


### PR DESCRIPTION
https://github.com/tendermint/tendermint/issues/510

Adds some fixes, and some breaking changes to the rc1

BREAKING:
- `node_laddr -> p2p.laddr`
- new `rpc` subconfig
- unsafe rpc calls disabled by default, can be enabled with `--rpc.unsafe`

Fixes
- use `state:info,*:error` for logging, and log the height and number of txs on committing state
- limit `/blockchain_info` to return max 20 blocks
- compute and overwrite the pubkey and address when loading priv_validator.json
