### PR TITLE
WIP: rpc: use /iavl repo in test

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -118,10 +118,8 @@ imports:
   subpackages:
   - data
   - data/base58
-- name: github.com/tendermint/merkleeyes
-  version: 2a93256d2c6fbcc3b55673c0d2b96a7e32c6238b
-  subpackages:
-  - iavl
+- name: github.com/tendermint/iavl
+  version: 9233811d241ac8d4441a7223a4e79b83931dfae0
 - name: github.com/tendermint/tmlibs
   version: 096dcb90e60aa00b748b3fe49a4b95e48ebf1e13
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,8 +25,8 @@ import:
   version: ~0.6.2
   subpackages:
   - data
-- package: github.com/tendermint/merkleeyes
-  version: master
+- package: github.com/tendermint/iavl
+  version: develop
   subpackages:
   - iavl
 - package: github.com/tendermint/tmlibs

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tendermint/merkleeyes/iavl" //TODO use tendermint/iavl ?
+	"github.com/tendermint/iavl"
 	"github.com/tendermint/tendermint/rpc/client"
 	rpctest "github.com/tendermint/tendermint/rpc/test"
 	"github.com/tendermint/tendermint/types"
@@ -174,13 +174,13 @@ func TestAppCalls(t *testing.T) {
 		// and we got a proof that works!
 		pres, err := c.ABCIQuery("/key", k, true)
 		if assert.Nil(err) && assert.True(pres.Code.IsOK()) {
-			proof, err := iavl.ReadProof(pres.Proof)
+			proof, err := iavl.ReadKeyExistsProof(pres.Proof)
 			if assert.Nil(err) {
 				key := pres.Key
 				value := pres.Value
 				assert.EqualValues(appHash, proof.RootHash)
 				valid := proof.Verify(key, value, appHash)
-				assert.True(valid)
+				assert.Nil(valid)
 			}
 		}
 	}


### PR DESCRIPTION
#713 

Test fails with:
```
Error Trace:    rpc_test.go:178
Error:	        Expected nil, but got: &errors.errorString{s:"Unexpected type byte BE for ptr of untyped thing"}
```

still debugging, maybe @cloudhead knows the fix off hand