### PR TITLE
From CGO_ENABLED=0 from make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ BUILD_FLAGS = -ldflags "-X github.com/tendermint/tendermint/version.GitCommit=`g
 all: get_vendor_deps install test
 
 install:
-	CGO_ENABLED=0 go install $(BUILD_FLAGS) ./cmd/tendermint
+	go install $(BUILD_FLAGS) ./cmd/tendermint
 
 build:
-	CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/tendermint ./cmd/tendermint/
+	go build $(BUILD_FLAGS) -o build/tendermint ./cmd/tendermint/
 
 build_race:
-	CGO_ENABLED=0 go build -race $(BUILD_FLAGS) -o build/tendermint ./cmd/tendermint
+	go build -race $(BUILD_FLAGS) -o build/tendermint ./cmd/tendermint
 
 # dist builds binaries for all platforms and packages them for distribution
 dist:


### PR DESCRIPTION
It was writing to stdlib packages net, x/crypto, etc. and failing when it didn't have write access to them (which it often shouldn't)

Fixes issue #941 

Explained in golang issue: https://github.com/golang/go/issues/18981 (fixed in develop/1.10)