### PR TITLE
Add Timestamp to Proposal/Vote

### DIFF
--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -74,6 +74,7 @@ func (vs *validatorStub) signVote(voteType byte, hash []byte, header types.PartS
 		ValidatorAddress: vs.PrivValidator.GetAddress(),
 		Height:           vs.Height,
 		Round:            vs.Round,
+		Timestamp:        time.Now().UTC(),
 		Type:             voteType,
 		BlockID:          types.BlockID{hash, header},
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1466,6 +1466,7 @@ func (cs *ConsensusState) signVote(type_ byte, hash []byte, header types.PartSet
 		ValidatorIndex:   valIndex,
 		Height:           cs.Height,
 		Round:            cs.Round,
+		Timestamp:        time.Now().UTC(),
 		Type:             type_,
 		BlockID:          types.BlockID{hash, header},
 	}

--- a/consensus/types/height_vote_set_test.go
+++ b/consensus/types/height_vote_set_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"testing"
+	"time"
 
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/types"
@@ -54,6 +55,7 @@ func makeVoteHR(t *testing.T, height int64, round int, privVals []*types.PrivVal
 		ValidatorIndex:   valIndex,
 		Height:           height,
 		Round:            round,
+		Timestamp:        time.Now().UTC(),
 		Type:             types.VoteTypePrecommit,
 		BlockID:          types.BlockID{[]byte("fakehash"), types.PartSetHeader{}},
 	}

--- a/lite/helpers.go
+++ b/lite/helpers.go
@@ -97,6 +97,7 @@ func makeVote(header *types.Header, vals *types.ValidatorSet, key crypto.PrivKey
 		ValidatorIndex:   idx,
 		Height:           header.Height,
 		Round:            1,
+		Timestamp:        time.Now().UTC(),
 		Type:             types.VoteTypePrecommit,
 		BlockID:          types.BlockID{Hash: header.Hash()},
 	}

--- a/types/block.go
+++ b/types/block.go
@@ -420,7 +420,7 @@ func (data *Data) StringIndented(indent string) string {
 
 // BlockID defines the unique ID of a block as its Hash and its PartSetHeader
 type BlockID struct {
-	Hash        data.Bytes    `json:"hash"`
+	Hash        data.Bytes    `json:"hash,omitempty"`
 	PartsHeader PartSetHeader `json:"parts"`
 }
 

--- a/types/block.go
+++ b/types/block.go
@@ -420,7 +420,7 @@ func (data *Data) StringIndented(indent string) string {
 
 // BlockID defines the unique ID of a block as its Hash and its PartSetHeader
 type BlockID struct {
-	Hash        data.Bytes    `json:"hash,omitempty"`
+	Hash        data.Bytes    `json:"hash"`
 	PartsHeader PartSetHeader `json:"parts"`
 }
 

--- a/types/canonical_json.go
+++ b/types/canonical_json.go
@@ -3,13 +3,14 @@ package types
 import (
 	"time"
 
+	wire "github.com/tendermint/go-wire"
 	"github.com/tendermint/go-wire/data"
 )
 
 // canonical json is go-wire's json for structs with fields in alphabetical order
 
-// timeFormat is RFC3339Millis, used for generating the sigs
-const timeFormat = "2006-01-02T15:04:05.999Z07:00"
+// timeFormat is used for generating the sigs
+const timeFormat = wire.RFC3339Millis
 
 type CanonicalJSONBlockID struct {
 	Hash        data.Bytes                 `json:"hash,omitempty"`

--- a/types/canonical_json.go
+++ b/types/canonical_json.go
@@ -1,10 +1,15 @@
 package types
 
 import (
+	"time"
+
 	"github.com/tendermint/go-wire/data"
 )
 
 // canonical json is go-wire's json for structs with fields in alphabetical order
+
+// timeFormat is RFC3339Millis, used for generating the sigs
+const timeFormat = "2006-01-02T15:04:05.999Z07:00"
 
 type CanonicalJSONBlockID struct {
 	Hash        data.Bytes                 `json:"hash,omitempty"`
@@ -26,10 +31,11 @@ type CanonicalJSONProposal struct {
 }
 
 type CanonicalJSONVote struct {
-	BlockID CanonicalJSONBlockID `json:"block_id"`
-	Height  int64                `json:"height"`
-	Round   int                  `json:"round"`
-	Type    byte                 `json:"type"`
+	BlockID   CanonicalJSONBlockID `json:"block_id"`
+	Height    int64                `json:"height"`
+	Round     int                  `json:"round"`
+	Timestamp string               `json:"timestamp"`
+	Type      byte                 `json:"type"`
 }
 
 type CanonicalJSONHeartbeat struct {
@@ -79,7 +85,7 @@ func CanonicalProposal(proposal *Proposal) CanonicalJSONProposal {
 	return CanonicalJSONProposal{
 		BlockPartsHeader: CanonicalPartSetHeader(proposal.BlockPartsHeader),
 		Height:           proposal.Height,
-		Timestamp:        proposal.TimeString(),
+		Timestamp:        CanonicalTime(proposal.Timestamp),
 		POLBlockID:       CanonicalBlockID(proposal.POLBlockID),
 		POLRound:         proposal.POLRound,
 		Round:            proposal.Round,
@@ -88,10 +94,11 @@ func CanonicalProposal(proposal *Proposal) CanonicalJSONProposal {
 
 func CanonicalVote(vote *Vote) CanonicalJSONVote {
 	return CanonicalJSONVote{
-		CanonicalBlockID(vote.BlockID),
-		vote.Height,
-		vote.Round,
-		vote.Type,
+		BlockID:   CanonicalBlockID(vote.BlockID),
+		Height:    vote.Height,
+		Round:     vote.Round,
+		Timestamp: CanonicalTime(vote.Timestamp),
+		Type:      vote.Type,
 	}
 }
 
@@ -103,4 +110,8 @@ func CanonicalHeartbeat(heartbeat *Heartbeat) CanonicalJSONHeartbeat {
 		heartbeat.ValidatorAddress,
 		heartbeat.ValidatorIndex,
 	}
+}
+
+func CanonicalTime(t time.Time) string {
+	return t.Format(timeFormat)
 }

--- a/types/canonical_json.go
+++ b/types/canonical_json.go
@@ -22,6 +22,7 @@ type CanonicalJSONProposal struct {
 	POLBlockID       CanonicalJSONBlockID       `json:"pol_block_id"`
 	POLRound         int                        `json:"pol_round"`
 	Round            int                        `json:"round"`
+	Timestamp        string                     `json:"timestamp"`
 }
 
 type CanonicalJSONVote struct {
@@ -78,6 +79,7 @@ func CanonicalProposal(proposal *Proposal) CanonicalJSONProposal {
 	return CanonicalJSONProposal{
 		BlockPartsHeader: CanonicalPartSetHeader(proposal.BlockPartsHeader),
 		Height:           proposal.Height,
+		Timestamp:        proposal.TimeString(),
 		POLBlockID:       CanonicalBlockID(proposal.POLBlockID),
 		POLRound:         proposal.POLRound,
 		Round:            proposal.Round,

--- a/types/canonical_json.go
+++ b/types/canonical_json.go
@@ -113,5 +113,8 @@ func CanonicalHeartbeat(heartbeat *Heartbeat) CanonicalJSONHeartbeat {
 }
 
 func CanonicalTime(t time.Time) string {
-	return t.Format(timeFormat)
+	// note that sending time over go-wire resets it to
+	// local time, we need to force UTC here, so the
+	// signatures match
+	return t.UTC().Format(timeFormat)
 }

--- a/types/priv_validator_test.go
+++ b/types/priv_validator_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -165,6 +166,7 @@ func newVote(addr data.Bytes, idx int, height int64, round int, typ byte, blockI
 		Height:           height,
 		Round:            round,
 		Type:             typ,
+		Timestamp:        time.Now().UTC(),
 		BlockID:          blockID,
 	}
 }

--- a/types/proposal.go
+++ b/types/proposal.go
@@ -15,9 +15,6 @@ var (
 	ErrInvalidBlockPartHash      = errors.New("Error invalid block part hash")
 )
 
-// TimeFormat is RFC3339Millis, used for generating the sigs
-const TimeFormat = "2006-01-02T15:04:05.999Z07:00"
-
 // Proposal defines a block proposal for the consensus.
 // It refers to the block only by its PartSetHeader.
 // It must be signed by the correct proposer for the given Height/Round
@@ -46,16 +43,11 @@ func NewProposal(height int64, round int, blockPartsHeader PartSetHeader, polRou
 	}
 }
 
-// TimeString returns the canonical encoding of timestamp
-func (p *Proposal) TimeString() string {
-	return p.Timestamp.Format(TimeFormat)
-}
-
 // String returns a string representation of the Proposal.
 func (p *Proposal) String() string {
 	return fmt.Sprintf("Proposal{%v/%v %v (%v,%v) %v @ %s}",
 		p.Height, p.Round, p.BlockPartsHeader, p.POLRound,
-		p.POLBlockID, p.Signature, p.TimeString())
+		p.POLBlockID, p.Signature, CanonicalTime(p.Timestamp))
 }
 
 // WriteSignBytes writes the Proposal bytes for signing

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -8,7 +8,7 @@ import (
 var testProposal *Proposal
 
 func init() {
-	var stamp, err = time.Parse(TimeFormat, "2018-02-11T07:09:22.765Z")
+	var stamp, err = time.Parse(timeFormat, "2018-02-11T07:09:22.765Z")
 	if err != nil {
 		panic(err)
 	}

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -2,20 +2,30 @@ package types
 
 import (
 	"testing"
+	"time"
 )
 
-var testProposal = &Proposal{
-	Height:           12345,
-	Round:            23456,
-	BlockPartsHeader: PartSetHeader{111, []byte("blockparts")},
-	POLRound:         -1,
+var testProposal *Proposal
+
+func init() {
+	var stamp, err = time.Parse(TimeFormat, "2018-02-11T07:09:22.765Z")
+	if err != nil {
+		panic(err)
+	}
+	testProposal = &Proposal{
+		Height:           12345,
+		Round:            23456,
+		BlockPartsHeader: PartSetHeader{111, []byte("blockparts")},
+		POLRound:         -1,
+		Timestamp:        stamp,
+	}
 }
 
 func TestProposalSignable(t *testing.T) {
 	signBytes := SignBytes("test_chain_id", testProposal)
 	signStr := string(signBytes)
 
-	expected := `{"chain_id":"test_chain_id","proposal":{"block_parts_header":{"hash":"626C6F636B7061727473","total":111},"height":12345,"pol_block_id":{},"pol_round":-1,"round":23456}}`
+	expected := `{"chain_id":"test_chain_id","proposal":{"block_parts_header":{"hash":"626C6F636B7061727473","total":111},"height":12345,"pol_block_id":{},"pol_round":-1,"round":23456,"timestamp":"2018-02-11T07:09:22.765Z"}}`
 	if signStr != expected {
 		t.Errorf("Got unexpected sign string for Proposal. Expected:\n%v\nGot:\n%v", expected, signStr)
 	}

--- a/types/vote.go
+++ b/types/vote.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/tendermint/go-crypto"
 	"github.com/tendermint/go-wire"
@@ -53,6 +54,7 @@ type Vote struct {
 	ValidatorIndex   int              `json:"validator_index"`
 	Height           int64            `json:"height"`
 	Round            int              `json:"round"`
+	Timestamp        time.Time        `json:"timestamp"`
 	Type             byte             `json:"type"`
 	BlockID          BlockID          `json:"block_id"` // zero if vote is nil.
 	Signature        crypto.Signature `json:"signature"`
@@ -84,8 +86,9 @@ func (vote *Vote) String() string {
 		cmn.PanicSanity("Unknown vote type")
 	}
 
-	return fmt.Sprintf("Vote{%v:%X %v/%02d/%v(%v) %X %v}",
+	return fmt.Sprintf("Vote{%v:%X %v/%02d/%v(%v) %X %v @ %s}",
 		vote.ValidatorIndex, cmn.Fingerprint(vote.ValidatorAddress),
 		vote.Height, vote.Round, vote.Type, typeString,
-		cmn.Fingerprint(vote.BlockID.Hash), vote.Signature)
+		cmn.Fingerprint(vote.BlockID.Hash), vote.Signature,
+		CanonicalTime(vote.Timestamp))
 }

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	crypto "github.com/tendermint/go-crypto"
 	cmn "github.com/tendermint/tmlibs/common"
@@ -92,6 +93,7 @@ func TestAddVote(t *testing.T) {
 		Height:           height,
 		Round:            round,
 		Type:             VoteTypePrevote,
+		Timestamp:        time.Now().UTC(),
 		BlockID:          BlockID{nil, PartSetHeader{}},
 	}
 	_, err := signAddVote(val0, vote, voteSet)
@@ -121,6 +123,7 @@ func Test2_3Majority(t *testing.T) {
 		Height:           height,
 		Round:            round,
 		Type:             VoteTypePrevote,
+		Timestamp:        time.Now().UTC(),
 		BlockID:          BlockID{nil, PartSetHeader{}},
 	}
 	// 6 out of 10 voted for nil.
@@ -176,6 +179,7 @@ func Test2_3MajorityRedux(t *testing.T) {
 		ValidatorIndex:   -1,  // NOTE: must fill in
 		Height:           height,
 		Round:            round,
+		Timestamp:        time.Now().UTC(),
 		Type:             VoteTypePrevote,
 		BlockID:          BlockID{blockHash, blockPartsHeader},
 	}
@@ -270,6 +274,7 @@ func TestBadVotes(t *testing.T) {
 		ValidatorIndex:   -1,
 		Height:           height,
 		Round:            round,
+		Timestamp:        time.Now().UTC(),
 		Type:             VoteTypePrevote,
 		BlockID:          BlockID{nil, PartSetHeader{}},
 	}
@@ -331,6 +336,7 @@ func TestConflicts(t *testing.T) {
 		ValidatorIndex:   -1,
 		Height:           height,
 		Round:            round,
+		Timestamp:        time.Now().UTC(),
 		Type:             VoteTypePrevote,
 		BlockID:          BlockID{nil, PartSetHeader{}},
 	}
@@ -459,6 +465,7 @@ func TestMakeCommit(t *testing.T) {
 		ValidatorIndex:   -1,
 		Height:           height,
 		Round:            round,
+		Timestamp:        time.Now().UTC(),
 		Type:             VoteTypePrecommit,
 		BlockID:          BlockID{blockHash, blockPartsHeader},
 	}

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -2,14 +2,21 @@ package types
 
 import (
 	"testing"
+	"time"
 )
 
 func TestVoteSignable(t *testing.T) {
+	var stamp, err = time.Parse(timeFormat, "2017-12-25T03:00:01.234Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	vote := &Vote{
 		ValidatorAddress: []byte("addr"),
 		ValidatorIndex:   56789,
 		Height:           12345,
 		Round:            23456,
+		Timestamp:        stamp,
 		Type:             byte(2),
 		BlockID: BlockID{
 			Hash: []byte("hash"),
@@ -22,7 +29,7 @@ func TestVoteSignable(t *testing.T) {
 	signBytes := SignBytes("test_chain_id", vote)
 	signStr := string(signBytes)
 
-	expected := `{"chain_id":"test_chain_id","vote":{"block_id":{"hash":"68617368","parts":{"hash":"70617274735F68617368","total":1000000}},"height":12345,"round":23456,"type":2}}`
+	expected := `{"chain_id":"test_chain_id","vote":{"block_id":{"hash":"68617368","parts":{"hash":"70617274735F68617368","total":1000000}},"height":12345,"round":23456,"timestamp":"2017-12-25T03:00:01.234Z","type":2}}`
 	if signStr != expected {
 		// NOTE: when this fails, you probably want to fix up consensus/replay_test too
 		t.Errorf("Got unexpected sign string for Vote. Expected:\n%v\nGot:\n%v", expected, signStr)

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	wire "github.com/tendermint/go-wire"
 )
 
@@ -18,7 +19,7 @@ func exampleVote() *Vote {
 		ValidatorAddress: []byte("addr"),
 		ValidatorIndex:   56789,
 		Height:           12345,
-		Round:            23456,
+		Round:            2,
 		Timestamp:        stamp,
 		Type:             byte(2),
 		BlockID: BlockID{
@@ -36,10 +37,18 @@ func TestVoteSignable(t *testing.T) {
 	signBytes := SignBytes("test_chain_id", vote)
 	signStr := string(signBytes)
 
-	expected := `{"chain_id":"test_chain_id","vote":{"block_id":{"hash":"68617368","parts":{"hash":"70617274735F68617368","total":1000000}},"height":12345,"round":23456,"timestamp":"2017-12-25T03:00:01.234Z","type":2}}`
+	expected := `{"chain_id":"test_chain_id","vote":{"block_id":{"hash":"68617368","parts":{"hash":"70617274735F68617368","total":1000000}},"height":12345,"round":2,"timestamp":"2017-12-25T03:00:01.234Z","type":2}}`
 	if signStr != expected {
 		// NOTE: when this fails, you probably want to fix up consensus/replay_test too
 		t.Errorf("Got unexpected sign string for Vote. Expected:\n%v\nGot:\n%v", expected, signStr)
+	}
+}
+
+func TestVoteString(t *testing.T) {
+	str := exampleVote().String()
+	expected := `Vote{56789:616464720000 12345/02/2(Precommit) 686173680000 {<nil>} @ 2017-12-25T03:00:01.234Z}`
+	if str != expected {
+		t.Errorf("Got unexpected string for Proposal. Expected:\n%v\nGot:\n%v", expected, str)
 	}
 }
 


### PR DESCRIPTION
Fixes issue #929

Store it as time.Timestamp locally, encode it as RFC3339 with milliseconds
before signing the canonical form.