### PR TITLE
Do some cleanup in the test, so it doesn't fail in my shell

### DIFF
--- a/cmd/tendermint/commands/root_test.go
+++ b/cmd/tendermint/commands/root_test.go
@@ -25,6 +25,11 @@ const (
 // isolate provides a clean setup and returns a copy of RootCmd you can
 // modify in the test cases
 func isolate(cmds ...*cobra.Command) cli.Executable {
+	os.Unsetenv("TMHOME")
+	os.Unsetenv("TM_HOME")
+	os.Unsetenv("TMROOT")
+	os.Unsetenv("TM_ROOT")
+
 	viper.Reset()
 	config = cfg.DefaultConfig()
 	r := &cobra.Command{


### PR DESCRIPTION
I was having some weird test errors locally...

Turned out having TM_HOME set in my shell was messing with all the commands tests in tendermint.  Let's make it less fragile to being run in an active dev system...