### PR TITLE
Pass loggers in the constructor as a first class citizen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,23 @@ BREAKING CHANGES:
 - rpc/lib/types: RPCResponse is no longer a pointer; WSRPCConnection interface has been modified
 - rpc/client: WaitForOneEvent takes an EventsClient instead of types.EventSwitch
 - rpc/client: Add/RemoveListenerForEvent are now Subscribe/Unsubscribe
+- NewBlockPool requires log.Logger in function arguments
+- newBPPeer requires log.Logger in function argument
+- the following function signatures now require log.Logger as an argument:
+  - NewBlockPool
+  - NewBlockchainReactor
+  - NewConsensusReactor
+  - NewConsensusState
+  - NewMempool
+  - NewMempoolReactor
+  - NewAddrBook
+  - NewPEXReactor
+  - NewBaseReactor
+  - NewSwitch
+  - NewTrustMetricStore
+  - NewEventBus
+  - newBPPeer
+  - newBPRequester
 
 FEATURES:
 - rpc: new `/unsubscribe_all` WebSocket RPC endpoint

--- a/benchmarks/simu/counter.go
+++ b/benchmarks/simu/counter.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"time"
 
-	rpcclient "github.com/tendermint/tendermint/rpc/lib/client"
 	cmn "github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tmlibs/log"
