### PR TITLE
logger key doesn't support blank space

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -106,7 +106,7 @@ func execBlockOnProxyApp(eventCache types.Fireable, proxyAppConn proxy.AppConnCo
 
 	valDiff := abciResponses.EndBlock.Diffs
 
-	logger.Info("Executed block", "height", block.Height, "valid txs", validTxs, "invalid txs", invalidTxs)
+	logger.Info("Executed block", "height", block.Height, "validTxs", validTxs, "invalidTxs", invalidTxs)
 	if len(valDiff) > 0 {
 		logger.Info("Update to validator set", "updates", abci.ValidatorsString(valDiff))
 	}


### PR DESCRIPTION
The log info in 109 line of `state/execution.go` didn't output:
```
logger.Info("Executed block", "height", block.Height, "valid txs", validTxs, "invalid txs", invalidTxs)
```
the keys `valid txs` and `invalid txs` contain a **blank space**  that leads the logger not output log.

after fixing, this line of log can output as follows:
```
I[06-14|06:52:07.015] Finalizing commit of block with 0 txs        module=consensus height=7899 hash=33E0C0E2F22379E71A24493939D28027014B2C11 root=0000000000000001
I[06-14|06:52:07.015] Block{
  Header{
    ChainID:        test-chain-KbzJQK
    Height:         7899
    Time:           2017-06-14 14:52:07.008 +0800 CST
    NumTxs:         0
    LastBlockID:    6AE7197A2C5D1E637428A1249EDBFF7150379539:1:E96236C517BA
    LastCommit:     A9B155817550B4957FC19E748793493555FB2E9D
    Data:
    Validators:     E301CD317348BF4E615B259E6271448D199C4869
    App:            0000000000000001
  }#33E0C0E2F22379E71A24493939D28027014B2C11
  Data{

  }#
  Commit{
    BlockID:    6AE7197A2C5D1E637428A1249EDBFF7150379539:1:E96236C517BA
    Precommits: Vote{0:E22C5B175EE5 7898/00/2(Precommit) 6AE7197A2C5D /17D338C1585A.../}
  }#A9B155817550B4957FC19E748793493555FB2E9D
}#33E0C0E2F22379E71A24493939D28027014B2C11 module=consensus
I[06-14|06:52:07.016] Executed block                               module=state height=7899 valid_txs=0 invalid_txs=0
I[06-14|06:52:07.017] Committed state                              module=state hash=0000000000000001
```



