### PR TITLE
Make RPCError an actual error and don't swallow its companion data

### DIFF
--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -147,7 +147,7 @@ func unmarshalResponseBytes(responseBytes []byte, result interface{}) (interface
 		return nil, errors.Errorf("Error unmarshalling rpc response: %v", err)
 	}
 	if response.Error != nil {
-		return nil, errors.Errorf("Response error: %v", response.Error.Message)
+		return nil, errors.Errorf("Response error: %v", response.Error)
 	}
 	// unmarshal the RawMessage into the result
 	err = json.Unmarshal(*response.Result, result)

--- a/rpc/lib/client/ws_client.go
+++ b/rpc/lib/client/ws_client.go
@@ -437,7 +437,7 @@ func (c *WSClient) readRoutine() {
 			continue
 		}
 		if response.Error != nil {
-			c.ErrorsCh <- errors.New(response.Error.Message)
+			c.ErrorsCh <- response.Error
 			continue
 		}
 		c.Logger.Info("got response", "resp", response.Result)

--- a/rpc/lib/types/types.go
+++ b/rpc/lib/types/types.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	events "github.com/tendermint/tmlibs/events"
 )
 
@@ -58,6 +57,14 @@ type RPCError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
 	Data    string `json:"data,omitempty"`
+}
+
+func (err RPCError) Error() string {
+	const baseFormat = "RPC error %v - %s"
+	if err.Data != "" {
+		return fmt.Sprintf(baseFormat+": %s", err.Code, err.Message, err.Data)
+	}
+	return fmt.Sprintf(baseFormat, err.Code, err.Message)
 }
 
 type RPCResponse struct {

--- a/rpc/lib/types/types_test.go
+++ b/rpc/lib/types/types_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -29,4 +31,19 @@ func TestResponses(t *testing.T) {
 	h, _ := json.Marshal(g)
 	i := `{"jsonrpc":"2.0","id":"2","error":{"code":-32601,"message":"Method not found"}}`
 	assert.Equal(string(h), string(i))
+}
+
+func TestRPCError(t *testing.T) {
+	assert.Equal(t, "RPC error 12 - Badness: One worse than a code 11",
+		fmt.Sprintf("%v", &RPCError{
+			Code:    12,
+			Message: "Badness",
+			Data:    "One worse than a code 11",
+		}))
+
+	assert.Equal(t, "RPC error 12 - Badness",
+		fmt.Sprintf("%v", &RPCError{
+			Code:    12,
+			Message: "Badness",
+		}))
 }


### PR DESCRIPTION
Currently the RPC clients swallow useful nested error data, this PR surfaces that and makes RPCError implement the Go error interface.