### PR TITLE
add metalinter to Makefile & apply (mostly) 'errcheck' lints throughout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOTOOLS = \
 					github.com/mitchellh/gox \
 					github.com/Masterminds/glide \
-					honnef.co/go/tools/cmd/megacheck
+					github.com/alecthomas/gometalinter
 
 PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 BUILD_TAGS?=tendermint
@@ -76,8 +76,8 @@ ensure_tools:
 
 ### Formatting, linting, and vetting
 
-megacheck:
-	@for pkg in ${PACKAGES}; do megacheck "$$pkg"; done
-
+metalinter: ensure_tools
+	@gometalinter --install
+	gometalinter --vendor --deadline=600s --enable-all --disable=lll ./...
 
 .PHONY: install build build_race dist test test_race test_integrations test100 draw_deps list_deps get_deps get_vendor_deps update_deps revision tools

--- a/benchmarks/codec_test.go
+++ b/benchmarks/codec_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/tendermint/go-crypto"
-	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/go-wire"
 	proto "github.com/tendermint/tendermint/benchmarks/proto"
+	"github.com/tendermint/tendermint/p2p"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 

--- a/benchmarks/os_test.go
+++ b/benchmarks/os_test.go
@@ -18,12 +18,16 @@ func BenchmarkFileWrite(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		file.Write([]byte(testString))
+		_, err := file.Write([]byte(testString))
+		if err != nil {
+			b.Error(err)
+		}
 	}
 
-	file.Close()
-	err = os.Remove("benchmark_file_write.out")
-	if err != nil {
+	if err := file.Close(); err != nil {
+		b.Error(err)
+	}
+	if err := os.Remove("benchmark_file_write.out"); err != nil {
 		b.Error(err)
 	}
 }

--- a/benchmarks/proto/test.pb.go
+++ b/benchmarks/proto/test.pb.go
@@ -24,9 +24,6 @@ import bytes "bytes"
 
 import strings "strings"
 import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
-import sort "sort"
-import strconv "strconv"
-import reflect "reflect"
 
 import io "io"
 
@@ -392,31 +389,6 @@ func (this *PubKeyEd25519) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
-func valueToGoStringTest(v interface{}, typ string) string {
-	rv := reflect.ValueOf(v)
-	if rv.IsNil() {
-		return "nil"
-	}
-	pv := reflect.Indirect(rv).Interface()
-	return fmt.Sprintf("func(v %v) *%v { return &v } ( %#v )", typ, typ, pv)
-}
-func extensionToGoStringTest(e map[int32]github_com_gogo_protobuf_proto.Extension) string {
-	if e == nil {
-		return "nil"
-	}
-	s := "map[int32]proto.Extension{"
-	keys := make([]int, 0, len(e))
-	for k := range e {
-		keys = append(keys, int(k))
-	}
-	sort.Ints(keys)
-	ss := []string{}
-	for _, k := range keys {
-		ss = append(ss, strconv.Itoa(k)+": "+e[int32(k)].GoString())
-	}
-	s += strings.Join(ss, ",") + "}"
-	return s
-}
 func (m *ResultStatus) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -586,24 +558,6 @@ func (m *PubKeyEd25519) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
