### PR TITLE
rpc: fix client websocket timeout

### DIFF
--- a/rpc/lib/server/handlers.go
+++ b/rpc/lib/server/handlers.go
@@ -488,6 +488,10 @@ func (wsc *wsConnection) readRoutine() {
 		wsc.baseConn.Close()
 	}()
 
+	wsc.baseConn.SetPongHandler(func(m string) error {
+		return wsc.baseConn.SetReadDeadline(time.Now().Add(wsc.readWait))
+	})
+
 	for {
 		select {
 		case <-wsc.Quit:


### PR DESCRIPTION
Since version 0.10.2, ping/pong between server and client are broken. Server is not notified that client is alive because pong message was not handled.
Each 30 seconds, log "Failed to read request" appeared.