### PR TITLE
No empty blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.10.3 (TBD)
+
+FEATURES:
+- New `--consensus.no_empty_blocks` flag prevents the creation of blocks until there are transactions available
+
 ## 0.10.2 (July 10, 2017)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.10.3 (TBD)
 
 FEATURES:
-- New `--consensus.no_empty_blocks` flag prevents the creation of blocks until there are transactions available
+- New `--consensus.create_empty_blocks` flag; when set to false, only creates blocks when there are txs or when the AppHash changes
+- New `consensus.create_empty_blocks_interval` config option; when greater than 0, will create an empty block after waiting that many seconds
 
 ## 0.10.2 (July 10, 2017)
 

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -45,6 +45,9 @@ func AddNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("p2p.seeds", config.P2P.Seeds, "Comma delimited host:port seed nodes")
 	cmd.Flags().Bool("p2p.skip_upnp", config.P2P.SkipUPNP, "Skip UPNP configuration")
 	cmd.Flags().Bool("p2p.pex", config.P2P.PexReactor, "Enable Peer-Exchange (dev feature)")
+
+	// consensus flags
+	cmd.Flags().Bool("consensus.no_empty_blocks", config.Consensus.NoEmptyBlocks, "Prevent empty blocks from being proposed by correct processes")
 }
 
 // Users wishing to:

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -47,7 +47,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("p2p.pex", config.P2P.PexReactor, "Enable Peer-Exchange (dev feature)")
 
 	// consensus flags
-	cmd.Flags().Bool("consensus.no_empty_blocks", config.Consensus.NoEmptyBlocks, "Only produce blocks when there are txs and when the AppHash changes")
+	cmd.Flags().Bool("consensus.create_empty_blocks", config.Consensus.CreateEmptyBlocks, "Set this to false to only produce blocks when there are txs or when the AppHash changes")
 }
 
 // Users wishing to:

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -47,7 +47,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("p2p.pex", config.P2P.PexReactor, "Enable Peer-Exchange (dev feature)")
 
 	// consensus flags
-	cmd.Flags().Bool("consensus.no_empty_blocks", config.Consensus.NoEmptyBlocks, "Prevent empty blocks from being proposed by correct processes")
+	cmd.Flags().Bool("consensus.no_empty_blocks", config.Consensus.NoEmptyBlocks, "Only produce blocks when there are txs and when the AppHash changes")
 }
 
 // Users wishing to:

--- a/config/config.go
+++ b/config/config.go
@@ -359,7 +359,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		SkipTimeoutCommit:           false,
 		MaxBlockSizeTxs:             10000,
 		MaxBlockSizeBytes:           1, // TODO
-		NoEmptyBlocks:               true,
+		NoEmptyBlocks:               false,
 		BlockPartSize:               types.DefaultBlockPartSize, // TODO: we shouldnt be importing types
 		PeerGossipSleepDuration:     100,
 		PeerQueryMaj23SleepDuration: 2000,
