### PR TITLE
Enable homebrew installation from source

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,10 +8,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[Makefile]
-indent_style = tab
-
-[*.sh]
+[*.{sh,Makefile}]
 indent_style = tab
 
 [*.proto]

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test_race:
 test_integrations:
 	@bash ./test/test.sh
 
-release:
+test_release:
 	@go test -tags release $(PACKAGES)
 
 test100:
@@ -114,4 +114,4 @@ metalinter_test:
 		#--enable=vet \
 		#--enable=vetshadow \
 
-.PHONY: install build build_race dist test test_race test_integrations test100 draw_deps list_deps get_deps get_vendor_deps update_deps revision tools
+.PHONY: install build build_race dist test test_race test_integrations test100 draw_deps list_deps get_deps get_vendor_deps update_deps update_tools tools test_release

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TMHOME = $${TMHOME:-$$HOME/.tendermint}
 
 BUILD_FLAGS = -ldflags "-X github.com/tendermint/tendermint/version.GitCommit=`git rev-parse --short HEAD`"
 
-all: install test
+all: get_vendor_deps install test
 
 install:
 	CGO_ENABLED=0 go install $(BUILD_FLAGS) ./cmd/tendermint

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,24 @@
 GOTOOLS = \
 					github.com/mitchellh/gox \
 					github.com/tcnksm/ghr \
-					github.com/Masterminds/glide \
 					github.com/alecthomas/gometalinter
 
 PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 BUILD_TAGS?=tendermint
 TMHOME = $${TMHOME:-$$HOME/.tendermint}
 
+BUILD_FLAGS = -ldflags "-X github.com/tendermint/tendermint/version.GitCommit=`git rev-parse --short HEAD`"
+
 all: install test
 
-install: get_vendor_deps
-	@go install --ldflags '-extldflags "-static"' \
-		--ldflags "-X github.com/tendermint/tendermint/version.GitCommit=`git rev-parse HEAD`" ./cmd/tendermint
+install:
+	CGO_ENABLED=0 go install $(BUILD_FLAGS) ./cmd/tendermint
 
 build:
-	go build \
-		--ldflags "-X github.com/tendermint/tendermint/version.GitCommit=`git rev-parse HEAD`"  -o build/tendermint ./cmd/tendermint/
+	CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/tendermint ./cmd/tendermint/
 
 build_race:
-	go build -race -o build/tendermint ./cmd/tendermint
+	CGO_ENABLED=0 go build -race $(BUILD_FLAGS) -o build/tendermint ./cmd/tendermint
 
 # dist builds binaries for all platforms and packages them for distribution
 dist:

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ tools:
 
 ensure_tools:
 	go get $(GOTOOLS)
-	@gometalinter --install
+	test -f gometalinter & gometalinter --install
 
 ### Formatting, linting, and vetting
 

--- a/Makefile
+++ b/Makefile
@@ -60,25 +60,24 @@ get_deps:
 		grep -v /vendor/ | sort | uniq | \
 		xargs go get -v -d
 
-get_vendor_deps: ensure_tools
+update_deps:
+	@echo "--> Updating dependencies"
+	@go get -d -u ./...
+
+get_vendor_deps:
+	@hash glide 2>/dev/null || go get github.com/Masterminds/glide
 	@rm -rf vendor/
 	@echo "--> Running glide install"
 	@glide install
 
-update_deps: tools
-	@echo "--> Updating dependencies"
-	@go get -d -u ./...
-
-revision:
-	-echo `git rev-parse --verify HEAD` > $(TMHOME)/revision
-	-echo `git rev-parse --verify HEAD` >> $(TMHOME)/revision_history
+update_tools:
+	@echo "--> Updating tools"
+	@go get -u $(GOTOOLS)
 
 tools:
-	go get -u -v $(GOTOOLS)
-
-ensure_tools:
-	go get $(GOTOOLS)
-	test -f gometalinter & gometalinter --install
+	@echo "--> Installing tools"
+	@go get $(GOTOOLS)
+	@gometalinter --install
 
 ### Formatting, linting, and vetting
 

--- a/scripts/dist_build.sh
+++ b/scripts/dist_build.sh
@@ -11,7 +11,6 @@ cd "$DIR"
 
 # Get the git commit
 GIT_COMMIT="$(git rev-parse --short HEAD)"
-GIT_DESCRIBE="$(git describe --tags --always)"
 GIT_IMPORT="github.com/tendermint/tendermint/version"
 
 # Determine the arch/os combos we're building for
@@ -25,12 +24,14 @@ make tools
 make get_vendor_deps
 
 # Build!
+# ldflags: -s Omit the symbol table and debug information.
+#	         -w Omit the DWARF symbol table.
 echo "==> Building..."
 "$(which gox)" \
 		-os="${XC_OS}" \
 		-arch="${XC_ARCH}" \
 		-osarch="!darwin/arm !solaris/amd64 !freebsd/amd64" \
-		-ldflags "-X ${GIT_IMPORT}.GitCommit='${GIT_COMMIT}' -X ${GIT_IMPORT}.GitDescribe='${GIT_DESCRIBE}'" \
+		-ldflags "-s -w -X ${GIT_IMPORT}.GitCommit='${GIT_COMMIT}'" \
 		-output "build/pkg/{{.OS}}_{{.Arch}}/tendermint" \
 		-tags="${BUILD_TAGS}" \
 		github.com/tendermint/tendermint/cmd/tendermint

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR $REPO
 ADD glide.yaml glide.yaml
 ADD glide.lock glide.lock
 ADD Makefile Makefile
+RUN make tools
 RUN make get_vendor_deps
 
 # Install the apps

--- a/version/version.go
+++ b/version/version.go
@@ -5,15 +5,16 @@ const Min = "12"
 const Fix = "1"
 
 var (
-	// The full version string
+	// Version is the current version of Tendermint
+	// Must be a string because scripts like dist.sh read this file.
 	Version = "0.12.1"
 
-	// GitCommit is set with --ldflags "-X main.gitCommit=$(git rev-parse HEAD)"
+	// GitCommit is the current HEAD set using ldflags.
 	GitCommit string
 )
 
 func init() {
 	if GitCommit != "" {
-		Version += "-" + GitCommit[:8]
+		Version += "-" + GitCommit
 	}
 }


### PR DESCRIPTION
The problem is that in homebrew GOPATH is set to /tmp and it is not in PATH. So metalinter fails with:

```
brew install tendermint --HEAD
==> Installing tendermint from tendermint/tendermint
==> Cloning https://github.com/tendermint/tendermint.git
Cloning into '/Users/antonk/Library/Caches/Homebrew/tendermint--git'...
remote: Counting objects: 437, done.
remote: Compressing objects: 100% (412/412), done.
remote: Total 437 (delta 7), reused 129 (delta 2), pack-reused 0
Receiving objects: 100% (437/437), 3.04 MiB | 1006.00 KiB/s, done.
Resolving deltas: 100% (7/7), done.
==> Checking out branch develop
==> make get_vendor_deps
Last 15 lines from /Users/antonk/Library/Logs/Homebrew/tendermint/01.make:
2017-12-04 14:54:54 -0600

make
get_vendor_deps

go get github.com/mitchellh/gox github.com/tcnksm/ghr github.com/Masterminds/glide github.com/alecthomas/gometalinter
make: gometalinter: No such file or directory
make: *** [ensure_tools] Error 1

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
https://github.com/tendermint/homebrew-tendermint/issues
```