### PR TITLE
p2p: use bytes.Equal for key comparison

### DIFF
--- a/p2p/secret_connection.go
+++ b/p2p/secret_connection.go
@@ -67,8 +67,12 @@ func MakeSecretConnection(conn io.ReadWriteCloser, locPrivKey crypto.PrivKeyEd25
 	// Sort by lexical order.
 	loEphPub, hiEphPub := sort32(locEphPub, remEphPub)
 
+	// Check if the local ephemeral public key
+	// was the least, lexicographically sorted.
+	locIsLeast := bytes.Equal(locEphPub[:], loEphPub[:])
+
 	// Generate nonces to use for secretbox.
-	recvNonce, sendNonce := genNonces(loEphPub, hiEphPub, locEphPub == loEphPub)
+	recvNonce, sendNonce := genNonces(loEphPub, hiEphPub, locIsLeast)
 
 	// Generate common challenge to sign.
 	challenge := genChallenge(loEphPub, hiEphPub)


### PR DESCRIPTION
Updates https://github.com/tendermint/tendermint/issues/850
    
My security alarms falsely blarred when I skimmed and noticed
keys being compared with `==`, without the proper context
so I mistakenly filed an issue, yet the purpose of that
comparison was to check if the local ephemeral public key
was just the least, sorted lexicographically.
    
Anyways, let's use the proper bytes.Equal check, to save future labor.