### PR TITLE
consensus: Fix typo on ticker.go documentation

### DIFF
--- a/consensus/ticker.go
+++ b/consensus/ticker.go
@@ -68,7 +68,7 @@ func (t *timeoutTicker) Chan() <-chan timeoutInfo {
 }
 
 // ScheduleTimeout schedules a new timeout by sending on the internal tickChan.
-// The timeoutRoutine is alwaya available to read from tickChan, so this won't block.
+// The timeoutRoutine is always available to read from tickChan, so this won't block.
 // The scheduling may fail if the timeoutRoutine has already scheduled a timeout for a later height/round/step.
 func (t *timeoutTicker) ScheduleTimeout(ti timeoutInfo) {
 	t.tickChan <- ti


### PR DESCRIPTION
While reading the code I've found a typo in the documentation.