### PR TITLE
Change log level to Info when proposal block hashing fails 

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1130,7 +1130,7 @@ func (cs *ConsensusState) tryFinalizeCommit(height int) {
 	if !cs.ProposalBlock.HashesTo(blockID.Hash) {
 		// TODO: this happens every time if we're not a validator (ugly logs)
 		// TODO: ^^ wait, why does it matter that we're a validator?
-		cs.Logger.Error("Attempt to finalize failed. We don't have the commit block.", "height", height, "proposal-block", cs.ProposalBlock.Hash(), "commit-block", blockID.Hash)
+		cs.Logger.Info("Attempt to finalize failed. We don't have the commit block.", "height", height, "proposal-block", cs.ProposalBlock.Hash(), "commit-block", blockID.Hash)
 		return
 	}
 


### PR DESCRIPTION
Change log level to Info when proposal block hashing fails due to partially complete block
Closes #769 