### PR TITLE
docs: added passchain to the ecosystem.rst in the applications section

### DIFF
--- a/docs/ecosystem.rst
+++ b/docs/ecosystem.rst
@@ -63,6 +63,11 @@ Passwerk
 
 Encrypted storage web-utility backed by Tendermint, written in Go, `authored by Rigel Rozanski <https://github.com/rigelrozanski/passwerk>`__.
 
+Passchain
+^^^^^^^^^
+
+Passchain is a tool to securely store and share passwords, tokens and other short secrets, `authored by trusch <https://github.com/trusch/passchain>`__.
+
 ABCI Servers
 ------------
 


### PR DESCRIPTION
This adds passchain to the correct doc location and not in the toplevel README.md file since it is outdated.