### PR TITLE
write config.toml with all defaults & improve config doc 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,12 @@ import (
 	"time"
 )
 
+// Note: Most of the structs & relevant comments + the
+// default configuration options were used to manually
+// generate the config.toml. Please reflect any changes
+// made here in the defaultConfigTemplate constant in
+// config/toml.go
+
 // Config defines the top level configuration for a Tendermint node
 type Config struct {
 	// Top level options use an anonymous struct

--- a/config/config.go
+++ b/config/config.go
@@ -62,10 +62,10 @@ type BaseConfig struct {
 	// The ID of the chain to join (should be signed with every transaction and vote)
 	ChainID string `mapstructure:"chain_id"`
 
-	// A JSON file containing the initial validator set and other meta data
+	// Path to the JSON file containing the initial validator set and other meta data
 	Genesis string `mapstructure:"genesis_file"`
 
-	// A JSON file containing the private key to use as a validator in the consensus protocol
+	// Path to the JSON file containing the private key to use as a validator in the consensus protocol
 	PrivValidator string `mapstructure:"priv_validator_file"`
 
 	// A custom human readable name for this node
@@ -108,8 +108,8 @@ func DefaultBaseConfig() BaseConfig {
 	return BaseConfig{
 		Genesis:           "genesis.json",
 		PrivValidator:     "priv_validator.json",
-		Moniker:           "anonymous",
 		ProxyApp:          "tcp://127.0.0.1:46658",
+		Moniker:           "anonymous",
 		ABCI:              "socket",
 		LogLevel:          DefaultPackageLogLevels(),
 		ProfListenAddress: "",
@@ -298,7 +298,7 @@ type ConsensusConfig struct {
 	WalLight bool   `mapstructure:"wal_light"`
 	walFile  string // overrides WalPath if set
 
-	// All timeouts are in ms
+	// All timeouts are in milliseconds
 	TimeoutPropose        int `mapstructure:"timeout_propose"`
 	TimeoutProposeDelta   int `mapstructure:"timeout_propose_delta"`
 	TimeoutPrevote        int `mapstructure:"timeout_prevote"`
@@ -318,7 +318,7 @@ type ConsensusConfig struct {
 	CreateEmptyBlocks         bool `mapstructure:"create_empty_blocks"`
 	CreateEmptyBlocksInterval int  `mapstructure:"create_empty_blocks_interval"`
 
-	// Reactor sleep duration parameters are in ms
+	// Reactor sleep duration parameters are in milliseconds
 	PeerGossipSleepDuration     int `mapstructure:"peer_gossip_sleep_duration"`
 	PeerQueryMaj23SleepDuration int `mapstructure:"peer_query_maj23_sleep_duration"`
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -48,6 +48,8 @@ func writeConfigFile(configFilePath string) {
 	cmn.MustWriteFile(configFilePath, buffer.Bytes(), 0644)
 }
 
+// Note: any changes to the comments/variables/mapstructure
+// must be reflected in the appropriate struct in config/config.go
 const defaultConfigTemplate = `# This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml
 
@@ -98,7 +100,9 @@ filter_peers = {{ .BaseConfig.FilterPeers }}
 # What indexer to use for transactions
 tx_index = "{{ .BaseConfig.TxIndex }}"
 
+##### advanced configuration options #####
 
+##### rpc server configuration options #####
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
@@ -111,7 +115,7 @@ grpc_laddr = "{{ .RPC.GRPCListenAddress }}"
 # Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
 unsafe = {{ .RPC.Unsafe }}
 
-
+##### peer to peer configuration options #####
 [p2p]
 
 # Address to listen for incoming connections
@@ -141,7 +145,7 @@ send_rate = {{ .P2P.SendRate }}
 # Rate at which packets can be received, in bytes/second
 recv_rate = {{ .P2P.RecvRate }}
 
-
+##### mempool configuration options #####
 [mempool]
 
 recheck = {{ .Mempool.Recheck }}
@@ -149,7 +153,7 @@ recheck_empty = {{ .Mempool.RecheckEmpty }}
 broadcast = {{ .Mempool.Broadcast }}
 wal_dir = "{{ .Mempool.WalPath }}"
 
-
+##### consensus configuration options #####
 [consensus]
 
 wal_file = "{{ .Consensus.WalPath }}"

--- a/config/toml.go
+++ b/config/toml.go
@@ -1,13 +1,24 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	cmn "github.com/tendermint/tmlibs/common"
 )
+
+var configTemplate *template.Template
+
+func init() {
+	var err error
+	if configTemplate, err = template.New("configFileTemplate").Parse(defaultConfigTemplate); err != nil {
+		panic(err)
+	}
+}
 
 /****** these are for production settings ***********/
 
@@ -17,34 +28,153 @@ func EnsureRoot(rootDir string) {
 
 	configFilePath := path.Join(rootDir, "config.toml")
 
-	// Write default config file if missing.
-	if !cmn.FileExists(configFilePath) {
-		// Ask user for moniker
-		// moniker := cfg.Prompt("Type hostname: ", "anonymous")
-		cmn.MustWriteFile(configFilePath, []byte(defaultConfig("anonymous")), 0644)
+	if cmn.FileExists(configFilePath) {
+		// TODO: Prompt user to replace if config file already exists.
+	} else {
+		// If file doesn't exist
+		// Ask user for moniker [moniker := cfg.Prompt("Type hostname: ", "anonymous")] (TODO)
+		// Then write the default config from template
+		var buffer bytes.Buffer
+
+		if err := configTemplate.Execute(&buffer, DefaultConfig()); err != nil {
+			panic(err)
+		}
+
+		cmn.MustWriteFile(configFilePath, buffer.Bytes(), 0644)
 	}
 }
 
-var defaultConfigTmpl = `# This is a TOML config file.
+const defaultConfigTemplate = `# This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml
 
-proxy_app = "tcp://127.0.0.1:46658"
-moniker = "__MONIKER__"
-fast_sync = true
-db_backend = "leveldb"
-log_level = "state:info,*:error"
+##### main base config options #####
+
+# TCP or UNIX socket address of the ABCI application,
+# or the name of an ABCI application compiled in with the Tendermint binary
+proxy_app = "{{ .BaseConfig.ProxyApp }}"
+
+# A custom human readable name for this node
+moniker = "{{ .BaseConfig.Moniker }}"
+
+# If this node is many blocks behind the tip of the chain, FastSync
+# allows them to catchup quickly by downloading blocks in parallel
+# and verifying their commits
+fast_sync = {{ .BaseConfig.FastSync }}
+
+# Database backend: leveldb | memdb
+db_backend = "{{ .BaseConfig.DBBackend }}"
+
+# Database directory
+db_path = "{{ .BaseConfig.DBPath }}"
+
+# Output level for logging
+log_level = "{{ .BaseConfig.LogLevel }}"
+
+##### additional base config options #####
+
+# The ID of the chain to join (should be signed with every transaction and vote)
+chain_id = "{{ .BaseConfig.ChainID }}"
+
+# Path to the JSON file containing the initial validator set and other meta data
+genesis_file = "{{ .BaseConfig.Genesis }}"
+
+# Path to the JSON file containing the private key to use as a validator in the consensus protocol
+priv_validator_file = "{{ .BaseConfig.PrivValidator }}"
+
+# Mechanism to connect to the ABCI application: socket | grpc
+abci = "{{ .BaseConfig.ABCI }}"
+
+# TCP or UNIX socket address for the profiling server to listen on
+prof_laddr = "{{ .BaseConfig.ProfListenAddress }}"
+
+# If true, query the ABCI app on connecting to a new peer
+# so the app can decide if we should keep the connection or not
+filter_peers = {{ .BaseConfig.FilterPeers }}
+
+# What indexer to use for transactions
+tx_index = "{{ .BaseConfig.TxIndex }}"
+
 
 [rpc]
-laddr = "tcp://0.0.0.0:46657"
+
+# TCP or UNIX socket address for the RPC server to listen on
+laddr = "{{ .RPC.ListenAddress }}"
+
+# TCP or UNIX socket address for the gRPC server to listen on
+# NOTE: This server only supports /broadcast_tx_commit
+grpc_laddr = "{{ .RPC.GRPCListenAddress }}"
+
+# Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
+unsafe = {{ .RPC.Unsafe }}
+
 
 [p2p]
-laddr = "tcp://0.0.0.0:46656"
-seeds = ""
-`
 
-func defaultConfig(moniker string) string {
-	return strings.Replace(defaultConfigTmpl, "__MONIKER__", moniker, -1)
-}
+# Address to listen for incoming connections
+laddr = "{{ .P2P.ListenAddress }}"
+
+# Comma separated list of seed nodes to connect to
+seeds = ""
+
+# Path to address book
+addr_book_file = "{{ .P2P.AddrBook }}"
+
+# Set true for strict address routability rules
+addr_book_strict = {{ .P2P.AddrBookStrict }}
+
+# Time to wait before flushing messages out on the connection, in ms
+flush_throttle_timeout = {{ .P2P.FlushThrottleTimeout }}
+
+# Maximum number of peers to connect to
+max_num_peers = {{ .P2P.MaxNumPeers }}
+
+# Maximum size of a message packet payload, in bytes
+max_msg_packet_payload_size = {{ .P2P.MaxMsgPacketPayloadSize }}
+
+# Rate at which packets can be sent, in bytes/second
+send_rate = {{ .P2P.SendRate }}
+
+# Rate at which packets can be received, in bytes/second
+recv_rate = {{ .P2P.RecvRate }}
+
+
+[mempool]
+
+recheck = {{ .Mempool.Recheck }}
+recheck_empty = {{ .Mempool.RecheckEmpty }}
+broadcast = {{ .Mempool.Broadcast }}
+wal_dir = "{{ .Mempool.WalPath }}"
+
+
+[consensus]
+
+wal_file = "{{ .Consensus.WalPath }}"
+wal_light = {{ .Consensus.WalLight }}
+
+# All timeouts are in milliseconds
+timeout_propose = {{ .Consensus.TimeoutPropose }}
+timeout_propose_delta = {{ .Consensus.TimeoutProposeDelta }}
+timeout_prevote = {{ .Consensus.TimeoutPrevote }}
+timeout_prevote_delta = {{ .Consensus.TimeoutPrevoteDelta }}
+timeout_precommit = {{ .Consensus.TimeoutPrecommit }}
+timeout_precommit_delta = {{ .Consensus.TimeoutPrecommitDelta }}
+timeout_commit = {{ .Consensus.TimeoutCommit }}
+
+# Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
+skip_timeout_commit = {{ .Consensus.SkipTimeoutCommit }}
+
+# BlockSize
+max_block_size_txs = {{ .Consensus.MaxBlockSizeTxs }}
+max_block_size_bytes = {{ .Consensus.MaxBlockSizeBytes }}
+
+# EmptyBlocks mode and possible interval between empty blocks in seconds
+create_empty_blocks = {{ .Consensus.CreateEmptyBlocks }}
+create_empty_blocks_interval = {{ .Consensus.CreateEmptyBlocksInterval }}
+
+# Reactor sleep duration parameters are in milliseconds
+peer_gossip_sleep_duration = {{ .Consensus.PeerGossipSleepDuration }}
+peer_query_maj23_sleep_duration = {{ .Consensus.PeerQueryMaj23SleepDuration }}
+`
 
 /****** these are for test settings ***********/
 

--- a/config/toml_test.go
+++ b/config/toml_test.go
@@ -32,7 +32,7 @@ func TestEnsureRoot(t *testing.T) {
 	// make sure config is set properly
 	data, err := ioutil.ReadFile(filepath.Join(tmpDir, "config.toml"))
 	require.Nil(err)
-	assert.Equal([]byte(defaultConfig("anonymous")), data)
+	assert.Equal([]byte(defaultConfigHardcoded), data)
 
 	ensureFiles(t, tmpDir, "data")
 }
@@ -49,9 +49,141 @@ func TestEnsureTestRoot(t *testing.T) {
 	// make sure config is set properly
 	data, err := ioutil.ReadFile(filepath.Join(rootDir, "config.toml"))
 	require.Nil(err)
-	assert.Equal([]byte(testConfig("anonymous")), data)
+	assert.Equal([]byte(defaultConfigHardcoded), data)
 
 	// TODO: make sure the cfg returned and testconfig are the same!
 
 	ensureFiles(t, rootDir, "data", "genesis.json", "priv_validator.json")
 }
+
+const defaultConfigHardcoded = `# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+##### main base config options #####
+
+# TCP or UNIX socket address of the ABCI application,
+# or the name of an ABCI application compiled in with the Tendermint binary
+proxy_app = "tcp://127.0.0.1:46658"
+
+# A custom human readable name for this node
+moniker = "anonymous"
+
+# If this node is many blocks behind the tip of the chain, FastSync
+# allows them to catchup quickly by downloading blocks in parallel
+# and verifying their commits
+fast_sync = true
+
+# Database backend: leveldb | memdb
+db_backend = "leveldb"
+
+# Database directory
+db_path = "data"
+
+# Output level for logging
+log_level = "state:info,*:error"
+
+##### additional base config options #####
+
+# The ID of the chain to join (should be signed with every transaction and vote)
+chain_id = ""
+
+# Path to the JSON file containing the initial validator set and other meta data
+genesis_file = "genesis.json"
+
+# Path to the JSON file containing the private key to use as a validator in the consensus protocol
+priv_validator_file = "priv_validator.json"
+
+# Mechanism to connect to the ABCI application: socket | grpc
+abci = "socket"
+
+# TCP or UNIX socket address for the profiling server to listen on
+prof_laddr = ""
+
+# If true, query the ABCI app on connecting to a new peer
+# so the app can decide if we should keep the connection or not
+filter_peers = false
+
+# What indexer to use for transactions
+tx_index = "kv"
+
+
+[rpc]
+
+# TCP or UNIX socket address for the RPC server to listen on
+laddr = "tcp://0.0.0.0:46657"
+
+# TCP or UNIX socket address for the gRPC server to listen on
+# NOTE: This server only supports /broadcast_tx_commit
+grpc_laddr = ""
+
+# Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
+unsafe = false
+
+
+[p2p]
+
+# Address to listen for incoming connections
+laddr = "tcp://0.0.0.0:46656"
+
+# Comma separated list of seed nodes to connect to
+seeds = ""
+
+# Path to address book
+addr_book_file = "addrbook.json"
+
+# Set true for strict address routability rules
+addr_book_strict = true
+
+# Time to wait before flushing messages out on the connection, in ms
+flush_throttle_timeout = 100
+
+# Maximum number of peers to connect to
+max_num_peers = 50
+
+# Maximum size of a message packet payload, in bytes
+max_msg_packet_payload_size = 1024
+
+# Rate at which packets can be sent, in bytes/second
+send_rate = 512000
+
+# Rate at which packets can be received, in bytes/second
+recv_rate = 512000
+
+
+[mempool]
+
+recheck = true
+recheck_empty = true
+broadcast = true
+wal_dir = "data/mempool.wal"
+
+
+[consensus]
+
+wal_file = "data/cs.wal/wal"
+wal_light = false
+
+# All timeouts are in milliseconds
+timeout_propose = 3000
+timeout_propose_delta = 500
+timeout_prevote = 1000
+timeout_prevote_delta = 500
+timeout_precommit = 1000
+timeout_precommit_delta = 500
+timeout_commit = 1000
+
+# Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
+skip_timeout_commit = false
+
+# BlockSize
+max_block_size_txs = 10000
+max_block_size_bytes = 1
+
+# EmptyBlocks mode and possible interval between empty blocks in seconds
+create_empty_blocks = true
+create_empty_blocks_interval = 0
+
+# Reactor sleep duration parameters are in milliseconds
+peer_gossip_sleep_duration = 100
+peer_query_maj23_sleep_duration = 2000
+`

--- a/config/toml_test.go
+++ b/config/toml_test.go
@@ -106,7 +106,9 @@ filter_peers = false
 # What indexer to use for transactions
 tx_index = "kv"
 
+##### advanced configuration options #####
 
+##### rpc server configuration options #####
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
@@ -119,7 +121,7 @@ grpc_laddr = ""
 # Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
 unsafe = false
 
-
+##### peer to peer configuration options #####
 [p2p]
 
 # Address to listen for incoming connections
@@ -149,7 +151,7 @@ send_rate = 512000
 # Rate at which packets can be received, in bytes/second
 recv_rate = 512000
 
-
+##### mempool configuration options #####
 [mempool]
 
 recheck = true
@@ -157,7 +159,7 @@ recheck_empty = true
 broadcast = true
 wal_dir = "data/mempool.wal"
 
-
+##### consensus configuration options #####
 [consensus]
 
 wal_file = "data/cs.wal/wal"

--- a/config/toml_test.go
+++ b/config/toml_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +33,7 @@ func TestEnsureRoot(t *testing.T) {
 	// make sure config is set properly
 	data, err := ioutil.ReadFile(filepath.Join(tmpDir, "config.toml"))
 	require.Nil(err)
-	assert.Equal([]byte(defaultConfigHardcoded), data)
+	assert.Equal(checkConfig(string(data)), true)
 
 	ensureFiles(t, tmpDir, "data")
 }
@@ -49,143 +50,37 @@ func TestEnsureTestRoot(t *testing.T) {
 	// make sure config is set properly
 	data, err := ioutil.ReadFile(filepath.Join(rootDir, "config.toml"))
 	require.Nil(err)
-	assert.Equal([]byte(defaultConfigHardcoded), data)
-
-	// TODO: make sure the cfg returned and testconfig are the same!
+	assert.Equal(checkConfig(string(data)), true)
 
 	ensureFiles(t, rootDir, "data", "genesis.json", "priv_validator.json")
 }
 
-const defaultConfigHardcoded = `# This is a TOML config file.
-# For more information, see https://github.com/toml-lang/toml
+func checkConfig(configFile string) bool {
+	var valid bool
 
-##### main base config options #####
-
-# TCP or UNIX socket address of the ABCI application,
-# or the name of an ABCI application compiled in with the Tendermint binary
-proxy_app = "tcp://127.0.0.1:46658"
-
-# A custom human readable name for this node
-moniker = "anonymous"
-
-# If this node is many blocks behind the tip of the chain, FastSync
-# allows them to catchup quickly by downloading blocks in parallel
-# and verifying their commits
-fast_sync = true
-
-# Database backend: leveldb | memdb
-db_backend = "leveldb"
-
-# Database directory
-db_path = "data"
-
-# Output level for logging
-log_level = "state:info,*:error"
-
-##### additional base config options #####
-
-# The ID of the chain to join (should be signed with every transaction and vote)
-chain_id = ""
-
-# Path to the JSON file containing the initial validator set and other meta data
-genesis_file = "genesis.json"
-
-# Path to the JSON file containing the private key to use as a validator in the consensus protocol
-priv_validator_file = "priv_validator.json"
-
-# Mechanism to connect to the ABCI application: socket | grpc
-abci = "socket"
-
-# TCP or UNIX socket address for the profiling server to listen on
-prof_laddr = ""
-
-# If true, query the ABCI app on connecting to a new peer
-# so the app can decide if we should keep the connection or not
-filter_peers = false
-
-# What indexer to use for transactions
-tx_index = "kv"
-
-##### advanced configuration options #####
-
-##### rpc server configuration options #####
-[rpc]
-
-# TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:46657"
-
-# TCP or UNIX socket address for the gRPC server to listen on
-# NOTE: This server only supports /broadcast_tx_commit
-grpc_laddr = ""
-
-# Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
-unsafe = false
-
-##### peer to peer configuration options #####
-[p2p]
-
-# Address to listen for incoming connections
-laddr = "tcp://0.0.0.0:46656"
-
-# Comma separated list of seed nodes to connect to
-seeds = ""
-
-# Path to address book
-addr_book_file = "addrbook.json"
-
-# Set true for strict address routability rules
-addr_book_strict = true
-
-# Time to wait before flushing messages out on the connection, in ms
-flush_throttle_timeout = 100
-
-# Maximum number of peers to connect to
-max_num_peers = 50
-
-# Maximum size of a message packet payload, in bytes
-max_msg_packet_payload_size = 1024
-
-# Rate at which packets can be sent, in bytes/second
-send_rate = 512000
-
-# Rate at which packets can be received, in bytes/second
-recv_rate = 512000
-
-##### mempool configuration options #####
-[mempool]
-
-recheck = true
-recheck_empty = true
-broadcast = true
-wal_dir = "data/mempool.wal"
-
-##### consensus configuration options #####
-[consensus]
-
-wal_file = "data/cs.wal/wal"
-wal_light = false
-
-# All timeouts are in milliseconds
-timeout_propose = 3000
-timeout_propose_delta = 500
-timeout_prevote = 1000
-timeout_prevote_delta = 500
-timeout_precommit = 1000
-timeout_precommit_delta = 500
-timeout_commit = 1000
-
-# Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
-skip_timeout_commit = false
-
-# BlockSize
-max_block_size_txs = 10000
-max_block_size_bytes = 1
-
-# EmptyBlocks mode and possible interval between empty blocks in seconds
-create_empty_blocks = true
-create_empty_blocks_interval = 0
-
-# Reactor sleep duration parameters are in milliseconds
-peer_gossip_sleep_duration = 100
-peer_query_maj23_sleep_duration = 2000
-`
+	// list of words we expect in the config
+	var elems = []string{
+		"moniker",
+		"seeds",
+		"proxy_app",
+		"fast_sync",
+		"create_empty_blocks",
+		"peer",
+		"timeout",
+		"broadcast",
+		"send",
+		"addr",
+		"wal",
+		"propose",
+		"max",
+		"genesis",
+	}
+	for _, e := range elems {
+		if !strings.Contains(configFile, e) {
+			valid = false
+		} else {
+			valid = true
+		}
+	}
+	return valid
+}

--- a/docs/specification/configuration.rst
+++ b/docs/specification/configuration.rst
@@ -3,10 +3,12 @@ Configuration
 
 Tendermint Core can be configured via a TOML file in
 ``$TMHOME/config.toml``. Some of these parameters can be overridden by
-command-line flags.
+command-line flags. For most users, the options in the ``##### main
+base configuration options #####`` are intended to be modified while
+config options further below are intended for advance power users.
 
-Config parameters
-~~~~~~~~~~~~~~~~~
+Config options
+~~~~~~~~~~~~~~
 
 The default configuration file create by ``tendermint init`` has all
 the parameters set with their default values. It will look something
@@ -17,7 +19,7 @@ like the file below, however, double check by inspecting the
 
     # This is a TOML config file.
     # For more information, see https://github.com/toml-lang/toml
-
+    
     ##### main base config options #####
     
     # TCP or UNIX socket address of the ABCI application,
@@ -65,7 +67,9 @@ like the file below, however, double check by inspecting the
     # What indexer to use for transactions
     tx_index = "kv"
     
+    ##### advanced configuration options #####
     
+    ##### rpc server configuration options #####
     [rpc]
     
     # TCP or UNIX socket address for the RPC server to listen on
@@ -78,7 +82,7 @@ like the file below, however, double check by inspecting the
     # Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
     unsafe = false
     
-    
+    ##### peer to peer configuration options #####
     [p2p]
     
     # Address to listen for incoming connections
@@ -108,7 +112,7 @@ like the file below, however, double check by inspecting the
     # Rate at which packets can be received, in bytes/second
     recv_rate = 512000
     
-    
+    ##### mempool configuration options #####
     [mempool]
     
     recheck = true
@@ -116,7 +120,7 @@ like the file below, however, double check by inspecting the
     broadcast = true
     wal_dir = "data/mempool.wal"
     
-    
+    ##### consensus configuration options #####
     [consensus]
     
     wal_file = "data/cs.wal/wal"

--- a/docs/specification/configuration.rst
+++ b/docs/specification/configuration.rst
@@ -1,57 +1,147 @@
 Configuration
 =============
 
-TendermintCore can be configured via a TOML file in
+Tendermint Core can be configured via a TOML file in
 ``$TMHOME/config.toml``. Some of these parameters can be overridden by
 command-line flags.
 
 Config parameters
 ~~~~~~~~~~~~~~~~~
 
-The main config parameters are defined
-`here <https://github.com/tendermint/tendermint/blob/master/config/config.go>`__.
+The default configuration file create by ``tendermint init`` has all
+the parameters set with their default values. It will look something
+like the file below, however, double check by inspecting the 
+``config.toml`` created with your version of ``tendermint`` installed:
 
--  ``abci``: ABCI transport (socket \| grpc). *Default*: ``socket``
--  ``db_backend``: Database backend for the blockchain and
-   TendermintCore state. ``leveldb`` or ``memdb``. *Default*:
-   ``"leveldb"``
--  ``db_dir``: Database dir. *Default*: ``"$TMHOME/data"``
--  ``fast_sync``: Whether to sync faster from the block pool. *Default*:
-   ``true``
--  ``genesis_file``: The location of the genesis file. *Default*:
-   ``"$TMHOME/genesis.json"``
--  ``log_level``: *Default*: ``"state:info,*:error"``
--  ``moniker``: Name of this node. *Default*: ``"anonymous"``
--  ``priv_validator_file``: Validator private key file. *Default*:
-   ``"$TMHOME/priv_validator.json"``
--  ``prof_laddr``: Profile listen address. *Default*: ``""``
--  ``proxy_app``: The ABCI app endpoint. *Default*:
-   ``"tcp://127.0.0.1:46658"``
+::
 
--  ``consensus.max_block_size_txs``: Maximum number of block txs.
-   *Default*: ``10000``
--  ``consensus.create_empty_blocks``: Create empty blocks w/o txs.
-   *Default*: ``true``
--  ``consensus.create_empty_blocks_interval``: Block creation interval, even if empty.
--  ``consensus.timeout_*``: Various consensus timeout parameters
--  ``consensus.wal_file``: Consensus state WAL. *Default*:
-   ``"$TMHOME/data/cs.wal/wal"``
--  ``consensus.wal_light``: Whether to use light-mode for Consensus
-   state WAL. *Default*: ``false``
+    # This is a TOML config file.
+    # For more information, see https://github.com/toml-lang/toml
 
--  ``mempool.*``: Various mempool parameters
-
--  ``p2p.addr_book_file``: Peer address book. *Default*:
-   ``"$TMHOME/addrbook.json"``. **NOT USED**
--  ``p2p.laddr``: Node listen address. (0.0.0.0:0 means any interface,
-   any port). *Default*: ``"0.0.0.0:46656"``
--  ``p2p.pex``: Enable Peer-Exchange (dev feature). *Default*: ``false``
--  ``p2p.seeds``: Comma delimited host:port seed nodes. *Default*:
-   ``""``
--  ``p2p.skip_upnp``: Skip UPNP detection. *Default*: ``false``
-
--  ``rpc.grpc_laddr``: GRPC listen address (BroadcastTx only). Port
-   required. *Default*: ``""``
--  ``rpc.laddr``: RPC listen address. Port required. *Default*:
-   ``"0.0.0.0:46657"``
--  ``rpc.unsafe``: Enabled unsafe rpc methods. *Default*: ``true``
+    ##### main base config options #####
+    
+    # TCP or UNIX socket address of the ABCI application,
+    # or the name of an ABCI application compiled in with the Tendermint binary
+    proxy_app = "tcp://127.0.0.1:46658"
+    
+    # A custom human readable name for this node
+    moniker = "anonymous"
+    
+    # If this node is many blocks behind the tip of the chain, FastSync
+    # allows them to catchup quickly by downloading blocks in parallel
+    # and verifying their commits
+    fast_sync = true
+    
+    # Database backend: leveldb | memdb
+    db_backend = "leveldb"
+    
+    # Database directory
+    db_path = "data"
+    
+    # Output level for logging
+    log_level = "state:info,*:error"
+    
+    ##### additional base config options #####
+    
+    # The ID of the chain to join (should be signed with every transaction and vote)
+    chain_id = ""
+    
+    # Path to the JSON file containing the initial validator set and other meta data
+    genesis_file = "genesis.json"
+    
+    # Path to the JSON file containing the private key to use as a validator in the consensus protocol
+    priv_validator_file = "priv_validator.json"
+    
+    # Mechanism to connect to the ABCI application: socket | grpc
+    abci = "socket"
+    
+    # TCP or UNIX socket address for the profiling server to listen on
+    prof_laddr = ""
+    
+    # If true, query the ABCI app on connecting to a new peer
+    # so the app can decide if we should keep the connection or not
+    filter_peers = false
+    
+    # What indexer to use for transactions
+    tx_index = "kv"
+    
+    
+    [rpc]
+    
+    # TCP or UNIX socket address for the RPC server to listen on
+    laddr = "tcp://0.0.0.0:46657"
+    
+    # TCP or UNIX socket address for the gRPC server to listen on
+    # NOTE: This server only supports /broadcast_tx_commit
+    grpc_laddr = ""
+    
+    # Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
+    unsafe = false
+    
+    
+    [p2p]
+    
+    # Address to listen for incoming connections
+    laddr = "tcp://0.0.0.0:46656"
+    
+    # Comma separated list of seed nodes to connect to
+    seeds = ""
+    
+    # Path to address book
+    addr_book_file = "addrbook.json"
+    
+    # Set true for strict address routability rules
+    addr_book_strict = true
+    
+    # Time to wait before flushing messages out on the connection, in ms
+    flush_throttle_timeout = 100
+    
+    # Maximum number of peers to connect to
+    max_num_peers = 50
+    
+    # Maximum size of a message packet payload, in bytes
+    max_msg_packet_payload_size = 1024
+    
+    # Rate at which packets can be sent, in bytes/second
+    send_rate = 512000
+    
+    # Rate at which packets can be received, in bytes/second
+    recv_rate = 512000
+    
+    
+    [mempool]
+    
+    recheck = true
+    recheck_empty = true
+    broadcast = true
+    wal_dir = "data/mempool.wal"
+    
+    
+    [consensus]
+    
+    wal_file = "data/cs.wal/wal"
+    wal_light = false
+    
+    # All timeouts are in milliseconds
+    timeout_propose = 3000
+    timeout_propose_delta = 500
+    timeout_prevote = 1000
+    timeout_prevote_delta = 500
+    timeout_precommit = 1000
+    timeout_precommit_delta = 500
+    timeout_commit = 1000
+    
+    # Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
+    skip_timeout_commit = false
+    
+    # BlockSize
+    max_block_size_txs = 10000
+    max_block_size_bytes = 1
+    
+    # EmptyBlocks mode and possible interval between empty blocks in seconds
+    create_empty_blocks = true
+    create_empty_blocks_interval = 0
+    
+    # Reactor sleep duration parameters are in milliseconds
+    peer_gossip_sleep_duration = 100
+    peer_query_maj23_sleep_duration = 2000

--- a/rpc/lib/doc.go
+++ b/rpc/lib/doc.go
@@ -1,3 +1,5 @@
+package rpc
+
 /*
 HTTP RPC server supporting calls via uri params, jsonrpc, and jsonrpc over websockets
 

--- a/rpc/lib/doc.go
+++ b/rpc/lib/doc.go
@@ -1,5 +1,3 @@
-package rpc
-
 /*
 HTTP RPC server supporting calls via uri params, jsonrpc, and jsonrpc over websockets
 


### PR DESCRIPTION
closes #705 
links to:  #709, #636

Running `tendermint init` used to produce the following `config.toml`:
```
# This is a TOML config file.
# For more information, see https://github.com/toml-lang/toml

proxy_app = "tcp://127.0.0.1:46658"
moniker = "anonymous"
fast_sync = true
db_backend = "leveldb"
log_level = "state:info,*:error"

[rpc]
laddr = "tcp://0.0.0.0:46657"

[p2p]
laddr = "tcp://0.0.0.0:46656"
seeds = ""
```
which did not provide all that much information about the many config options. Now, the `config.toml` looks like:
```
# This is a TOML config file.
# For more information, see https://github.com/toml-lang/toml

##### main base config options #####

# TCP or UNIX socket address of the ABCI application,
# or the name of an ABCI application compiled in with the Tendermint binary
proxy_app = "tcp://127.0.0.1:46658"

# A custom human readable name for this node
moniker = "anonymous"

# If this node is many blocks behind the tip of the chain, FastSync
# allows them to catchup quickly by downloading blocks in parallel
# and verifying their commits
fast_sync = true

# Database backend: leveldb | memdb
db_backend = "leveldb"

# Database directory
db_path = "data"

# Output level for logging
log_level = "state:info,*:error"

##### additional base config options #####

# The ID of the chain to join (should be signed with every transaction and vote)
chain_id = ""

# Path to the JSON file containing the initial validator set and other meta data
genesis_file = "genesis.json"

# Path to the JSON file containing the private key to use as a validator in the consensus protocol
priv_validator_file = "priv_validator.json"

# Mechanism to connect to the ABCI application: socket | grpc
abci = "socket"

# TCP or UNIX socket address for the profiling server to listen on
prof_laddr = ""

# If true, query the ABCI app on connecting to a new peer
# so the app can decide if we should keep the connection or not
filter_peers = false

# What indexer to use for transactions
tx_index = "kv"


[rpc]

# TCP or UNIX socket address for the RPC server to listen on
laddr = "tcp://0.0.0.0:46657"

# TCP or UNIX socket address for the gRPC server to listen on
# NOTE: This server only supports /broadcast_tx_commit
grpc_laddr = ""

# Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
unsafe = false


[p2p]

# Address to listen for incoming connections
laddr = "tcp://0.0.0.0:46656"

# Comma separated list of seed nodes to connect to
seeds = ""

# Path to address book
addr_book_file = "addrbook.json"

# Set true for strict address routability rules
addr_book_strict = true

# Time to wait before flushing messages out on the connection, in ms
flush_throttle_timeout = 100

# Maximum number of peers to connect to
max_num_peers = 50

# Maximum size of a message packet payload, in bytes
max_msg_packet_payload_size = 1024

# Rate at which packets can be sent, in bytes/second
send_rate = 512000

# Rate at which packets can be received, in bytes/second
recv_rate = 512000


[mempool]

recheck = true
recheck_empty = true
broadcast = true
wal_dir = "data/mempool.wal"


[consensus]

wal_file = "data/cs.wal/wal"
wal_light = false

# All timeouts are in milliseconds
timeout_propose = 3000
timeout_propose_delta = 500
timeout_prevote = 1000
timeout_prevote_delta = 500
timeout_precommit = 1000
timeout_precommit_delta = 500
timeout_commit = 1000

# Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
skip_timeout_commit = false

# BlockSize
max_block_size_txs = 10000
max_block_size_bytes = 1

# EmptyBlocks mode and possible interval between empty blocks in seconds
create_empty_blocks = true
create_empty_blocks_interval = 0

# Reactor sleep duration parameters are in milliseconds
peer_gossip_sleep_duration = 100
peer_query_maj23_sleep_duration = 2000
```
and the documentation for the `config.toml` now shows the full config file, replacing this:
![screenshot from 2017-10-10 14-33-13](https://user-images.githubusercontent.com/8304391/31403710-f738ca6a-adc7-11e7-8eb3-8a795ec51ac0.png)
with this:
![screenshot from 2017-10-10 14-34-00](https://user-images.githubusercontent.com/8304391/31403749-16360edc-adc8-11e7-868c-bfa582ebefbc.png)
