### PR TITLE
p2p: invoke only a single OnStop per single OnStart

### DIFF
--- a/p2p/connection_test.go
+++ b/p2p/connection_test.go
@@ -55,6 +55,19 @@ func TestMConnectionSend(t *testing.T) {
 	assert.False(mconn.Send(0x05, "Absorbing Man"), "Send should return false because channel is unknown")
 }
 
+func TestMConnectionNonCrashingSuccessiveOnStop(t *testing.T) {
+	require := require.New(t)
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	mconn := createTestMConnection(client)
+	require.Nil(mconn.OnStart())
+	mconn.OnStop()
+	mconn.OnStop()
+}
+
 func TestMConnectionReceive(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 


### PR DESCRIPTION
Fixes #841

Prevent crashes on invoking successive OnStop's by
using a sync.Once protection, reset per OnStart invocation.

The code isn't that critical or for an exploit but it'll
protect any crashes that come from folks many mconn.OnStop
either by error or by copy and paste

Without the protection the test fails with
```shell
$ go test -v -run=Successive
=== RUN   TestMConnectionNonCrashingSuccessiveOnStop
--- FAIL: TestMConnectionNonCrashingSuccessiveOnStop (0.00s)
panic: close of closed channel [recovered]
	panic: close of closed channel

goroutine 20 [running]:
testing.tRunner.func1(0xc4202000f0)
	/Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:734 +0x291
panic(0x1350040, 0x15203f0)
	/Users/emmanuelodeke/go/src/go.googlesource.com/go/src/runtime/panic.go:502 +0x229
github.com/tendermint/tendermint/vendor/github.com/tendermint/tmlibs/common.(*ThrottleTimer).Stop(0xc42009db00, 0x0)
	/Users/emmanuelodeke/go/src/github.com/tendermint/tendermint/vendor/github.com/tendermint/tmlibs/common/throttle_timer.go:71 +0x41
github.com/tendermint/tendermint/p2p.(*MConnection).OnStop(0xc4202001e0)
	/Users/emmanuelodeke/go/src/github.com/tendermint/tendermint/p2p/connection.go:177 +0x36
github.com/tendermint/tendermint/p2p.TestMConnectionNonCrashingSuccessiveOnStop(0xc4202000f0)
	/Users/emmanuelodeke/go/src/github.com/tendermint/tendermint/p2p/connection_test.go:68 +0x12d
testing.tRunner(0xc4202000f0, 0x14f6020)
	/Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:769 +0xc0
created by testing.(*T).Run
	/Users/emmanuelodeke/go/src/go.googlesource.com/go/src/testing/testing.go:812 +0x2a5
exit status 2
FAIL	github.com/tendermint/tendermint/p2p	0.013s
```