### PR TITLE
types: test Vote* and implement Copy for many related structs

### DIFF
--- a/types/part_set.go
+++ b/types/part_set.go
@@ -62,6 +62,15 @@ type PartSetHeader struct {
 	Hash  data.Bytes `json:"hash"`
 }
 
+func (psh *PartSetHeader) Copy() *PartSetHeader {
+	if psh == nil {
+		return nil
+	}
+	pshc := *psh
+	pshc.Hash = copyBytes(psh.Hash)
+	return &pshc
+}
+
 func (psh PartSetHeader) String() string {
 	return fmt.Sprintf("%v:%X", psh.Total, cmn.Fingerprint(psh.Hash))
 }

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -100,9 +100,9 @@ func (valSet *ValidatorSet) GetByAddress(address []byte) (index int, val *Valida
 }
 
 // GetByIndex returns the validator by index.
-// It returns nil values if index >= len(ValidatorSet.Validators)
+// It returns nil values if index < 0  or index >= len(ValidatorSet.Validators)
 func (valSet *ValidatorSet) GetByIndex(index int) (address []byte, val *Validator) {
-	if index >= len(valSet.Validators) {
+	if index < 0 || index >= len(valSet.Validators) {
 		return nil, nil
 	}
 	val = valSet.Validators[index]

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/go-crypto"
+	cmn "github.com/tendermint/tmlibs/common"
 )
 
 func randPubKey() crypto.PubKey {

--- a/types/vote.go
+++ b/types/vote.go
@@ -17,6 +17,8 @@ var (
 	ErrVoteInvalidValidatorAddress = errors.New("Invalid validator address")
 	ErrVoteInvalidSignature        = errors.New("Invalid signature")
 	ErrVoteInvalidBlockHash        = errors.New("Invalid block hash")
+
+	errNilVote = errors.New("nil/non-dereferenceable votes are not allowed")
 )
 
 type ErrVoteConflictingVotes struct {
@@ -65,7 +67,12 @@ func (vote *Vote) WriteSignBytes(chainID string, w io.Writer, n *int, err *error
 }
 
 func (vote *Vote) Copy() *Vote {
+	if vote == nil {
+		return nil
+	}
 	voteCopy := *vote
+	voteCopy.ValidatorAddress = copyBytes(vote.ValidatorAddress)
+	voteCopy.BlockID = *(vote.BlockID.Copy())
 	return &voteCopy
 }
 

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -2,10 +2,12 @@ package types
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestVoteSignable(t *testing.T) {
-	vote := &Vote{
+var (
+	vote1 = Vote{
 		ValidatorAddress: []byte("addr"),
 		ValidatorIndex:   56789,
 		Height:           12345,
@@ -19,7 +21,10 @@ func TestVoteSignable(t *testing.T) {
 			},
 		},
 	}
-	signBytes := SignBytes("test_chain_id", vote)
+)
+
+func TestVoteSignable(t *testing.T) {
+	signBytes := SignBytes("test_chain_id", &vote1)
 	signStr := string(signBytes)
 
 	expected := `{"chain_id":"test_chain_id","vote":{"block_id":{"hash":"68617368","parts":{"hash":"70617274735F68617368","total":1000000}},"height":12345,"round":23456,"type":2}}`
@@ -27,4 +32,20 @@ func TestVoteSignable(t *testing.T) {
 		// NOTE: when this fails, you probably want to fix up consensus/replay_test too
 		t.Errorf("Got unexpected sign string for Vote. Expected:\n%v\nGot:\n%v", expected, signStr)
 	}
+}
+
+func TestVoteCopy(t *testing.T) {
+	require.Nil(t, ((*Vote)(nil)).Copy(), "Copy of a nil vote should return nil too")
+
+	v1 := vote1.Copy()
+
+	aTendermint := []byte("aTendermint")
+	aFoo := []byte("aFoo")
+	v1.ValidatorAddress = aTendermint[:]
+	v2 := v1.Copy()
+	require.Equal(t, v2, v1, "expecting a copy")
+
+	copy(v2.ValidatorAddress, aFoo)
+	require.NotEqual(t, v2, v1, "a mutation of v2 shouldn't mutate v1")
+	require.Equal(t, string(v1.ValidatorAddress), "aTendermint", "v1.ValidatorAddress shouldn't have changed")
 }


### PR DESCRIPTION
Updates https://github.com/tendermint/tendermint/issues/693

* Tests for VoteSet
* More guards for GetByIndex
* Implemented a mostly deep-Copy for:
- Block
- BlockID
- Commit
- Data
- Header
- PartSetHeader
- VoteSet
Whose purposes are to ensure that
after a vote has been added/cast to a VoteSet
it cannot be mutated by the outside actor. Not too sure
though if the extra copy might instead become a DOS Vector
but I believe most importantly no outside actor should
be able to modify a vote after we've added it to the VoteSet.

Piecemeal PR for the mentioned issue, more work coming as we go.