### PR TITLE
cmd/tendermint: fix initialization file creation checks

### DIFF
--- a/cmd/tendermint/commands/init.go
+++ b/cmd/tendermint/commands/init.go
@@ -16,12 +16,14 @@ var InitFilesCmd = &cobra.Command{
 
 func initFiles(cmd *cobra.Command, args []string) {
 	privValFile := config.PrivValidatorFile()
-	privValidator := types.GenPrivValidatorFS(privValFile)
+	var privValidator *types.PrivValidatorFS
 	if cmn.FileExists(privValFile) {
-		logger.Info("Already initialized", "priv_validator", config.PrivValidatorFile())
+		privValidator = types.LoadPrivValidatorFS(privValFile)
+		logger.Info("Already initialized", "priv_validator", privValFile)
 	} else {
+		privValidator = types.GenPrivValidatorFS(privValFile)
 		privValidator.Save()
-		logger.Info("Initialized tendermint", "privValidator")
+		logger.Info("Initialized tendermint", "privValidator", privValFile)
 	}
 
 	genFile := config.GenesisFile()

--- a/cmd/tendermint/commands/init.go
+++ b/cmd/tendermint/commands/init.go
@@ -15,20 +15,22 @@ var InitFilesCmd = &cobra.Command{
 }
 
 func initFiles(cmd *cobra.Command, args []string) {
+	// private validator
 	privValFile := config.PrivValidatorFile()
 	var privValidator *types.PrivValidatorFS
 	if cmn.FileExists(privValFile) {
 		privValidator = types.LoadPrivValidatorFS(privValFile)
-		logger.Info("Already initialized", "priv_validator", privValFile)
+		logger.Info("Found private validator", "path", privValFile)
 	} else {
 		privValidator = types.GenPrivValidatorFS(privValFile)
 		privValidator.Save()
-		logger.Info("Initialized tendermint", "privValidator", privValFile)
+		logger.Info("Genetated private validator", "path", privValFile)
 	}
 
+	// genesis file
 	genFile := config.GenesisFile()
 	if cmn.FileExists(genFile) {
-		logger.Info("Already initialized", "geneisis", genFile)
+		logger.Info("Found genesis file", "path", genFile)
 	} else {
 		genDoc := types.GenesisDoc{
 			ChainID: cmn.Fmt("test-chain-%v", cmn.RandStr(6)),
@@ -41,6 +43,6 @@ func initFiles(cmd *cobra.Command, args []string) {
 		if err := genDoc.SaveAs(genFile); err != nil {
 			panic(err)
 		}
-		logger.Info("Initialized tendermint", "genesis", genFile)
+		logger.Info("Genetated genesis file", "path", genFile)
 	}
 }


### PR DESCRIPTION
Fixes #989.

The original initialization sequence started to inexplicably
fail
```shell
tendermint unsafe_reset_all
tendermint init
tendermint node --proxy_app=dummy
```

used to fail with
```shell
ERROR: Failed to create node: Couldn't read GenesisDoc file: open
/Users/emmanuelodeke/.tendermint/genesis.json: no such file or directory
```

because the initialization sequence always assumed that the
genesisDoc would only be set if the privValidator was generated.

However, `tendermint unsafe_reset_all` only created the
`priv_validator.json` file which would mean that then running
`tendermint init` would never create the `genesis.json` file
which if following the recommended sequence would then fail
since the `genesis.json` was absent.