### PR TITLE
fix test using uncommon names

### DIFF
--- a/p2p/netaddress_test.go
+++ b/p2p/netaddress_test.go
@@ -31,9 +31,9 @@ func TestNewNetAddressString(t *testing.T) {
 	}{
 		{"127.0.0.1:8080", true},
 		// {"127.0.0:8080", false},
-		{"a", false},
-		{"127.0.0.1:a", false},
-		{"a:8080", false},
+		{"notahost", false},
+		{"127.0.0.1:notapath", false},
+		{"notahost:8080", false},
 		{"8082", false},
 		{"127.0.0:8080000", false},
 	}


### PR DESCRIPTION
A test assumes that `"a"` is not a valid hostname however it is in fact one of the most common because it is so short so this test is likely to cause spurious errors. It fails on my LAN here:

```
ok  	github.com/tendermint/tendermint/consensus	46.703s
ok  	github.com/tendermint/tendermint/consensus/types	0.039s
ok  	github.com/tendermint/tendermint/mempool	4.073s
ok  	github.com/tendermint/tendermint/node	2.017s
--- FAIL: TestNewNetAddressString (0.00s)
        Error Trace:    netaddress_test.go:48
	Error:      	Expected value not to be nil.
	Messages:   	a:8080
FAIL
FAIL	github.com/tendermint/tendermint/p2p	7.341s
?   	github.com/tendermint/tendermint/p2p/upnp	[no test files]
```

With this PR this test and all tests pass on my system.
