### PR TITLE
fix dead tendermint types links in specs

### DIFF
--- a/docs/specs/fast-sync.md
+++ b/docs/specs/fast-sync.md
@@ -8,6 +8,6 @@ In a proof of work blockchain, syncing with the chain is the same process as sta
 
 To support faster syncing, tendermint offers a `fast-sync` mode, which is enabled by default, and can be toggled in the `config.toml` or via `--fast_sync=false`. 
 
-In this mode, the tendermint daemon will sync hundreds of times faster than if it used the real-time consensus process. Once caught up, the daemon will switch out of fast sync and into the normal consensus mode. After running for some time, the node is considered `caught up` if it has at least one peer and it's height is at least as high as the max reported peer height. See [the IsCaughtUp method](https://github.com/tendermint/tendermint/blob/master/blockchain/pool.go#L128).
+In this mode, the tendermint daemon will sync hundreds of times faster than if it used the real-time consensus process. Once caught up, the daemon will switch out of fast sync and into the normal consensus mode. After running for some time, the node is considered `caught up` if it has at least one peer and it's height is at least as high as the max reported peer height. See [the IsCaughtUp method](https://github.com/tendermint/tendermint/blob/b467515719e686e4678e6da4e102f32a491b85a0/blockchain/pool.go#L128).
 
 If we're lagging sufficiently, we should go back to fast syncing, but this is an open issue: https://github.com/tendermint/tendermint/issues/129

--- a/docs/specs/genesis.md
+++ b/docs/specs/genesis.md
@@ -16,7 +16,8 @@ NOTE: This does not (yet) specify the application state (e.g. initial distributi
 
 ### Sample genesis.json
 
-This example is from the Basecoin mintnet example ([link to file](https://github.com/tendermint/mintnet/blob/master/examples/basecoin/mach1/core/genesis.json)).
+This example is from the Basecoin mintnet example:
+
 ```json
 {
   "genesis_time": "2016-02-05T06:02:31.526Z",

--- a/docs/specs/light-client-protocol.md
+++ b/docs/specs/light-client-protocol.md
@@ -2,14 +2,11 @@
 
 Light clients are an important part of the complete blockchain system for most applications.  Tendermint provides unique speed and security properties for light client applications.
 
-See our developing [light-client repository](github.com/tendermint/light-client).
+See our developing [light-client repository](https://github.com/tendermint/light-client).
 
 ## Overview
 
 The objective of the light client protocol is to get a [commit](/docs/specs/validators#committing-a-block) for a recent [block hash](/docs/specs/block-structure#block-hash) where the commit includes a majority of signatures from the last known validator set.  From there, all the application state is verifiable with [merkle proofs](/docs/specs/merkle-trees#iavl-tree).
-
-### Syncing the Validator Set
-TODO
 
 ## Properties
 

--- a/docs/specs/tendermint-types.md
+++ b/docs/specs/tendermint-types.md
@@ -1,4 +1,2 @@
-
-
 # types
 see the [godoc version](https://godoc.org/github.com/tendermint/tendermint/types)


### PR DESCRIPTION
- closes https://github.com/zramsay/tendermint/issues/1
- cleans up any other links required for longevity in the face of changing code.