### PR TITLE
remove getRoundState()

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -270,12 +270,7 @@ func (cs *ConsensusState) GetState() *sm.State {
 func (cs *ConsensusState) GetRoundState() *RoundState {
 	cs.mtx.Lock()
 	defer cs.mtx.Unlock()
-	return cs.getRoundState()
-}
-
-func (cs *ConsensusState) getRoundState() *RoundState {
-	rs := cs.RoundState // copy
-	return &rs
+	return &cs.RoundState
 }
 
 func (cs *ConsensusState) GetValidators() (int, []*types.Validator) {


### PR DESCRIPTION
I don't know why use getRoundState, it looks like a superfluous function