### PR TITLE
Remove reliance on default Signer

### DIFF
--- a/cmd/hsm/main.go
+++ b/cmd/hsm/main.go
@@ -35,8 +35,12 @@ func main() {
 	rootCmd.AddCommand(tc.TestnetFilesCmd)
 	rootCmd.AddCommand(tc.VersionCmd)
 
-	privValidator := types.LoadOrGenPrivValidator(config.PrivValidatorFile(), logger)
-	privValidator.SetSigner(types.NewDefaultSigner(privValidator.PrivKey))
+	// Override with HSM implementation, otherwise nil will trigger default
+	// software signer:
+	var signer types.Signer = nil
+
+	privValidator := types.LoadPrivValidatorWithSigner(config.PrivValidatorFile(),
+		signer)
 	rootCmd.AddCommand(tc.NewRunNodeCmd(privValidator))
 
 	cmd := cli.PrepareBaseCmd(rootCmd, "TM", os.ExpandEnv("$HOME/.tendermint"))

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -111,6 +111,10 @@ func GenPrivValidator() *PrivValidator {
 }
 
 func LoadPrivValidator(filePath string) *PrivValidator {
+	return LoadPrivValidatorWithSigner(filePath, nil)
+}
+
+func LoadPrivValidatorWithSigner(filePath string, signer Signer) *PrivValidator {
 	privValJSONBytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		Exit(err.Error())
@@ -122,7 +126,11 @@ func LoadPrivValidator(filePath string) *PrivValidator {
 	}
 
 	privVal.filePath = filePath
-	privVal.Signer = NewDefaultSigner(privVal.PrivKey)
+	if signer == nil {
+		privVal.Signer = NewDefaultSigner(privVal.PrivKey)
+	} else {
+		privVal.Signer = signer
+	}
 	privVal.setPubKeyAndAddress()
 	return &privVal
 }


### PR DESCRIPTION
This change allows the default privValidator to use a custom Signer implementation with no reliance on the default Signer implementation.

Due to the existing naming of methods (and not wishing to break backwards compatibility), the downside of my change is that we lose logging information. There was no natural place to insert a logger object.