### PR TITLE
Added max_msg_packet_payload_size, send_rate and recv_rate to [p2p] section of config.toml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -224,6 +224,15 @@ type P2PConfig struct {
 
 	// Time to wait before flushing messages out on the connection. In ms
 	FlushThrottleTimeout int `mapstructure:"flush_throttle_timeout"`
+
+	// max_msg_packet_payload_size
+	MaxMsgPacketPayloadSize int `mapstructure:"max_msg_packet_payload_size"`
+
+	// send_rate
+	SendRate int64 `mapstructure:"send_rate"`
+
+	// recv_rate
+	RecvRate int64 `mapstructure:"recv_rate"`
 }
 
 // DefaultP2PConfig returns a default configuration for the peer-to-peer layer
@@ -234,6 +243,9 @@ func DefaultP2PConfig() *P2PConfig {
 		AddrBookStrict:       true,
 		MaxNumPeers:          50,
 		FlushThrottleTimeout: 100,
+		MaxMsgPacketPayloadSize: 65536,
+		SendRate:             512000,
+		RecvRate:             512000,
 	}
 }
 

--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -12,6 +12,7 @@ import (
 
 	wire "github.com/tendermint/go-wire"
 	cmn "github.com/tendermint/tmlibs/common"
+	cfg "github.com/tendermint/tendermint/config"
 	flow "github.com/tendermint/tmlibs/flowrate"
 )
 
@@ -22,16 +23,9 @@ const (
 	updateState        = 2 * time.Second
 	pingTimeout        = 40 * time.Second
 
-	// flushThrottle used here as a default.
-	// overwritten by the user config.
-	// TODO: remove
-	flushThrottle = 100 * time.Millisecond
-
 	defaultSendQueueCapacity   = 1
-	defaultSendRate            = int64(512000) // 500KB/s
 	defaultRecvBufferCapacity  = 4096
 	defaultRecvMessageCapacity = 22020096      // 21MB
-	defaultRecvRate            = int64(512000) // 500KB/s
 	defaultSendTimeout         = 10 * time.Second
 )
 
@@ -98,22 +92,22 @@ type MConnConfig struct {
 }
 
 // DefaultMConnConfig returns the default config.
-func DefaultMConnConfig() *MConnConfig {
+func DefaultMConnConfig(config *cfg.P2PConfig) *MConnConfig {
 	return &MConnConfig{
-		SendRate:      defaultSendRate,
-		RecvRate:      defaultRecvRate,
-		flushThrottle: flushThrottle,
+		SendRate:      config.SendRate,
+		RecvRate:      config.RecvRate,
+		flushThrottle: time.Duration(config.FlushThrottleTimeout) * time.Millisecond,
 	}
 }
 
 // NewMConnection wraps net.Conn and creates multiplex connection
-func NewMConnection(conn net.Conn, chDescs []*ChannelDescriptor, onReceive receiveCbFunc, onError errorCbFunc) *MConnection {
+func NewMConnection(config *cfg.P2PConfig, conn net.Conn, chDescs []*ChannelDescriptor, onReceive receiveCbFunc, onError errorCbFunc) *MConnection {
 	return NewMConnectionWithConfig(
 		conn,
 		chDescs,
 		onReceive,
 		onError,
-		DefaultMConnConfig())
+		DefaultMConnConfig(config))
 }
 
 // NewMConnectionWithConfig wraps net.Conn and creates multiplex connection with a config

--- a/p2p/connection_test.go
+++ b/p2p/connection_test.go
@@ -8,8 +8,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	p2p "github.com/tendermint/tendermint/p2p"
+	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tmlibs/log"
 )
