### PR TITLE
Fix nondeterministic tests failures related to pubsub

### DIFF
--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -288,7 +288,12 @@ func TestReactorWithTimeoutCommit(t *testing.T) {
 
 func waitForAndValidateBlock(t *testing.T, n int, activeVals map[string]struct{}, eventChans []chan interface{}, css []*ConsensusState, txs ...[]byte) {
 	timeoutWaitGroup(t, n, func(wg *sync.WaitGroup, j int) {
-		newBlockI := <-eventChans[j]
+		defer wg.Done()
+
+		newBlockI, ok := <-eventChans[j]
+		if !ok {
+			return
+		}
 		newBlock := newBlockI.(types.TMEventData).Unwrap().(types.EventDataNewBlock).Block
 		t.Logf("Got block height=%v validator=%v", newBlock.Height, j)
 		err := validateBlock(newBlock, activeVals)
@@ -300,16 +305,20 @@ func waitForAndValidateBlock(t *testing.T, n int, activeVals map[string]struct{}
 				t.Fatal(err)
 			}
 		}
-		wg.Done()
 	}, css)
 }
 
 func waitForBlockWithUpdatedValsAndValidateIt(t *testing.T, n int, updatedVals map[string]struct{}, eventChans []chan interface{}, css []*ConsensusState, txs ...[]byte) {
 	timeoutWaitGroup(t, n, func(wg *sync.WaitGroup, j int) {
+		defer wg.Done()
+
 		var newBlock *types.Block
 	LOOP:
 		for {
-			newBlockI := <-eventChans[j]
+			newBlockI, ok := <-eventChans[j]
+			if !ok {
+				return
+			}
 			newBlock = newBlockI.(types.TMEventData).Unwrap().(types.EventDataNewBlock).Block
 			if newBlock.LastCommit.Size() == len(updatedVals) {
 				t.Logf("Block with new validators height=%v validator=%v", newBlock.Height, j)
@@ -323,8 +332,6 @@ func waitForBlockWithUpdatedValsAndValidateIt(t *testing.T, n int, updatedVals m
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		wg.Done()
 	}, css)
 }
 


### PR DESCRIPTION
```
panic: interface conversion: interface {} is nil, not types.TMEventData

goroutine 7690 [running]:
github.com/tendermint/tendermint/consensus.waitForAndValidateBlock.func1(0xc427727620, 0x3)
        /go/src/github.com/tendermint/tendermint/consensus/reactor_test.go:292 +0x62b
created by github.com/tendermint/tendermint/consensus.timeoutWaitGroup
        /go/src/github.com/tendermint/tendermint/consensus/reactor_test.go:349 +0xa4
exit status 2
FAIL    github.com/tendermint/tendermint/consensus      38.614s

```