@@ -377,7 +377,6 @@ func TestConsensusConfig() *ConsensusConfig {
 	config.TimeoutPrecommitDelta = 1
 	config.TimeoutCommit = 10
 	config.SkipTimeoutCommit = true
-	config.NoEmptyBlocks = false
 	return config
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -301,8 +301,9 @@ type ConsensusConfig struct {
 	SkipTimeoutCommit bool `mapstructure:"skip_timeout_commit"`
 
 	// BlockSize
-	MaxBlockSizeTxs   int `mapstructure:"max_block_size_txs"`
-	MaxBlockSizeBytes int `mapstructure:"max_block_size_bytes"`
+	MaxBlockSizeTxs   int  `mapstructure:"max_block_size_txs"`
+	MaxBlockSizeBytes int  `mapstructure:"max_block_size_bytes"`
+	NoEmptyBlocks     bool `mapstructure:"no_empty_blocks"`
 
 	// TODO: This probably shouldn't be exposed but it makes it
 	// easy to write tests for the wal/replay
@@ -357,7 +358,8 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		TimeoutCommit:               1000,
 		SkipTimeoutCommit:           false,
 		MaxBlockSizeTxs:             10000,
-		MaxBlockSizeBytes:           1,                          // TODO
+		MaxBlockSizeBytes:           1, // TODO
+		NoEmptyBlocks:               true,
 		BlockPartSize:               types.DefaultBlockPartSize, // TODO: we shouldnt be importing types
 		PeerGossipSleepDuration:     100,
 		PeerQueryMaj23SleepDuration: 2000,
@@ -375,6 +377,7 @@ func TestConsensusConfig() *ConsensusConfig {
 	config.TimeoutPrecommitDelta = 1
 	config.TimeoutCommit = 10
 	config.SkipTimeoutCommit = true
+	config.NoEmptyBlocks = false
 	return config
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -323,7 +323,7 @@ func (cfg *ConsensusConfig) WaitForTxs() bool {
 }
 
 // EmptyBlocks returns the amount of time to wait before proposing an empty block or starting the propose timer if there are no txs available
-func (cfg *ConsensusConfig) EmptyBlocks() time.Duration {
+func (cfg *ConsensusConfig) EmptyBlocksInterval() time.Duration {
 	return time.Duration(cfg.CreateEmptyBlocksInterval) * time.Second
 }
 

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -293,6 +293,15 @@ func (privVal *ByzantinePrivValidator) SignProposal(chainID string, proposal *ty
 	return nil
 }
 
+func (privVal *ByzantinePrivValidator) SignHeartbeat(chainID string, heartbeat *types.Heartbeat) error {
+	privVal.mtx.Lock()
+	defer privVal.mtx.Unlock()
+
+	// Sign
+	heartbeat.Signature = privVal.Sign(types.SignBytes(chainID, heartbeat))
+	return nil
+}
+
 func (privVal *ByzantinePrivValidator) String() string {
 	return Fmt("PrivValidator{%X}", privVal.Address)
 }

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -294,12 +294,22 @@ func randConsensusState(nValidators int) (*ConsensusState, []*validatorStub) {
 //-------------------------------------------------------------------------------
 
 func ensureNoNewStep(stepCh chan interface{}) {
-	timeout := time.NewTicker(ensureTimeout * time.Second)
+	timer := time.NewTimer(ensureTimeout * time.Second)
 	select {
-	case <-timeout.C:
+	case <-timer.C:
 		break
 	case <-stepCh:
-		panic("We should be stuck waiting for more votes, not moving to the next step")
+		panic("We should be stuck waiting, not moving to the next step")
+	}
+}
+
+func ensureNewStep(stepCh chan interface{}) {
+	timer := time.NewTimer(ensureTimeout * time.Second)
+	select {
+	case <-timer.C:
+		panic("We shouldnt be stuck waiting")
+	case <-stepCh:
+		break
 	}
 }
 

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -31,7 +31,7 @@ import (
 
 // genesis, chain_id, priv_val
 var config *cfg.Config // NOTE: must be reset for each _test.go file
-var ensureTimeout = time.Duration(2)
+var ensureTimeout = time.Second * 2
 
 func ensureDir(dir string, mode os.FileMode) {
 	if err := EnsureDir(dir, mode); err != nil {
@@ -297,7 +297,7 @@ func randConsensusState(nValidators int) (*ConsensusState, []*validatorStub) {
 //-------------------------------------------------------------------------------
 
 func ensureNoNewStep(stepCh chan interface{}) {
-	timer := time.NewTimer(ensureTimeout * time.Second)
+	timer := time.NewTimer(ensureTimeout)
 	select {
 	case <-timer.C:
 		break
@@ -307,7 +307,7 @@ func ensureNoNewStep(stepCh chan interface{}) {
 }
 
 func ensureNewStep(stepCh chan interface{}) {
-	timer := time.NewTimer(ensureTimeout * time.Second)
+	timer := time.NewTimer(ensureTimeout)
 	select {
 	case <-timer.C:
 		panic("We shouldnt be stuck waiting")

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -242,7 +242,7 @@ func newConsensusStateWithConfig(thisConfig *cfg.Config, state *sm.State, pv *ty
 	// Make Mempool
 	mempool := mempl.NewMempool(thisConfig.Mempool, proxyAppConnMem, 0)
 	mempool.SetLogger(log.TestingLogger().With("module", "mempool"))
-	if thisConfig.Consensus.NoEmptyBlocks {
+	if thisConfig.Consensus.WaitForTxs() {
 		mempool.EnableTxsAvailable()
 	}
 

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -240,8 +240,11 @@ func newConsensusStateWithConfig(thisConfig *cfg.Config, state *sm.State, pv *ty
 	proxyAppConnCon := abcicli.NewLocalClient(mtx, app)
 
 	// Make Mempool
-	mempool := mempl.NewMempool(thisConfig.Mempool, proxyAppConnMem)
+	mempool := mempl.NewMempool(thisConfig.Mempool, proxyAppConnMem, 0)
 	mempool.SetLogger(log.TestingLogger().With("module", "mempool"))
+	if thisConfig.Consensus.NoEmptyBlocks {
+		mempool.EnableTxsAvailable()
+	}
 
 	// Make ConsensusReactor
 	cs := NewConsensusState(thisConfig.Consensus, state, proxyAppConnCon, blockStore, mempool)

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -31,6 +31,37 @@ func TestNoProgressUntilTxsAvailable(t *testing.T) {
 	ensureNewStep(newBlockCh) // commit txs
 	ensureNewStep(newBlockCh) // commit updated app hash
 	ensureNoNewStep(newBlockCh)
+
+}
+
+func TestProgressInHigherRound(t *testing.T) {
+	config := ResetConfig("consensus_mempool_txs_available_test")
+	config.Consensus.NoEmptyBlocks = true
+	state, privVals := randGenesisState(1, false, 10)
+	cs := newConsensusStateWithConfig(config, state, privVals[0], NewCounterApplication())
+	cs.mempool.EnableTxsAvailable()
+	height, round := cs.Height, cs.Round
+	newBlockCh := subscribeToEvent(cs.evsw, "tester", types.EventStringNewBlock(), 1)
+	newRoundCh := subscribeToEvent(cs.evsw, "tester", types.EventStringNewRound(), 1)
+	timeoutCh := subscribeToEvent(cs.evsw, "tester", types.EventStringTimeoutPropose(), 1)
+	cs.setProposal = func(proposal *types.Proposal) error {
+		if cs.Height == 2 && cs.Round == 0 {
+			// dont set the proposal in round 0 so we timeout and
+			// go to next round
+			cs.Logger.Info("Ignoring set proposal at height 2, round 0")
+			return nil
+		}
+		return cs.defaultSetProposal(proposal)
+	}
+	startTestRound(cs, height, round)
+
+	ensureNewStep(newRoundCh) // first round at first height
+	ensureNewStep(newBlockCh) // first block gets committed
+	ensureNewStep(newRoundCh) // first round at next height
+	deliverTxsRange(cs, 0, 2) // we deliver txs, but dont set a proposal so we get the next round
+	<-timeoutCh
+	ensureNewStep(newRoundCh) // wait for the next round
+	ensureNewStep(newBlockCh) // now we can commit the block
 }
 
 func deliverTxsRange(cs *ConsensusState, start, end int) {

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -20,7 +20,7 @@ func TestNoProgressUntilTxsAvailable(t *testing.T) {
 	config.Consensus.NoEmptyBlocks = true
 	state, privVals := randGenesisState(1, false, 10)
 	cs := newConsensusStateWithConfig(config, state, privVals[0], NewCounterApplication())
-	cs.mempool.FireOnTxsAvailable()
+	cs.mempool.EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
 	newBlockCh := subscribeToEvent(cs.evsw, "tester", types.EventStringNewBlock(), 1)
 	startTestRound(cs, height, round)

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -17,7 +17,7 @@ func init() {
 
 func TestNoProgressUntilTxsAvailable(t *testing.T) {
 	config := ResetConfig("consensus_mempool_txs_available_test")
-	config.Consensus.NoEmptyBlocks = true
+	config.Consensus.CreateEmptyBlocks = false
 	state, privVals := randGenesisState(1, false, 10)
 	cs := newConsensusStateWithConfig(config, state, privVals[0], NewCounterApplication())
 	cs.mempool.EnableTxsAvailable()
@@ -36,7 +36,7 @@ func TestNoProgressUntilTxsAvailable(t *testing.T) {
 
 func TestProgressInHigherRound(t *testing.T) {
 	config := ResetConfig("consensus_mempool_txs_available_test")
-	config.Consensus.NoEmptyBlocks = true
+	config.Consensus.CreateEmptyBlocks = false
 	state, privVals := randGenesisState(1, false, 10)
 	cs := newConsensusStateWithConfig(config, state, privVals[0], NewCounterApplication())
 	cs.mempool.EnableTxsAvailable()

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -311,6 +311,16 @@ func (conR *ConsensusReactor) registerEventCallbacks() {
 		edv := data.Unwrap().(types.EventDataVote)
 		conR.broadcastHasVoteMessage(edv.Vote)
 	})
+
+	types.AddListenerForEvent(conR.evsw, "conR", types.EventStringProposalHeartbeat(), func(data types.TMEventData) {
+		heartbeat := data.Unwrap().(types.EventDataProposalHeartbeat)
+		conR.broadcastProposalHeartbeatMessage(heartbeat)
+	})
+}
+
+func (conR *ConsensusReactor) broadcastProposalHeartbeatMessage(heartbeat types.EventDataProposalHeartbeat) {
+	msg := &ProposalHeartbeatMessage{heartbeat.Heartbeat}
+	conR.Switch.Broadcast(StateChannel, struct{ ConsensusMessage }{msg})
 }
 
 func (conR *ConsensusReactor) broadcastNewRoundStep(rs *RoundState) {
@@ -1304,4 +1314,16 @@ type VoteSetBitsMessage struct {
 // String returns a string representation.
 func (m *VoteSetBitsMessage) String() string {
 	return fmt.Sprintf("[VSB %v/%02d/%v %v %v]", m.Height, m.Round, m.Type, m.BlockID, m.Votes)
+}
+
+//-------------------------------------
+
+// ProposalHeartbeatMessage is sent to signal that a node is alive and waiting for transactions for a proposal.
+type ProposalHeartbeatMessage struct {
+	Heartbeat *types.Heartbeat
+}
+
+// String returns a string representation.
+func (m *ProposalHeartbeatMessage) String() string {
+	return fmt.Sprintf("[HEARTBEAT %v]", m.Heartbeat)
 }

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -82,7 +82,7 @@ func (cs *ConsensusState) readReplayMessage(msgBytes []byte, newStepCh chan inte
 				"blockID", v.BlockID, "peer", peerKey)
 		}
 
-		cs.handleMsg(m, cs.RoundState)
+		cs.handleMsg(m)
 	case timeoutInfo:
 		cs.Logger.Info("Replay: Timeout", "height", m.Height, "round", m.Round, "step", m.Step, "dur", m.Duration)
 		cs.handleTimeout(m, cs.RoundState)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -790,9 +790,9 @@ func (cs *ConsensusState) enterNewRound(height int, round int) {
 func (cs *ConsensusState) waitForTxs(height, round int) {
 	// if we're the proposer, start a heartbeat routine
 	// to tell other peers we're just waiting for txs (for debugging)
-	done := make(chan struct{})
-	defer close(done)
 	if cs.isProposer() {
+		done := make(chan struct{})
+		defer close(done)
 		go cs.proposerHeartbeat(done)
 	}
 
@@ -816,7 +816,8 @@ func (cs *ConsensusState) proposerHeartbeat(done chan struct{}) {
 	}
 }
 
-// Enter: from enter NewRound(height,round), once txs are in the mempool
+// Enter (!NoEmptyBlocks): from enterNewRound(height,round)
+// Enter (NoEmptyBlocks) : after enterNewRound(height,round), once txs are in the mempool
 func (cs *ConsensusState) enterPropose(height int, round int) {
 	if cs.Height != height || round < cs.Round || (cs.Round == round && RoundStepPropose <= cs.Step) {
 		cs.Logger.Debug(cmn.Fmt("enterPropose(%v/%v): Invalid args. Current step: %v/%v/%v", height, round, cs.Height, cs.Round, cs.Step))

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -795,7 +795,7 @@ func (cs *ConsensusState) enterNewRound(height int, round int) {
 	waitForTxs := cs.config.WaitForTxs() && round == 0 && !cs.needProofBlock(height)
 	if waitForTxs {
 		if cs.config.CreateEmptyBlocksInterval > 0 {
-			cs.scheduleTimeout(cs.config.EmptyBlocks(), height, round, RoundStepNewRound)
+			cs.scheduleTimeout(cs.config.EmptyBlocksInterval(), height, round, RoundStepNewRound)
 		}
 		go cs.proposalHeartbeat(height, round)
 	} else {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -804,7 +804,7 @@ func (cs *ConsensusState) enterPropose(height int, round int) {
 		return
 	}
 
-	if !bytes.Equal(cs.Validators.GetProposer().Address, cs.privValidator.GetAddress()) {
+	if !cs.isProposer() {
 		cs.Logger.Info("enterPropose: Not our turn to propose", "proposer", cs.Validators.GetProposer().Address, "privValidator", cs.privValidator)
 		if cs.Validators.HasAddress(cs.privValidator.GetAddress()) {
 			cs.Logger.Debug("This node is a validator")
@@ -816,6 +816,10 @@ func (cs *ConsensusState) enterPropose(height int, round int) {
 		cs.Logger.Debug("This node is a validator")
 		cs.decideProposal(height, round)
 	}
+}
+
+func (cs *ConsensusState) isProposer() bool {
+	return bytes.Equal(cs.Validators.GetProposer().Address, cs.privValidator.GetAddress())
 }
 
 func (cs *ConsensusState) defaultDecideProposal(height, round int) {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -24,6 +24,10 @@ import (
 //-----------------------------------------------------------------------------
 // Config
 
+const (
+	proposalHeartbeatIntervalSeconds = 2
+)
+
 //-----------------------------------------------------------------------------
 // Errors
 
@@ -833,7 +837,7 @@ func (cs *ConsensusState) proposalHeartbeat(height, round int) {
 		heartbeatEvent := types.EventDataProposalHeartbeat{heartbeat}
 		types.FireEventProposalHeartbeat(cs.evsw, heartbeatEvent)
 		counter += 1
-		time.Sleep(time.Second)
+		time.Sleep(proposalHeartbeatIntervalSeconds * time.Second)
 	}
 }
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -780,7 +780,11 @@ func (cs *ConsensusState) enterNewRound(height int, round int) {
 
 	// Wait for txs to be available in the mempool
 	// before we enterPropose
-	go cs.waitForTxs(height, round)
+	if cs.config.NoEmptyBlocks {
+		go cs.waitForTxs(height, round)
+	} else {
+		cs.enterPropose(height, round)
+	}
 }
 
 func (cs *ConsensusState) waitForTxs(height, round int) {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -92,11 +92,16 @@ func NewMempool(config *cfg.MempoolConfig, proxyAppConn proxy.AppConnMempool) *M
 		recheckEnd:    nil,
 		logger:        log.NewNopLogger(),
 		cache:         newTxCache(cacheSize),
-		txsAvailable:  make(chan struct{}, 1),
 	}
 	mempool.initWAL()
 	proxyAppConn.SetResponseCallback(mempool.resCb)
 	return mempool
+}
+
+// FireOnTxsAvailable initializes the TxsAvailable channel,
+// ensuring it will trigger once every height when transactions are available.
+func (mem *Mempool) FireOnTxsAvailable() {
+	mem.txsAvailable = make(chan struct{}, 1)
 }
 
 // SetLogger sets the Logger.
@@ -277,8 +282,23 @@ func (mem *Mempool) alertIfTxsAvailable() {
 	}
 }
 
+// TxsAvailable returns a channel which fires once for every height,
+// and only when transactions are available in the mempool.
+// XXX: Will panic if mem.FireOnTxsAvailable() has not been called.
 func (mem *Mempool) TxsAvailable() chan struct{} {
+	if mem.txsAvailable == nil {
+		panic("mem.txsAvailable is nil")
+	}
 	return mem.txsAvailable
+}
+
+func (mem *Mempool) alertIfTxsAvailable() {
+	if mem.txsAvailable != nil &&
+		!mem.notifiedTxsAvailable && mem.Size() > 0 {
+
+		mem.notifiedTxsAvailable = true
+		mem.txsAvailable <- struct{}{}
+	}
 }
 
 // Reap returns a list of transactions currently in the mempool.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -224,7 +224,7 @@ func (mem *Mempool) resCbNormal(req *abci.Request, res *abci.Response) {
 				tx:      req.GetCheckTx().Tx,
 			}
 			mem.txs.PushBack(memTx)
-			mem.notifyIfTxsAvailable()
+			mem.notifyTxsAvailable()
 		} else {
 			// ignore bad transaction
 			mem.logger.Info("Bad Transaction", "res", r)
@@ -267,7 +267,7 @@ func (mem *Mempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 			atomic.StoreInt32(&mem.rechecking, 0)
 			mem.logger.Info("Done rechecking txs")
 
-			mem.notifyIfTxsAvailable()
+			mem.notifyTxsAvailable()
 		}
 	default:
 		// ignore other messages
@@ -281,7 +281,7 @@ func (mem *Mempool) TxsAvailable() chan int {
 	return mem.txsAvailable
 }
 
-func (mem *Mempool) notifyIfTxsAvailable() {
+func (mem *Mempool) notifyTxsAvailable() {
 	if mem.Size() == 0 {
 		panic("notified txs available but mempool is empty!")
 	}

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -23,12 +23,12 @@ func newMempoolWithApp(t *testing.T, cc proxy.ClientCreator) *Mempool {
 	if _, err := appConnMem.Start(); err != nil {
 		t.Fatalf("Error starting ABCI client: %v", err.Error())
 	}
-	mempool := NewMempool(config.Mempool, appConnMem)
+	mempool := NewMempool(config.Mempool, appConnMem, 0)
 	mempool.SetLogger(log.TestingLogger())
 	return mempool
 }
 
-func ensureNoFire(t *testing.T, ch chan struct{}, timeoutMS int) {
+func ensureNoFire(t *testing.T, ch chan int, timeoutMS int) {
 	timer := time.NewTimer(time.Duration(timeoutMS) * time.Millisecond)
 	select {
 	case <-ch:
@@ -37,7 +37,7 @@ func ensureNoFire(t *testing.T, ch chan struct{}, timeoutMS int) {
 	}
 }
 
-func ensureFire(t *testing.T, ch chan struct{}, timeoutMS int) {
+func ensureFire(t *testing.T, ch chan int, timeoutMS int) {
 	timer := time.NewTimer(time.Duration(timeoutMS) * time.Millisecond)
 	select {
 	case <-ch:
@@ -64,7 +64,7 @@ func TestTxsAvailable(t *testing.T) {
 	app := dummy.NewDummyApplication()
 	cc := proxy.NewLocalClientCreator(app)
 	mempool := newMempoolWithApp(t, cc)
-	mempool.FireOnTxsAvailable()
+	mempool.EnableTxsAvailable()
 
 	timeoutMS := 500
 

--- a/node/node.go
+++ b/node/node.go
@@ -143,6 +143,10 @@ func NewNode(config *cfg.Config, privValidator *types.PrivValidator, clientCreat
 	mempoolReactor := mempl.NewMempoolReactor(config.Mempool, mempool)
 	mempoolReactor.SetLogger(mempoolLogger)
 
+	if config.Consensus.NoEmptyBlocks {
+		mempool.FireOnTxsAvailable()
+	}
+
 	// Make ConsensusReactor
 	consensusState := consensus.NewConsensusState(config.Consensus, state.Copy(), proxyApp.Consensus(), blockStore, mempool)
 	consensusState.SetLogger(consensusLogger)

--- a/node/node.go
+++ b/node/node.go
@@ -139,6 +139,7 @@ func NewNode(config *cfg.Config, privValidator *types.PrivValidator, clientCreat
 	mempoolLogger := logger.With("module", "mempool")
 	mempool := mempl.NewMempool(config.Mempool, proxyApp.Mempool())
 	mempool.SetLogger(mempoolLogger)
+	mempool.Update(state.LastBlockHeight, nil)
 	mempoolReactor := mempl.NewMempoolReactor(config.Mempool, mempool)
 	mempoolReactor.SetLogger(mempoolLogger)
 

--- a/node/node.go
+++ b/node/node.go
@@ -142,7 +142,7 @@ func NewNode(config *cfg.Config, privValidator *types.PrivValidator, clientCreat
 	mempoolReactor := mempl.NewMempoolReactor(config.Mempool, mempool)
 	mempoolReactor.SetLogger(mempoolLogger)
 
-	if config.Consensus.NoEmptyBlocks {
+	if config.Consensus.WaitForTxs() {
 		mempool.EnableTxsAvailable()
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -137,14 +137,13 @@ func NewNode(config *cfg.Config, privValidator *types.PrivValidator, clientCreat
 
 	// Make MempoolReactor
 	mempoolLogger := logger.With("module", "mempool")
-	mempool := mempl.NewMempool(config.Mempool, proxyApp.Mempool())
+	mempool := mempl.NewMempool(config.Mempool, proxyApp.Mempool(), state.LastBlockHeight)
 	mempool.SetLogger(mempoolLogger)
-	mempool.Update(state.LastBlockHeight, nil)
 	mempoolReactor := mempl.NewMempoolReactor(config.Mempool, mempool)
 	mempoolReactor.SetLogger(mempoolLogger)
 
 	if config.Consensus.NoEmptyBlocks {
-		mempool.FireOnTxsAvailable()
+		mempool.EnableTxsAvailable()
 	}
 
 	// Make ConsensusReactor

--- a/types/canonical_json.go
+++ b/types/canonical_json.go
@@ -31,6 +31,14 @@ type CanonicalJSONVote struct {
 	Type    byte                 `json:"type"`
 }
 
+type CanonicalJSONHeartbeat struct {
+	Height           int        `json:"height"`
+	Round            int        `json:"round"`
+	Sequence         int        `json:"sequence"`
+	ValidatorAddress data.Bytes `json:"validator_address"`
+	ValidatorIndex   int        `json:"validator_index"`
+}
+
 //------------------------------------
 // Messages including a "chain id" can only be applied to one chain, hence "Once"
 
@@ -42,6 +50,11 @@ type CanonicalJSONOnceProposal struct {
 type CanonicalJSONOnceVote struct {
 	ChainID string            `json:"chain_id"`
 	Vote    CanonicalJSONVote `json:"vote"`
+}
+
+type CanonicalJSONOnceHeartbeat struct {
+	ChainID   string                 `json:"chain_id"`
+	Heartbeat CanonicalJSONHeartbeat `json:"heartbeat"`
 }
 
 //-----------------------------------
@@ -77,5 +90,15 @@ func CanonicalVote(vote *Vote) CanonicalJSONVote {
 		vote.Height,
 		vote.Round,
 		vote.Type,
+	}
+}
+
+func CanonicalHeartbeat(heartbeat *Heartbeat) CanonicalJSONHeartbeat {
+	return CanonicalJSONHeartbeat{
+		heartbeat.Height,
+		heartbeat.Round,
+		heartbeat.Sequence,
+		heartbeat.ValidatorAddress,
+		heartbeat.ValidatorIndex,
 	}
 }

--- a/types/events.go
+++ b/types/events.go
@@ -31,6 +31,8 @@ func EventStringRelock() string           { return "Relock" }
 func EventStringTimeoutWait() string      { return "TimeoutWait" }
 func EventStringVote() string             { return "Vote" }
 
+func EventStringProposalHeartbeat() string { return "ProposalHeartbeat" }
+
 //----------------------------------------
 
 var (
@@ -39,6 +41,8 @@ var (
 	EventDataNameTx             = "tx"
 	EventDataNameRoundState     = "round_state"
 	EventDataNameVote           = "vote"
+
+	EventDataNameProposalHeartbeat = "proposer_heartbeat"
 )
 
 //----------------------------------------
@@ -84,6 +88,8 @@ const (
 
 	EventDataTypeRoundState = byte(0x11)
 	EventDataTypeVote       = byte(0x12)
+
+	EventDataTypeProposalHeartbeat = byte(0x20)
 )
 
 var tmEventDataMapper = data.NewMapper(TMEventData{}).
@@ -91,7 +97,8 @@ var tmEventDataMapper = data.NewMapper(TMEventData{}).
 	RegisterImplementation(EventDataNewBlockHeader{}, EventDataNameNewBlockHeader, EventDataTypeNewBlockHeader).
 	RegisterImplementation(EventDataTx{}, EventDataNameTx, EventDataTypeTx).
 	RegisterImplementation(EventDataRoundState{}, EventDataNameRoundState, EventDataTypeRoundState).
-	RegisterImplementation(EventDataVote{}, EventDataNameVote, EventDataTypeVote)
+	RegisterImplementation(EventDataVote{}, EventDataNameVote, EventDataTypeVote).
+	RegisterImplementation(EventDataProposalHeartbeat{}, EventDataNameProposalHeartbeat, EventDataTypeProposalHeartbeat)
 
 // Most event messages are basic types (a block, a transaction)
 // but some (an input to a call tx or a receive) are more exotic
@@ -115,6 +122,10 @@ type EventDataTx struct {
 	Error  string        `json:"error"` // this is redundant information for now
 }
 
+type EventDataProposalHeartbeat struct {
+	Heartbeat *Heartbeat
+}
+
 // NOTE: This goes into the replay WAL
 type EventDataRoundState struct {
 	Height int    `json:"height"`
@@ -134,6 +145,8 @@ func (_ EventDataNewBlockHeader) AssertIsTMEventData() {}
 func (_ EventDataTx) AssertIsTMEventData()             {}
 func (_ EventDataRoundState) AssertIsTMEventData()     {}
 func (_ EventDataVote) AssertIsTMEventData()           {}
+
+func (_ EventDataProposalHeartbeat) AssertIsTMEventData() {}
 
 //----------------------------------------
 // Wrappers for type safety
@@ -231,4 +244,8 @@ func FireEventRelock(fireable events.Fireable, rs EventDataRoundState) {
 
 func FireEventLock(fireable events.Fireable, rs EventDataRoundState) {
 	fireEvent(fireable, EventStringLock(), TMEventData{rs})
+}
+
+func FireEventProposalHeartbeat(fireable events.Fireable, rs EventDataProposalHeartbeat) {
+	fireEvent(fireable, EventStringProposalHeartbeat(), TMEventData{rs})
 }

--- a/types/heartbeat.go
+++ b/types/heartbeat.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/tendermint/go-crypto"
+	"github.com/tendermint/go-wire"
+	"github.com/tendermint/go-wire/data"
+	cmn "github.com/tendermint/tmlibs/common"
+)
+
+type Heartbeat struct {
+	ValidatorAddress data.Bytes       `json:"validator_address"`
+	ValidatorIndex   int              `json:"validator_index"`
+	Height           int              `json:"height"`
+	Round            int              `json:"round"`
+	Sequence         int              `json:"sequence"`
+	Signature        crypto.Signature `json:"signature"`
+}
+
+func (heartbeat *Heartbeat) WriteSignBytes(chainID string, w io.Writer, n *int, err *error) {
+	wire.WriteJSON(CanonicalJSONOnceHeartbeat{
+		chainID,
+		CanonicalHeartbeat(heartbeat),
+	}, w, n, err)
+}
+
+func (heartbeat *Heartbeat) Copy() *Heartbeat {
+	heartbeatCopy := *heartbeat
+	return &heartbeatCopy
+}
+
+func (heartbeat *Heartbeat) String() string {
+	if heartbeat == nil {
+		return "nil-heartbeat"
+	}
+
+	return fmt.Sprintf("Heartbeat{%v:%X %v/%02d (%v) %v}",
+		heartbeat.ValidatorIndex, cmn.Fingerprint(heartbeat.ValidatorAddress),
+		heartbeat.Height, heartbeat.Round, heartbeat.Sequence, heartbeat.Signature)
+}

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -252,6 +252,13 @@ func (privVal *PrivValidator) signBytesHRS(height, round int, step int8, signByt
 
 }
 
+func (privVal *PrivValidator) SignHeartbeat(chainID string, heartbeat *Heartbeat) error {
+	privVal.mtx.Lock()
+	defer privVal.mtx.Unlock()
+	heartbeat.Signature = privVal.Sign(SignBytes(chainID, heartbeat))
+	return nil
+}
+
 func (privVal *PrivValidator) String() string {
 	return fmt.Sprintf("PrivValidator{%v LH:%v, LR:%v, LS:%v}", privVal.Address, privVal.LastHeight, privVal.LastRound, privVal.LastStep)
 }

--- a/types/services.go
+++ b/types/services.go
@@ -25,6 +25,7 @@ type Mempool interface {
 	Flush()
 
 	TxsAvailable() chan struct{}
+	FireOnTxsAvailable()
 }
 
 type MockMempool struct {
@@ -38,6 +39,7 @@ func (m MockMempool) Reap(n int) Txs                               { return Txs{
 func (m MockMempool) Update(height int, txs Txs)                   {}
 func (m MockMempool) Flush()                                       {}
 func (m MockMempool) TxsAvailable() chan struct{}                  { return make(chan struct{}) }
+func (m MockMempool) FireOnTxsAvailable()                          {}
 
 //------------------------------------------------------
 // blockstore

--- a/types/services.go
+++ b/types/services.go
@@ -23,6 +23,8 @@ type Mempool interface {
 	Reap(int) Txs
 	Update(height int, txs Txs)
 	Flush()
+
+	TxsAvailable() chan struct{}
 }
 
 type MockMempool struct {
@@ -35,6 +37,7 @@ func (m MockMempool) CheckTx(tx Tx, cb func(*abci.Response)) error { return nil 
 func (m MockMempool) Reap(n int) Txs                               { return Txs{} }
 func (m MockMempool) Update(height int, txs Txs)                   {}
 func (m MockMempool) Flush()                                       {}
+func (m MockMempool) TxsAvailable() chan struct{}                  { return make(chan struct{}) }
 
 //------------------------------------------------------
 // blockstore

--- a/types/services.go
+++ b/types/services.go
@@ -24,8 +24,8 @@ type Mempool interface {
 	Update(height int, txs Txs)
 	Flush()
 
-	TxsAvailable() chan struct{}
-	FireOnTxsAvailable()
+	TxsAvailable() chan int
+	EnableTxsAvailable()
 }
 
 type MockMempool struct {
@@ -38,8 +38,8 @@ func (m MockMempool) CheckTx(tx Tx, cb func(*abci.Response)) error { return nil 
 func (m MockMempool) Reap(n int) Txs                               { return Txs{} }
 func (m MockMempool) Update(height int, txs Txs)                   {}
 func (m MockMempool) Flush()                                       {}
-func (m MockMempool) TxsAvailable() chan struct{}                  { return make(chan struct{}) }
-func (m MockMempool) FireOnTxsAvailable()                          {}
+func (m MockMempool) TxsAvailable() chan int                       { return make(chan int) }
+func (m MockMempool) EnableTxsAvailable()                          {}
 
 //------------------------------------------------------
 // blockstore


### PR DESCRIPTION
- option to prevent empty blocks. disabled by default. perhaps we enable by default for 0.11 ?

Note this is a breaking change to the `types.Mempool` interface since it adds a couple methods. As discussed in slack, we will make explicit which packages/types/funcs are covered by semver.  