### PR TITLE
p2p: netPipe for <Go1.10 in own file with own build tag

### DIFF
--- a/p2p/conn_notgo110.go
+++ b/p2p/conn_notgo110.go
@@ -1,0 +1,32 @@
+// +build !go1.10
+
+package p2p
+
+import (
+	"net"
+	"time"
+)
+
+// Only Go1.10 has a proper net.Conn implementation that
+// has the SetDeadline method implemented as per
+//  https://github.com/golang/go/commit/e2dd8ca946be884bb877e074a21727f1a685a706
+// lest we run into problems like
+//  https://github.com/tendermint/tendermint/issues/851
+// so for go versions < Go1.10 use our custom net.Conn creator
+// that doesn't return an `Unimplemented error` for net.Conn.
+// Before https://github.com/tendermint/tendermint/commit/49faa79bdce5663894b3febbf4955fb1d172df04
+// we hadn't cared about errors from SetDeadline so swallow them up anyways.
+type pipe struct {
+	net.Conn
+}
+
+func (p *pipe) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func netPipe() (net.Conn, net.Conn) {
+	p1, p2 := net.Pipe()
+	return &pipe{p1}, &pipe{p2}
+}
+
+var _ net.Conn = (*pipe)(nil)

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -593,27 +593,3 @@ func (sw *Switch) addPeerWithConnectionAndConfig(conn net.Conn, config *PeerConf
 
 	return nil
 }
-
-// Only Go1.10 has a proper net.Conn implementation that
-// has the SetDeadline method implemented as per
-//  https://github.com/golang/go/commit/e2dd8ca946be884bb877e074a21727f1a685a706
-// lest we run into problems like
-//  https://github.com/tendermint/tendermint/issues/851
-// so for go versions < Go1.10 use our custom net.Conn creator
-// that doesn't return an `Unimplemented error` for net.Conn.
-// Before https://github.com/tendermint/tendermint/commit/49faa79bdce5663894b3febbf4955fb1d172df04
-// we hadn't cared about errors from SetDeadline so swallow them up anyways.
-type pipe struct {
-	net.Conn
-}
-
-func (p *pipe) SetDeadline(t time.Time) error {
-	return nil
-}
-
-func netPipe() (net.Conn, net.Conn) {
-	p1, p2 := net.Pipe()
-	return &pipe{p1}, &pipe{p2}
-}
-
-var _ net.Conn = (*pipe)(nil)


### PR DESCRIPTION
Follow up of 283544c7f3ada24378fd6e0ac2f82cd927bc95e6
putting <Go1.10 implementation of netPipe in its own
file and protect it with its separate build tag.