+
+	rpcclient "github.com/tendermint/tendermint/rpc/lib/client"
 )
 
 func main() {
-	wsc := rpcclient.NewWSClient("127.0.0.1:46657", "/websocket")
+	wsc := rpcclient.NewWSClient("127.0.0.1:46657", "/websocket", log.NewNopLogger())
 	_, err := wsc.Start()
 	if err != nil {
 		cmn.Exit(err.Error())

--- a/blockchain/pool_test.go
+++ b/blockchain/pool_test.go
@@ -34,8 +34,7 @@ func TestBasic(t *testing.T) {
 	peers := makePeers(10, start+1, 1000)
 	timeoutsCh := make(chan string, 100)
 	requestsCh := make(chan BlockRequest, 100)
-	pool := NewBlockPool(start, requestsCh, timeoutsCh)
-	pool.SetLogger(log.TestingLogger())
+	pool := NewBlockPool(start, requestsCh, timeoutsCh, log.TestingLogger())
 	pool.Start()
 	defer pool.Stop()
 
@@ -86,8 +85,7 @@ func TestTimeout(t *testing.T) {
 	peers := makePeers(10, start+1, 1000)
 	timeoutsCh := make(chan string, 100)
 	requestsCh := make(chan BlockRequest, 100)
-	pool := NewBlockPool(start, requestsCh, timeoutsCh)
-	pool.SetLogger(log.TestingLogger())
+	pool := NewBlockPool(start, requestsCh, timeoutsCh, log.TestingLogger())
 	pool.Start()
 	defer pool.Stop()
 

--- a/blockchain/reactor_test.go
+++ b/blockchain/reactor_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	wire "github.com/tendermint/go-wire"
+
 	cmn "github.com/tendermint/tmlibs/common"
 	dbm "github.com/tendermint/tmlibs/db"
 	"github.com/tendermint/tmlibs/log"
@@ -27,11 +28,10 @@ func newBlockchainReactor(maxBlockHeight int) *BlockchainReactor {
 
 	// Make the blockchainReactor itself
 	fastSync := true
-	bcReactor := NewBlockchainReactor(state.Copy(), nil, blockStore, fastSync)
-	bcReactor.SetLogger(logger.With("module", "blockchain"))
+	bcReactor := NewBlockchainReactor(state.Copy(), nil, blockStore, fastSync, logger.With("module", "blockchain"))
 
 	// Next: we need to set a switch in order for peers to be added in
-	bcReactor.Switch = p2p.NewSwitch(cfg.DefaultP2PConfig())
+	bcReactor.Switch = p2p.NewSwitch(cfg.DefaultP2PConfig(), nil)
 
 	// Lastly: let's add some blocks in
 	for blockHeight := 1; blockHeight <= maxBlockHeight; blockHeight++ {

--- a/blockchain/reactor_test.go
+++ b/blockchain/reactor_test.go
@@ -28,7 +28,8 @@ func newBlockchainReactor(maxBlockHeight int) *BlockchainReactor {
 
 	// Make the blockchainReactor itself
 	fastSync := true
-	bcReactor := NewBlockchainReactor(state.Copy(), nil, blockStore, fastSync, logger.With("module", "blockchain"))
+	bcReactor := NewBlockchainReactor(state.Copy(), nil, blockStore, fastSync,
+		logger.With("module", "blockchain"))
 
 	// Next: we need to set a switch in order for peers to be added in
 	bcReactor.Switch = p2p.NewSwitch(cfg.DefaultP2PConfig(), nil)
@@ -78,13 +79,15 @@ func TestNoBlockMessageResponse(t *testing.T) {
 			if blockMsg, ok := msg.(*bcBlockResponseMessage); !ok {
 				t.Fatalf("Expected to receive a block response for height %d", tt.height)
 			} else if blockMsg.Block.Height != tt.height {
-				t.Fatalf("Expected response to be for height %d, got %d", tt.height, blockMsg.Block.Height)
+				t.Fatalf("Expected response to be for height %d, got %d", tt.height,
+					blockMsg.Block.Height)
 			}
 		} else {
 			if noBlockMsg, ok := msg.(*bcNoBlockResponseMessage); !ok {
 				t.Fatalf("Expected to receive a no block response for height %d", tt.height)
 			} else if noBlockMsg.Height != tt.height {
-				t.Fatalf("Expected response to be for height %d, got %d", tt.height, noBlockMsg.Height)
+				t.Fatalf("Expected response to be for height %d, got %d", tt.height,
+					noBlockMsg.Height)
 			}
 		}
 	}
@@ -106,7 +109,8 @@ func makeBlock(blockNumber int, state *sm.State) *types.Block {
 	valHash := state.Validators.Hash()
 	prevBlockID := types.BlockID{prevHash, prevParts}
 	block, _ := types.MakeBlock(blockNumber, "test_chain", makeTxs(blockNumber),
-		new(types.Commit), prevBlockID, valHash, state.AppHash, state.Params.BlockGossipParams.BlockPartSizeBytes)
+		new(types.Commit), prevBlockID, valHash, state.AppHash,
+		state.Params.BlockGossipParams.BlockPartSizeBytes)
 	return block
 }
 
@@ -130,7 +134,8 @@ func newbcrTestPeer(key string) *bcrTestPeer {
 func (tp *bcrTestPeer) lastValue() interface{} { return <-tp.ch }
 
 func (tp *bcrTestPeer) TrySend(chID byte, value interface{}) bool {
-	if _, ok := value.(struct{ BlockchainMessage }).BlockchainMessage.(*bcStatusResponseMessage); ok {
+	if _, ok := value.(struct{ BlockchainMessage }).
+		BlockchainMessage.(*bcStatusResponseMessage); ok {
 		// Discard status response messages since they skew our results
 		// We only want to deal with:
 		// + bcBlockResponseMessage

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -37,7 +37,7 @@ func TestByzantine(t *testing.T) {
 	css := randConsensusNet(N, "consensus_byzantine_test", newMockTickerFunc(false), newCounter)
 
 	// give the byzantine validator a normal ticker
-	css[0].SetTimeoutTicker(NewTimeoutTicker())
+	css[0].SetTimeoutTicker(NewTimeoutTicker(nil))
 
 	switches := make([]*p2p.Switch, N)
 	p2pLogger := logger.With("module", "p2p")
@@ -251,7 +251,7 @@ func (br *ByzantineReactor) AddPeer(peer p2p.Peer) {
 	}
 
 	// Create peerState for peer
-	peerState := NewPeerState(peer).SetLogger(br.reactor.Logger)
+	peerState := NewPeerState(peer, br.reactor.Logger)
 	peer.Set(types.PeerStateKey, peerState)
 
 	// Send our state to peer.

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -253,8 +253,7 @@ func newConsensusStateWithConfigAndBlockStore(thisConfig *cfg.Config, state *sm.
 	proxyAppConnCon := abcicli.NewLocalClient(mtx, app)
 
 	// Make Mempool
-	mempool := mempl.NewMempool(thisConfig.Mempool, proxyAppConnMem, 0)
-	mempool.SetLogger(log.TestingLogger().With("module", "mempool"))
+	mempool := mempl.NewMempool(thisConfig.Mempool, proxyAppConnMem, 0, log.TestingLogger().With("module", "mempool"))
 	if thisConfig.Consensus.WaitForTxs() {
 		mempool.EnableTxsAvailable()
 	}

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -69,7 +69,9 @@ func NewValidatorStub(privValidator types.PrivValidator, valIndex int) *validato
 	}
 }
 
-func (vs *validatorStub) signVote(voteType byte, hash []byte, header types.PartSetHeader) (*types.Vote, error) {
+func (vs *validatorStub) signVote(voteType byte, hash []byte,
+	header types.PartSetHeader) (*types.Vote, error) {
+
 	vote := &types.Vote{
 		ValidatorIndex:   vs.Index,
 		ValidatorAddress: vs.PrivValidator.GetAddress(),
@@ -83,7 +85,9 @@ func (vs *validatorStub) signVote(voteType byte, hash []byte, header types.PartS
 }
 
 // Sign vote for type/hash/header
-func signVote(vs *validatorStub, voteType byte, hash []byte, header types.PartSetHeader) *types.Vote {
+func signVote(vs *validatorStub, voteType byte, hash []byte,
+	header types.PartSetHeader) *types.Vote {
+
 	v, err := vs.signVote(voteType, hash, header)
 	if err != nil {
 		panic(fmt.Errorf("failed to sign vote: %v", err))
@@ -91,7 +95,9 @@ func signVote(vs *validatorStub, voteType byte, hash []byte, header types.PartSe
 	return v
 }
 
-func signVotes(voteType byte, hash []byte, header types.PartSetHeader, vss ...*validatorStub) []*types.Vote {
+func signVotes(voteType byte, hash []byte, header types.PartSetHeader,
+	vss ...*validatorStub) []*types.Vote {
+
 	votes := make([]*types.Vote, len(vss))
 	for i, vs := range vss {
 		votes[i] = signVote(vs, voteType, hash, header)
@@ -120,7 +126,9 @@ func startTestRound(cs *ConsensusState, height, round int) {
 }
 
 // Create proposal block from cs1 but sign it with vs
-func decideProposal(cs1 *ConsensusState, vs *validatorStub, height, round int) (proposal *types.Proposal, block *types.Block) {
+func decideProposal(cs1 *ConsensusState, vs *validatorStub, height,
+	round int) (proposal *types.Proposal, block *types.Block) {
+
 	block, blockParts := cs1.createProposalBlock()
 	if block == nil { // on error
 		panic("error creating proposal block")
@@ -141,12 +149,16 @@ func addVotes(to *ConsensusState, votes ...*types.Vote) {
 	}
 }
 
-func signAddVotes(to *ConsensusState, voteType byte, hash []byte, header types.PartSetHeader, vss ...*validatorStub) {
+func signAddVotes(to *ConsensusState, voteType byte, hash []byte, header types.PartSetHeader,
+	vss ...*validatorStub) {
+
 	votes := signVotes(voteType, hash, header, vss...)
 	addVotes(to, votes...)
 }
 
-func validatePrevote(t *testing.T, cs *ConsensusState, round int, privVal *validatorStub, blockHash []byte) {
+func validatePrevote(t *testing.T, cs *ConsensusState, round int, privVal *validatorStub,
+	blockHash []byte) {
+
 	prevotes := cs.Votes.Prevotes(round)
 	var vote *types.Vote
 	if vote = prevotes.GetByAddress(privVal.GetAddress()); vote == nil {
@@ -158,12 +170,15 @@ func validatePrevote(t *testing.T, cs *ConsensusState, round int, privVal *valid
 		}
 	} else {
 		if !bytes.Equal(vote.BlockID.Hash, blockHash) {
-			panic(fmt.Sprintf("Expected prevote to be for %X, got %X", blockHash, vote.BlockID.Hash))
+			panic(fmt.Sprintf("Expected prevote to be for %X, got %X", blockHash,
+				vote.BlockID.Hash))
 		}
 	}
 }
 
-func validateLastPrecommit(t *testing.T, cs *ConsensusState, privVal *validatorStub, blockHash []byte) {
+func validateLastPrecommit(t *testing.T, cs *ConsensusState, privVal *validatorStub,
+	blockHash []byte) {
+
 	votes := cs.LastCommit
 	var vote *types.Vote
 	if vote = votes.GetByAddress(privVal.GetAddress()); vote == nil {
@@ -174,7 +189,9 @@ func validateLastPrecommit(t *testing.T, cs *ConsensusState, privVal *validatorS
 	}
 }
 
-func validatePrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound int, privVal *validatorStub, votedBlockHash, lockedBlockHash []byte) {
+func validatePrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound int,
+	privVal *validatorStub, votedBlockHash, lockedBlockHash []byte) {
+
 	precommits := cs.Votes.Precommits(thisRound)
 	var vote *types.Vote
 	if vote = precommits.GetByAddress(privVal.GetAddress()); vote == nil {
@@ -203,7 +220,9 @@ func validatePrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound in
 
 }
 
-func validatePrevoteAndPrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound int, privVal *validatorStub, votedBlockHash, lockedBlockHash []byte) {
+func validatePrevoteAndPrecommit(t *testing.T, cs *ConsensusState, thisRound, lockRound int,
+	privVal *validatorStub, votedBlockHash, lockedBlockHash []byte) {
+
 	// verify the prevote
 	validatePrevote(t, cs, thisRound, privVal, votedBlockHash)
 	// verify precommit
@@ -215,7 +234,8 @@ func validatePrevoteAndPrecommit(t *testing.T, cs *ConsensusState, thisRound, lo
 // genesis
 func subscribeToVoter(cs *ConsensusState, addr []byte) chan interface{} {
 	voteCh0 := make(chan interface{})
-	err := cs.eventBus.Subscribe(context.Background(), testSubscriber, types.EventQueryVote, voteCh0)
+	err := cs.eventBus.Subscribe(context.Background(), testSubscriber, types.EventQueryVote,
+		voteCh0)
 	if err != nil {
 		panic(fmt.Sprintf("failed to subscribe %s to %v", testSubscriber, types.EventQueryVote))
 	}
@@ -352,7 +372,9 @@ func consensusLogger() log.Logger {
 	})
 }
 
-func randConsensusNet(nValidators int, testName string, tickerFunc func() TimeoutTicker, appFunc func() abci.Application, configOpts ...func(*cfg.Config)) []*ConsensusState {
+func randConsensusNet(nValidators int, testName string, tickerFunc func() TimeoutTicker,
+	appFunc func() abci.Application, configOpts ...func(*cfg.Config)) []*ConsensusState {
+
 	genDoc, privVals := randGenesisDoc(nValidators, false, 10)
 	css := make([]*ConsensusState, nValidators)
 	logger := consensusLogger()
@@ -378,7 +400,9 @@ func randConsensusNet(nValidators int, testName string, tickerFunc func() Timeou
 }
 
 // nPeers = nValidators + nNotValidator
-func randConsensusNetWithPeers(nValidators, nPeers int, testName string, tickerFunc func() TimeoutTicker, appFunc func() abci.Application) []*ConsensusState {
+func randConsensusNetWithPeers(nValidators, nPeers int, testName string,
+	tickerFunc func() TimeoutTicker, appFunc func() abci.Application) []*ConsensusState {
+
 	genDoc, privVals := randGenesisDoc(nValidators, false, int64(testMinPower))
 	css := make([]*ConsensusState, nPeers)
 	logger := consensusLogger()
@@ -421,7 +445,9 @@ func getSwitchIndex(switches []*p2p.Switch, peer p2p.Peer) int {
 //-------------------------------------------------------------------------------
 // genesis
 
-func randGenesisDoc(numValidators int, randPower bool, minPower int64) (*types.GenesisDoc, []*types.PrivValidatorFS) {
+func randGenesisDoc(numValidators int, randPower bool,
+	minPower int64) (*types.GenesisDoc, []*types.PrivValidatorFS) {
+
 	validators := make([]types.GenesisValidator, numValidators)
 	privValidators := make([]*types.PrivValidatorFS, numValidators)
 	for i := 0; i < numValidators; i++ {
@@ -440,7 +466,9 @@ func randGenesisDoc(numValidators int, randPower bool, minPower int64) (*types.G
 	}, privValidators
 }
 
-func randGenesisState(numValidators int, randPower bool, minPower int64) (*sm.State, []*types.PrivValidatorFS) {
+func randGenesisState(numValidators int, randPower bool,
+	minPower int64) (*sm.State, []*types.PrivValidatorFS) {
+
 	genDoc, privValidators := randGenesisDoc(numValidators, randPower, minPower)
 	db := dbm.NewMemDB()
 	s0, _ := sm.MakeGenesisState(db, genDoc)

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -107,13 +107,13 @@ func signVotes(voteType byte, hash []byte, header types.PartSetHeader,
 
 func incrementHeight(vss ...*validatorStub) {
 	for _, vs := range vss {
-		vs.Height += 1
+		vs.Height++
 	}
 }
 
 func incrementRound(vss ...*validatorStub) {
 	for _, vs := range vss {
-		vs.Round += 1
+		vs.Round++
 	}
 }
 

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	abci "github.com/tendermint/abci/types"
-	"github.com/tendermint/tendermint/types"
+
 	cmn "github.com/tendermint/tmlibs/common"
+
+	"github.com/tendermint/tendermint/types"
 )
 
 func init() {
@@ -196,9 +198,10 @@ func runTx(tx []byte, countPtr *int) abci.Result {
 	copy(tx8[len(tx8)-len(tx):], tx)
 	txValue := binary.BigEndian.Uint64(tx8)
 	if txValue != uint64(count) {
-		return abci.ErrBadNonce.AppendLog(cmn.Fmt("Invalid nonce. Expected %v, got %v", count, txValue))
+		return abci.ErrBadNonce.AppendLog(cmn.Fmt("Invalid nonce. Expected %v, got %v", count,
+			txValue))
 	}
-	*countPtr += 1
+	*countPtr++
 	return abci.OK
 }
 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	wire "github.com/tendermint/go-wire"
+
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 
@@ -43,12 +44,14 @@ type ConsensusReactor struct {
 }
 
 // NewConsensusReactor returns a new ConsensusReactor with the given consensusState.
-func NewConsensusReactor(consensusState *ConsensusState, fastSync bool) *ConsensusReactor {
+func NewConsensusReactor(consensusState *ConsensusState, fastSync bool,
+	logger log.Logger) *ConsensusReactor {
+
 	conR := &ConsensusReactor{
 		conS:     consensusState,
 		fastSync: fastSync,
 	}
-	conR.BaseReactor = *p2p.NewBaseReactor("ConsensusReactor", conR)
+	conR.BaseReactor = *p2p.NewBaseReactor(logger, "ConsensusReactor", conR)
 	return conR
 }
 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -176,7 +176,8 @@ func (conR *ConsensusReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) 
 
 	_, msg, err := DecodeMessage(msgBytes)
 	if err != nil {
-		conR.Logger.Error("Error decoding message", "src", src, "chId", chID, "msg", msg, "err", err, "bytes", msgBytes)
+		conR.Logger.Error("Error decoding message", "src", src, "chId", chID, "msg", msg, "err",
+			err, "bytes", msgBytes)
 		// TODO punish peer?
 		return
 	}

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -48,7 +48,8 @@ func startConsensusNet(t *testing.T, css []*ConsensusState,
 		reactors[i].SetEventBus(eventBuses[i])
 
 		eventChans[i] = make(chan interface{}, 1)
-		err = eventBuses[i].Subscribe(context.Background(), testSubscriber, types.EventQueryNewBlock, eventChans[i])
+		err = eventBuses[i].Subscribe(context.Background(), testSubscriber,
+			types.EventQueryNewBlock, eventChans[i])
 		require.NoError(t, err)
 	}
 	// make connected switches and start all reactors
@@ -103,7 +104,8 @@ func TestReactorProposalHeartbeats(t *testing.T) {
 	var err error
 	for i := 0; i < N; i++ {
 		heartbeatChans[i] = make(chan interface{}, 1)
-		err = eventBuses[i].Subscribe(context.Background(), testSubscriber, types.EventQueryProposalHeartbeat, heartbeatChans[i])
+		err = eventBuses[i].Subscribe(context.Background(), testSubscriber,
+			types.EventQueryProposalHeartbeat, heartbeatChans[i])
 		require.NoError(t, err)
 	}
 	// wait till everyone sends a proposal heartbeat
@@ -127,7 +129,8 @@ func TestReactorProposalHeartbeats(t *testing.T) {
 
 func TestVotingPowerChange(t *testing.T) {
 	nVals := 4
-	css := randConsensusNet(nVals, "consensus_voting_power_changes_test", newMockTickerFunc(true), newPersistentDummy)
+	css := randConsensusNet(nVals, "consensus_voting_power_changes_test", newMockTickerFunc(true),
+		newPersistentDummy)
 	reactors, eventChans, eventBuses := startConsensusNet(t, css, nVals)
 	defer stopConsensusNet(reactors, eventBuses)
 
@@ -144,7 +147,7 @@ func TestVotingPowerChange(t *testing.T) {
 	}, css)
 
 	//---------------------------------------------------------------------------
-	t.Log("---------------------------- Testing changing the voting power of one validator a few times")
+	t.Log("----------------------- Testing changing the voting power of one validator a few times")
 
 	val1PubKey := css[0].privValidator.GetPubKey()
 	updateValidatorTx := dummy.MakeValSetChangeTx(val1PubKey.Bytes(), 25)
@@ -156,7 +159,8 @@ func TestVotingPowerChange(t *testing.T) {
 	waitForAndValidateBlock(t, nVals, activeVals, eventChans, css)
 
 	if css[0].GetRoundState().LastValidators.TotalVotingPower() == previousTotalVotingPower {
-		t.Fatalf("expected voting power to change (before: %d, after: %d)", previousTotalVotingPower, css[0].GetRoundState().LastValidators.TotalVotingPower())
+		t.Fatalf("expected voting power to change (before: %d, after: %d)",
+			previousTotalVotingPower, css[0].GetRoundState().LastValidators.TotalVotingPower())
 	}
 
 	updateValidatorTx = dummy.MakeValSetChangeTx(val1PubKey.Bytes(), 2)
@@ -168,7 +172,8 @@ func TestVotingPowerChange(t *testing.T) {
 	waitForAndValidateBlock(t, nVals, activeVals, eventChans, css)
 
 	if css[0].GetRoundState().LastValidators.TotalVotingPower() == previousTotalVotingPower {
-		t.Fatalf("expected voting power to change (before: %d, after: %d)", previousTotalVotingPower, css[0].GetRoundState().LastValidators.TotalVotingPower())
+		t.Fatalf("expected voting power to change (before: %d, after: %d)",
+			previousTotalVotingPower, css[0].GetRoundState().LastValidators.TotalVotingPower())
 	}
 
 	updateValidatorTx = dummy.MakeValSetChangeTx(val1PubKey.Bytes(), 100)
@@ -180,14 +185,16 @@ func TestVotingPowerChange(t *testing.T) {
 	waitForAndValidateBlock(t, nVals, activeVals, eventChans, css)
 
 	if css[0].GetRoundState().LastValidators.TotalVotingPower() == previousTotalVotingPower {
-		t.Fatalf("expected voting power to change (before: %d, after: %d)", previousTotalVotingPower, css[0].GetRoundState().LastValidators.TotalVotingPower())
+		t.Fatalf("expected voting power to change (before: %d, after: %d)",
+			previousTotalVotingPower, css[0].GetRoundState().LastValidators.TotalVotingPower())
 	}
 }
 
 func TestValidatorSetChanges(t *testing.T) {
 	nPeers := 7
 	nVals := 4
-	css := randConsensusNetWithPeers(nVals, nPeers, "consensus_val_set_changes_test", newMockTickerFunc(true), newPersistentDummy)
+	css := randConsensusNetWithPeers(nVals, nPeers, "consensus_val_set_changes_test",
+		newMockTickerFunc(true), newPersistentDummy)
 
 	reactors, eventChans, eventBuses := startConsensusNet(t, css, nPeers)
 	defer stopConsensusNet(reactors, eventBuses)
@@ -243,7 +250,8 @@ func TestValidatorSetChanges(t *testing.T) {
 	waitForBlockWithUpdatedValsAndValidateIt(t, nPeers, activeVals, eventChans, css)
 
 	if css[nVals].GetRoundState().LastValidators.TotalVotingPower() == previousTotalVotingPower {
-		t.Errorf("expected voting power to change (before: %d, after: %d)", previousTotalVotingPower, css[nVals].GetRoundState().LastValidators.TotalVotingPower())
+		t.Errorf("expected voting power to change (before: %d, after: %d)",
+			previousTotalVotingPower, css[nVals].GetRoundState().LastValidators.TotalVotingPower())
 	}
 
 	//---------------------------------------------------------------------------
@@ -255,7 +263,8 @@ func TestValidatorSetChanges(t *testing.T) {
 	newValidatorPubKey3 := css[nVals+2].privValidator.GetPubKey()
 	newValidatorTx3 := dummy.MakeValSetChangeTx(newValidatorPubKey3.Bytes(), uint64(testMinPower))
 
-	waitForAndValidateBlock(t, nPeers, activeVals, eventChans, css, newValidatorTx2, newValidatorTx3)
+	waitForAndValidateBlock(t, nPeers, activeVals, eventChans, css, newValidatorTx2,
+		newValidatorTx3)
 	waitForAndValidateBlock(t, nPeers, activeVals, eventChans, css)
 	waitForAndValidateBlock(t, nPeers, activeVals, eventChans, css)
 	activeVals[string(newValidatorPubKey2.Address())] = struct{}{}
@@ -268,7 +277,8 @@ func TestValidatorSetChanges(t *testing.T) {
 	removeValidatorTx2 := dummy.MakeValSetChangeTx(newValidatorPubKey2.Bytes(), 0)
 	removeValidatorTx3 := dummy.MakeValSetChangeTx(newValidatorPubKey3.Bytes(), 0)
 
-	waitForAndValidateBlock(t, nPeers, activeVals, eventChans, css, removeValidatorTx2, removeValidatorTx3)
+	waitForAndValidateBlock(t, nPeers, activeVals, eventChans, css, removeValidatorTx2,
+		removeValidatorTx3)
 	waitForAndValidateBlock(t, nPeers, activeVals, eventChans, css)
 	waitForAndValidateBlock(t, nPeers, activeVals, eventChans, css)
 	delete(activeVals, string(newValidatorPubKey2.Address()))
@@ -279,7 +289,8 @@ func TestValidatorSetChanges(t *testing.T) {
 // Check we can make blocks with skip_timeout_commit=false
 func TestReactorWithTimeoutCommit(t *testing.T) {
 	N := 4
-	css := randConsensusNet(N, "consensus_reactor_with_timeout_commit_test", newMockTickerFunc(false), newCounter)
+	css := randConsensusNet(N, "consensus_reactor_with_timeout_commit_test",
+		newMockTickerFunc(false), newCounter)
 	// override default SkipTimeoutCommit == true for tests
 	for i := 0; i < N; i++ {
 		css[i].config.SkipTimeoutCommit = false
@@ -295,7 +306,9 @@ func TestReactorWithTimeoutCommit(t *testing.T) {
 	}, css)
 }
 
-func waitForAndValidateBlock(t *testing.T, n int, activeVals map[string]struct{}, eventChans []chan interface{}, css []*ConsensusState, txs ...[]byte) {
+func waitForAndValidateBlock(t *testing.T, n int, activeVals map[string]struct{},
+	eventChans []chan interface{}, css []*ConsensusState, txs ...[]byte) {
+
 	timeoutWaitGroup(t, n, func(wg *sync.WaitGroup, j int) {
 		defer wg.Done()
 
@@ -317,7 +330,9 @@ func waitForAndValidateBlock(t *testing.T, n int, activeVals map[string]struct{}
 	}, css)
 }
 
-func waitForBlockWithUpdatedValsAndValidateIt(t *testing.T, n int, updatedVals map[string]struct{}, eventChans []chan interface{}, css []*ConsensusState) {
+func waitForBlockWithUpdatedValsAndValidateIt(t *testing.T, n int, updatedVals map[string]struct{},
+	eventChans []chan interface{}, css []*ConsensusState) {
+
 	timeoutWaitGroup(t, n, func(wg *sync.WaitGroup, j int) {
 		defer wg.Done()
 
@@ -333,7 +348,8 @@ func waitForBlockWithUpdatedValsAndValidateIt(t *testing.T, n int, updatedVals m
 				t.Logf("Block with new validators height=%v validator=%v", newBlock.Height, j)
 				break LOOP
 			} else {
-				t.Logf("Block with no new validators height=%v validator=%v. Skipping...", newBlock.Height, j)
+				t.Logf("Block with no new validators height=%v validator=%v. Skipping...",
+					newBlock.Height, j)
 			}
 		}
 

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/abci/example/dummy"
 
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/types"
-
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -25,7 +25,9 @@ func init() {
 //----------------------------------------------
 // in-process testnets
 
-func startConsensusNet(t *testing.T, css []*ConsensusState, N int) ([]*ConsensusReactor, []chan interface{}, []*types.EventBus) {
+func startConsensusNet(t *testing.T, css []*ConsensusState,
+	N int) ([]*ConsensusReactor, []chan interface{}, []*types.EventBus) {
+
 	reactors := make([]*ConsensusReactor, N)
 	eventChans := make([]chan interface{}, N)
 	eventBuses := make([]*types.EventBus, N)
@@ -35,12 +37,11 @@ func startConsensusNet(t *testing.T, css []*ConsensusState, N int) ([]*Consensus
 		if err != nil {	t.Fatal(err)}*/
 		thisLogger := logger
 
-		reactors[i] = NewConsensusReactor(css[i], true) // so we dont start the consensus states
+		// so we dont start the consensus states
+		reactors[i] = NewConsensusReactor(css[i], true, thisLogger.With("validator", i))
 		reactors[i].conS.SetLogger(thisLogger.With("validator", i))
-		reactors[i].SetLogger(thisLogger.With("validator", i))
 
-		eventBuses[i] = types.NewEventBus()
-		eventBuses[i].SetLogger(thisLogger.With("module", "events", "validator", i))
+		eventBuses[i] = types.NewEventBus(thisLogger.With("module", "events", "validator", i))
 		_, err := eventBuses[i].Start()
 		require.NoError(t, err)
 

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -294,7 +294,7 @@ func newConsensusStateForReplay(config cfg.BaseConfig,
 
 	// Create proxyAppConn connection (consensus, mempool, query)
 	clientCreator := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
-	proxyApp := proxy.NewAppConns(clientCreator, NewHandshaker(state, blockStore))
+	proxyApp := proxy.NewAppConns(clientCreator, NewHandshaker(state, blockStore), nil)
 	_, err = proxyApp.Start()
 	if err != nil {
 		cmn.Exit(cmn.Fmt("Error starting proxy app conns: %v", err))

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -12,6 +12,7 @@ import (
 	fail "github.com/ebuchman/fail-test"
 
 	wire "github.com/tendermint/go-wire"
+
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 
@@ -113,7 +114,10 @@ type ConsensusState struct {
 }
 
 // NewConsensusState returns a new ConsensusState.
-func NewConsensusState(config *cfg.ConsensusConfig, state *sm.State, proxyAppConn proxy.AppConnConsensus, blockStore types.BlockStore, mempool types.Mempool) *ConsensusState {
+func NewConsensusState(config *cfg.ConsensusConfig, state *sm.State,
+	proxyAppConn proxy.AppConnConsensus, blockStore types.BlockStore,
+	mempool types.Mempool, logger log.Logger) *ConsensusState {
+
 	cs := &ConsensusState{
 		config:           config,
 		proxyAppConn:     proxyAppConn,
@@ -135,7 +139,7 @@ func NewConsensusState(config *cfg.ConsensusConfig, state *sm.State, proxyAppCon
 	// Don't call scheduleRound0 yet.
 	// We do that upon Start().
 	cs.reconstructLastCommit(state)
-	cs.BaseService = *cmn.NewBaseService(nil, "ConsensusState", cs)
+	cs.BaseService = *cmn.NewBaseService(logger, "ConsensusState", cs)
 	return cs
 }
 

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
-	cstypes "github.com/tendermint/tendermint/consensus/types"
-	"github.com/tendermint/tendermint/types"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 	tmpubsub "github.com/tendermint/tmlibs/pubsub"
+
+	cstypes "github.com/tendermint/tendermint/consensus/types"
+	"github.com/tendermint/tendermint/types"
 )
 
 func init() {
@@ -23,7 +24,6 @@ func ensureProposeTimeout(timeoutPropose int) time.Duration {
 }
 
 /*
-
 ProposeSuite
 x * TestProposerSelection0 - round robin ordering, round 0
 x * TestProposerSelection2 - round robin ordering, round 2++
@@ -49,7 +49,6 @@ CatchupSuite
   * TestCatchup - if we might be behind and we've seen any 2/3 prevotes, round skip to new round, precommit, or prevote
 HaltSuite
 x * TestHalt1 - if we see +2/3 precommits after timing out into new round, we should still commit
-
 */
 
 //----------------------------------------------------------------------------------------------------
@@ -223,14 +222,16 @@ func TestBadProposal(t *testing.T) {
 	validatePrevote(t, cs1, round, vss[0], nil)
 
 	// add bad prevote from vs2 and wait for it
-	signAddVotes(cs1, types.VoteTypePrevote, propBlock.Hash(), propBlock.MakePartSet(partSize).Header(), vs2)
+	signAddVotes(cs1, types.VoteTypePrevote, propBlock.Hash(),
+		propBlock.MakePartSet(partSize).Header(), vs2)
 	<-voteCh
 
 	// wait for precommit
 	<-voteCh
 
 	validatePrecommit(t, cs1, round, 0, vss[0], nil, nil)
-	signAddVotes(cs1, types.VoteTypePrecommit, propBlock.Hash(), propBlock.MakePartSet(partSize).Header(), vs2)
+	signAddVotes(cs1, types.VoteTypePrecommit, propBlock.Hash(),
+		propBlock.MakePartSet(partSize).Header(), vs2)
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -244,8 +245,7 @@ func TestFullRound1(t *testing.T) {
 	// NOTE: buffer capacity of 0 ensures we can validate prevote and last commit
 	// before consensus can move to the next height (and cause a race condition)
 	cs.eventBus.Stop()
-	eventBus := types.NewEventBusWithBufferCapacity(0)
-	eventBus.SetLogger(log.TestingLogger().With("module", "events"))
+	eventBus := types.NewEventBusWithBufferCapacity(0, log.TestingLogger().With("module", "events"))
 	cs.SetEventBus(eventBus)
 	eventBus.Start()
 

--- a/consensus/ticker.go
+++ b/consensus/ticker.go
@@ -14,13 +14,12 @@ var (
 // TimeoutTicker is a timer that schedules timeouts
 // conditional on the height/round/step in the timeoutInfo.
 // The timeoutInfo.Duration may be non-positive.
+// TODO: Embed cmn.Service instead of redefining it here.
 type TimeoutTicker interface {
 	Start() (bool, error)
 	Stop() bool
 	Chan() <-chan timeoutInfo       // on which to receive a timeout
 	ScheduleTimeout(ti timeoutInfo) // reset the timer
-
-	SetLogger(log.Logger)
 }
 
 // timeoutTicker wraps time.Timer,
@@ -37,13 +36,13 @@ type timeoutTicker struct {
 }
 
 // NewTimeoutTicker returns a new TimeoutTicker.
-func NewTimeoutTicker() TimeoutTicker {
+func NewTimeoutTicker(logger log.Logger) TimeoutTicker {
 	tt := &timeoutTicker{
 		timer:    time.NewTimer(0),
 		tickChan: make(chan timeoutInfo, tickTockBufferSize),
 		tockChan: make(chan timeoutInfo, tickTockBufferSize),
 	}
-	tt.BaseService = *cmn.NewBaseService(nil, "TimeoutTicker", tt)
+	tt.BaseService = *cmn.NewBaseService(logger, "TimeoutTicker", tt)
 	tt.stopTimer() // don't want to fire until the first scheduled timeout
 	return tt
 }

--- a/consensus/wal.go
+++ b/consensus/wal.go
@@ -12,9 +12,12 @@ import (
 	"github.com/pkg/errors"
 
 	wire "github.com/tendermint/go-wire"
-	"github.com/tendermint/tendermint/types"
+
 	auto "github.com/tendermint/tmlibs/autofile"
 	cmn "github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tmlibs/log"
+
+	"github.com/tendermint/tendermint/types"
 )
 
 //--------------------------------------------------------
@@ -72,7 +75,7 @@ type baseWAL struct {
 	enc *WALEncoder
 }
 
-func NewWAL(walFile string, light bool) (*baseWAL, error) {
+func NewWAL(walFile string, light bool, logger log.Logger) (*baseWAL, error) {
 	err := cmn.EnsureDir(filepath.Dir(walFile), 0700)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to ensure WAL directory is in place")
@@ -87,7 +90,7 @@ func NewWAL(walFile string, light bool) (*baseWAL, error) {
 		light: light,
 		enc:   NewWALEncoder(group),
 	}
-	wal.BaseService = *cmn.NewBaseService(nil, "baseWAL", wal)
+	wal.BaseService = *cmn.NewBaseService(logger, "baseWAL", wal)
 	return wal, nil
 }
 

--- a/consensus/wal_test.go
+++ b/consensus/wal_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tendermint/tendermint/consensus/types"
-	tmtypes "github.com/tendermint/tendermint/types"
-	cmn "github.com/tendermint/tmlibs/common"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cmn "github.com/tendermint/tmlibs/common"
+
+	"github.com/tendermint/tendermint/consensus/types"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 func TestWALEncoderDecoder(t *testing.T) {
@@ -40,7 +41,7 @@ func TestWALEncoderDecoder(t *testing.T) {
 }
 
 func TestSearchForEndHeight(t *testing.T) {
-	wal, err := NewWAL(path.Join(data_dir, "many_blocks.cswal"), false)
+	wal, err := NewWAL(path.Join(data_dir, "many_blocks.cswal"), false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -98,7 +98,7 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: github.com/tendermint/abci
-  version: 76ef8a0697c6179220a74c479b36c27a5b53008a
+  version: ed3aa7fd344f5b2531e53749a59ce05334ab1aab
   subpackages:
   - client
   - example/counter

--- a/glide.lock
+++ b/glide.lock
@@ -123,7 +123,7 @@ imports:
   subpackages:
   - iavl
 - name: github.com/tendermint/tmlibs
-  version: d9525c0fb671204450b160807480e1263053fb20
+  version: 9c8d382ae26e6d873622c146fda3ff126e555e71
   subpackages:
   - autofile
   - cli

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -107,11 +107,6 @@ func (mem *Mempool) EnableTxsAvailable() {
 	mem.txsAvailable = make(chan int, 1)
 }
 
-// SetLogger sets the Logger.
-func (mem *Mempool) SetLogger(l log.Logger) {
-	mem.logger = l
-}
-
 func (mem *Mempool) initWAL() {
 	walDir := mem.config.WalDir()
 	if walDir != "" {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	abci "github.com/tendermint/abci/types"
+
 	auto "github.com/tendermint/tmlibs/autofile"
 	"github.com/tendermint/tmlibs/clist"
 	cmn "github.com/tendermint/tmlibs/common"
@@ -21,7 +22,6 @@ import (
 )
 
 /*
-
 The mempool pushes new txs onto the proxyAppConn.
 It gets a stream of (req, res) tuples from the proxy.
 The mempool stores good txs in a concurrent linked-list.
@@ -45,7 +45,6 @@ the DetachPrev() call, which makes old elements not reachable by
 peer broadcastTxRoutine() automatically garbage collected.
 
 TODO: Better handle abci client errors. (make it automatically handle connection errors)
-
 */
 
 const cacheSize = 100000
@@ -79,7 +78,6 @@ type Mempool struct {
 }
 
 // NewMempool returns a new Mempool with the given configuration and connection to an application.
-// TODO: Extract logger into arguments.
 func NewMempool(config *cfg.MempoolConfig, proxyAppConn proxy.AppConnMempool, height int,
 	logger log.Logger) *Mempool {
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -80,7 +80,9 @@ type Mempool struct {
 
 // NewMempool returns a new Mempool with the given configuration and connection to an application.
 // TODO: Extract logger into arguments.
-func NewMempool(config *cfg.MempoolConfig, proxyAppConn proxy.AppConnMempool, height int) *Mempool {
+func NewMempool(config *cfg.MempoolConfig, proxyAppConn proxy.AppConnMempool, height int,
+	logger log.Logger) *Mempool {
+
 	mempool := &Mempool{
 		config:        config,
 		proxyAppConn:  proxyAppConn,
@@ -90,7 +92,7 @@ func NewMempool(config *cfg.MempoolConfig, proxyAppConn proxy.AppConnMempool, he
 		rechecking:    0,
 		recheckCursor: nil,
 		recheckEnd:    nil,
-		logger:        log.NewNopLogger(),
+		logger:        logger,
 		cache:         newTxCache(cacheSize),
 	}
 	mempool.initWAL()

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -18,8 +18,8 @@ import (
 func newMempoolWithApp(cc proxy.ClientCreator) *Mempool {
 	config := cfg.ResetTestRoot("mempool_test")
 
-	appConnMem, _ := cc.NewABCIClient()
-	appConnMem.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "mempool"))
+	appConnMem, _ := cc.NewABCIClient(
+		log.TestingLogger().With("module", "abci-client", "connection", "mempool"))
 	appConnMem.Start()
 	mempool := NewMempool(config.Mempool, appConnMem, 0, log.TestingLogger())
 	return mempool
@@ -102,9 +102,8 @@ func TestSerialReap(t *testing.T) {
 	cc := proxy.NewLocalClientCreator(app)
 
 	mempool := newMempoolWithApp(cc)
-	appConnCon, _ := cc.NewABCIClient()
-	appConnCon.SetLogger(log.TestingLogger().With("module", "abci-client", "connection",
-		"consensus"))
+	appConnCon, _ := cc.NewABCIClient(
+		log.TestingLogger().With("module", "abci-client", "connection", "consensus"))
 	if _, err := appConnCon.Start(); err != nil {
 		t.Fatalf("Error starting ABCI client: %v", err.Error())
 	}

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -21,8 +21,7 @@ func newMempoolWithApp(cc proxy.ClientCreator) *Mempool {
 	appConnMem, _ := cc.NewABCIClient()
 	appConnMem.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "mempool"))
 	appConnMem.Start()
-	mempool := NewMempool(config.Mempool, appConnMem, 0)
-	mempool.SetLogger(log.TestingLogger())
+	mempool := NewMempool(config.Mempool, appConnMem, 0, log.TestingLogger())
 	return mempool
 }
 

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -103,7 +103,8 @@ func TestSerialReap(t *testing.T) {
 
 	mempool := newMempoolWithApp(cc)
 	appConnCon, _ := cc.NewABCIClient()
-	appConnCon.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "consensus"))
+	appConnCon.SetLogger(log.TestingLogger().With("module", "abci-client", "connection",
+		"consensus"))
 	if _, err := appConnCon.Start(); err != nil {
 		t.Fatalf("Error starting ABCI client: %v", err.Error())
 	}

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -9,7 +9,6 @@ import (
 	abci "github.com/tendermint/abci/types"
 	wire "github.com/tendermint/go-wire"
 	"github.com/tendermint/tmlibs/clist"
-	"github.com/tendermint/tmlibs/log"
 
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/p2p"
@@ -37,14 +36,8 @@ func NewMempoolReactor(config *cfg.MempoolConfig, mempool *Mempool) *MempoolReac
 		Mempool: mempool,
 	}
 	memR.BaseReactor = *p2p.NewBaseReactor("MempoolReactor", memR)
+	memR.Logger = mempool.logger
 	return memR
-}
-
-// SetLogger sets the Logger on the reactor and the underlying Mempool.
-func (memR *MempoolReactor) SetLogger(l log.Logger) {
-	// logger on embedded p2p.BaseReactor
-	memR.Logger = l
-	memR.Mempool.SetLogger(l)
 }
 
 // GetChannels implements Reactor.

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	abci "github.com/tendermint/abci/types"
+
 	wire "github.com/tendermint/go-wire"
+
 	"github.com/tendermint/tmlibs/clist"
 	"github.com/tendermint/tmlibs/log"
 
@@ -165,7 +167,8 @@ func DecodeMessage(bz []byte) (msgType byte, msg MempoolMessage, err error) {
 	msgType = bz[0]
 	n := new(int)
 	r := bytes.NewReader(bz)
-	msg = wire.ReadBinary(struct{ MempoolMessage }{}, r, maxMempoolMessageSize, n, &err).(struct{ MempoolMessage }).MempoolMessage
+	msg = wire.ReadBinary(struct{ MempoolMessage }{}, r, maxMempoolMessageSize, n,
+		&err).(struct{ MempoolMessage }).MempoolMessage
 	return
 }
 

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -42,6 +42,7 @@ func NewMempoolReactor(config *cfg.MempoolConfig, mempool *Mempool) *MempoolReac
 
 // SetLogger sets the Logger on the reactor and the underlying Mempool.
 func (memR *MempoolReactor) SetLogger(l log.Logger) {
+	// logger on embedded p2p.BaseReactor
 	memR.Logger = l
 	memR.Mempool.SetLogger(l)
 }

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -9,6 +9,7 @@ import (
 	abci "github.com/tendermint/abci/types"
 	wire "github.com/tendermint/go-wire"
 	"github.com/tendermint/tmlibs/clist"
+	"github.com/tendermint/tmlibs/log"
 
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/p2p"
@@ -30,13 +31,14 @@ type MempoolReactor struct {
 }
 
 // NewMempoolReactor returns a new MempoolReactor with the given config and mempool.
-func NewMempoolReactor(config *cfg.MempoolConfig, mempool *Mempool) *MempoolReactor {
+func NewMempoolReactor(config *cfg.MempoolConfig, mempool *Mempool,
+	logger log.Logger) *MempoolReactor {
+
 	memR := &MempoolReactor{
 		config:  config,
 		Mempool: mempool,
 	}
-	memR.BaseReactor = *p2p.NewBaseReactor("MempoolReactor", memR)
-	memR.Logger = mempool.logger
+	memR.BaseReactor = *p2p.NewBaseReactor(logger, "MempoolReactor", memR)
 	return memR
 }
 

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/kit/log/term"
 
 	"github.com/tendermint/abci/example/dummy"
+
 	"github.com/tendermint/tmlibs/log"
 
 	cfg "github.com/tendermint/tendermint/config"
@@ -77,7 +78,8 @@ func waitForTxs(t *testing.T, txs types.Txs, reactors []*MempoolReactor) {
 }
 
 // wait for all txs on a single mempool
-func _waitForTxs(t *testing.T, wg *sync.WaitGroup, txs types.Txs, reactorIdx int, reactors []*MempoolReactor) {
+func _waitForTxs(t *testing.T, wg *sync.WaitGroup, txs types.Txs, reactorIdx int,
+	reactors []*MempoolReactor) {
 
 	mempool := reactors[reactorIdx].Mempool
 	for mempool.Size() != len(txs) {
@@ -86,7 +88,9 @@ func _waitForTxs(t *testing.T, wg *sync.WaitGroup, txs types.Txs, reactorIdx int
 
 	reapedTxs := mempool.Reap(len(txs))
 	for i, tx := range txs {
-		assert.Equal(t, tx, reapedTxs[i], fmt.Sprintf("txs at index %d on reactor %d don't match: %v vs %v", i, reactorIdx, tx, reapedTxs[i]))
+		assert.Equal(t, tx, reapedTxs[i],
+			fmt.Sprintf("txs at index %d on reactor %d don't match: %v vs %v", i, reactorIdx, tx,
+				reapedTxs[i]))
 	}
 	wg.Done()
 }

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -41,8 +41,8 @@ func makeAndConnectMempoolReactors(config *cfg.Config, N int) []*MempoolReactor 
 		cc := proxy.NewLocalClientCreator(app)
 		mempool := newMempoolWithApp(cc)
 
-		reactors[i] = NewMempoolReactor(config.Mempool, mempool) // so we dont start the consensus states
-		reactors[i].SetLogger(logger.With("validator", i))
+		// so we dont start the consensus states
+		reactors[i] = NewMempoolReactor(config.Mempool, mempool, logger.With("validator", i))
 	}
 
 	p2p.MakeConnectedSwitches(config.P2P, N, func(i int, s *p2p.Switch) *p2p.Switch {

--- a/node/node.go
+++ b/node/node.go
@@ -8,11 +8,15 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"strings"
 
 	abci "github.com/tendermint/abci/types"
+
 	crypto "github.com/tendermint/go-crypto"
+
 	wire "github.com/tendermint/go-wire"
+
 	cmn "github.com/tendermint/tmlibs/common"
 	dbm "github.com/tendermint/tmlibs/db"
 	"github.com/tendermint/tmlibs/log"
@@ -34,8 +38,6 @@ import (
 	"github.com/tendermint/tendermint/state/txindex/null"
 	"github.com/tendermint/tendermint/types"
 	"github.com/tendermint/tendermint/version"
-
-	_ "net/http/pprof"
 )
 
 //------------------------------------------------------------------------------
@@ -271,7 +273,8 @@ func NewNode(config *cfg.Config,
 			return errors.New(resQuery.Code.String())
 		})
 		sw.SetPubKeyFilter(func(pubkey crypto.PubKeyEd25519) error {
-			resQuery, err := proxyApp.Query().QuerySync(abci.RequestQuery{Path: cmn.Fmt("/p2p/filter/pubkey/%X", pubkey.Bytes())})
+			resQuery, err := proxyApp.Query().
+				QuerySync(abci.RequestQuery{Path: cmn.Fmt("/p2p/filter/pubkey/%X", pubkey.Bytes())})
 			if err != nil {
 				return err
 			}
@@ -338,7 +341,8 @@ func (n *Node) OnStart() error {
 
 	// Create & add listener
 	protocol, address := cmn.ProtocolAndAddress(n.config.P2P.ListenAddress)
-	l := p2p.NewDefaultListener(protocol, address, n.config.P2P.SkipUPNP, n.Logger.With("module", "p2p"))
+	l := p2p.NewDefaultListener(protocol, address, n.config.P2P.SkipUPNP,
+		n.Logger.With("module", "p2p"))
 	n.sw.AddListener(l)
 
 	// Start the switch

--- a/node/node.go
+++ b/node/node.go
@@ -208,33 +208,29 @@ func NewNode(config *cfg.Config,
 	}
 
 	// Make BlockchainReactor
-	bcReactor := bc.NewBlockchainReactor(state.Copy(), proxyApp.Consensus(), blockStore, fastSync)
-	bcReactor.SetLogger(logger.With("module", "blockchain"))
+	bcReactor := bc.NewBlockchainReactor(state.Copy(), proxyApp.Consensus(), blockStore, fastSync,
+		logger.With("module", "blockchain"))
 
 	// Make MempoolReactor
 	mempoolLogger := logger.With("module", "mempool")
 	mempool := mempl.NewMempool(config.Mempool, proxyApp.Mempool(), state.LastBlockHeight,
 		mempoolLogger)
-	mempoolReactor := mempl.NewMempoolReactor(config.Mempool, mempool)
-	mempoolReactor.SetLogger(mempoolLogger)
+	mempoolReactor := mempl.NewMempoolReactor(config.Mempool, mempool, mempoolLogger)
 
 	if config.Consensus.WaitForTxs() {
 		mempool.EnableTxsAvailable()
 	}
 
 	// Make ConsensusReactor
-	consensusState := consensus.NewConsensusState(config.Consensus, state.Copy(), proxyApp.Consensus(), blockStore, mempool)
-	consensusState.SetLogger(consensusLogger)
+	consensusState := consensus.NewConsensusState(config.Consensus, state.Copy(),
+		proxyApp.Consensus(), blockStore, mempool, consensusLogger)
 	if privValidator != nil {
 		consensusState.SetPrivValidator(privValidator)
 	}
-	consensusReactor := consensus.NewConsensusReactor(consensusState, fastSync)
-	consensusReactor.SetLogger(consensusLogger)
+	consensusReactor := consensus.NewConsensusReactor(consensusState, fastSync, consensusLogger)
 
 	p2pLogger := logger.With("module", "p2p")
-
-	sw := p2p.NewSwitch(config.P2P)
-	sw.SetLogger(p2pLogger)
+	sw := p2p.NewSwitch(config.P2P, p2pLogger)
 	sw.AddReactor("MEMPOOL", mempoolReactor)
 	sw.AddReactor("BLOCKCHAIN", bcReactor)
 	sw.AddReactor("CONSENSUS", consensusReactor)
@@ -243,19 +239,18 @@ func NewNode(config *cfg.Config,
 	var addrBook *p2p.AddrBook
 	var trustMetricStore *trust.TrustMetricStore
 	if config.P2P.PexReactor {
-		addrBook = p2p.NewAddrBook(config.P2P.AddrBookFile(), config.P2P.AddrBookStrict)
-		addrBook.SetLogger(p2pLogger.With("book", config.P2P.AddrBookFile()))
+		addrBook = p2p.NewAddrBook(config.P2P.AddrBookFile(), config.P2P.AddrBookStrict,
+			p2pLogger.With("book", config.P2P.AddrBookFile()))
 
 		// Get the trust metric history data
 		trustHistoryDB, err := dbProvider(&DBContext{"trusthistory", config})
 		if err != nil {
 			return nil, err
 		}
-		trustMetricStore = trust.NewTrustMetricStore(trustHistoryDB, trust.DefaultConfig())
-		trustMetricStore.SetLogger(p2pLogger)
+		trustMetricStore = trust.NewTrustMetricStore(trustHistoryDB, trust.DefaultConfig(),
+			p2pLogger)
 
-		pexReactor := p2p.NewPEXReactor(addrBook)
-		pexReactor.SetLogger(p2pLogger)
+		pexReactor := p2p.NewPEXReactor(addrBook, p2pLogger)
 		sw.AddReactor("PEX", pexReactor)
 	}
 
@@ -265,7 +260,8 @@ func NewNode(config *cfg.Config,
 	if config.FilterPeers {
 		// NOTE: addr is ip:port
 		sw.SetAddrFilter(func(addr net.Addr) error {
-			resQuery, err := proxyApp.Query().QuerySync(abci.RequestQuery{Path: cmn.Fmt("/p2p/filter/addr/%s", addr.String())})
+			resQuery, err := proxyApp.Query().
+				QuerySync(abci.RequestQuery{Path: cmn.Fmt("/p2p/filter/addr/%s", addr.String())})
 			if err != nil {
 				return err
 			}
@@ -286,8 +282,7 @@ func NewNode(config *cfg.Config,
 		})
 	}
 
-	eventBus := types.NewEventBus()
-	eventBus.SetLogger(logger.With("module", "events"))
+	eventBus := types.NewEventBus(logger.With("module", "events"))
 
 	// services which will be publishing and/or subscribing for messages (events)
 	bcReactor.SetEventBus(eventBus)

--- a/node/node.go
+++ b/node/node.go
@@ -213,8 +213,8 @@ func NewNode(config *cfg.Config,
 
 	// Make MempoolReactor
 	mempoolLogger := logger.With("module", "mempool")
-	mempool := mempl.NewMempool(config.Mempool, proxyApp.Mempool(), state.LastBlockHeight)
-	mempool.SetLogger(mempoolLogger)
+	mempool := mempl.NewMempool(config.Mempool, proxyApp.Mempool(), state.LastBlockHeight,
+		mempoolLogger)
 	mempoolReactor := mempl.NewMempoolReactor(config.Mempool, mempool)
 	mempoolReactor.SetLogger(mempoolLogger)
 

--- a/p2p/addrbook.go
+++ b/p2p/addrbook.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	crypto "github.com/tendermint/go-crypto"
+
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 )
@@ -637,7 +638,8 @@ func (a *AddrBook) moveToOld(ka *knownAddress) {
 		if !added {
 			added := a.addToNewBucket(oldest, freedBucket)
 			if !added {
-				a.Logger.Error(cmn.Fmt("Could not migrate oldest %v to freedBucket %v", oldest, freedBucket))
+				a.Logger.Error(cmn.Fmt("Could not migrate oldest %v to freedBucket %v", oldest,
+					freedBucket))
 			}
 		}
 		// Finally, add to bucket again.
@@ -649,7 +651,7 @@ func (a *AddrBook) moveToOld(ka *knownAddress) {
 }
 
 // doublesha256(  key + sourcegroup +
-//                int64(doublesha256(key + group + sourcegroup))%bucket_per_group  ) % num_new_buckets
+//             int64(doublesha256(key + group + sourcegroup))%bucket_per_group  ) % num_new_buckets
 func (a *AddrBook) calcNewBucket(addr, src *NetAddress) int {
 	data1 := []byte{}
 	data1 = append(data1, []byte(a.key)...)

--- a/p2p/addrbook.go
+++ b/p2p/addrbook.go
@@ -17,6 +17,7 @@ import (
 
 	crypto "github.com/tendermint/go-crypto"
 	cmn "github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tmlibs/log"
 )
 
 const (
@@ -100,7 +101,7 @@ type AddrBook struct {
 
 // NewAddrBook creates a new address book.
 // Use Start to begin processing asynchronous address updates.
-func NewAddrBook(filePath string, routabilityStrict bool) *AddrBook {
+func NewAddrBook(filePath string, routabilityStrict bool, logger log.Logger) *AddrBook {
 	am := &AddrBook{
 		rand:              rand.New(rand.NewSource(time.Now().UnixNano())),
 		ourAddrs:          make(map[string]*NetAddress),
@@ -109,7 +110,7 @@ func NewAddrBook(filePath string, routabilityStrict bool) *AddrBook {
 		routabilityStrict: routabilityStrict,
 	}
 	am.init()
-	am.BaseService = *cmn.NewBaseService(nil, "AddrBook", am)
+	am.BaseService = *cmn.NewBaseService(logger, "AddrBook", am)
 	return am
 }
 

--- a/p2p/addrbook_test.go
+++ b/p2p/addrbook_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/tendermint/tmlibs/log"
 )
 
@@ -28,8 +29,7 @@ func TestAddrBookPickAddress(t *testing.T) {
 	fname := createTempFileName("addrbook_test")
 
 	// 0 addresses
-	book := NewAddrBook(fname, true)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(fname, true, log.TestingLogger())
 	assert.Zero(book.Size())
 
 	addr := book.PickAddress(50)
@@ -63,12 +63,10 @@ func TestAddrBookSaveLoad(t *testing.T) {
 	fname := createTempFileName("addrbook_test")
 
 	// 0 addresses
-	book := NewAddrBook(fname, true)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(fname, true, log.TestingLogger())
 	book.saveToFile(fname)
 
-	book = NewAddrBook(fname, true)
-	book.SetLogger(log.TestingLogger())
+	book = NewAddrBook(fname, true, log.TestingLogger())
 	book.loadFromFile(fname)
 
 	assert.Zero(t, book.Size())
@@ -83,8 +81,7 @@ func TestAddrBookSaveLoad(t *testing.T) {
 	assert.Equal(t, 100, book.Size())
 	book.saveToFile(fname)
 
-	book = NewAddrBook(fname, true)
-	book.SetLogger(log.TestingLogger())
+	book = NewAddrBook(fname, true, log.TestingLogger())
 	book.loadFromFile(fname)
 
 	assert.Equal(t, 100, book.Size())
@@ -95,8 +92,7 @@ func TestAddrBookLookup(t *testing.T) {
 
 	randAddrs := randNetAddressPairs(t, 100)
 
-	book := NewAddrBook(fname, true)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(fname, true, log.TestingLogger())
 	for _, addrSrc := range randAddrs {
 		addr := addrSrc.addr
 		src := addrSrc.src
@@ -117,8 +113,7 @@ func TestAddrBookPromoteToOld(t *testing.T) {
 
 	randAddrs := randNetAddressPairs(t, 100)
 
-	book := NewAddrBook(fname, true)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(fname, true, log.TestingLogger())
 	for _, addrSrc := range randAddrs {
 		book.AddAddress(addrSrc.addr, addrSrc.src)
 	}
@@ -150,8 +145,7 @@ func TestAddrBookPromoteToOld(t *testing.T) {
 func TestAddrBookHandlesDuplicates(t *testing.T) {
 	fname := createTempFileName("addrbook_test")
 
-	book := NewAddrBook(fname, true)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(fname, true, log.TestingLogger())
 
 	randAddrs := randNetAddressPairs(t, 100)
 
@@ -197,8 +191,7 @@ func randIPv4Address(t *testing.T) *NetAddress {
 
 func TestAddrBookRemoveAddress(t *testing.T) {
 	fname := createTempFileName("addrbook_test")
-	book := NewAddrBook(fname, true)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(fname, true, log.TestingLogger())
 
 	addr := randIPv4Address(t)
 	book.AddAddress(addr, addr)

--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -14,6 +14,7 @@ import (
 	tmencoding "github.com/tendermint/go-wire/nowriter/tmencoding"
 	cmn "github.com/tendermint/tmlibs/common"
 	flow "github.com/tendermint/tmlibs/flowrate"
+	"github.com/tendermint/tmlibs/log"
 )
 
 var legacy = tmencoding.Legacy
@@ -117,17 +118,16 @@ func DefaultMConnConfig() *MConnConfig {
 }
 
 // NewMConnection wraps net.Conn and creates multiplex connection
-func NewMConnection(conn net.Conn, chDescs []*ChannelDescriptor, onReceive receiveCbFunc, onError errorCbFunc) *MConnection {
-	return NewMConnectionWithConfig(
-		conn,
-		chDescs,
-		onReceive,
-		onError,
-		DefaultMConnConfig())
+func NewMConnection(conn net.Conn, chDescs []*ChannelDescriptor, onReceive receiveCbFunc,
+	onError errorCbFunc, logger log.Logger) *MConnection {
+
+	return NewMConnectionWithConfig(conn, chDescs, onReceive, onError, DefaultMConnConfig(), logger)
 }
 
 // NewMConnectionWithConfig wraps net.Conn and creates multiplex connection with a config
-func NewMConnectionWithConfig(conn net.Conn, chDescs []*ChannelDescriptor, onReceive receiveCbFunc, onError errorCbFunc, config *MConnConfig) *MConnection {
+func NewMConnectionWithConfig(conn net.Conn, chDescs []*ChannelDescriptor, onReceive receiveCbFunc,
+	onError errorCbFunc, config *MConnConfig, logger log.Logger) *MConnection {
+
 	mconn := &MConnection{
 		conn:        conn,
 		bufReader:   bufio.NewReaderSize(conn, minReadBufferSize),
@@ -157,7 +157,7 @@ func NewMConnectionWithConfig(conn net.Conn, chDescs []*ChannelDescriptor, onRec
 	mconn.channels = channels
 	mconn.channelsIdx = channelsIdx
 
-	mconn.BaseService = *cmn.NewBaseService(nil, "MConnection", mconn)
+	mconn.BaseService = *cmn.NewBaseService(logger, "MConnection", mconn)
 
 	return mconn
 }

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	crypto "github.com/tendermint/go-crypto"
+
+	"github.com/tendermint/tmlibs/log"
 )
 
 func TestPeerBasic(t *testing.T) {
@@ -82,7 +84,8 @@ func createOutboundPeerAndPerformHandshake(addr *NetAddress, config *PeerConfig)
 	}
 	reactorsByCh := map[byte]Reactor{0x01: NewTestReactor(chDescs, true)}
 	pk := crypto.GenPrivKeyEd25519()
-	p, err := newOutboundPeer(addr, reactorsByCh, chDescs, func(p Peer, r interface{}) {}, pk, config)
+	p, err := newOutboundPeer(addr, reactorsByCh, chDescs, func(p Peer, r interface{}) {}, pk,
+		config, log.NewNopLogger())
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +136,8 @@ func (p *remotePeer) accept(l net.Listener) {
 		if err != nil {
 			golog.Fatalf("Failed to accept conn: %+v", err)
 		}
-		peer, err := newInboundPeer(conn, make(map[byte]Reactor), make([]*ChannelDescriptor, 0), func(p Peer, r interface{}) {}, p.PrivKey, p.Config)
+		peer, err := newInboundPeer(conn, make(map[byte]Reactor), make([]*ChannelDescriptor, 0),
+			func(p Peer, r interface{}) {}, p.PrivKey, p.Config, log.NewNopLogger())
 		if err != nil {
 			golog.Fatalf("Failed to create a peer: %+v", err)
 		}

--- a/p2p/pex_reactor.go
+++ b/p2p/pex_reactor.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	wire "github.com/tendermint/go-wire"
+
 	cmn "github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tmlibs/log"
 )
 
 const (
@@ -53,14 +55,14 @@ type PEXReactor struct {
 }
 
 // NewPEXReactor creates new PEX reactor.
-func NewPEXReactor(b *AddrBook) *PEXReactor {
+func NewPEXReactor(b *AddrBook, logger log.Logger) *PEXReactor {
 	r := &PEXReactor{
 		book:              b,
 		ensurePeersPeriod: defaultEnsurePeersPeriod,
 		msgCountByPeer:    cmn.NewCMap(),
 		maxMsgCountByPeer: defaultMaxMsgCountByPeer,
 	}
-	r.BaseReactor = *NewBaseReactor("PEXReactor", r)
+	r.BaseReactor = *NewBaseReactor(logger, "PEXReactor", r)
 	return r
 }
 

--- a/p2p/pex_reactor.go
+++ b/p2p/pex_reactor.go
@@ -106,7 +106,8 @@ func (r *PEXReactor) AddPeer(p Peer) {
 		addr, err := NewNetAddressString(p.NodeInfo().ListenAddr)
 		if err != nil {
 			// peer gave us a bad ListenAddr. TODO: punish
-			r.Logger.Error("Error in AddPeer: invalid peer address", "addr", p.NodeInfo().ListenAddr, "err", err)
+			r.Logger.Error("Error in AddPeer: invalid peer address", "addr",
+				p.NodeInfo().ListenAddr, "err", err)
 			return
 		}
 		r.book.AddAddress(addr, addr)
@@ -237,7 +238,8 @@ func (r *PEXReactor) ensurePeersRoutine() {
 func (r *PEXReactor) ensurePeers() {
 	numOutPeers, _, numDialing := r.Switch.NumPeers()
 	numToDial := minNumOutboundPeers - (numOutPeers + numDialing)
-	r.Logger.Info("Ensure peers", "numOutPeers", numOutPeers, "numDialing", numDialing, "numToDial", numToDial)
+	r.Logger.Info("Ensure peers", "numOutPeers", numOutPeers, "numDialing", numDialing,
+		"numToDial", numToDial)
 	if numToDial <= 0 {
 		return
 	}
@@ -325,7 +327,8 @@ func DecodeMessage(bz []byte) (msgType byte, msg PexMessage, err error) {
 	msgType = bz[0]
 	n := new(int)
 	r := bytes.NewReader(bz)
-	msg = wire.ReadBinary(struct{ PexMessage }{}, r, maxPexMessageSize, n, &err).(struct{ PexMessage }).PexMessage
+	msg = wire.ReadBinary(struct{ PexMessage }{}, r, maxPexMessageSize, n,
+		&err).(struct{ PexMessage }).PexMessage
 	return
 }
 

--- a/p2p/pex_reactor_test.go
+++ b/p2p/pex_reactor_test.go
@@ -73,7 +73,7 @@ func TestPEXReactorRunning(t *testing.T) {
 	// create switches
 	for i := 0; i < N; i++ {
 		switches[i] = makeSwitch(config, i, "127.0.0.1", "123.123.123", func(i int, sw *Switch) *Switch {
-			sw.SetLogger(log.TestingLogger().With("switch", i))
+			sw.BaseService.Logger = log.TestingLogger().With("switch", i)
 
 			r := NewPEXReactor(book, log.TestingLogger())
 			r.SetEnsurePeersPeriod(250 * time.Millisecond)
@@ -103,7 +103,9 @@ func TestPEXReactorRunning(t *testing.T) {
 	}
 }
 
-func assertSomePeersWithTimeout(t *testing.T, switches []*Switch, checkPeriod, timeout time.Duration) {
+func assertSomePeersWithTimeout(t *testing.T, switches []*Switch, checkPeriod,
+	timeout time.Duration) {
+
 	ticker := time.NewTicker(checkPeriod)
 	for {
 		select {
@@ -123,9 +125,11 @@ func assertSomePeersWithTimeout(t *testing.T, switches []*Switch, checkPeriod, t
 			numPeersStr := ""
 			for i, s := range switches {
 				outbound, inbound, _ := s.NumPeers()
-				numPeersStr += fmt.Sprintf("%d => {outbound: %d, inbound: %d}, ", i, outbound, inbound)
+				numPeersStr += fmt.Sprintf("%d => {outbound: %d, inbound: %d}, ", i, outbound,
+					inbound)
 			}
-			t.Errorf("expected all switches to be connected to at least one peer (switches: %s)", numPeersStr)
+			t.Errorf("expected all switches to be connected to at least one peer (switches: %s)",
+				numPeersStr)
 		}
 	}
 }
@@ -176,7 +180,8 @@ func TestPEXReactorAbuseFromPeer(t *testing.T) {
 
 func createRoutableAddr() (addr string, netAddr *NetAddress) {
 	for {
-		addr = cmn.Fmt("%v.%v.%v.%v:46656", rand.Int()%256, rand.Int()%256, rand.Int()%256, rand.Int()%256)
+		addr = cmn.Fmt("%v.%v.%v.%v:46656", rand.Int()%256, rand.Int()%256, rand.Int()%256,
+			rand.Int()%256)
 		netAddr, _ = NewNetAddressString(addr)
 		if netAddr.Routable() {
 			break
@@ -196,6 +201,6 @@ func createRandomPeer(outbound bool) *peer {
 		outbound: outbound,
 		mconn:    &MConnection{RemoteAddress: netAddr},
 	}
-	p.SetLogger(log.TestingLogger().With("peer", addr))
+	p.BaseService.Logger = log.TestingLogger().With("peer", addr)
 	return p
 }

--- a/p2p/pex_reactor_test.go
+++ b/p2p/pex_reactor_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	wire "github.com/tendermint/go-wire"
+
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 )
@@ -21,11 +23,9 @@ func TestPEXReactorBasic(t *testing.T) {
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	require.Nil(err)
 	defer os.RemoveAll(dir)
-	book := NewAddrBook(dir+"addrbook.json", true)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(dir+"addrbook.json", true, log.TestingLogger())
 
-	r := NewPEXReactor(book)
-	r.SetLogger(log.TestingLogger())
+	r := NewPEXReactor(book, log.TestingLogger())
 
 	assert.NotNil(r)
 	assert.NotEmpty(r.GetChannels())
@@ -37,11 +37,9 @@ func TestPEXReactorAddRemovePeer(t *testing.T) {
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	require.Nil(err)
 	defer os.RemoveAll(dir)
-	book := NewAddrBook(dir+"addrbook.json", true)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(dir+"addrbook.json", true, log.TestingLogger())
 
-	r := NewPEXReactor(book)
-	r.SetLogger(log.TestingLogger())
+	r := NewPEXReactor(book, log.TestingLogger())
 
 	size := book.Size()
 	peer := createRandomPeer(false)
@@ -70,16 +68,14 @@ func TestPEXReactorRunning(t *testing.T) {
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	require.Nil(err)
 	defer os.RemoveAll(dir)
-	book := NewAddrBook(dir+"addrbook.json", false)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(dir+"addrbook.json", false, log.TestingLogger())
 
 	// create switches
 	for i := 0; i < N; i++ {
 		switches[i] = makeSwitch(config, i, "127.0.0.1", "123.123.123", func(i int, sw *Switch) *Switch {
 			sw.SetLogger(log.TestingLogger().With("switch", i))
 
-			r := NewPEXReactor(book)
-			r.SetLogger(log.TestingLogger())
+			r := NewPEXReactor(book, log.TestingLogger())
 			r.SetEnsurePeersPeriod(250 * time.Millisecond)
 			sw.AddReactor("pex", r)
 			return sw
@@ -140,11 +136,9 @@ func TestPEXReactorReceive(t *testing.T) {
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	require.Nil(err)
 	defer os.RemoveAll(dir)
-	book := NewAddrBook(dir+"addrbook.json", false)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(dir+"addrbook.json", false, log.TestingLogger())
 
-	r := NewPEXReactor(book)
-	r.SetLogger(log.TestingLogger())
+	r := NewPEXReactor(book, log.TestingLogger())
 
 	peer := createRandomPeer(false)
 
@@ -165,11 +159,9 @@ func TestPEXReactorAbuseFromPeer(t *testing.T) {
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	require.Nil(err)
 	defer os.RemoveAll(dir)
-	book := NewAddrBook(dir+"addrbook.json", true)
-	book.SetLogger(log.TestingLogger())
+	book := NewAddrBook(dir+"addrbook.json", true, log.TestingLogger())
 
-	r := NewPEXReactor(book)
-	r.SetLogger(log.TestingLogger())
+	r := NewPEXReactor(book, log.TestingLogger())
 	r.SetMaxMsgCountByPeer(5)
 
 	peer := createRandomPeer(false)

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -354,12 +354,11 @@ func (sw *Switch) DialPeerWithAddress(addr *NetAddress, persistent bool) (Peer, 
 
 	sw.Logger.Info("Dialing peer", "address", addr)
 	peer, err := newOutboundPeer(addr, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError,
-		sw.nodePrivKey, sw.peerConfig)
+		sw.nodePrivKey, sw.peerConfig, sw.Logger.With("peer", addr))
 	if err != nil {
 		sw.Logger.Error("Failed to dial peer", "address", addr, "err", err)
 		return nil, err
 	}
-	peer.SetLogger(sw.Logger.With("peer", addr))
 	if persistent {
 		peer.makePersistent()
 	}
@@ -583,12 +582,11 @@ func makeSwitch(cfg *cfg.P2PConfig, i int, network, version string,
 
 func (sw *Switch) addPeerWithConnection(conn net.Conn) error {
 	peer, err := newInboundPeer(conn, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError,
-		sw.nodePrivKey, sw.peerConfig)
+		sw.nodePrivKey, sw.peerConfig, sw.Logger.With("peer", conn.RemoteAddr()))
 	if err != nil {
 		conn.Close()
 		return err
 	}
-	peer.SetLogger(sw.Logger.With("peer", conn.RemoteAddr()))
 	if err = sw.addPeer(peer); err != nil {
 		peer.CloseConn()
 		return err
@@ -599,12 +597,11 @@ func (sw *Switch) addPeerWithConnection(conn net.Conn) error {
 
 func (sw *Switch) addPeerWithConnectionAndConfig(conn net.Conn, config *PeerConfig) error {
 	peer, err := newInboundPeer(conn, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError,
-		sw.nodePrivKey, config)
+		sw.nodePrivKey, config, sw.Logger.With("peer", conn.RemoteAddr()))
 	if err != nil {
 		conn.Close()
 		return err
 	}
-	peer.SetLogger(sw.Logger.With("peer", conn.RemoteAddr()))
 	if err = sw.addPeer(peer); err != nil {
 		peer.CloseConn()
 		return err

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -8,9 +8,11 @@ import (
 	"time"
 
 	crypto "github.com/tendermint/go-crypto"
-	cfg "github.com/tendermint/tendermint/config"
+
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
+
+	cfg "github.com/tendermint/tendermint/config"
 )
 
 const (
@@ -111,7 +113,8 @@ func (sw *Switch) AddReactor(name string, reactor Reactor) Reactor {
 	for _, chDesc := range reactorChannels {
 		chID := chDesc.ID
 		if sw.reactorsByCh[chID] != nil {
-			cmn.PanicSanity(fmt.Sprintf("Channel %X has multiple reactors %v & %v", chID, sw.reactorsByCh[chID], reactor))
+			cmn.PanicSanity(fmt.Sprintf("Channel %X has multiple reactors %v & %v", chID,
+				sw.reactorsByCh[chID], reactor))
 		}
 		sw.chDescs = append(sw.chDescs, chDesc)
 		sw.reactorsByCh[chID] = reactor
@@ -151,7 +154,8 @@ func (sw *Switch) IsListening() bool {
 	return len(sw.listeners) > 0
 }
 
-// SetNodeInfo sets the switch's NodeInfo for checking compatibility and handshaking with other nodes.
+// SetNodeInfo sets the switch's NodeInfo for checking compatibility and handshaking with other
+// nodes.
 // NOTE: Not goroutine safe.
 func (sw *Switch) SetNodeInfo(nodeInfo *NodeInfo) {
 	sw.nodeInfo = nodeInfo
@@ -224,7 +228,8 @@ func (sw *Switch) addPeer(peer *peer) error {
 		return err
 	}
 
-	if err := peer.HandshakeTimeout(sw.nodeInfo, time.Duration(sw.peerConfig.HandshakeTimeout*time.Second)); err != nil {
+	if err := peer.HandshakeTimeout(sw.nodeInfo,
+		time.Duration(sw.peerConfig.HandshakeTimeout*time.Second)); err != nil {
 		return err
 	}
 
@@ -341,13 +346,15 @@ func (sw *Switch) dialSeed(addr *NetAddress) {
 }
 
 // DialPeerWithAddress dials the given peer and runs sw.addPeer if it connects successfully.
-// If `persistent == true`, the switch will always try to reconnect to this peer if the connection ever fails.
+// If `persistent == true`, the switch will always try to reconnect to this peer if the connection
+// ever fails.
 func (sw *Switch) DialPeerWithAddress(addr *NetAddress, persistent bool) (Peer, error) {
 	sw.dialing.Set(addr.IP.String(), addr)
 	defer sw.dialing.Delete(addr.IP.String())
 
 	sw.Logger.Info("Dialing peer", "address", addr)
-	peer, err := newOutboundPeer(addr, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, sw.peerConfig)
+	peer, err := newOutboundPeer(addr, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError,
+		sw.nodePrivKey, sw.peerConfig)
 	if err != nil {
 		sw.Logger.Error("Failed to dial peer", "address", addr, "err", err)
 		return nil, err
@@ -426,10 +433,12 @@ func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 				peer, err := sw.DialPeerWithAddress(addr, true)
 				if err != nil {
 					if i == reconnectAttempts {
-						sw.Logger.Info("Error reconnecting to peer. Giving up", "tries", i, "err", err)
+						sw.Logger.Info("Error reconnecting to peer. Giving up", "tries", i,
+							"err", err)
 						return
 					}
-					sw.Logger.Info("Error reconnecting to peer. Trying again", "tries", i, "err", err)
+					sw.Logger.Info("Error reconnecting to peer. Trying again", "tries", i,
+						"err", err)
 					time.Sleep(reconnectInterval)
 					continue
 				}
@@ -466,14 +475,16 @@ func (sw *Switch) listenerRoutine(l Listener) {
 		// ignore connection if we already have enough
 		maxPeers := sw.config.MaxNumPeers
 		if maxPeers <= sw.peers.Size() {
-			sw.Logger.Info("Ignoring inbound connection: already have enough peers", "address", inConn.RemoteAddr().String(), "numPeers", sw.peers.Size(), "max", maxPeers)
+			sw.Logger.Info("Ignoring inbound connection: already have enough peers", "address",
+				inConn.RemoteAddr().String(), "numPeers", sw.peers.Size(), "max", maxPeers)
 			continue
 		}
 
 		// New inbound connection!
 		err := sw.addPeerWithConnectionAndConfig(inConn, sw.peerConfig)
 		if err != nil {
-			sw.Logger.Info("Ignoring inbound connection: error while adding peer", "address", inConn.RemoteAddr().String(), "err", err)
+			sw.Logger.Info("Ignoring inbound connection: error while adding peer", "address",
+				inConn.RemoteAddr().String(), "err", err)
 			continue
 		}
 
@@ -492,7 +503,9 @@ func (sw *Switch) listenerRoutine(l Listener) {
 // If connect==Connect2Switches, the switches will be fully connected.
 // initSwitch defines how the i'th switch should be initialized (ie. with what reactors).
 // NOTE: panics if any switch fails to start.
-func MakeConnectedSwitches(cfg *cfg.P2PConfig, n int, initSwitch func(int, *Switch) *Switch, connect func([]*Switch, int, int)) []*Switch {
+func MakeConnectedSwitches(cfg *cfg.P2PConfig, n int,
+	initSwitch func(int, *Switch) *Switch, connect func([]*Switch, int, int)) []*Switch {
+
 	switches := make([]*Switch, n)
 	for i := 0; i < n; i++ {
 		switches[i] = makeSwitch(cfg, i, "testing", "123.123.123", initSwitch)
@@ -549,7 +562,9 @@ func StartSwitches(switches []*Switch) error {
 	return nil
 }
 
-func makeSwitch(cfg *cfg.P2PConfig, i int, network, version string, initSwitch func(int, *Switch) *Switch) *Switch {
+func makeSwitch(cfg *cfg.P2PConfig, i int, network, version string,
+	initSwitch func(int, *Switch) *Switch) *Switch {
+
 	privKey := crypto.GenPrivKeyEd25519()
 	// new switch, add reactors
 	// TODO: let the config be passed in?
@@ -567,7 +582,8 @@ func makeSwitch(cfg *cfg.P2PConfig, i int, network, version string, initSwitch f
 }
 
 func (sw *Switch) addPeerWithConnection(conn net.Conn) error {
-	peer, err := newInboundPeer(conn, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, sw.peerConfig)
+	peer, err := newInboundPeer(conn, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError,
+		sw.nodePrivKey, sw.peerConfig)
 	if err != nil {
 		conn.Close()
 		return err
@@ -582,7 +598,8 @@ func (sw *Switch) addPeerWithConnection(conn net.Conn) error {
 }
 
 func (sw *Switch) addPeerWithConnectionAndConfig(conn net.Conn, config *PeerConfig) error {
-	peer, err := newInboundPeer(conn, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, config)
+	peer, err := newInboundPeer(conn, sw.reactorsByCh, sw.chDescs, sw.StopPeerForError,
+		sw.nodePrivKey, config)
 	if err != nil {
 		conn.Close()
 		return err

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -10,11 +10,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	crypto "github.com/tendermint/go-crypto"
+
 	wire "github.com/tendermint/go-wire"
 
-	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tmlibs/log"
+
+	cfg "github.com/tendermint/tendermint/config"
 )
 
 var (
@@ -75,7 +78,8 @@ func (tr *TestReactor) Receive(chID byte, peer Peer, msgBytes []byte) {
 		tr.mtx.Lock()
 		defer tr.mtx.Unlock()
 		//fmt.Printf("Received: %X, %X\n", chID, msgBytes)
-		tr.msgsReceived[chID] = append(tr.msgsReceived[chID], PeerMessage{peer.Key(), msgBytes, tr.msgsCounter})
+		tr.msgsReceived[chID] = append(tr.msgsReceived[chID], PeerMessage{peer.Key(), msgBytes,
+			tr.msgsCounter})
 		tr.msgsCounter++
 	}
 }
@@ -130,12 +134,17 @@ func TestSwitches(t *testing.T) {
 	s1.Broadcast(byte(0x01), ch1Msg)
 	s1.Broadcast(byte(0x02), ch2Msg)
 
-	assertMsgReceivedWithTimeout(t, ch0Msg, byte(0x00), s2.Reactor("foo").(*TestReactor), 10*time.Millisecond, 5*time.Second)
-	assertMsgReceivedWithTimeout(t, ch1Msg, byte(0x01), s2.Reactor("foo").(*TestReactor), 10*time.Millisecond, 5*time.Second)
-	assertMsgReceivedWithTimeout(t, ch2Msg, byte(0x02), s2.Reactor("bar").(*TestReactor), 10*time.Millisecond, 5*time.Second)
+	assertMsgReceivedWithTimeout(t, ch0Msg, byte(0x00), s2.Reactor("foo").(*TestReactor),
+		10*time.Millisecond, 5*time.Second)
+	assertMsgReceivedWithTimeout(t, ch1Msg, byte(0x01), s2.Reactor("foo").(*TestReactor),
+		10*time.Millisecond, 5*time.Second)
+	assertMsgReceivedWithTimeout(t, ch2Msg, byte(0x02), s2.Reactor("bar").(*TestReactor),
+		10*time.Millisecond, 5*time.Second)
 }
 
-func assertMsgReceivedWithTimeout(t *testing.T, msg string, channel byte, reactor *TestReactor, checkPeriod, timeout time.Duration) {
+func assertMsgReceivedWithTimeout(t *testing.T, msg string, channel byte, reactor *TestReactor,
+	checkPeriod, timeout time.Duration) {
+
 	ticker := time.NewTicker(checkPeriod)
 	for {
 		select {
@@ -143,7 +152,8 @@ func assertMsgReceivedWithTimeout(t *testing.T, msg string, channel byte, reacto
 			msgs := reactor.getMsgs(channel)
 			if len(msgs) > 0 {
 				if !bytes.Equal(msgs[0].Bytes, wire.BinaryBytes(msg)) {
-					t.Fatalf("Unexpected message bytes. Wanted: %X, Got: %X", wire.BinaryBytes(msg), msgs[0].Bytes)
+					t.Fatalf("Unexpected message bytes. Wanted: %X, Got: %X",
+						wire.BinaryBytes(msg), msgs[0].Bytes)
 				}
 				return
 			}
@@ -227,7 +237,8 @@ func TestSwitchStopsNonPersistentPeerOnError(t *testing.T) {
 	rp.Start()
 	defer rp.Stop()
 
-	peer, err := newOutboundPeer(rp.Addr(), sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, DefaultPeerConfig())
+	peer, err := newOutboundPeer(rp.Addr(), sw.reactorsByCh, sw.chDescs, sw.StopPeerForError,
+		sw.nodePrivKey, DefaultPeerConfig(), log.NewNopLogger())
 	require.Nil(err)
 	err = sw.addPeer(peer)
 	require.Nil(err)
@@ -251,7 +262,8 @@ func TestSwitchReconnectsToPersistentPeer(t *testing.T) {
 	rp.Start()
 	defer rp.Stop()
 
-	peer, err := newOutboundPeer(rp.Addr(), sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodePrivKey, DefaultPeerConfig())
+	peer, err := newOutboundPeer(rp.Addr(), sw.reactorsByCh, sw.chDescs, sw.StopPeerForError,
+		sw.nodePrivKey, DefaultPeerConfig(), log.NewNopLogger())
 	peer.makePersistent()
 	require.Nil(err)
 	err = sw.addPeer(peer)

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -50,8 +50,7 @@ func NewTestReactor(channels []*ChannelDescriptor, logMessages bool) *TestReacto
 		logMessages:  logMessages,
 		msgsReceived: make(map[byte][]PeerMessage),
 	}
-	tr.BaseReactor = *NewBaseReactor("TestReactor", tr)
-	tr.SetLogger(log.TestingLogger())
+	tr.BaseReactor = *NewBaseReactor(log.TestingLogger(), "TestReactor", tr)
 	return tr
 }
 

--- a/p2p/trust/trustmetric.go
+++ b/p2p/trust/trustmetric.go
@@ -11,6 +11,7 @@ import (
 
 	cmn "github.com/tendermint/tmlibs/common"
 	dbm "github.com/tendermint/tmlibs/db"
+	"github.com/tendermint/tmlibs/log"
 )
 
 const defaultStorePeriodicSaveInterval = 1 * time.Minute
@@ -34,14 +35,14 @@ type TrustMetricStore struct {
 
 // NewTrustMetricStore returns a store that saves data to the DB
 // and uses the config when creating new trust metrics
-func NewTrustMetricStore(db dbm.DB, tmc TrustMetricConfig) *TrustMetricStore {
+func NewTrustMetricStore(db dbm.DB, tmc TrustMetricConfig, logger log.Logger) *TrustMetricStore {
 	tms := &TrustMetricStore{
 		peerMetrics: make(map[string]*TrustMetric),
 		db:          db,
 		config:      tmc,
 	}
 
-	tms.BaseService = *cmn.NewBaseService(nil, "TrustMetricStore", tms)
+	tms.BaseService = *cmn.NewBaseService(logger, "TrustMetricStore", tms)
 	return tms
 }
 

--- a/proxy/app_conn_test.go
+++ b/proxy/app_conn_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tendermint/abci/example/dummy"
 	"github.com/tendermint/abci/server"
 	"github.com/tendermint/abci/types"
+
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 )

--- a/proxy/app_conn_test.go
+++ b/proxy/app_conn_test.go
@@ -50,19 +50,18 @@ func TestEcho(t *testing.T) {
 	clientCreator := NewRemoteClientCreator(sockPath, SOCKET, true)
 
 	// Start server
-	s := server.NewSocketServer(sockPath, dummy.NewDummyApplication())
-	s.SetLogger(log.TestingLogger().With("module", "abci-server"))
+	s := server.NewSocketServer(sockPath, dummy.NewDummyApplication(),
+		log.TestingLogger().With("module", "abci-server"))
 	if _, err := s.Start(); err != nil {
 		t.Fatalf("Error starting socket server: %v", err.Error())
 	}
 	defer s.Stop()
 
 	// Start client
-	cli, err := clientCreator.NewABCIClient()
+	cli, err := clientCreator.NewABCIClient(log.TestingLogger().With("module", "abci-client"))
 	if err != nil {
 		t.Fatalf("Error creating ABCI client: %v", err.Error())
 	}
-	cli.SetLogger(log.TestingLogger().With("module", "abci-client"))
 	if _, err := cli.Start(); err != nil {
 		t.Fatalf("Error starting ABCI client: %v", err.Error())
 	}
@@ -82,19 +81,18 @@ func BenchmarkEcho(b *testing.B) {
 	clientCreator := NewRemoteClientCreator(sockPath, SOCKET, true)
 
 	// Start server
-	s := server.NewSocketServer(sockPath, dummy.NewDummyApplication())
-	s.SetLogger(log.TestingLogger().With("module", "abci-server"))
+	s := server.NewSocketServer(sockPath, dummy.NewDummyApplication(),
+		log.TestingLogger().With("module", "abci-server"))
 	if _, err := s.Start(); err != nil {
 		b.Fatalf("Error starting socket server: %v", err.Error())
 	}
 	defer s.Stop()
 
 	// Start client
-	cli, err := clientCreator.NewABCIClient()
+	cli, err := clientCreator.NewABCIClient(log.TestingLogger().With("module", "abci-client"))
 	if err != nil {
 		b.Fatalf("Error creating ABCI client: %v", err.Error())
 	}
-	cli.SetLogger(log.TestingLogger().With("module", "abci-client"))
 	if _, err := cli.Start(); err != nil {
 		b.Fatalf("Error starting ABCI client: %v", err.Error())
 	}
@@ -119,19 +117,18 @@ func TestInfo(t *testing.T) {
 	clientCreator := NewRemoteClientCreator(sockPath, SOCKET, true)
 
 	// Start server
-	s := server.NewSocketServer(sockPath, dummy.NewDummyApplication())
-	s.SetLogger(log.TestingLogger().With("module", "abci-server"))
+	s := server.NewSocketServer(sockPath, dummy.NewDummyApplication(),
+		log.TestingLogger().With("module", "abci-server"))
 	if _, err := s.Start(); err != nil {
 		t.Fatalf("Error starting socket server: %v", err.Error())
 	}
 	defer s.Stop()
 
 	// Start client
-	cli, err := clientCreator.NewABCIClient()
+	cli, err := clientCreator.NewABCIClient(log.TestingLogger().With("module", "abci-client"))
 	if err != nil {
 		t.Fatalf("Error creating ABCI client: %v", err.Error())
 	}
-	cli.SetLogger(log.TestingLogger().With("module", "abci-client"))
 	if _, err := cli.Start(); err != nil {
 		t.Fatalf("Error starting ABCI client: %v", err.Error())
 	}

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -8,11 +8,13 @@ import (
 	abcicli "github.com/tendermint/abci/client"
 	"github.com/tendermint/abci/example/dummy"
 	"github.com/tendermint/abci/types"
+
+	"github.com/tendermint/tmlibs/log"
 )
 
 // NewABCIClient returns newly connected client
 type ClientCreator interface {
-	NewABCIClient() (abcicli.Client, error)
+	NewABCIClient(log.Logger) (abcicli.Client, error)
 }
 
 //----------------------------------------------------
@@ -30,8 +32,10 @@ func NewLocalClientCreator(app types.Application) ClientCreator {
 	}
 }
 
-func (l *localClientCreator) NewABCIClient() (abcicli.Client, error) {
-	return abcicli.NewLocalClient(l.mtx, l.app), nil
+func (l *localClientCreator) NewABCIClient(logger log.Logger) (abcicli.Client, error) {
+	c := abcicli.NewLocalClient(l.mtx, l.app)
+	c.BaseService.Logger = logger
+	return c, nil
 }
 
 //---------------------------------------------------------------
@@ -51,8 +55,8 @@ func NewRemoteClientCreator(addr, transport string, mustConnect bool) ClientCrea
 	}
 }
 
-func (r *remoteClientCreator) NewABCIClient() (abcicli.Client, error) {
-	remoteApp, err := abcicli.NewClient(r.addr, r.transport, r.mustConnect)
+func (r *remoteClientCreator) NewABCIClient(logger log.Logger) (abcicli.Client, error) {
+	remoteApp, err := abcicli.NewClient(r.addr, r.transport, r.mustConnect, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to connect to proxy")
 	}

--- a/rpc/client/httpclient.go
+++ b/rpc/client/httpclient.go
@@ -9,10 +9,12 @@ import (
 	"github.com/pkg/errors"
 
 	data "github.com/tendermint/go-wire/data"
+
+	cmn "github.com/tendermint/tmlibs/common"
+
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	rpcclient "github.com/tendermint/tendermint/rpc/lib/client"
 	"github.com/tendermint/tendermint/types"
-	cmn "github.com/tendermint/tmlibs/common"
 )
 
 /*
@@ -216,7 +218,7 @@ func newWSEvents(remote, endpoint string) *WSEvents {
 // events.eventSwitch.  If only it wasn't private...
 // BaseService.Start -> eventSwitch.OnStart -> WSEvents.Start
 func (w *WSEvents) Start() (bool, error) {
-	ws := rpcclient.NewWSClient(w.remote, w.endpoint, rpcclient.OnReconnect(func() {
+	ws := rpcclient.NewWSClient(w.remote, w.endpoint, nil, rpcclient.OnReconnect(func() {
 		w.redoSubscriptions()
 	}))
 	started, err := ws.Start()

--- a/rpc/lib/client/ws_client_test.go
+++ b/rpc/lib/client/ws_client_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gorilla/websocket"
+
 	"github.com/tendermint/tmlibs/log"
 
 	types "github.com/tendermint/tendermint/rpc/lib/types"
@@ -187,10 +189,9 @@ func TestNotBlockingOnStop(t *testing.T) {
 }
 
 func startClient(t *testing.T, addr net.Addr) *WSClient {
-	c := NewWSClient(addr.String(), "/websocket")
+	c := NewWSClient(addr.String(), "/websocket", log.TestingLogger())
 	_, err := c.Start()
 	require.Nil(t, err)
-	c.SetLogger(log.TestingLogger())
 	return c
 }
 

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -7,12 +7,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/abci/example/dummy"
+
 	crypto "github.com/tendermint/go-crypto"
+
+	dbm "github.com/tendermint/tmlibs/db"
+	"github.com/tendermint/tmlibs/log"
+
 	"github.com/tendermint/tendermint/proxy"
 	"github.com/tendermint/tendermint/state/txindex"
 	"github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tmlibs/db"
-	"github.com/tendermint/tmlibs/log"
 )
 
 var (
@@ -24,7 +27,7 @@ var (
 
 func TestApplyBlock(t *testing.T) {
 	cc := proxy.NewLocalClientCreator(dummy.NewDummyApplication())
-	proxyApp := proxy.NewAppConns(cc, nil)
+	proxyApp := proxy.NewAppConns(cc, nil, nil)
 	_, err := proxyApp.Start()
 	require.Nil(t, err)
 	defer proxyApp.Stop()

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -20,22 +20,19 @@ type EventBus struct {
 }
 
 // NewEventBus returns a new event bus.
-func NewEventBus() *EventBus {
-	return NewEventBusWithBufferCapacity(defaultCapacity)
+func NewEventBus(logger log.Logger) *EventBus {
+	return NewEventBusWithBufferCapacity(defaultCapacity, logger)
 }
 
 // NewEventBusWithBufferCapacity returns a new event bus with the given buffer capacity.
-func NewEventBusWithBufferCapacity(cap int) *EventBus {
+func NewEventBusWithBufferCapacity(cap int, logger log.Logger) *EventBus {
 	// capacity could be exposed later if needed
 	pubsub := tmpubsub.NewServer(tmpubsub.BufferCapacity(cap))
-	b := &EventBus{pubsub: pubsub}
-	b.BaseService = *cmn.NewBaseService(nil, "EventBus", b)
-	return b
-}
+	pubsub.SetLogger(logger.With("module", "pubsub"))
 
-func (b *EventBus) SetLogger(l log.Logger) {
-	b.BaseService.SetLogger(l)
-	b.pubsub.SetLogger(l.With("module", "pubsub"))
+	b := &EventBus{pubsub: pubsub}
+	b.BaseService = *cmn.NewBaseService(logger, "EventBus", b)
+	return b
 }
 
 func (b *EventBus) OnStart() error {

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -27,8 +27,7 @@ func NewEventBus(logger log.Logger) *EventBus {
 // NewEventBusWithBufferCapacity returns a new event bus with the given buffer capacity.
 func NewEventBusWithBufferCapacity(cap int, logger log.Logger) *EventBus {
 	// capacity could be exposed later if needed
-	pubsub := tmpubsub.NewServer(tmpubsub.BufferCapacity(cap))
-	pubsub.SetLogger(logger.With("module", "pubsub"))
+	pubsub := tmpubsub.NewServer(logger.With("module", "pubsub"), tmpubsub.BufferCapacity(cap))
 
 	b := &EventBus{pubsub: pubsub}
 	b.BaseService = *cmn.NewBaseService(logger, "EventBus", b)

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -45,7 +45,8 @@ func benchmarkEventBus(numClients int, randQueries bool, randEvents bool, b *tes
 	// for random* functions
 	rand.Seed(time.Now().Unix())
 
-	eventBus := NewEventBusWithBufferCapacity(0) // set buffer capacity to 0 so we are not testing cache
+	// set buffer capacity to 0 so we are not testing cache
+	eventBus := NewEventBusWithBufferCapacity(0, nil)
 	eventBus.Start()
 	defer eventBus.Stop()
 


### PR DESCRIPTION
This is a breaking change for many of the public APIs.

- [ ] Add Changelog

**Questions**
In [tmlibs](https://github.com/tendermint/tmlibs/blob/master/common/service.go) the service has `SetLogger`. What is the purpose of it? Unless you know which concrete object (which implements service) you are dealing with you cannot set a sensible logger. I'd be in favour of removing `SetLogger` from the Service interface.

Related:
abci needs to be updated to follow the same convention: https://github.com/tendermint/abci/commits/feature/logger
tmlibs needs to be updated: https://github.com/tendermint/tmlibs/pull/82