+
+var (
+	config *cfg.P2PConfig
+)
+
+func init() {
+	config = cfg.DefaultP2PConfig()
+	config.PexReactor = true
+}
 
 func createMConnection(conn net.Conn) *p2p.MConnection {
 	onReceive := func(chID byte, msgBytes []byte) {
@@ -23,7 +33,7 @@ func createMConnection(conn net.Conn) *p2p.MConnection {
 
 func createMConnectionWithCallbacks(conn net.Conn, onReceive func(chID byte, msgBytes []byte), onError func(r interface{})) *p2p.MConnection {
 	chDescs := []*p2p.ChannelDescriptor{&p2p.ChannelDescriptor{ID: 0x01, Priority: 1, SendQueueCapacity: 1}}
-	c := p2p.NewMConnection(conn, chDescs, onReceive, onError)
+	c := p2p.NewMConnection(config, conn, chDescs, onReceive, onError)
 	c.SetLogger(log.TestingLogger())
 	return c
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -10,6 +10,7 @@ import (
 	crypto "github.com/tendermint/go-crypto"
 	wire "github.com/tendermint/go-wire"
 	cmn "github.com/tendermint/tmlibs/common"
+	cfg "github.com/tendermint/tendermint/config"
 )
 
 // Peer could be marked as persistent, in which case you can use
@@ -48,12 +49,12 @@ type PeerConfig struct {
 }
 
 // DefaultPeerConfig returns the default config.
-func DefaultPeerConfig() *PeerConfig {
+func DefaultPeerConfig(config *cfg.P2PConfig) *PeerConfig {
 	return &PeerConfig{
 		AuthEnc:          true,
 		HandshakeTimeout: 20, // * time.Second,
 		DialTimeout:      3,  // * time.Second,
-		MConfig:          DefaultMConnConfig(),
+		MConfig:          DefaultMConnConfig(config),
 		Fuzz:             false,
 		FuzzConfig:       DefaultFuzzConnConfig(),
 	}

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -16,11 +16,11 @@ func TestPeerBasic(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	// simulate remote peer
-	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: DefaultPeerConfig()}
+	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: DefaultPeerConfig(config)}
 	rp.Start()
 	defer rp.Stop()
 
-	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), DefaultPeerConfig())
+	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), DefaultPeerConfig(config))
 	require.Nil(err)
 
 	p.Start()
@@ -38,7 +38,7 @@ func TestPeerBasic(t *testing.T) {
 func TestPeerWithoutAuthEnc(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
-	config := DefaultPeerConfig()
+	config := DefaultPeerConfig(config)
 	config.AuthEnc = false
 
 	// simulate remote peer
@@ -58,7 +58,7 @@ func TestPeerWithoutAuthEnc(t *testing.T) {
 func TestPeerSend(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
-	config := DefaultPeerConfig()
+	config := DefaultPeerConfig(config)
 	config.AuthEnc = false
 
 	// simulate remote peer

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -82,7 +82,7 @@ var (
 func NewSwitch(config *cfg.P2PConfig) *Switch {
 	sw := &Switch{
 		config:       config,
-		peerConfig:   DefaultPeerConfig(),
+		peerConfig:   DefaultPeerConfig(config),
 		reactors:     make(map[string]Reactor),
 		chDescs:      make([]*ChannelDescriptor, 0),
 		reactorsByCh: make(map[byte]Reactor),
@@ -176,7 +176,7 @@ func (sw *Switch) OnStart() error {
 			return err
 		}
 	}
-	
+
 	// Start listeners
 	for _, listener := range sw.listeners {
 		go sw.listenerRoutine(listener)

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -240,11 +240,11 @@ func TestSwitchStopsNonPersistentPeerOnError(t *testing.T) {
 	defer sw.Stop()
 
 	// simulate remote peer
-	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: DefaultPeerConfig()}
+	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: DefaultPeerConfig(config)}
 	rp.Start()
 	defer rp.Stop()
 
-	peer, err := newOutboundPeer(rp.Addr(), sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, DefaultPeerConfig())
+	peer, err := newOutboundPeer(rp.Addr(), sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, DefaultPeerConfig(config))
 	require.Nil(err)
 	err = sw.AddPeer(peer)
 	require.Nil(err)
@@ -266,11 +266,11 @@ func TestSwitchReconnectsToPersistentPeer(t *testing.T) {
 	defer sw.Stop()
 
 	// simulate remote peer
-	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: DefaultPeerConfig()}
+	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: DefaultPeerConfig(config)}
 	rp.Start()
 	defer rp.Stop()
 
-	peer, err := newOutboundPeer(rp.Addr(), sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, DefaultPeerConfig())
+	peer, err := newOutboundPeer(rp.Addr(), sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, DefaultPeerConfig(config))
 	peer.makePersistent()
 	require.Nil(err)
 	err = sw.AddPeer(peer)


### PR DESCRIPTION
A quick addition so max_msg_packet_payload_size, send_rate and recv_rate can be configured in config.toml