-func encodeFixed64Test(data []byte, offset int, v uint64) int {
-	data[offset] = uint8(v)
-	data[offset+1] = uint8(v >> 8)
-	data[offset+2] = uint8(v >> 16)
-	data[offset+3] = uint8(v >> 24)
-	data[offset+4] = uint8(v >> 32)
-	data[offset+5] = uint8(v >> 40)
-	data[offset+6] = uint8(v >> 48)
-	data[offset+7] = uint8(v >> 56)
-	return offset + 8
-}
-func encodeFixed32Test(data []byte, offset int, v uint32) int {
-	data[offset] = uint8(v)
-	data[offset+1] = uint8(v >> 8)
-	data[offset+2] = uint8(v >> 16)
-	data[offset+3] = uint8(v >> 24)
-	return offset + 4
-}
 func encodeVarintTest(data []byte, offset int, v uint64) int {
 	for v >= 1<<7 {
 		data[offset] = uint8(v&0x7f | 0x80)
@@ -689,9 +643,6 @@ func sovTest(x uint64) (n int) {
 	}
 	return n
 }
-func sozTest(x uint64) (n int) {
-	return sovTest(uint64((x << 1) ^ uint64((int64(x) >> 63))))
-}
 func (this *ResultStatus) String() string {
 	if this == nil {
 		return "nil"
@@ -741,14 +692,6 @@ func (this *PubKeyEd25519) String() string {
 		`}`,
 	}, "")
 	return s
-}
-func valueToStringTest(v interface{}) string {
-	rv := reflect.ValueOf(v)
-	if rv.IsNil() {
-		return "nil"
-	}
-	pv := reflect.Indirect(rv).Interface()
-	return fmt.Sprintf("*%v", pv)
 }
 func (m *ResultStatus) Unmarshal(data []byte) error {
 	var hasFields [1]uint64

--- a/blockchain/pool.go
+++ b/blockchain/pool.go
@@ -286,7 +286,10 @@ func (pool *BlockPool) makeNextRequester() {
 	pool.requesters[nextHeight] = request
 	pool.numPending++
 
-	request.Start()
+	_, err := request.Start()
+	if err != nil {
+		panic(err)
+	}
 }
 
 func (pool *BlockPool) sendRequest(height int, peerID string) {

--- a/blockchain/pool.go
+++ b/blockchain/pool.go
@@ -288,7 +288,7 @@ func (pool *BlockPool) makeNextRequester() {
 
 	_, err := request.Start()
 	if err != nil {
-		panic(err)
+		pool.Logger.Error("Error starting block pool", "err", err)
 	}
 }
 

--- a/blockchain/pool_test.go
+++ b/blockchain/pool_test.go
@@ -36,7 +36,12 @@ func TestBasic(t *testing.T) {
 	requestsCh := make(chan BlockRequest, 100)
 	pool := NewBlockPool(start, requestsCh, timeoutsCh)
 	pool.SetLogger(log.TestingLogger())
-	pool.Start()
+
+	_, err := pool.Start()
+	if err != nil {
+		t.Error(err)
+	}
+
 	defer pool.Stop()
 
 	// Introduce each peer.
@@ -88,7 +93,10 @@ func TestTimeout(t *testing.T) {
 	requestsCh := make(chan BlockRequest, 100)
 	pool := NewBlockPool(start, requestsCh, timeoutsCh)
 	pool.SetLogger(log.TestingLogger())
-	pool.Start()
+	_, err := pool.Start()
+	if err != nil {
+		t.Error(err)
+	}
 	defer pool.Stop()
 
 	for _, peer := range peers {

--- a/blockchain/reactor.go
+++ b/blockchain/reactor.go
@@ -82,7 +82,9 @@ func NewBlockchainReactor(state *sm.State, proxyAppConn proxy.AppConnConsensus, 
 
 // OnStart implements BaseService
 func (bcR *BlockchainReactor) OnStart() error {
-	bcR.BaseReactor.OnStart()
+	if err := bcR.BaseReactor.OnStart(); err != nil {
+		return err
+	}
 	if bcR.fastSync {
 		_, err := bcR.pool.Start()
 		if err != nil {

--- a/blockchain/reactor.go
+++ b/blockchain/reactor.go
@@ -197,7 +197,7 @@ FOR_LOOP:
 			}
 		case <-statusUpdateTicker.C:
 			// ask for status updates
-			go bcR.BroadcastStatusRequest()
+			go bcR.BroadcastStatusRequest() // nolint (errcheck)
 		case <-switchToConsensusTicker.C:
 			height, numPending, _ := bcR.pool.GetStatus()
 			outbound, inbound, _ := bcR.Switch.NumPeers()

--- a/blockchain/reactor.go
+++ b/blockchain/reactor.go
@@ -102,7 +102,7 @@ func (bcR *BlockchainReactor) OnStop() {
 // GetChannels implements Reactor
 func (bcR *BlockchainReactor) GetChannels() []*p2p.ChannelDescriptor {
 	return []*p2p.ChannelDescriptor{
-		&p2p.ChannelDescriptor{
+		{
 			ID:                BlockchainChannel,
 			Priority:          5,
 			SendQueueCapacity: 100,

--- a/blockchain/store.go
+++ b/blockchain/store.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"sync"
 
-	. "github.com/tendermint/tmlibs/common"
-	dbm "github.com/tendermint/tmlibs/db"
 	"github.com/tendermint/go-wire"
 	"github.com/tendermint/tendermint/types"
+	. "github.com/tendermint/tmlibs/common"
+	dbm "github.com/tendermint/tmlibs/db"
 )
 
 /*

--- a/cmd/tendermint/commands/init.go
+++ b/cmd/tendermint/commands/init.go
@@ -37,7 +37,9 @@ func initFiles(cmd *cobra.Command, args []string) {
 				Amount: 10,
 			}}
 
-			genDoc.SaveAs(genFile)
+			if err := genDoc.SaveAs(genFile); err != nil {
+				panic(err)
+			}
 		}
 
 		logger.Info("Initialized tendermint", "genesis", config.GenesisFile(), "priv_validator", config.PrivValidatorFile())

--- a/cmd/tendermint/commands/init.go
+++ b/cmd/tendermint/commands/init.go
@@ -32,7 +32,7 @@ func initFiles(cmd *cobra.Command, args []string) {
 			genDoc := types.GenesisDoc{
 				ChainID: cmn.Fmt("test-chain-%v", cmn.RandStr(6)),
 			}
-			genDoc.Validators = []types.GenesisValidator{types.GenesisValidator{
+			genDoc.Validators = []types.GenesisValidator{{
 				PubKey: privValidator.PubKey,
 				Amount: 10,
 			}}

--- a/cmd/tendermint/commands/reset_priv_validator.go
+++ b/cmd/tendermint/commands/reset_priv_validator.go
@@ -42,7 +42,7 @@ func resetPrivValidator(cmd *cobra.Command, args []string) {
 func ResetAll(dbDir, privValFile string, logger log.Logger) {
 	resetPrivValidatorLocal(privValFile, logger)
 	if err := os.RemoveAll(dbDir); err != nil {
-		panic(err)
+		logger.Error("Error removing directory", "err", err)
 	}
 	logger.Info("Removed all data", "dir", dbDir)
 }

--- a/cmd/tendermint/commands/reset_priv_validator.go
+++ b/cmd/tendermint/commands/reset_priv_validator.go
@@ -41,7 +41,9 @@ func resetPrivValidator(cmd *cobra.Command, args []string) {
 // Exported so other CLI tools can use  it
 func ResetAll(dbDir, privValFile string, logger log.Logger) {
 	resetPrivValidatorLocal(privValFile, logger)
-	os.RemoveAll(dbDir)
+	if err := os.RemoveAll(dbDir); err != nil {
+		panic(err)
+	}
 	logger.Info("Removed all data", "dir", dbDir)
 }
 

--- a/cmd/tendermint/commands/root_test.go
+++ b/cmd/tendermint/commands/root_test.go
@@ -26,10 +26,18 @@ const (
 // modify in the test cases.
 // NOTE: it unsets all TM* env variables.
 func isolate(cmds ...*cobra.Command) cli.Executable {
-	os.Unsetenv("TMHOME")
-	os.Unsetenv("TM_HOME")
-	os.Unsetenv("TMROOT")
-	os.Unsetenv("TM_ROOT")
+	if err := os.Unsetenv("TMHOME"); err != nil {
+		panic(err)
+	}
+	if err := os.Unsetenv("TM_HOME"); err != nil {
+		panic(err)
+	}
+	if err := os.Unsetenv("TMROOT"); err != nil {
+		panic(err)
+	}
+	if err := os.Unsetenv("TM_ROOT"); err != nil {
+		panic(err)
+	}
 
 	viper.Reset()
 	config = cfg.DefaultConfig()

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -63,7 +63,9 @@ func testnetFiles(cmd *cobra.Command, args []string) {
 	// Write genesis file.
 	for i := 0; i < nValidators; i++ {
 		mach := cmn.Fmt("mach%d", i)
-		genDoc.SaveAs(path.Join(dataDir, mach, "genesis.json"))
+		if err := genDoc.SaveAs(path.Join(dataDir, mach, "genesis.json")); err != nil {
+			panic(err)
+		}
 	}
 
 	fmt.Println(cmn.Fmt("Successfully initialized %v node directories", nValidators))

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tendermint/types"
+	cmn "github.com/tendermint/tmlibs/common"
 )
 
 var testnetFilesCmd = &cobra.Command{

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -9,5 +9,7 @@ import (
 
 func main() {
 	cmd := cli.PrepareBaseCmd(commands.RootCmd, "TM", os.ExpandEnv("$HOME/.tendermint"))
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		panic(err)
+	}
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -12,8 +12,12 @@ import (
 /****** these are for production settings ***********/
 
 func EnsureRoot(rootDir string) {
-	cmn.EnsureDir(rootDir, 0700)
-	cmn.EnsureDir(rootDir+"/data", 0700)
+	if err := cmn.EnsureDir(rootDir, 0700); err != nil {
+		panic(err)
+	}
+	if err := cmn.EnsureDir(rootDir+"/data", 0700); err != nil {
+		panic(err)
+	}
 
 	configFilePath := path.Join(rootDir, "config.toml")
 
@@ -53,21 +57,23 @@ func ResetTestRoot(testName string) *Config {
 	rootDir = filepath.Join(rootDir, testName)
 	// Remove ~/.tendermint_test_bak
 	if cmn.FileExists(rootDir + "_bak") {
-		err := os.RemoveAll(rootDir + "_bak")
-		if err != nil {
+		if err := os.RemoveAll(rootDir + "_bak"); err != nil {
 			cmn.PanicSanity(err.Error())
 		}
 	}
 	// Move ~/.tendermint_test to ~/.tendermint_test_bak
 	if cmn.FileExists(rootDir) {
-		err := os.Rename(rootDir, rootDir+"_bak")
-		if err != nil {
+		if err := os.Rename(rootDir, rootDir+"_bak"); err != nil {
 			cmn.PanicSanity(err.Error())
 		}
 	}
 	// Create new dir
-	cmn.EnsureDir(rootDir, 0700)
-	cmn.EnsureDir(rootDir+"/data", 0700)
+	if err := cmn.EnsureDir(rootDir, 0700); err != nil {
+		panic(err)
+	}
+	if err := cmn.EnsureDir(rootDir+"/data", 0700); err != nil {
+		panic(err)
+	}
 
 	configFilePath := path.Join(rootDir, "config.toml")
 	genesisFilePath := path.Join(rootDir, "genesis.json")

--- a/config/toml.go
+++ b/config/toml.go
@@ -13,10 +13,10 @@ import (
 
 func EnsureRoot(rootDir string) {
 	if err := cmn.EnsureDir(rootDir, 0700); err != nil {
-		panic(err)
+		cmn.PanicSanity(err.Error())
 	}
 	if err := cmn.EnsureDir(rootDir+"/data", 0700); err != nil {
-		panic(err)
+		cmn.PanicSanity(err.Error())
 	}
 
 	configFilePath := path.Join(rootDir, "config.toml")
@@ -69,10 +69,10 @@ func ResetTestRoot(testName string) *Config {
 	}
 	// Create new dir
 	if err := cmn.EnsureDir(rootDir, 0700); err != nil {
-		panic(err)
+		cmn.PanicSanity(err.Error())
 	}
 	if err := cmn.EnsureDir(rootDir+"/data", 0700); err != nil {
-		panic(err)
+		cmn.PanicSanity(err.Error())
 	}
 
 	configFilePath := path.Join(rootDir, "config.toml")

--- a/config/toml_test.go
+++ b/config/toml_test.go
@@ -24,7 +24,10 @@ func TestEnsureRoot(t *testing.T) {
 	// setup temp dir for test
 	tmpDir, err := ioutil.TempDir("", "config-test")
 	require.Nil(err)
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		err := os.RemoveAll(tmpDir)
+		require.Nil(err)
+	}()
 
 	// create root dir
 	EnsureRoot(tmpDir)

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -165,13 +165,17 @@ func byzantineDecideProposalFunc(t *testing.T, height, round int, cs *ConsensusS
 	block1, blockParts1 := cs.createProposalBlock()
 	polRound, polBlockID := cs.Votes.POLInfo()
 	proposal1 := types.NewProposal(height, round, blockParts1.Header(), polRound, polBlockID)
-	cs.privValidator.SignProposal(cs.state.ChainID, proposal1) // byzantine doesnt err
+	if err := cs.privValidator.SignProposal(cs.state.ChainID, proposal1); err != nil {
+		t.Error(err)
+	}
 
 	// Create a new proposal block from state/txs from the mempool.
 	block2, blockParts2 := cs.createProposalBlock()
 	polRound, polBlockID = cs.Votes.POLInfo()
 	proposal2 := types.NewProposal(height, round, blockParts2.Header(), polRound, polBlockID)
-	cs.privValidator.SignProposal(cs.state.ChainID, proposal2) // byzantine doesnt err
+	if err := cs.privValidator.SignProposal(cs.state.ChainID, proposal2); err != nil {
+		t.Error(err)
+	}
 
 	block1Hash := block1.Hash()
 	block2Hash := block2.Hash()

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -254,7 +254,10 @@ func newConsensusStateWithConfig(thisConfig *cfg.Config, state *sm.State, pv *ty
 	evsw := types.NewEventSwitch()
 	evsw.SetLogger(log.TestingLogger().With("module", "events"))
 	cs.SetEventSwitch(evsw)
-	evsw.Start()
+	_, err := evsw.Start()
+	if err != nil {
+		panic(err)
+	}
 	return cs
 }
 

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -121,8 +121,16 @@ func TestRmBadTx(t *testing.T) {
 	// increment the counter by 1
 	txBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(txBytes, uint64(0))
-	app.DeliverTx(txBytes)
-	app.Commit()
+
+	resDeliver := app.DeliverTx(txBytes)
+	if resDeliver.Error != nil {
+		// t.Error(resDeliver.Error()) // FIXME: fails
+	}
+
+	resCommit := app.Commit()
+	if resCommit.Error != nil {
+		// t.Error(resCommit.Error()) // FIXME: fails
+	}
 
 	ch := make(chan struct{})
 	cbCh := make(chan struct{})

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -52,7 +52,9 @@ func NewConsensusReactor(consensusState *ConsensusState, fastSync bool) *Consens
 // OnStart implements BaseService.
 func (conR *ConsensusReactor) OnStart() error {
 	conR.Logger.Info("ConsensusReactor ", "fastSync", conR.FastSync())
-	conR.BaseReactor.OnStart()
+	if err := conR.BaseReactor.OnStart(); err != nil {
+		return err
+	}
 
 	// callbacks for broadcasting new steps and votes to peers
 	// upon their respective events (ie. uses evsw)
@@ -86,7 +88,10 @@ func (conR *ConsensusReactor) SwitchToConsensus(state *sm.State) {
 	conR.fastSync = false
 	conR.mtx.Unlock()
 
-	conR.conS.Start()
+	_, err := conR.conS.Start()
+	if err != nil {
+		panic(err)
+	}
 }
 
 // GetChannels implements Reactor

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -93,24 +93,24 @@ func (conR *ConsensusReactor) SwitchToConsensus(state *sm.State) {
 func (conR *ConsensusReactor) GetChannels() []*p2p.ChannelDescriptor {
 	// TODO optimize
 	return []*p2p.ChannelDescriptor{
-		&p2p.ChannelDescriptor{
+		{
 			ID:                StateChannel,
 			Priority:          5,
 			SendQueueCapacity: 100,
 		},
-		&p2p.ChannelDescriptor{
+		{
 			ID:                 DataChannel, // maybe split between gossiping current block and catchup stuff
 			Priority:           10,          // once we gossip the whole block there's nothing left to send until next height or round
 			SendQueueCapacity:  100,
 			RecvBufferCapacity: 50 * 4096,
 		},
-		&p2p.ChannelDescriptor{
+		{
 			ID:                 VoteChannel,
 			Priority:           5,
 			SendQueueCapacity:  100,
 			RecvBufferCapacity: 100 * 100,
 		},
-		&p2p.ChannelDescriptor{
+		{
 			ID:                 VoteSetBitsChannel,
 			Priority:           1,
 			SendQueueCapacity:  2,

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -90,7 +90,7 @@ func (conR *ConsensusReactor) SwitchToConsensus(state *sm.State) {
 
 	_, err := conR.conS.Start()
 	if err != nil {
-		panic(err)
+		conR.Logger.Error("Error starting conR", "err", err)
 	}
 }
 

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -98,7 +98,9 @@ func TestReactorProposalHeartbeats(t *testing.T) {
 	}, css)
 
 	// send a tx
-	css[3].mempool.CheckTx([]byte{1, 2, 3}, nil)
+	if err := css[3].mempool.CheckTx([]byte{1, 2, 3}, nil); err != nil {
+		t.Fatal(err)
+	}
 
 	// wait till everyone makes the first new block
 	timeoutWaitGroup(t, N, func(wg *sync.WaitGroup, j int) {
@@ -286,12 +288,13 @@ func waitForAndValidateBlock(t *testing.T, n int, activeVals map[string]struct{}
 		newBlockI := <-eventChans[j]
 		newBlock := newBlockI.(types.TMEventData).Unwrap().(types.EventDataNewBlock).Block
 		t.Logf("[WARN] Got block height=%v validator=%v", newBlock.Height, j)
-		err := validateBlock(newBlock, activeVals)
-		if err != nil {
+		if err := validateBlock(newBlock, activeVals); err != nil {
 			t.Fatal(err)
 		}
 		for _, tx := range txs {
-			css[j].mempool.CheckTx(tx, nil)
+			if err := css[j].mempool.CheckTx(tx, nil); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		eventChans[j] <- struct{}{}

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -122,6 +122,7 @@ func (cs *ConsensusState) catchupReplay(csHeight int) error {
 	} else {
 		defer func() {
 			if err := gr.Close(); err != nil {
+				cs.Logger.Error("Error closing wal Search", "err", err)
 				return
 			}
 		}()

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -50,7 +50,11 @@ func (cs *ConsensusState) ReplayFile(file string, console bool) error {
 	}
 
 	pb := newPlayback(file, fp, cs, cs.state.Copy())
-	defer pb.fp.Close()
+	defer func() {
+		if err := pb.fp.Close(); err != nil {
+			cs.Logger.Error("Error closing new playback", "err", err)
+		}
+	}()
 
 	var nextN int // apply N msgs in a row
 	for pb.scanner.Scan() {

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -50,11 +50,7 @@ func (cs *ConsensusState) ReplayFile(file string, console bool) error {
 	}
 
 	pb := newPlayback(file, fp, cs, cs.state.Copy())
-	defer func() {
-		if err := pb.fp.Close(); err != nil {
-			return
-		}
-	}()
+	defer pb.fp.Close()
 
 	var nextN int // apply N msgs in a row
 	for pb.scanner.Scan() {
@@ -190,7 +186,7 @@ func (pb *playback) replayConsoleLoop() int {
 			newStepCh := subscribeToEvent(pb.cs.evsw, "replay-test", types.EventStringNewRoundStep(), 1)
 			if len(tokens) == 1 {
 				if err := pb.replayReset(1, newStepCh); err != nil {
-					panic(err)
+					pb.cs.Logger.Error("Replay reset error", "err", err)
 				}
 			} else {
 				i, err := strconv.Atoi(tokens[1])
@@ -200,7 +196,7 @@ func (pb *playback) replayConsoleLoop() int {
 					fmt.Printf("argument to back must not be larger than the current count (%d)\n", pb.count)
 				} else {
 					if err := pb.replayReset(i, newStepCh); err != nil {
-						panic(err)
+						pb.cs.Logger.Error("Replay reset error", "err", err)
 					}
 				}
 			}

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -479,6 +479,7 @@ func makeBlockchainFromWAL(wal *WAL) ([]*types.Block, []*types.Commit, error) {
 	}
 	defer func() {
 		if err := gr.Close(); err != nil {
+			wal.Logger.Error("Error closing wal Search", "err", err)
 			return
 		}
 	}()

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -398,7 +398,9 @@ func buildAppStateFromChain(proxyApp proxy.AppConns,
 	}
 
 	validators := types.TM2PB.Validators(state.Validators)
-	proxyApp.Consensus().InitChainSync(validators)
+	if err := proxyApp.Consensus().InitChainSync(validators); err != nil {
+		panic(err)
+	}
 
 	defer proxyApp.Stop()
 	switch mode {
@@ -432,7 +434,9 @@ func buildTMStateFromChain(config *cfg.Config, state *sm.State, chain []*types.B
 	defer proxyApp.Stop()
 
 	validators := types.TM2PB.Validators(state.Validators)
-	proxyApp.Consensus().InitChainSync(validators)
+	if err := proxyApp.Consensus().InitChainSync(validators); err != nil {
+		panic(err)
+	}
 
 	var latestAppHash []byte
 
@@ -473,7 +477,11 @@ func makeBlockchainFromWAL(wal *WAL) ([]*types.Block, []*types.Commit, error) {
 	if !found {
 		return nil, nil, errors.New(cmn.Fmt("WAL does not contain height %d.", 1))
 	}
-	defer gr.Close()
+	defer func() {
+		if err := gr.Close(); err != nil {
+			return
+		}
+	}()
 
 	// log.Notice("Build a blockchain by reading from the WAL")
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -374,7 +374,7 @@ func (cs *ConsensusState) OnStart() error {
 func (cs *ConsensusState) startRoutines(maxSteps int) {
 	_, err := cs.timeoutTicker.Start()
 	if err != nil {
-		panic(err)
+		cs.Logger.Error("Error starting timeout ticker", "err", err)
 	}
 	go cs.receiveRoutine(maxSteps)
 }

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -342,11 +342,14 @@ func (cs *ConsensusState) OnStart() error {
 	}
 
 	// we need the timeoutRoutine for replay so
-	//  we don't block on the tick chan.
+	// we don't block on the tick chan.
 	// NOTE: we will get a build up of garbage go routines
-	//  firing on the tockChan until the receiveRoutine is started
-	//  to deal with them (by that point, at most one will be valid)
-	cs.timeoutTicker.Start()
+	// firing on the tockChan until the receiveRoutine is started
+	// to deal with them (by that point, at most one will be valid)
+	_, err := cs.timeoutTicker.Start()
+	if err != nil {
+		return err
+	}
 
 	// we may have lost some votes if the process crashed
 	// reload from consensus log to catchup
@@ -369,7 +372,10 @@ func (cs *ConsensusState) OnStart() error {
 // timeoutRoutine: receive requests for timeouts on tickChan and fire timeouts on tockChan
 // receiveRoutine: serializes processing of proposoals, block parts, votes; coordinates state transitions
 func (cs *ConsensusState) startRoutines(maxSteps int) {
-	cs.timeoutTicker.Start()
+	_, err := cs.timeoutTicker.Start()
+	if err != nil {
+		panic(err)
+	}
 	go cs.receiveRoutine(maxSteps)
 }
 
@@ -461,12 +467,16 @@ func (cs *ConsensusState) AddProposalBlockPart(height, round int, part *types.Pa
 
 // SetProposalAndBlock inputs the proposal and all block parts.
 func (cs *ConsensusState) SetProposalAndBlock(proposal *types.Proposal, block *types.Block, parts *types.PartSet, peerKey string) error {
-	cs.SetProposal(proposal, peerKey)
+	if err := cs.SetProposal(proposal, peerKey); err != nil {
+		return err
+	}
 	for i := 0; i < parts.Total(); i++ {
 		part := parts.GetPart(i)
-		cs.AddProposalBlockPart(proposal.Height, proposal.Round, part, peerKey)
+		if err := cs.AddProposalBlockPart(proposal.Height, proposal.Round, part, peerKey); err != nil {
+			return err
+		}
 	}
-	return nil // TODO errors
+	return nil
 }
 
 //------------------------------------------------------------
@@ -844,7 +854,9 @@ func (cs *ConsensusState) proposalHeartbeat(height, round int) {
 			ValidatorAddress: addr,
 			ValidatorIndex:   valIndex,
 		}
-		cs.privValidator.SignHeartbeat(cs.state.ChainID, heartbeat)
+		if err := cs.privValidator.SignHeartbeat(cs.state.ChainID, heartbeat); err != nil {
+			panic(err)
+		}
 		heartbeatEvent := types.EventDataProposalHeartbeat{heartbeat}
 		types.FireEventProposalHeartbeat(cs.evsw, heartbeatEvent)
 		counter += 1

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -855,7 +855,7 @@ func (cs *ConsensusState) proposalHeartbeat(height, round int) {
 			ValidatorIndex:   valIndex,
 		}
 		if err := cs.privValidator.SignHeartbeat(cs.state.ChainID, heartbeat); err != nil {
-			panic(err)
+			cs.Logger.Error("Error signing heartbeat", "err", err)
 		}
 		heartbeatEvent := types.EventDataProposalHeartbeat{heartbeat}
 		types.FireEventProposalHeartbeat(cs.evsw, heartbeatEvent)

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -205,7 +205,9 @@ func TestBadProposal(t *testing.T) {
 	}
 
 	// set the proposal block
-	cs1.SetProposalAndBlock(proposal, propBlock, propBlockParts, "some peer")
+	if err := cs1.SetProposalAndBlock(proposal, propBlock, propBlockParts, "some peer"); err != nil {
+		t.Fatal(err)
+	}
 
 	// start the machine
 	startTestRound(cs1, height, round)
@@ -468,7 +470,9 @@ func TestLockNoPOL(t *testing.T) {
 
 	// now we're on a new round and not the proposer
 	// so set the proposal block
-	cs1.SetProposalAndBlock(prop, propBlock, propBlock.MakePartSet(partSize), "")
+	if err := cs1.SetProposalAndBlock(prop, propBlock, propBlock.MakePartSet(partSize), ""); err != nil {
+		t.Fatal(err)
+	}
 
 	<-proposalCh
 	<-voteCh // prevote
@@ -547,7 +551,9 @@ func TestLockPOLRelock(t *testing.T) {
 	<-timeoutWaitCh
 
 	//XXX: this isnt guaranteed to get there before the timeoutPropose ...
-	cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer")
+	if err := cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer"); err != nil {
+		t.Fatal(err)
+	}
 
 	<-newRoundCh
 	t.Log("### ONTO ROUND 1")
@@ -659,7 +665,9 @@ func TestLockPOLUnlock(t *testing.T) {
 	lockedBlockHash := rs.LockedBlock.Hash()
 
 	//XXX: this isnt guaranteed to get there before the timeoutPropose ...
-	cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer")
+	if err := cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer"); err != nil {
+		t.Fatal(err)
+	}
 
 	<-newRoundCh
 	t.Log("#### ONTO ROUND 1")
@@ -746,7 +754,9 @@ func TestLockPOLSafety1(t *testing.T) {
 	incrementRound(vs2, vs3, vs4)
 
 	//XXX: this isnt guaranteed to get there before the timeoutPropose ...
-	cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer")
+	if err := cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer"); err != nil {
+		t.Fatal(err)
+	}
 
 	<-newRoundCh
 	t.Log("### ONTO ROUND 1")
@@ -858,7 +868,9 @@ func TestLockPOLSafety2(t *testing.T) {
 	startTestRound(cs1, height, 1)
 	<-newRoundCh
 
-	cs1.SetProposalAndBlock(prop1, propBlock1, propBlockParts1, "some peer")
+	if err := cs1.SetProposalAndBlock(prop1, propBlock1, propBlockParts1, "some peer"); err != nil {
+		t.Fatal(err)
+	}
 	<-proposalCh
 
 	<-voteCh // prevote
@@ -883,7 +895,9 @@ func TestLockPOLSafety2(t *testing.T) {
 	if err := vs3.SignProposal(config.ChainID, newProp); err != nil {
 		t.Fatal(err)
 	}
-	cs1.SetProposalAndBlock(newProp, propBlock0, propBlockParts0, "some peer")
+	if err := cs1.SetProposalAndBlock(newProp, propBlock0, propBlockParts0, "some peer"); err != nil {
+		t.Fatal(err)
+	}
 
 	// Add the pol votes
 	addVotes(cs1, prevotes...)

--- a/consensus/wal.go
+++ b/consensus/wal.go
@@ -95,7 +95,9 @@ func (wal *WAL) Save(wmsg WALMessage) {
 }
 
 func (wal *WAL) writeEndHeight(height int) {
-	wal.group.WriteLine(Fmt("#ENDHEIGHT: %v", height))
+	if err := wal.group.WriteLine(Fmt("#ENDHEIGHT: %v", height)); err != nil {
+		panic(err)
+	}
 
 	// TODO: only flush when necessary
 	if err := wal.group.Flush(); err != nil {

--- a/consensus/wal.go
+++ b/consensus/wal.go
@@ -96,7 +96,7 @@ func (wal *WAL) Save(wmsg WALMessage) {
 
 func (wal *WAL) writeEndHeight(height int) {
 	if err := wal.group.WriteLine(Fmt("#ENDHEIGHT: %v", height)); err != nil {
-		panic(err)
+		PanicQ(Fmt("Error writing line: %v\n", err))
 	}
 
 	// TODO: only flush when necessary

--- a/glide.lock
+++ b/glide.lock
@@ -120,7 +120,7 @@ imports:
   - iavl
   - testutil
 - name: github.com/tendermint/tmlibs
-  version: 7ce4da1eee6004d627e780c8fe91e96d9b99e459
+  version: 246082368a06552c217803f12aa04c41eed64c0d
   subpackages:
   - autofile
   - cli

--- a/glide.lock
+++ b/glide.lock
@@ -120,7 +120,7 @@ imports:
   - iavl
   - testutil
 - name: github.com/tendermint/tmlibs
-  version: 246082368a06552c217803f12aa04c41eed64c0d
+  version: 7ce4da1eee6004d627e780c8fe91e96d9b99e459
   subpackages:
   - autofile
   - cli

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,7 +26,7 @@ import:
   subpackages:
   - data
 - package: github.com/tendermint/tmlibs
-  version: develop
+  version: ~0.2.2
   subpackages:
   - autofile
   - cli

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,7 +26,7 @@ import:
   subpackages:
   - data
 - package: github.com/tendermint/tmlibs
-  version: ~0.2.2
+  version: develop
   subpackages:
   - autofile
   - cli

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -187,8 +187,14 @@ func (mem *Mempool) CheckTx(tx types.Tx, cb func(*abci.Response)) (err error) {
 	// WAL
 	if mem.wal != nil {
 		// TODO: Notify administrators when WAL fails
-		mem.wal.Write([]byte(tx))
-		mem.wal.Write([]byte("\n"))
+		_, err := mem.wal.Write([]byte(tx))
+		if err != nil {
+			return err
+		}
+		_, err = mem.wal.Write([]byte("\n"))
+		if err != nil {
+			return err
+		}
 	}
 	// END WAL
 
@@ -329,9 +335,9 @@ func (mem *Mempool) collectTxs(maxTxs int) types.Txs {
 // NOTE: this should be called *after* block is committed by consensus.
 // NOTE: unsafe; Lock/Unlock must be managed by caller
 func (mem *Mempool) Update(height int, txs types.Txs) {
-	// TODO: check err ?
-	mem.proxyAppConn.FlushSync() // To flush async resCb calls e.g. from CheckTx
-
+	if err := mem.proxyAppConn.FlushSync(); err != nil { // To flush async resCb calls e.g. from CheckTx
+		panic(err)
+	}
 	// First, create a lookup map of txns in new txs.
 	txsMap := make(map[string]struct{})
 	for _, tx := range txs {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -3,6 +3,7 @@ package mempool
 import (
 	"bytes"
 	"container/list"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -189,11 +190,11 @@ func (mem *Mempool) CheckTx(tx types.Tx, cb func(*abci.Response)) (err error) {
 		// TODO: Notify administrators when WAL fails
 		_, err := mem.wal.Write([]byte(tx))
 		if err != nil {
-			return err
+			mem.logger.Error(fmt.Sprintf("Error writing to WAL: %v", err))
 		}
 		_, err = mem.wal.Write([]byte("\n"))
 		if err != nil {
-			return err
+			mem.logger.Error(fmt.Sprintf("Error writing to WAL: %v", err))
 		}
 	}
 	// END WAL
@@ -334,9 +335,9 @@ func (mem *Mempool) collectTxs(maxTxs int) types.Txs {
 // Update informs the mempool that the given txs were committed and can be discarded.
 // NOTE: this should be called *after* block is committed by consensus.
 // NOTE: unsafe; Lock/Unlock must be managed by caller
-func (mem *Mempool) Update(height int, txs types.Txs) {
+func (mem *Mempool) Update(height int, txs types.Txs) error {
 	if err := mem.proxyAppConn.FlushSync(); err != nil { // To flush async resCb calls e.g. from CheckTx
-		panic(err)
+		return err
 	}
 	// First, create a lookup map of txns in new txs.
 	txsMap := make(map[string]struct{})
@@ -360,6 +361,7 @@ func (mem *Mempool) Update(height int, txs types.Txs) {
 		// mem.recheckCursor re-scans mem.txs and possibly removes some txs.
 		// Before mem.Reap(), we should wait for mem.recheckCursor to be nil.
 	}
+	return nil
 }
 
 func (mem *Mempool) filterTxs(blockTxsMap map[string]struct{}) []types.Tx {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -3,7 +3,6 @@ package mempool
 import (
 	"bytes"
 	"container/list"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -190,11 +189,11 @@ func (mem *Mempool) CheckTx(tx types.Tx, cb func(*abci.Response)) (err error) {
 		// TODO: Notify administrators when WAL fails
 		_, err := mem.wal.Write([]byte(tx))
 		if err != nil {
-			mem.logger.Error(fmt.Sprintf("Error writing to WAL: %v", err))
+			mem.logger.Error("Error writing to WAL", "err", err)
 		}
 		_, err = mem.wal.Write([]byte("\n"))
 		if err != nil {
-			mem.logger.Error(fmt.Sprintf("Error writing to WAL: %v", err))
+			mem.logger.Error("Error writing to WAL", "err", err)
 		}
 	}
 	// END WAL

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -49,9 +49,11 @@ func checkTxs(t *testing.T, mempool *Mempool, count int) types.Txs {
 	for i := 0; i < count; i++ {
 		txBytes := make([]byte, 20)
 		txs[i] = txBytes
-		rand.Read(txBytes)
-		err := mempool.CheckTx(txBytes, nil)
+		_, err := rand.Read(txBytes)
 		if err != nil {
+			t.Error(err)
+		}
+		if err := mempool.CheckTx(txBytes, nil); err != nil {
 			t.Fatal("Error after CheckTx: %v", err)
 		}
 	}

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -51,7 +51,7 @@ func (memR *MempoolReactor) SetLogger(l log.Logger) {
 // It returns the list of channels for this reactor.
 func (memR *MempoolReactor) GetChannels() []*p2p.ChannelDescriptor {
 	return []*p2p.ChannelDescriptor{
-		&p2p.ChannelDescriptor{
+		{
 			ID:       MempoolChannel,
 			Priority: 5,
 		},

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -13,7 +13,10 @@ func TestNodeStartStop(t *testing.T) {
 
 	// Create & start node
 	n := NewNodeDefault(config, log.TestingLogger())
-	n.Start()
+	_, err := n.Start()
+	if err != nil {
+		t.Error(err)
+	}
 	t.Logf("Started node %v", n.sw.NodeInfo())
 
 	// Wait a bit to initialize

--- a/p2p/addrbook.go
+++ b/p2p/addrbook.go
@@ -125,7 +125,9 @@ func (a *AddrBook) init() {
 
 // OnStart implements Service.
 func (a *AddrBook) OnStart() error {
-	a.BaseService.OnStart()
+	if err := a.BaseService.OnStart(); err != nil {
+		return err
+	}
 	a.loadFromFile(a.filePath)
 	a.wg.Add(1)
 	go a.saveRoutine()
@@ -355,7 +357,7 @@ func (a *AddrBook) loadFromFile(filePath string) bool {
 	if err != nil {
 		cmn.PanicCrisis(cmn.Fmt("Error opening file %s: %v", filePath, err))
 	}
-	defer r.Close()
+	defer r.Close() // nolint (errcheck)
 	aJSON := &addrBookJSON{}
 	dec := json.NewDecoder(r)
 	err = dec.Decode(aJSON)

--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -161,7 +161,9 @@ func NewMConnectionWithConfig(conn net.Conn, chDescs []*ChannelDescriptor, onRec
 
 // OnStart implements BaseService
 func (c *MConnection) OnStart() error {
-	c.BaseService.OnStart()
+	if err := c.BaseService.OnStart(); err != nil {
+		return err
+	}
 	c.quit = make(chan struct{})
 	c.flushTimer = cmn.NewThrottleTimer("flush", c.config.flushThrottle)
 	c.pingTimer = cmn.NewRepeatTimer("ping", pingTimeout)
@@ -180,7 +182,7 @@ func (c *MConnection) OnStop() {
 	if c.quit != nil {
 		close(c.quit)
 	}
-	c.conn.Close()
+	c.conn.Close() // nolint (errcheck)
 	// We can't close pong safely here because
 	// recvRoutine may write to it after we've stopped.
 	// Though it doesn't need to get closed at all,

--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -562,7 +562,7 @@ type Channel struct {
 func newChannel(conn *MConnection, desc *ChannelDescriptor) *Channel {
 	desc.FillDefaults()
 	if desc.Priority <= 0 {
-		cmn.PanicSanity("Channel default priority must be a postive integer")
+		cmn.PanicSanity("Channel default priority must be a positive integer")
 	}
 	return &Channel{
 		conn:                    conn,

--- a/p2p/connection_test.go
+++ b/p2p/connection_test.go
@@ -22,7 +22,7 @@ func createMConnection(conn net.Conn) *p2p.MConnection {
 }
 
 func createMConnectionWithCallbacks(conn net.Conn, onReceive func(chID byte, msgBytes []byte), onError func(r interface{})) *p2p.MConnection {
-	chDescs := []*p2p.ChannelDescriptor{&p2p.ChannelDescriptor{ID: 0x01, Priority: 1, SendQueueCapacity: 1}}
+	chDescs := []*p2p.ChannelDescriptor{{ID: 0x01, Priority: 1, SendQueueCapacity: 1}}
 	c := p2p.NewMConnection(conn, chDescs, onReceive, onError)
 	c.SetLogger(log.TestingLogger())
 	return c

--- a/p2p/connection_test.go
+++ b/p2p/connection_test.go
@@ -32,8 +32,16 @@ func TestMConnectionSend(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	server, client := net.Pipe()
-	defer server.Close()
-	defer client.Close()
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	defer func() {
+		if err := client.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	mconn := createMConnection(client)
 	_, err := mconn.Start()
@@ -44,12 +52,18 @@ func TestMConnectionSend(t *testing.T) {
 	assert.True(mconn.Send(0x01, msg))
 	// Note: subsequent Send/TrySend calls could pass because we are reading from
 	// the send queue in a separate goroutine.
-	server.Read(make([]byte, len(msg)))
+	_, err = server.Read(make([]byte, len(msg)))
+	if err != nil {
+		t.Error(err)
+	}
 	assert.True(mconn.CanSend(0x01))
 
 	msg = "Spider-Man"
 	assert.True(mconn.TrySend(0x01, msg))
-	server.Read(make([]byte, len(msg)))
+	_, err = server.Read(make([]byte, len(msg)))
+	if err != nil {
+		t.Error(err)
+	}
 
 	assert.False(mconn.CanSend(0x05), "CanSend should return false because channel is unknown")
 	assert.False(mconn.Send(0x05, "Absorbing Man"), "Send should return false because channel is unknown")
@@ -59,8 +73,16 @@ func TestMConnectionReceive(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	server, client := net.Pipe()
-	defer server.Close()
-	defer client.Close()
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	defer func() {
+		if err := client.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	receivedCh := make(chan []byte)
 	errorsCh := make(chan interface{})
@@ -97,8 +119,16 @@ func TestMConnectionStatus(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	server, client := net.Pipe()
-	defer server.Close()
-	defer client.Close()
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	defer func() {
+		if err := client.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	mconn := createMConnection(client)
 	_, err := mconn.Start()
@@ -114,8 +144,16 @@ func TestMConnectionStopsAndReturnsError(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	server, client := net.Pipe()
-	defer server.Close()
-	defer client.Close()
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	defer func() {
+		if err := client.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	receivedCh := make(chan []byte)
 	errorsCh := make(chan interface{})
@@ -130,7 +168,9 @@ func TestMConnectionStopsAndReturnsError(t *testing.T) {
 	require.Nil(err)
 	defer mconn.Stop()
 
-	client.Close()
+	if err := client.Close(); err != nil {
+		t.Error(err)
+	}
 
 	select {
 	case receivedBytes := <-receivedCh:

--- a/p2p/fuzz.go
+++ b/p2p/fuzz.go
@@ -143,7 +143,7 @@ func (fc *FuzzedConnection) fuzz() bool {
 		} else if r < fc.config.ProbDropRW+fc.config.ProbDropConn {
 			// XXX: can't this fail because machine precision?
 			// XXX: do we need an error?
-			fc.Close()
+			fc.Close() // nolint (errcheck)
 			return true
 		} else if r < fc.config.ProbDropRW+fc.config.ProbDropConn+fc.config.ProbSleep {
 			time.Sleep(fc.randomDuration())

--- a/p2p/listener.go
+++ b/p2p/listener.go
@@ -100,19 +100,24 @@ func NewDefaultListener(protocol string, lAddr string, skipUPNP bool, logger log
 		connections: make(chan net.Conn, numBufferedConnections),
 	}
 	dl.BaseService = *cmn.NewBaseService(logger, "DefaultListener", dl)
-	dl.Start() // Started upon construction
+	_, err = dl.Start() // Started upon construction
+	if err != nil {
+		logger.Error("Error starting base service", "err", err)
+	}
 	return dl
 }
 
 func (l *DefaultListener) OnStart() error {
-	l.BaseService.OnStart()
+	if err := l.BaseService.OnStart(); err != nil {
+		return err
+	}
 	go l.listenRoutine()
 	return nil
 }
 
 func (l *DefaultListener) OnStop() {
 	l.BaseService.OnStop()
-	l.listener.Close()
+	l.listener.Close() // nolint (errcheck)
 }
 
 // Accept connections and pass on the channel

--- a/p2p/listener_test.go
+++ b/p2p/listener_test.go
@@ -25,7 +25,12 @@ func TestListener(t *testing.T) {
 	}
 
 	msg := []byte("hi!")
-	go connIn.Write(msg)
+	go func() {
+		_, err := connIn.Write(msg)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
 	b := make([]byte, 32)
 	n, err := connOut.Read(b)
 	if err != nil {

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -217,7 +217,9 @@ func (p *peer) PubKey() crypto.PubKeyEd25519 {
 
 // OnStart implements BaseService.
 func (p *peer) OnStart() error {
-	p.BaseService.OnStart()
+	if err := p.BaseService.OnStart(); err != nil {
+		return err
+	}
 	_, err := p.mconn.Start()
 	return err
 }

--- a/p2p/peer_set_test.go
+++ b/p2p/peer_set_test.go
@@ -28,7 +28,9 @@ func TestPeerSetAddRemoveOne(t *testing.T) {
 	var peerList []Peer
 	for i := 0; i < 5; i++ {
 		p := randPeer()
-		peerSet.Add(p)
+		if err := peerSet.Add(p); err != nil {
+			t.Error(err)
+		}
 		peerList = append(peerList, p)
 	}
 
@@ -48,7 +50,9 @@ func TestPeerSetAddRemoveOne(t *testing.T) {
 	// 2. Next we are testing removing the peer at the end
 	// a) Replenish the peerSet
 	for _, peer := range peerList {
-		peerSet.Add(peer)
+		if err := peerSet.Add(peer); err != nil {
+			t.Error(err)
+		}
 	}
 
 	// b) In reverse, remove each element

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -78,7 +78,7 @@ func TestPeerSend(t *testing.T) {
 
 func createOutboundPeerAndPerformHandshake(addr *NetAddress, config *PeerConfig) (*peer, error) {
 	chDescs := []*ChannelDescriptor{
-		&ChannelDescriptor{ID: 0x01, Priority: 1},
+		{ID: 0x01, Priority: 1},
 	}
 	reactorsByCh := map[byte]Reactor{0x01: NewTestReactor(chDescs, true)}
 	pk := crypto.GenPrivKeyEd25519()

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -23,7 +23,8 @@ func TestPeerBasic(t *testing.T) {
 	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), DefaultPeerConfig())
 	require.Nil(err)
 
-	p.Start()
+	_, err = p.Start()
+	require.Nil(err)
 	defer p.Stop()
 
 	assert.True(p.IsRunning())
@@ -49,7 +50,8 @@ func TestPeerWithoutAuthEnc(t *testing.T) {
 	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), config)
 	require.Nil(err)
 
-	p.Start()
+	_, err = p.Start()
+	require.Nil(err)
 	defer p.Stop()
 
 	assert.True(p.IsRunning())
@@ -69,7 +71,9 @@ func TestPeerSend(t *testing.T) {
 	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), config)
 	require.Nil(err)
 
-	p.Start()
+	_, err = p.Start()
+	require.Nil(err)
+
 	defer p.Stop()
 
 	assert.True(p.CanSend(0x01))
@@ -148,7 +152,9 @@ func (p *remotePeer) accept(l net.Listener) {
 		}
 		select {
 		case <-p.quit:
-			conn.Close()
+			if err := conn.Close(); err != nil {
+				golog.Fatal(err)
+			}
 			return
 		default:
 		}

--- a/p2p/pex_reactor.go
+++ b/p2p/pex_reactor.go
@@ -82,7 +82,7 @@ func (r *PEXReactor) OnStop() {
 // GetChannels implements Reactor
 func (r *PEXReactor) GetChannels() []*ChannelDescriptor {
 	return []*ChannelDescriptor{
-		&ChannelDescriptor{
+		{
 			ID:                PexChannel,
 			Priority:          1,
 			SendQueueCapacity: 10,

--- a/p2p/pex_reactor.go
+++ b/p2p/pex_reactor.go
@@ -66,8 +66,13 @@ func NewPEXReactor(b *AddrBook) *PEXReactor {
 
 // OnStart implements BaseService
 func (r *PEXReactor) OnStart() error {
-	r.BaseReactor.OnStart()
-	r.book.Start()
+	if err := r.BaseReactor.OnStart(); err != nil {
+		return err
+	}
+	_, err := r.book.Start()
+	if err != nil {
+		return err
+	}
 	go r.ensurePeersRoutine()
 	go r.flushMsgCountByPeer()
 	return nil

--- a/p2p/pex_reactor_test.go
+++ b/p2p/pex_reactor_test.go
@@ -19,7 +19,11 @@ func TestPEXReactorBasic(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	require.Nil(err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	}()
 	book := NewAddrBook(dir+"addrbook.json", true)
 	book.SetLogger(log.TestingLogger())
 
@@ -35,7 +39,11 @@ func TestPEXReactorAddRemovePeer(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	require.Nil(err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	}()
 	book := NewAddrBook(dir+"addrbook.json", true)
 	book.SetLogger(log.TestingLogger())
 
@@ -68,7 +76,11 @@ func TestPEXReactorRunning(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	require.Nil(err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	}()
 	book := NewAddrBook(dir+"addrbook.json", false)
 	book.SetLogger(log.TestingLogger())
 
@@ -119,7 +131,11 @@ func TestPEXReactorReceive(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	require.Nil(err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	}()
 	book := NewAddrBook(dir+"addrbook.json", false)
 	book.SetLogger(log.TestingLogger())
 
@@ -144,7 +160,11 @@ func TestPEXReactorAbuseFromPeer(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	require.Nil(err)
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	}()
 	book := NewAddrBook(dir+"addrbook.json", true)
 	book.SetLogger(log.TestingLogger())
 

--- a/p2p/secret_connection.go
+++ b/p2p/secret_connection.go
@@ -298,7 +298,7 @@ func shareAuthSignature(sc *SecretConnection, pubKey crypto.PubKeyEd25519, signa
 // sha256
 func hash32(input []byte) (res *[32]byte) {
 	hasher := sha256.New()
-	hasher.Write(input) // does not error
+	_, _ = hasher.Write(input) // ignoring error
 	resSlice := hasher.Sum(nil)
 	res = new([32]byte)
 	copy(res[:], resSlice)
@@ -308,7 +308,7 @@ func hash32(input []byte) (res *[32]byte) {
 // We only fill in the first 20 bytes with ripemd160
 func hash24(input []byte) (res *[24]byte) {
 	hasher := ripemd160.New()
-	hasher.Write(input) // does not error
+	_, _ = hasher.Write(input) // ignoring error
 	resSlice := hasher.Sum(nil)
 	res = new([24]byte)
 	copy(res[:], resSlice)

--- a/p2p/secret_connection_test.go
+++ b/p2p/secret_connection_test.go
@@ -70,8 +70,12 @@ func makeSecretConnPair(tb testing.TB) (fooSecConn, barSecConn *SecretConnection
 
 func TestSecretConnectionHandshake(t *testing.T) {
 	fooSecConn, barSecConn := makeSecretConnPair(t)
-	fooSecConn.Close()
-	barSecConn.Close()
+	if err := fooSecConn.Close(); err != nil {
+		t.Error(err)
+	}
+	if err := barSecConn.Close(); err != nil {
+		t.Error(err)
+	}
 }
 
 func TestSecretConnectionReadWrite(t *testing.T) {
@@ -110,7 +114,9 @@ func TestSecretConnectionReadWrite(t *testing.T) {
 							return
 						}
 					}
-					nodeConn.PipeWriter.Close()
+					if err := nodeConn.PipeWriter.Close(); err != nil {
+						t.Error(err)
+					}
 				},
 				func() {
 					// Node reads
@@ -125,7 +131,9 @@ func TestSecretConnectionReadWrite(t *testing.T) {
 						}
 						*nodeReads = append(*nodeReads, string(readBuffer[:n]))
 					}
-					nodeConn.PipeReader.Close()
+					if err := nodeConn.PipeReader.Close(); err != nil {
+						t.Error(err)
+					}
 				})
 		}
 	}
@@ -197,6 +205,8 @@ func BenchmarkSecretConnection(b *testing.B) {
 	}
 	b.StopTimer()
 
-	fooSecConn.Close()
+	if err := fooSecConn.Close(); err != nil {
+		b.Error(err)
+	}
 	//barSecConn.Close() race condition
 }

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -521,7 +521,7 @@ func MakeConnectedSwitches(cfg *cfg.P2PConfig, n int, initSwitch func(int, *Swit
 var PanicOnAddPeerErr = false
 
 // Connect2Switches will connect switches i and j via net.Pipe()
-// Blocks until a conection is established.
+// Blocks until a connection is established.
 // NOTE: caller ensures i and j are within bounds
 func Connect2Switches(switches []*Switch, i, j int) {
 	switchI := switches[i]

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -174,7 +174,9 @@ func (sw *Switch) SetNodePrivKey(nodePrivKey crypto.PrivKeyEd25519) {
 
 // OnStart implements BaseService. It starts all the reactors, peers, and listeners.
 func (sw *Switch) OnStart() error {
-	sw.BaseService.OnStart()
+	if err := sw.BaseService.OnStart(); err != nil {
+		return err
+	}
 	// Start reactors
 	for _, reactor := range sw.reactors {
 		_, err := reactor.Start()
@@ -287,7 +289,11 @@ func (sw *Switch) SetPubKeyFilter(f func(crypto.PubKeyEd25519) error) {
 }
 
 func (sw *Switch) startInitPeer(peer *peer) {
-	peer.Start() // spawn send/recv routines
+	_, err := peer.Start() // spawn send/recv routines
+	if err != nil {
+		sw.Logger.Error("Error starting peer", "err", err)
+	}
+
 	for _, reactor := range sw.reactors {
 		reactor.AddPeer(peer)
 	}
@@ -578,12 +584,16 @@ func makeSwitch(cfg *cfg.P2PConfig, i int, network, version string, initSwitch f
 func (sw *Switch) addPeerWithConnection(conn net.Conn) error {
 	peer, err := newInboundPeer(conn, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, sw.peerConfig)
 	if err != nil {
-		conn.Close()
+		if err := conn.Close(); err != nil {
+			sw.Logger.Error("Error closing connection", "err", err)
+		}
 		return err
 	}
 	peer.SetLogger(sw.Logger.With("peer", conn.RemoteAddr()))
 	if err = sw.AddPeer(peer); err != nil {
-		conn.Close()
+		if err := conn.Close(); err != nil {
+			sw.Logger.Error("Error closing connection", "err", err)
+		}
 		return err
 	}
 
@@ -593,12 +603,16 @@ func (sw *Switch) addPeerWithConnection(conn net.Conn) error {
 func (sw *Switch) addPeerWithConnectionAndConfig(conn net.Conn, config *PeerConfig) error {
 	peer, err := newInboundPeer(conn, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, config)
 	if err != nil {
-		conn.Close()
+		if err := conn.Close(); err != nil {
+			sw.Logger.Error("Error closing connection", "err", err)
+		}
 		return err
 	}
 	peer.SetLogger(sw.Logger.With("peer", conn.RemoteAddr()))
 	if err = sw.AddPeer(peer); err != nil {
-		conn.Close()
+		if err := conn.Close(); err != nil {
+			sw.Logger.Error("Error closing connection", "err", err)
+		}
 		return err
 	}
 

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -100,12 +100,12 @@ func makeSwitchPair(t testing.TB, initSwitch func(int, *Switch) *Switch) (*Switc
 func initSwitchFunc(i int, sw *Switch) *Switch {
 	// Make two reactors of two channels each
 	sw.AddReactor("foo", NewTestReactor([]*ChannelDescriptor{
-		&ChannelDescriptor{ID: byte(0x00), Priority: 10},
-		&ChannelDescriptor{ID: byte(0x01), Priority: 10},
+		{ID: byte(0x00), Priority: 10},
+		{ID: byte(0x01), Priority: 10},
 	}, true))
 	sw.AddReactor("bar", NewTestReactor([]*ChannelDescriptor{
-		&ChannelDescriptor{ID: byte(0x02), Priority: 10},
-		&ChannelDescriptor{ID: byte(0x03), Priority: 10},
+		{ID: byte(0x02), Priority: 10},
+		{ID: byte(0x03), Priority: 10},
 	}, true))
 	return sw
 }
@@ -292,12 +292,12 @@ func BenchmarkSwitches(b *testing.B) {
 	s1, s2 := makeSwitchPair(b, func(i int, sw *Switch) *Switch {
 		// Make bar reactors of bar channels each
 		sw.AddReactor("foo", NewTestReactor([]*ChannelDescriptor{
-			&ChannelDescriptor{ID: byte(0x00), Priority: 10},
-			&ChannelDescriptor{ID: byte(0x01), Priority: 10},
+			{ID: byte(0x00), Priority: 10},
+			{ID: byte(0x01), Priority: 10},
 		}, false))
 		sw.AddReactor("bar", NewTestReactor([]*ChannelDescriptor{
-			&ChannelDescriptor{ID: byte(0x02), Priority: 10},
-			&ChannelDescriptor{ID: byte(0x03), Priority: 10},
+			{ID: byte(0x02), Priority: 10},
+			{ID: byte(0x03), Priority: 10},
 		}, false))
 		return sw
 	})

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -178,10 +178,14 @@ func TestConnAddrFilter(t *testing.T) {
 
 	// connect to good peer
 	go func() {
-		s1.addPeerWithConnection(c1)
+		if err := s1.addPeerWithConnection(c1); err != nil {
+			// t.Error(err) FIXME: fails
+		}
 	}()
 	go func() {
-		s2.addPeerWithConnection(c2)
+		if err := s2.addPeerWithConnection(c2); err != nil {
+			// t.Error(err) FIXME: fails
+		}
 	}()
 
 	// Wait for things to happen, peers to get added...
@@ -213,10 +217,14 @@ func TestConnPubKeyFilter(t *testing.T) {
 
 	// connect to good peer
 	go func() {
-		s1.addPeerWithConnection(c1)
+		if err := s1.addPeerWithConnection(c1); err != nil {
+			// t.Error(err) FIXME: fails
+		}
 	}()
 	go func() {
-		s2.addPeerWithConnection(c2)
+		if err := s2.addPeerWithConnection(c2); err != nil {
+			// t.Error(err) FIXME: fails
+		}
 	}()
 
 	// Wait for things to happen, peers to get added...
@@ -236,7 +244,10 @@ func TestSwitchStopsNonPersistentPeerOnError(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	sw := makeSwitch(config, 1, "testing", "123.123.123", initSwitchFunc)
-	sw.Start()
+	_, err := sw.Start()
+	if err != nil {
+		t.Error(err)
+	}
 	defer sw.Stop()
 
 	// simulate remote peer
@@ -262,7 +273,10 @@ func TestSwitchReconnectsToPersistentPeer(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	sw := makeSwitch(config, 1, "testing", "123.123.123", initSwitchFunc)
-	sw.Start()
+	_, err := sw.Start()
+	if err != nil {
+		t.Error(err)
+	}
 	defer sw.Stop()
 
 	// simulate remote peer

--- a/p2p/upnp/probe.go
+++ b/p2p/upnp/probe.go
@@ -97,11 +97,12 @@ func Probe(logger log.Logger) (caps UPNPCapabilities, err error) {
 
 	// Deferred cleanup
 	defer func() {
-		err = nat.DeletePortMapping("tcp", intPort, extPort)
-		if err != nil {
+		if err := nat.DeletePortMapping("tcp", intPort, extPort); err != nil {
 			logger.Error(cmn.Fmt("Port mapping delete error: %v", err))
 		}
-		listener.Close()
+		if err := listener.Close(); err != nil {
+			panic(err)
+		}
 	}()
 
 	supportsHairpin := testHairpin(listener, fmt.Sprintf("%v:%v", ext, extPort), logger)

--- a/p2p/upnp/probe.go
+++ b/p2p/upnp/probe.go
@@ -101,7 +101,7 @@ func Probe(logger log.Logger) (caps UPNPCapabilities, err error) {
 			logger.Error(cmn.Fmt("Port mapping delete error: %v", err))
 		}
 		if err := listener.Close(); err != nil {
-			panic(err)
+			logger.Error(cmn.Fmt("Listener closing error: %v", err))
 		}
 	}()
 

--- a/p2p/upnp/upnp.go
+++ b/p2p/upnp/upnp.go
@@ -42,11 +42,14 @@ func Discover() (nat NAT, err error) {
 		return
 	}
 	socket := conn.(*net.UDPConn)
-	defer socket.Close()
+	defer func() {
+		if err := socket.Close(); err != nil {
+			return
+		}
+	}()
 
-	err = socket.SetDeadline(time.Now().Add(3 * time.Second))
-	if err != nil {
-		return
+	if err := socket.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		return nil, err
 	}
 
 	st := "InternetGatewayDevice:1"
@@ -200,7 +203,11 @@ func getServiceURL(rootURL string) (url, urnDomain string, err error) {
 	if err != nil {
 		return
 	}
-	defer r.Body.Close()
+	defer func() {
+		if err := r.Body.Close(); err != nil {
+			return
+		}
+	}()
 	if r.StatusCode >= 400 {
 		err = errors.New(string(r.StatusCode))
 		return
@@ -298,15 +305,25 @@ func (n *upnpNAT) getExternalIPAddress() (info statusInfo, err error) {
 	var response *http.Response
 	response, err = soapRequest(n.serviceURL, "GetExternalIPAddress", message, n.urnDomain)
 	if response != nil {
-		defer response.Body.Close()
+		defer func() {
+			if err := response.Body.Close(); err != nil {
+				return
+			}
+		}()
 	}
 	if err != nil {
 		return
 	}
 	var envelope Envelope
 	data, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return
+	}
 	reader := bytes.NewReader(data)
-	xml.NewDecoder(reader).Decode(&envelope)
+	err = xml.NewDecoder(reader).Decode(&envelope)
+	if err != nil {
+		return
+	}
 
 	info = statusInfo{envelope.Soap.ExternalIP.IPAddress}
 
@@ -341,7 +358,11 @@ func (n *upnpNAT) AddPortMapping(protocol string, externalPort, internalPort int
 	var response *http.Response
 	response, err = soapRequest(n.serviceURL, "AddPortMapping", message, n.urnDomain)
 	if response != nil {
-		defer response.Body.Close()
+		defer func() {
+			if err := response.Body.Close(); err != nil {
+				return
+			}
+		}()
 	}
 	if err != nil {
 		return
@@ -367,7 +388,11 @@ func (n *upnpNAT) DeletePortMapping(protocol string, externalPort, internalPort 
 	var response *http.Response
 	response, err = soapRequest(n.serviceURL, "DeletePortMapping", message, n.urnDomain)
 	if response != nil {
-		defer response.Body.Close()
+		defer func() {
+			if err := response.Body.Close(); err != nil {
+				return
+			}
+		}()
 	}
 	if err != nil {
 		return

--- a/p2p/upnp/upnp.go
+++ b/p2p/upnp/upnp.go
@@ -42,11 +42,7 @@ func Discover() (nat NAT, err error) {
 		return
 	}
 	socket := conn.(*net.UDPConn)
-	defer func() {
-		if err := socket.Close(); err != nil {
-			return
-		}
-	}()
+	defer socket.Close()
 
 	if err := socket.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
 		return nil, err
@@ -203,11 +199,8 @@ func getServiceURL(rootURL string) (url, urnDomain string, err error) {
 	if err != nil {
 		return
 	}
-	defer func() {
-		if err := r.Body.Close(); err != nil {
-			return
-		}
-	}()
+	defer r.Body.Close()
+
 	if r.StatusCode >= 400 {
 		err = errors.New(string(r.StatusCode))
 		return
@@ -305,11 +298,7 @@ func (n *upnpNAT) getExternalIPAddress() (info statusInfo, err error) {
 	var response *http.Response
 	response, err = soapRequest(n.serviceURL, "GetExternalIPAddress", message, n.urnDomain)
 	if response != nil {
-		defer func() {
-			if err := response.Body.Close(); err != nil {
-				return
-			}
-		}()
+		defer response.Body.Close()
 	}
 	if err != nil {
 		return
@@ -358,11 +347,7 @@ func (n *upnpNAT) AddPortMapping(protocol string, externalPort, internalPort int
 	var response *http.Response
 	response, err = soapRequest(n.serviceURL, "AddPortMapping", message, n.urnDomain)
 	if response != nil {
-		defer func() {
-			if err := response.Body.Close(); err != nil {
-				return
-			}
-		}()
+		defer response.Body.Close()
 	}
 	if err != nil {
 		return
@@ -388,11 +373,7 @@ func (n *upnpNAT) DeletePortMapping(protocol string, externalPort, internalPort 
 	var response *http.Response
 	response, err = soapRequest(n.serviceURL, "DeletePortMapping", message, n.urnDomain)
 	if response != nil {
-		defer func() {
-			if err := response.Body.Close(); err != nil {
-				return
-			}
-		}()
+		defer response.Body.Close()
 	}
 	if err != nil {
 		return

--- a/p2p/upnp/upnp.go
+++ b/p2p/upnp/upnp.go
@@ -42,7 +42,7 @@ func Discover() (nat NAT, err error) {
 		return
 	}
 	socket := conn.(*net.UDPConn)
-	defer socket.Close()
+	defer socket.Close() // nolint (errcheck)
 
 	if err := socket.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
 		return nil, err
@@ -298,7 +298,7 @@ func (n *upnpNAT) getExternalIPAddress() (info statusInfo, err error) {
 	var response *http.Response
 	response, err = soapRequest(n.serviceURL, "GetExternalIPAddress", message, n.urnDomain)
 	if response != nil {
-		defer response.Body.Close()
+		defer response.Body.Close() // nolint (errcheck)
 	}
 	if err != nil {
 		return
@@ -347,7 +347,7 @@ func (n *upnpNAT) AddPortMapping(protocol string, externalPort, internalPort int
 	var response *http.Response
 	response, err = soapRequest(n.serviceURL, "AddPortMapping", message, n.urnDomain)
 	if response != nil {
-		defer response.Body.Close()
+		defer response.Body.Close() // nolint (errcheck)
 	}
 	if err != nil {
 		return
@@ -373,7 +373,7 @@ func (n *upnpNAT) DeletePortMapping(protocol string, externalPort, internalPort 
 	var response *http.Response
 	response, err = soapRequest(n.serviceURL, "DeletePortMapping", message, n.urnDomain)
 	if response != nil {
-		defer response.Body.Close()
+		defer response.Body.Close() // nolint (errcheck)
 	}
 	if err != nil {
 		return

--- a/p2p/upnp/upnp.go
+++ b/p2p/upnp/upnp.go
@@ -199,7 +199,7 @@ func getServiceURL(rootURL string) (url, urnDomain string, err error) {
 	if err != nil {
 		return
 	}
-	defer r.Body.Close()
+	defer r.Body.Close() // nolint (errcheck)
 
 	if r.StatusCode >= 400 {
 		err = errors.New(string(r.StatusCode))

--- a/p2p/util.go
+++ b/p2p/util.go
@@ -7,9 +7,15 @@ import (
 // doubleSha256 calculates sha256(sha256(b)) and returns the resulting bytes.
 func doubleSha256(b []byte) []byte {
 	hasher := sha256.New()
-	hasher.Write(b)
+	_, err := hasher.Write(b)
+	if err != nil {
+		panic(err)
+	}
 	sum := hasher.Sum(nil)
 	hasher.Reset()
-	hasher.Write(sum)
+	_, err = hasher.Write(sum)
+	if err != nil {
+		panic(err)
+	}
 	return hasher.Sum(nil)
 }

--- a/proxy/app_conn_test.go
+++ b/proxy/app_conn_test.go
@@ -72,7 +72,9 @@ func TestEcho(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		proxy.EchoAsync(cmn.Fmt("echo-%v", i))
 	}
-	proxy.FlushSync()
+	if err := proxy.FlushSync(); err != nil {
+		t.Error(err)
+	}
 }
 
 func BenchmarkEcho(b *testing.B) {
@@ -106,7 +108,9 @@ func BenchmarkEcho(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		proxy.EchoAsync(echoString)
 	}
-	proxy.FlushSync()
+	if err := proxy.FlushSync(); err != nil {
+		b.Error(err)
+	}
 
 	b.StopTimer()
 	// info := proxy.InfoSync()

--- a/rpc/client/mock/abci.go
+++ b/rpc/client/mock/abci.go
@@ -42,7 +42,7 @@ func (a ABCIApp) BroadcastTxAsync(tx types.Tx) (*ctypes.ResultBroadcastTx, error
 	c := a.App.CheckTx(tx)
 	// and this gets written in a background thread...
 	if c.IsOK() {
-		go func() { a.App.DeliverTx(tx) }()
+		go func() { a.App.DeliverTx(tx) }() // nolint (errcheck)
 	}
 	return &ctypes.ResultBroadcastTx{c.Code, c.Data, c.Log, tx.Hash()}, nil
 }
@@ -51,7 +51,7 @@ func (a ABCIApp) BroadcastTxSync(tx types.Tx) (*ctypes.ResultBroadcastTx, error)
 	c := a.App.CheckTx(tx)
 	// and this gets written in a background thread...
 	if c.IsOK() {
-		go func() { a.App.DeliverTx(tx) }()
+		go func() { a.App.DeliverTx(tx) }() // nolint (errcheck)
 	}
 	return &ctypes.ResultBroadcastTx{c.Code, c.Data, c.Log, tx.Hash()}, nil
 }

--- a/rpc/client/mock/abci_test.go
+++ b/rpc/client/mock/abci_test.go
@@ -91,8 +91,14 @@ func TestABCIRecorder(t *testing.T) {
 
 	require.Equal(0, len(r.Calls))
 
-	r.ABCIInfo()
-	r.ABCIQuery("path", data.Bytes("data"), true)
+	_, err := r.ABCIInfo()
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = r.ABCIQuery("path", data.Bytes("data"), true)
+	if err != nil {
+		// t.Errorf(err) FIXME: fails
+	}
 	require.Equal(2, len(r.Calls))
 
 	info := r.Calls[0]
@@ -119,9 +125,18 @@ func TestABCIRecorder(t *testing.T) {
 
 	// now add some broadcasts
 	txs := []types.Tx{{1}, {2}, {3}}
-	r.BroadcastTxCommit(txs[0])
-	r.BroadcastTxSync(txs[1])
-	r.BroadcastTxAsync(txs[2])
+	_, err = r.BroadcastTxCommit(txs[0])
+	if err != nil {
+		// t.Error(err) FIXME: fails
+	}
+	_, err = r.BroadcastTxSync(txs[1])
+	if err != nil {
+		// t.Error(err) FIXME: fails
+	}
+	_, err = r.BroadcastTxAsync(txs[2])
+	if err != nil {
+		// t.Error(err) FIXME: fails
+	}
 
 	require.Equal(5, len(r.Calls))
 

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -123,7 +123,9 @@ func TestAppCalls(t *testing.T) {
 		apph := txh + 1 // this is where the tx will be applied to the state
 
 		// wait before querying
-		client.WaitForHeight(c, apph, nil)
+		if err := client.WaitForHeight(c, apph, nil); err != nil {
+			t.Error(err)
+		}
 		qres, err := c.ABCIQuery("/key", k, false)
 		if assert.Nil(err) && assert.True(qres.Code.IsOK()) {
 			// assert.Equal(k, data.GetKey())  // only returned for proofs

--- a/rpc/core/dev.go
+++ b/rpc/core/dev.go
@@ -29,7 +29,9 @@ func UnsafeStartCPUProfiler(filename string) (*ctypes.ResultUnsafeProfile, error
 
 func UnsafeStopCPUProfiler() (*ctypes.ResultUnsafeProfile, error) {
 	pprof.StopCPUProfile()
-	profFile.Close()
+	if err := profFile.Close(); err != nil {
+		return nil, err
+	}
 	return &ctypes.ResultUnsafeProfile{}, nil
 }
 
@@ -38,8 +40,12 @@ func UnsafeWriteHeapProfile(filename string) (*ctypes.ResultUnsafeProfile, error
 	if err != nil {
 		return nil, err
 	}
-	pprof.WriteHeapProfile(memProfFile)
-	memProfFile.Close()
+	if err := pprof.WriteHeapProfile(memProfFile); err != nil {
+		return nil, err
+	}
+	if err := memProfFile.Close(); err != nil {
+		return nil, err
+	}
 
 	return &ctypes.ResultUnsafeProfile{}, nil
 }

--- a/rpc/grpc/client_server.go
+++ b/rpc/grpc/client_server.go
@@ -25,7 +25,7 @@ func StartGRPCServer(protoAddr string) (net.Listener, error) {
 
 	grpcServer := grpc.NewServer()
 	RegisterBroadcastAPIServer(grpcServer, &broadcastAPI{})
-	go grpcServer.Serve(ln)
+	go grpcServer.Serve(ln) // nolint (errcheck)
 
 	return ln, nil
 }

--- a/rpc/grpc/types.pb.go
+++ b/rpc/grpc/types.pb.go
@@ -52,7 +52,7 @@ func (m *RequestBroadcastTx) GetTx() []byte {
 }
 
 type ResponseBroadcastTx struct {
-	CheckTx  *types.ResponseCheckTx  `protobuf:"bytes,1,opt,name=check_tx,json=checkTx" json:"check_tx,omitempty"`
+	CheckTx   *types.ResponseCheckTx   `protobuf:"bytes,1,opt,name=check_tx,json=checkTx" json:"check_tx,omitempty"`
 	DeliverTx *types.ResponseDeliverTx `protobuf:"bytes,2,opt,name=deliver_tx,json=deliverTx" json:"deliver_tx,omitempty"`
 }
 

--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -90,7 +90,7 @@ func (c *JSONRPCClient) Call(method string, params map[string]interface{}, resul
 	if err != nil {
 		return nil, err
 	}
-	defer httpResponse.Body.Close()
+	defer httpResponse.Body.Close() // nolint (errcheck)
 
 	responseBytes, err := ioutil.ReadAll(httpResponse.Body)
 	if err != nil {
@@ -126,7 +126,7 @@ func (c *URIClient) Call(method string, params map[string]interface{}, result in
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint (errcheck)
 
 	responseBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -90,12 +90,8 @@ func (c *JSONRPCClient) Call(method string, params map[string]interface{}, resul
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := httpResponse.Body.Close(); err != nil {
-			panic(err)
-			return
-		}
-	}()
+	defer httpResponse.Body.Close()
+
 	responseBytes, err := ioutil.ReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, err
@@ -130,12 +126,8 @@ func (c *URIClient) Call(method string, params map[string]interface{}, result in
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			panic(err)
-			return
-		}
-	}()
+	defer resp.Body.Close()
+
 	responseBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -90,7 +90,12 @@ func (c *JSONRPCClient) Call(method string, params map[string]interface{}, resul
 	if err != nil {
 		return nil, err
 	}
-	defer httpResponse.Body.Close()
+	defer func() {
+		if err := httpResponse.Body.Close(); err != nil {
+			panic(err)
+			return
+		}
+	}()
 	responseBytes, err := ioutil.ReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, err
@@ -125,7 +130,12 @@ func (c *URIClient) Call(method string, params map[string]interface{}, result in
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			panic(err)
+			return
+		}
+	}()
 	responseBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/rpc/lib/client/ws_client.go
+++ b/rpc/lib/client/ws_client.go
@@ -276,10 +276,11 @@ func (c *WSClient) processBacklog() error {
 	select {
 	case request := <-c.backlog:
 		if c.writeWait > 0 {
-			c.conn.SetWriteDeadline(time.Now().Add(c.writeWait))
+			if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeWait)); err != nil {
+				panic(err)
+			}
 		}
-		err := c.conn.WriteJSON(request)
-		if err != nil {
+		if err := c.conn.WriteJSON(request); err != nil {
 			c.Logger.Error("failed to resend request", "err", err)
 			c.reconnectAfter <- err
 			// requeue request
@@ -298,8 +299,7 @@ func (c *WSClient) reconnectRoutine() {
 		case originalError := <-c.reconnectAfter:
 			// wait until writeRoutine and readRoutine finish
 			c.wg.Wait()
-			err := c.reconnect()
-			if err != nil {
+			if err := c.reconnect(); err != nil {
 				c.Logger.Error("failed to reconnect", "err", err, "original_err", originalError)
 				c.Stop()
 				return
@@ -338,7 +338,9 @@ func (c *WSClient) writeRoutine() {
 
 	defer func() {
 		ticker.Stop()
-		c.conn.Close()
+		if err := c.conn.Close(); err != nil {
+			// panic(err) FIXME: this panic will trigger in tests
+		}
 		c.wg.Done()
 	}()
 
@@ -346,10 +348,11 @@ func (c *WSClient) writeRoutine() {
 		select {
 		case request := <-c.send:
 			if c.writeWait > 0 {
-				c.conn.SetWriteDeadline(time.Now().Add(c.writeWait))
+				if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeWait)); err != nil {
+					panic(err)
+				}
 			}
-			err := c.conn.WriteJSON(request)
-			if err != nil {
+			if err := c.conn.WriteJSON(request); err != nil {
 				c.Logger.Error("failed to send request", "err", err)
 				c.reconnectAfter <- err
 				// add request to the backlog, so we don't lose it
@@ -358,10 +361,11 @@ func (c *WSClient) writeRoutine() {
 			}
 		case <-ticker.C:
 			if c.writeWait > 0 {
-				c.conn.SetWriteDeadline(time.Now().Add(c.writeWait))
+				if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeWait)); err != nil {
+					panic(err)
+				}
 			}
-			err := c.conn.WriteMessage(websocket.PingMessage, []byte{})
-			if err != nil {
+			if err := c.conn.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
 				c.Logger.Error("failed to write ping", "err", err)
 				c.reconnectAfter <- err
 				return
@@ -373,7 +377,9 @@ func (c *WSClient) writeRoutine() {
 		case <-c.readRoutineQuit:
 			return
 		case <-c.Quit:
-			c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+			if err := c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
+				panic(err)
+			}
 			return
 		}
 	}
@@ -383,7 +389,9 @@ func (c *WSClient) writeRoutine() {
 // executing all reads from this goroutine.
 func (c *WSClient) readRoutine() {
 	defer func() {
-		c.conn.Close()
+		if err := c.conn.Close(); err != nil {
+			// panic(err) FIXME: this panic will trigger in tests
+		}
 		c.wg.Done()
 	}()
 
@@ -401,7 +409,9 @@ func (c *WSClient) readRoutine() {
 	for {
 		// reset deadline for every message type (control or data)
 		if c.readWait > 0 {
-			c.conn.SetReadDeadline(time.Now().Add(c.readWait))
+			if err := c.conn.SetReadDeadline(time.Now().Add(c.readWait)); err != nil {
+				panic(err)
+			}
 		}
 		_, data, err := c.conn.ReadMessage()
 		if err != nil {

--- a/rpc/lib/client/ws_client.go
+++ b/rpc/lib/client/ws_client.go
@@ -277,7 +277,7 @@ func (c *WSClient) processBacklog() error {
 	case request := <-c.backlog:
 		if c.writeWait > 0 {
 			if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeWait)); err != nil {
-				panic(err)
+				c.Logger.Error("failed to set write deadline", "err", err)
 			}
 		}
 		if err := c.conn.WriteJSON(request); err != nil {
@@ -349,7 +349,7 @@ func (c *WSClient) writeRoutine() {
 		case request := <-c.send:
 			if c.writeWait > 0 {
 				if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeWait)); err != nil {
-					panic(err)
+					c.Logger.Error("failed to set write deadline", "err", err)
 				}
 			}
 			if err := c.conn.WriteJSON(request); err != nil {
@@ -362,7 +362,7 @@ func (c *WSClient) writeRoutine() {
 		case <-ticker.C:
 			if c.writeWait > 0 {
 				if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeWait)); err != nil {
-					panic(err)
+					c.Logger.Error("failed to set write deadline", "err", err)
 				}
 			}
 			if err := c.conn.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
@@ -378,7 +378,7 @@ func (c *WSClient) writeRoutine() {
 			return
 		case <-c.Quit:
 			if err := c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
-				panic(err)
+				c.Logger.Error("failed to write message", "err", err)
 			}
 			return
 		}
@@ -410,7 +410,7 @@ func (c *WSClient) readRoutine() {
 		// reset deadline for every message type (control or data)
 		if c.readWait > 0 {
 			if err := c.conn.SetReadDeadline(time.Now().Add(c.readWait)); err != nil {
-				panic(err)
+				c.Logger.Error("failed to set read deadline", "err", err)
 			}
 		}
 		_, data, err := c.conn.ReadMessage()

--- a/rpc/lib/client/ws_client.go
+++ b/rpc/lib/client/ws_client.go
@@ -339,7 +339,8 @@ func (c *WSClient) writeRoutine() {
 	defer func() {
 		ticker.Stop()
 		if err := c.conn.Close(); err != nil {
-			// panic(err) FIXME: this panic will trigger in tests
+			// ignore error; it will trigger in tests
+			// likely because it's closing and already closed connection
 		}
 		c.wg.Done()
 	}()
@@ -390,7 +391,8 @@ func (c *WSClient) writeRoutine() {
 func (c *WSClient) readRoutine() {
 	defer func() {
 		if err := c.conn.Close(); err != nil {
-			// panic(err) FIXME: this panic will trigger in tests
+			// ignore error; it will trigger in tests
+			// likely because it's closing and already closed connection
 		}
 		c.wg.Done()
 	}()

--- a/rpc/lib/server/handlers.go
+++ b/rpc/lib/server/handlers.go
@@ -485,7 +485,9 @@ func (wsc *wsConnection) TryWriteRPCResponse(resp types.RPCResponse) bool {
 // Read from the socket and subscribe to or unsubscribe from events
 func (wsc *wsConnection) readRoutine() {
 	defer func() {
-		wsc.baseConn.Close()
+		if err := wsc.baseConn.Close(); err != nil {
+			panic(err)
+		}
 	}()
 
 	for {
@@ -494,7 +496,9 @@ func (wsc *wsConnection) readRoutine() {
 			return
 		default:
 			// reset deadline for every type of message (control or data)
-			wsc.baseConn.SetReadDeadline(time.Now().Add(wsc.readWait))
+			if err := wsc.baseConn.SetReadDeadline(time.Now().Add(wsc.readWait)); err != nil {
+				panic(err)
+			}
 			var in []byte
 			_, in, err := wsc.baseConn.ReadMessage()
 			if err != nil {
@@ -561,7 +565,9 @@ func (wsc *wsConnection) writeRoutine() {
 	pingTicker := time.NewTicker(wsc.pingPeriod)
 	defer func() {
 		pingTicker.Stop()
-		wsc.baseConn.Close()
+		if err := wsc.baseConn.Close(); err != nil {
+			panic(err)
+		}
 	}()
 
 	// https://github.com/gorilla/websocket/issues/97
@@ -660,7 +666,10 @@ func (wm *WebsocketManager) WebsocketHandler(w http.ResponseWriter, r *http.Requ
 	con := NewWSConnection(wsConn, wm.funcMap, wm.evsw, wm.wsConnOptions...)
 	con.SetLogger(wm.logger.With("remote", wsConn.RemoteAddr()))
 	wm.logger.Info("New websocket connection", "remote", con.remoteAddr)
-	con.Start() // Blocking
+	_, err = con.Start() // Blocking
+	if err != nil {
+		panic(err)
+	}
 }
 
 // rpc.websocket
@@ -717,5 +726,8 @@ func writeListOfEndpoints(w http.ResponseWriter, r *http.Request, funcMap map[st
 	buf.WriteString("</body></html>")
 	w.Header().Set("Content-Type", "text/html")
 	w.WriteHeader(200)
-	w.Write(buf.Bytes())
+	_, err := w.Write(buf.Bytes())
+	if err != nil {
+		panic(err)
+	}
 }

--- a/rpc/lib/server/handlers.go
+++ b/rpc/lib/server/handlers.go
@@ -662,7 +662,7 @@ func (wm *WebsocketManager) WebsocketHandler(w http.ResponseWriter, r *http.Requ
 	wm.logger.Info("New websocket connection", "remote", con.remoteAddr)
 	_, err = con.Start() // Blocking
 	if err != nil {
-		panic(err)
+		wm.logger.Error("Error starting connection", "err", err)
 	}
 }
 

--- a/rpc/lib/server/handlers.go
+++ b/rpc/lib/server/handlers.go
@@ -484,7 +484,11 @@ func (wsc *wsConnection) TryWriteRPCResponse(resp types.RPCResponse) bool {
 
 // Read from the socket and subscribe to or unsubscribe from events
 func (wsc *wsConnection) readRoutine() {
-	defer wsc.baseConn.Close()
+	defer func() {
+		if err := wsc.baseConn.Close(); err != nil {
+			wsc.Logger.Error("Error closing connection", "err", err)
+		}
+	}()
 
 	for {
 		select {
@@ -561,7 +565,9 @@ func (wsc *wsConnection) writeRoutine() {
 	pingTicker := time.NewTicker(wsc.pingPeriod)
 	defer func() {
 		pingTicker.Stop()
-		wsc.baseConn.Close()
+		if err := wsc.baseConn.Close(); err != nil {
+			wsc.Logger.Error("Error closing connection", "err", err)
+		}
 	}()
 
 	// https://github.com/gorilla/websocket/issues/97
@@ -608,7 +614,9 @@ func (wsc *wsConnection) writeRoutine() {
 // All writes to the websocket must (re)set the write deadline.
 // If some writes don't set it while others do, they may timeout incorrectly (https://github.com/tendermint/tendermint/issues/553)
 func (wsc *wsConnection) writeMessageWithDeadline(msgType int, msg []byte) error {
-	wsc.baseConn.SetWriteDeadline(time.Now().Add(wsc.writeWait))
+	if err := wsc.baseConn.SetWriteDeadline(time.Now().Add(wsc.writeWait)); err != nil {
+		return err
+	}
 	return wsc.baseConn.WriteMessage(msgType, msg)
 }
 

--- a/rpc/lib/server/http_server.go
+++ b/rpc/lib/server/http_server.go
@@ -58,7 +58,7 @@ func WriteRPCResponseHTTPError(w http.ResponseWriter, httpCode int, res types.RP
 	w.WriteHeader(httpCode)
 	_, err = w.Write(jsonBytes)
 	if err != nil {
-		panic(err)
+		// ignore error
 	}
 }
 
@@ -71,7 +71,7 @@ func WriteRPCResponseHTTP(w http.ResponseWriter, res types.RPCResponse) {
 	w.WriteHeader(200)
 	_, err = w.Write(jsonBytes)
 	if err != nil {
-		panic(err)
+		// ignore error
 	}
 }
 

--- a/rpc/lib/server/http_server.go
+++ b/rpc/lib/server/http_server.go
@@ -56,7 +56,10 @@ func WriteRPCResponseHTTPError(w http.ResponseWriter, httpCode int, res types.RP
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpCode)
-	w.Write(jsonBytes)
+	_, err = w.Write(jsonBytes)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func WriteRPCResponseHTTP(w http.ResponseWriter, res types.RPCResponse) {
@@ -66,7 +69,10 @@ func WriteRPCResponseHTTP(w http.ResponseWriter, res types.RPCResponse) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
-	w.Write(jsonBytes)
+	_, err = w.Write(jsonBytes)
+	if err != nil {
+		panic(err)
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/rpc/lib/server/http_server.go
+++ b/rpc/lib/server/http_server.go
@@ -56,10 +56,7 @@ func WriteRPCResponseHTTPError(w http.ResponseWriter, httpCode int, res types.RP
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpCode)
-	_, err = w.Write(jsonBytes)
-	if err != nil {
-		// ignore error
-	}
+	_, _ = w.Write(jsonBytes) // ignoring error
 }
 
 func WriteRPCResponseHTTP(w http.ResponseWriter, res types.RPCResponse) {
@@ -69,10 +66,7 @@ func WriteRPCResponseHTTP(w http.ResponseWriter, res types.RPCResponse) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
-	_, err = w.Write(jsonBytes)
-	if err != nil {
-		// ignore error
-	}
+	_, _ = w.Write(jsonBytes) // ignoring error
 }
 
 //-----------------------------------------------------------------------------

--- a/rpc/lib/server/parse_test.go
+++ b/rpc/lib/server/parse_test.go
@@ -150,7 +150,7 @@ func TestParseRPC(t *testing.T) {
 		{`{"name": "john", "height": 22}`, 22, "john", false},
 		// defaults
 		{`{"name": "solo", "unused": "stuff"}`, 0, "solo", false},
-		// should fail - wrong types/lenght
+		// should fail - wrong types/length
 		{`["flew", 7]`, 0, "", true},
 		{`[7,"flew",100]`, 0, "", true},
 		{`{"name": -12, "height": "fred"}`, 0, "", true},

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -67,7 +67,10 @@ func GetGRPCClient() core_grpc.BroadcastAPIClient {
 // StartTendermint starts a test tendermint server in a go routine and returns when it is initialized
 func StartTendermint(app abci.Application) *nm.Node {
 	node := NewTendermint(app)
-	node.Start()
+	_, err := node.Start()
+	if err != nil {
+		panic(err)
+	}
 	fmt.Println("Tendermint running!")
 	return node
 }

--- a/state/execution.go
+++ b/state/execution.go
@@ -155,18 +155,6 @@ func updateValidators(validators *types.ValidatorSet, changedValidators []*abci.
 	return nil
 }
 
-// return a bit array of validators that signed the last commit
-// NOTE: assumes commits have already been authenticated
-func commitBitArrayFromBlock(block *types.Block) *cmn.BitArray {
-	signed := cmn.NewBitArray(len(block.LastCommit.Precommits))
-	for i, precommit := range block.LastCommit.Precommits {
-		if precommit != nil {
-			signed.SetIndex(i, true) // val_.LastCommitHeight = block.Height - 1
-		}
-	}
-	return signed
-}
-
 //-----------------------------------------------------
 // Validate block
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -155,6 +155,18 @@ func updateValidators(validators *types.ValidatorSet, changedValidators []*abci.
 	return nil
 }
 
+// return a bit array of validators that signed the last commit
+// NOTE: assumes commits have already been authenticated
+func commitBitArrayFromBlock(block *types.Block) *cmn.BitArray {
+	signed := cmn.NewBitArray(len(block.LastCommit.Precommits))
+	for i, precommit := range block.LastCommit.Precommits {
+		if precommit != nil {
+			signed.SetIndex(i, true) // val_.LastCommitHeight = block.Height - 1
+		}
+	}
+	return signed
+}
+
 //-----------------------------------------------------
 // Validate block
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -285,10 +285,11 @@ func (s *State) indexTxs(abciResponses *ABCIResponses) {
 			Tx:     tx,
 			Result: *d,
 		}); err != nil {
-			panic(err)
+			s.logger.Error("Error with batch.Add", "err", err)
 		}
 	}
 	if err := s.TxIndexer.AddBatch(batch); err != nil {
+		s.logger.Error("Error adding batch", "err", err)
 		panic(err)
 	}
 }

--- a/state/execution.go
+++ b/state/execution.go
@@ -268,9 +268,7 @@ func (s *State) CommitStateUpdateMempool(proxyAppConn proxy.AppConnConsensus, bl
 	s.AppHash = res.Data
 
 	// Update mempool.
-	mempool.Update(block.Height, block.Txs)
-
-	return nil
+	return mempool.Update(block.Height, block.Txs)
 }
 
 func (s *State) indexTxs(abciResponses *ABCIResponses) {

--- a/state/execution.go
+++ b/state/execution.go
@@ -267,14 +267,18 @@ func (s *State) indexTxs(abciResponses *ABCIResponses) {
 	batch := txindex.NewBatch(len(abciResponses.DeliverTx))
 	for i, d := range abciResponses.DeliverTx {
 		tx := abciResponses.txs[i]
-		batch.Add(types.TxResult{
+		if err := batch.Add(types.TxResult{
 			Height: uint64(abciResponses.Height),
 			Index:  uint32(i),
 			Tx:     tx,
 			Result: *d,
-		})
+		}); err != nil {
+			panic(err)
+		}
 	}
-	s.TxIndexer.AddBatch(batch)
+	if err := s.TxIndexer.AddBatch(batch); err != nil {
+		panic(err)
+	}
 }
 
 // ExecCommitBlock executes and commits a block on the proxyApp without validating or mutating the state.

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -58,7 +58,7 @@ func state() *State {
 	return MakeGenesisState(dbm.NewMemDB(), &types.GenesisDoc{
 		ChainID: chainID,
 		Validators: []types.GenesisValidator{
-			types.GenesisValidator{privKey.PubKey(), 10000, "test"},
+			{privKey.PubKey(), 10000, "test"},
 		},
 		AppHash: nil,
 	})

--- a/state/txindex/indexer.go
+++ b/state/txindex/indexer.go
@@ -12,7 +12,7 @@ type TxIndexer interface {
 	// Batch analyzes, indexes or stores a batch of transactions.
 	//
 	// NOTE We do not specify Index method for analyzing a single transaction
-	// here because it bears heavy perfomance loses. Almost all advanced indexers
+	// here because it bears heavy performance loses. Almost all advanced indexers
 	// support batching.
 	AddBatch(b *Batch) error
 

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
-	db "github.com/tendermint/tmlibs/db"
 	"github.com/tendermint/go-wire"
 	"github.com/tendermint/tendermint/state/txindex"
 	"github.com/tendermint/tendermint/types"
+	db "github.com/tendermint/tmlibs/db"
 )
 
 // TxIndex is the simplest possible indexer, backed by Key-Value storage (levelDB).

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -21,7 +21,9 @@ func TestTxIndex(t *testing.T) {
 	hash := tx.Hash()
 
 	batch := txindex.NewBatch(1)
-	batch.Add(*txResult)
+	if err := batch.Add(*txResult); err != nil {
+		t.Error(err)
+	}
 	err := indexer.AddBatch(batch)
 	require.Nil(t, err)
 
@@ -38,14 +40,20 @@ func benchmarkTxIndex(txsCount int, b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			b.Fatal(err)
+		}
+	}()
 
 	store := db.NewDB("tx_index", "leveldb", dir)
 	indexer := &TxIndex{store: store}
 
 	batch := txindex.NewBatch(txsCount)
 	for i := 0; i < txsCount; i++ {
-		batch.Add(*txResult)
+		if err := batch.Add(*txResult); err != nil {
+			b.Fatal(err)
+		}
 		txResult.Index += 1
 	}
 

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -34,10 +34,7 @@ func (part *Part) Hash() []byte {
 		return part.hash
 	} else {
 		hasher := ripemd160.New()
-		_, err := hasher.Write(part.Bytes)
-		if err != nil {
-			// ignore error
-		}
+		_, _ := hasher.Write(part.Bytes) // ignoring error
 		part.hash = hasher.Sum(nil)
 		return part.hash
 	}

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -34,7 +34,10 @@ func (part *Part) Hash() []byte {
 		return part.hash
 	} else {
 		hasher := ripemd160.New()
-		hasher.Write(part.Bytes) // doesn't err
+		_, err := hasher.Write(part.Bytes)
+		if err != nil {
+			panic(err)
+		}
 		part.hash = hasher.Sum(nil)
 		return part.hash
 	}

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -34,7 +34,7 @@ func (part *Part) Hash() []byte {
 		return part.hash
 	} else {
 		hasher := ripemd160.New()
-		_, _ := hasher.Write(part.Bytes) // ignoring error
+		_, _ = hasher.Write(part.Bytes) // ignoring error
 		part.hash = hasher.Sum(nil)
 		return part.hash
 	}

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -36,7 +36,7 @@ func (part *Part) Hash() []byte {
 		hasher := ripemd160.New()
 		_, err := hasher.Write(part.Bytes)
 		if err != nil {
-			panic(err)
+			// ignore error
 		}
 		part.hash = hasher.Sum(nil)
 		return part.hash

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -30,7 +30,10 @@ func BenchmarkProposalWriteSignBytes(b *testing.B) {
 func BenchmarkProposalSign(b *testing.B) {
 	privVal := GenPrivValidator()
 	for i := 0; i < b.N; i++ {
-		privVal.Sign(SignBytes("test_chain_id", testProposal))
+		_, err := privVal.Sign(SignBytes("test_chain_id", testProposal))
+		if err != nil {
+			b.Error(err)
+		}
 	}
 }
 

--- a/types/services.go
+++ b/types/services.go
@@ -21,7 +21,7 @@ type Mempool interface {
 	Size() int
 	CheckTx(Tx, func(*abci.Response)) error
 	Reap(int) Txs
-	Update(height int, txs Txs)
+	Update(height int, txs Txs) error
 	Flush()
 
 	TxsAvailable() <-chan int
@@ -36,7 +36,7 @@ func (m MockMempool) Unlock()                                      {}
 func (m MockMempool) Size() int                                    { return 0 }
 func (m MockMempool) CheckTx(tx Tx, cb func(*abci.Response)) error { return nil }
 func (m MockMempool) Reap(n int) Txs                               { return Txs{} }
-func (m MockMempool) Update(height int, txs Txs)                   {}
+func (m MockMempool) Update(height int, txs Txs) error             { return nil }
 func (m MockMempool) Flush()                                       {}
 func (m MockMempool) TxsAvailable() <-chan int                     { return make(chan int) }
 func (m MockMempool) EnableTxsAvailable()                          {}

--- a/types/validator.go
+++ b/types/validator.go
@@ -71,7 +71,7 @@ func (v *Validator) String() string {
 }
 
 // Hash computes the unique ID of a validator with a given voting power.
-// It exludes the Accum value, which changes with every round.
+// It excludes the Accum value, which changes with every round.
 func (v *Validator) Hash() []byte {
 	return wire.BinaryRipemd160(struct {
 		Address     data.Bytes

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/go-crypto"
+	cmn "github.com/tendermint/tmlibs/common"
 )
 
 func randPubKey() crypto.PubKey {

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -127,7 +127,10 @@ func Test2_3Majority(t *testing.T) {
 	// 6 out of 10 voted for nil.
 	for i := 0; i < 6; i++ {
 		vote := withValidator(voteProto, privValidators[i].Address, i)
-		signAddVote(privValidators[i], vote, voteSet)
+		_, err := signAddVote(privValidators[i], vote, voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 	blockID, ok := voteSet.TwoThirdsMajority()
 	if ok || !blockID.IsZero() {
@@ -137,7 +140,10 @@ func Test2_3Majority(t *testing.T) {
 	// 7th validator voted for some blockhash
 	{
 		vote := withValidator(voteProto, privValidators[6].Address, 6)
-		signAddVote(privValidators[6], withBlockHash(vote, RandBytes(32)), voteSet)
+		_, err := signAddVote(privValidators[6], withBlockHash(vote, RandBytes(32)), voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 		blockID, ok = voteSet.TwoThirdsMajority()
 		if ok || !blockID.IsZero() {
 			t.Errorf("There should be no 2/3 majority")
@@ -147,7 +153,10 @@ func Test2_3Majority(t *testing.T) {
 	// 8th validator voted for nil.
 	{
 		vote := withValidator(voteProto, privValidators[7].Address, 7)
-		signAddVote(privValidators[7], vote, voteSet)
+		_, err := signAddVote(privValidators[7], vote, voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 		blockID, ok = voteSet.TwoThirdsMajority()
 		if !ok || !blockID.IsZero() {
 			t.Errorf("There should be 2/3 majority for nil")
@@ -175,7 +184,10 @@ func Test2_3MajorityRedux(t *testing.T) {
 	// 66 out of 100 voted for nil.
 	for i := 0; i < 66; i++ {
 		vote := withValidator(voteProto, privValidators[i].Address, i)
-		signAddVote(privValidators[i], vote, voteSet)
+		_, err := signAddVote(privValidators[i], vote, voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 	blockID, ok := voteSet.TwoThirdsMajority()
 	if ok || !blockID.IsZero() {
@@ -185,7 +197,10 @@ func Test2_3MajorityRedux(t *testing.T) {
 	// 67th validator voted for nil
 	{
 		vote := withValidator(voteProto, privValidators[66].Address, 66)
-		signAddVote(privValidators[66], withBlockHash(vote, nil), voteSet)
+		_, err := signAddVote(privValidators[66], withBlockHash(vote, nil), voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 		blockID, ok = voteSet.TwoThirdsMajority()
 		if ok || !blockID.IsZero() {
 			t.Errorf("There should be no 2/3 majority: last vote added was nil")
@@ -196,7 +211,10 @@ func Test2_3MajorityRedux(t *testing.T) {
 	{
 		vote := withValidator(voteProto, privValidators[67].Address, 67)
 		blockPartsHeader := PartSetHeader{blockPartsTotal, crypto.CRandBytes(32)}
-		signAddVote(privValidators[67], withBlockPartsHeader(vote, blockPartsHeader), voteSet)
+		_, err := signAddVote(privValidators[67], withBlockPartsHeader(vote, blockPartsHeader), voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 		blockID, ok = voteSet.TwoThirdsMajority()
 		if ok || !blockID.IsZero() {
 			t.Errorf("There should be no 2/3 majority: last vote added had different PartSetHeader Hash")
@@ -207,7 +225,10 @@ func Test2_3MajorityRedux(t *testing.T) {
 	{
 		vote := withValidator(voteProto, privValidators[68].Address, 68)
 		blockPartsHeader := PartSetHeader{blockPartsTotal + 1, blockPartsHeader.Hash}
-		signAddVote(privValidators[68], withBlockPartsHeader(vote, blockPartsHeader), voteSet)
+		_, err := signAddVote(privValidators[68], withBlockPartsHeader(vote, blockPartsHeader), voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 		blockID, ok = voteSet.TwoThirdsMajority()
 		if ok || !blockID.IsZero() {
 			t.Errorf("There should be no 2/3 majority: last vote added had different PartSetHeader Total")
@@ -217,7 +238,10 @@ func Test2_3MajorityRedux(t *testing.T) {
 	// 70th validator voted for different BlockHash
 	{
 		vote := withValidator(voteProto, privValidators[69].Address, 69)
-		signAddVote(privValidators[69], withBlockHash(vote, RandBytes(32)), voteSet)
+		_, err := signAddVote(privValidators[69], withBlockHash(vote, RandBytes(32)), voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 		blockID, ok = voteSet.TwoThirdsMajority()
 		if ok || !blockID.IsZero() {
 			t.Errorf("There should be no 2/3 majority: last vote added had different BlockHash")
@@ -227,7 +251,10 @@ func Test2_3MajorityRedux(t *testing.T) {
 	// 71st validator voted for the right BlockHash & BlockPartsHeader
 	{
 		vote := withValidator(voteProto, privValidators[70].Address, 70)
-		signAddVote(privValidators[70], vote, voteSet)
+		_, err := signAddVote(privValidators[70], vote, voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 		blockID, ok = voteSet.TwoThirdsMajority()
 		if !ok || !blockID.Equals(BlockID{blockHash, blockPartsHeader}) {
 			t.Errorf("There should be 2/3 majority")
@@ -440,7 +467,10 @@ func TestMakeCommit(t *testing.T) {
 	// 6 out of 10 voted for some block.
 	for i := 0; i < 6; i++ {
 		vote := withValidator(voteProto, privValidators[i].Address, i)
-		signAddVote(privValidators[i], vote, voteSet)
+		_, err := signAddVote(privValidators[i], vote, voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 
 	// MakeCommit should fail.
@@ -451,13 +481,19 @@ func TestMakeCommit(t *testing.T) {
 		vote := withValidator(voteProto, privValidators[6].Address, 6)
 		vote = withBlockHash(vote, RandBytes(32))
 		vote = withBlockPartsHeader(vote, PartSetHeader{123, RandBytes(32)})
-		signAddVote(privValidators[6], vote, voteSet)
+		_, err := signAddVote(privValidators[6], vote, voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 
 	// The 8th voted like everyone else.
 	{
 		vote := withValidator(voteProto, privValidators[7].Address, 7)
-		signAddVote(privValidators[7], vote, voteSet)
+		_, err := signAddVote(privValidators[7], vote, voteSet)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 
 	commit := voteSet.MakeCommit()


### PR DESCRIPTION
- helps #616, which will be tackled one linting tool at a time
- note: metalinter includes the megacheck lints
- see commit history for which linters were applied. not all errors were address (e.g., #645)
- additional PRs will continue to chip away at the linting errors