### PR TITLE
Add results hash to header

### DIFF
--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -301,7 +301,10 @@ func (h *Handshaker) ReplayBlocks(appHash []byte, appBlockHeight int64, proxyApp
 
 		} else if appBlockHeight == storeBlockHeight {
 			// We ran Commit, but didn't save the state, so replayBlock with mock app
-			abciResponses := h.state.LoadABCIResponses()
+			abciResponses, err := h.state.LoadABCIResponses(storeBlockHeight)
+			if err != nil {
+				return nil, err
+			}
 			mockApp := newMockProxyApp(appHash, abciResponses)
 			h.logger.Info("Replay last block using mock app")
 			return h.replayBlock(storeBlockHeight, mockApp)

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -107,14 +107,15 @@ func TestWALCrash(t *testing.T) {
 		{"block with a smaller part size",
 			func(cs *ConsensusState, ctx context.Context) {
 				// XXX: is there a better way to change BlockPartSizeBytes?
-				params := cs.state.ConsensusParams
-				params.BlockPartSizeBytes = 512
-				cs.state.ConsensusParams = params
-				sendTxs(cs, ctx)
+				cs.state.ConsensusParams.BlockPartSizeBytes = 512
+				cs.state.Save()
+				go sendTxs(cs, ctx)
 			},
 			1},
 		{"many non-empty blocks",
-			sendTxs,
+			func(cs *ConsensusState, ctx context.Context) {
+				go sendTxs(cs, ctx)
+			},
 			3},
 	}
 
@@ -147,7 +148,7 @@ LOOP:
 
 		// start sending transactions
 		ctx, cancel := context.WithCancel(context.Background())
-		go initFn(cs, ctx)
+		initFn(cs, ctx)
 
 		// clean up WAL file from the previous iteration
 		walFile := cs.config.WalFile()

--- a/lite/dynamic_test.go
+++ b/lite/dynamic_test.go
@@ -46,7 +46,7 @@ func TestDynamicCert(t *testing.T) {
 
 	for _, tc := range cases {
 		check := tc.keys.GenCommit(chainID, tc.height, nil, tc.vals,
-			[]byte("bar"), []byte("params"), tc.first, tc.last)
+			[]byte("bar"), []byte("params"), []byte("results"), tc.first, tc.last)
 		err := cert.Certify(check)
 		if tc.proper {
 			assert.Nil(err, "%+v", err)
@@ -71,7 +71,7 @@ func TestDynamicUpdate(t *testing.T) {
 
 	// one valid block to give us a sense of time
 	h := int64(100)
-	good := keys.GenCommit(chainID, h, nil, vals, []byte("foo"), []byte("params"), 0, len(keys))
+	good := keys.GenCommit(chainID, h, nil, vals, []byte("foo"), []byte("params"), []byte("results"), 0, len(keys))
 	err := cert.Certify(good)
 	require.Nil(err, "%+v", err)
 
@@ -109,7 +109,7 @@ func TestDynamicUpdate(t *testing.T) {
 
 	for _, tc := range cases {
 		fc := tc.keys.GenFullCommit(chainID, tc.height, nil, tc.vals,
-			[]byte("bar"), []byte("params"), tc.first, tc.last)
+			[]byte("bar"), []byte("params"), []byte("results"), tc.first, tc.last)
 		err := cert.Update(fc)
 		if tc.proper {
 			assert.Nil(err, "%d: %+v", tc.height, err)

--- a/lite/files/commit_test.go
+++ b/lite/files/commit_test.go
@@ -29,7 +29,7 @@ func TestSerializeFullCommits(t *testing.T) {
 	// build a fc
 	keys := lite.GenValKeys(5)
 	vals := keys.ToValidators(10, 0)
-	fc := keys.GenFullCommit(chainID, h, nil, vals, appHash, []byte("params"), 0, 5)
+	fc := keys.GenFullCommit(chainID, h, nil, vals, appHash, []byte("params"), []byte("results"), 0, 5)
 
 	require.Equal(h, fc.Height())
 	require.Equal(vals.Hash(), fc.ValidatorsHash())

--- a/lite/files/provider_test.go
+++ b/lite/files/provider_test.go
@@ -46,7 +46,7 @@ func TestFileProvider(t *testing.T) {
 		// (10, 0), (10, 1), (10, 1), (10, 2), (10, 2), ...
 		vals := keys.ToValidators(10, int64(count/2))
 		h := int64(20 + 10*i)
-		check := keys.GenCommit(chainID, h, nil, vals, appHash, []byte("params"), 0, 5)
+		check := keys.GenCommit(chainID, h, nil, vals, appHash, []byte("params"), []byte("results"), 0, 5)
 		seeds[i] = lite.NewFullCommit(check, vals)
 	}
 

--- a/lite/helpers.go
+++ b/lite/helpers.go
@@ -120,11 +120,11 @@ func genHeader(chainID string, height int64, txs types.Txs,
 		TotalTxs: int64(len(txs)),
 		// LastBlockID
 		// LastCommitHash
-		ValidatorsHash: vals.Hash(),
-		DataHash:       txs.Hash(),
-		AppHash:        appHash,
-		ConsensusHash:  consHash,
-		ResultsHash:    resHash,
+		ValidatorsHash:  vals.Hash(),
+		DataHash:        txs.Hash(),
+		AppHash:         appHash,
+		ConsensusHash:   consHash,
+		LastResultsHash: resHash,
 	}
 }
 

--- a/lite/helpers.go
+++ b/lite/helpers.go
@@ -110,7 +110,7 @@ func makeVote(header *types.Header, vals *types.ValidatorSet, key crypto.PrivKey
 // Silences warning that vals can also be merkle.Hashable
 // nolint: interfacer
 func genHeader(chainID string, height int64, txs types.Txs,
-	vals *types.ValidatorSet, appHash, consHash []byte) *types.Header {
+	vals *types.ValidatorSet, appHash, consHash, resHash []byte) *types.Header {
 
 	return &types.Header{
 		ChainID:  chainID,
@@ -124,14 +124,15 @@ func genHeader(chainID string, height int64, txs types.Txs,
 		DataHash:       txs.Hash(),
 		AppHash:        appHash,
 		ConsensusHash:  consHash,
+		ResultsHash:    resHash,
 	}
 }
 
 // GenCommit calls genHeader and signHeader and combines them into a Commit.
 func (v ValKeys) GenCommit(chainID string, height int64, txs types.Txs,
-	vals *types.ValidatorSet, appHash, consHash []byte, first, last int) Commit {
+	vals *types.ValidatorSet, appHash, consHash, resHash []byte, first, last int) Commit {
 
-	header := genHeader(chainID, height, txs, vals, appHash, consHash)
+	header := genHeader(chainID, height, txs, vals, appHash, consHash, resHash)
 	check := Commit{
 		Header: header,
 		Commit: v.signHeader(header, first, last),
@@ -141,9 +142,9 @@ func (v ValKeys) GenCommit(chainID string, height int64, txs types.Txs,
 
 // GenFullCommit calls genHeader and signHeader and combines them into a Commit.
 func (v ValKeys) GenFullCommit(chainID string, height int64, txs types.Txs,
-	vals *types.ValidatorSet, appHash, consHash []byte, first, last int) FullCommit {
+	vals *types.ValidatorSet, appHash, consHash, resHash []byte, first, last int) FullCommit {
 
-	header := genHeader(chainID, height, txs, vals, appHash, consHash)
+	header := genHeader(chainID, height, txs, vals, appHash, consHash, resHash)
 	commit := Commit{
 		Header: header,
 		Commit: v.signHeader(header, first, last),

--- a/lite/inquirer_test.go
+++ b/lite/inquirer_test.go
@@ -23,6 +23,7 @@ func TestInquirerValidPath(t *testing.T) {
 	// construct a bunch of commits, each with one more height than the last
 	chainID := "inquiry-test"
 	consHash := []byte("params")
+	resHash := []byte("results")
 	count := 50
 	commits := make([]lite.FullCommit, count)
 	for i := 0; i < count; i++ {
@@ -31,7 +32,7 @@ func TestInquirerValidPath(t *testing.T) {
 		vals := keys.ToValidators(vote, 0)
 		h := int64(20 + 10*i)
 		appHash := []byte(fmt.Sprintf("h=%d", h))
-		commits[i] = keys.GenFullCommit(chainID, h, nil, vals, appHash, consHash, 0, len(keys))
+		commits[i] = keys.GenFullCommit(chainID, h, nil, vals, appHash, consHash, resHash, 0, len(keys))
 	}
 
 	// initialize a certifier with the initial state
@@ -79,7 +80,8 @@ func TestInquirerMinimalPath(t *testing.T) {
 		vals := keys.ToValidators(vote, 0)
 		h := int64(5 + 10*i)
 		appHash := []byte(fmt.Sprintf("h=%d", h))
-		commits[i] = keys.GenFullCommit(chainID, h, nil, vals, appHash, consHash, 0, len(keys))
+		resHash := []byte(fmt.Sprintf("res=%d", h))
+		commits[i] = keys.GenFullCommit(chainID, h, nil, vals, appHash, consHash, resHash, 0, len(keys))
 	}
 
 	// initialize a certifier with the initial state
@@ -127,7 +129,8 @@ func TestInquirerVerifyHistorical(t *testing.T) {
 		vals := keys.ToValidators(vote, 0)
 		h := int64(20 + 10*i)
 		appHash := []byte(fmt.Sprintf("h=%d", h))
-		commits[i] = keys.GenFullCommit(chainID, h, nil, vals, appHash, consHash, 0, len(keys))
+		resHash := []byte(fmt.Sprintf("res=%d", h))
+		commits[i] = keys.GenFullCommit(chainID, h, nil, vals, appHash, consHash, resHash, 0, len(keys))
 	}
 
 	// initialize a certifier with the initial state

--- a/lite/performance_test.go
+++ b/lite/performance_test.go
@@ -33,7 +33,8 @@ func benchmarkGenCommit(b *testing.B, keys lite.ValKeys) {
 	for i := 0; i < b.N; i++ {
 		h := int64(1 + i)
 		appHash := []byte(fmt.Sprintf("h=%d", h))
-		keys.GenCommit(chainID, h, nil, vals, appHash, []byte("params"), 0, len(keys))
+		resHash := []byte(fmt.Sprintf("res=%d", h))
+		keys.GenCommit(chainID, h, nil, vals, appHash, []byte("params"), resHash, 0, len(keys))
 	}
 }
 
@@ -105,7 +106,7 @@ func benchmarkCertifyCommit(b *testing.B, keys lite.ValKeys) {
 	chainID := "bench-certify"
 	vals := keys.ToValidators(20, 10)
 	cert := lite.NewStatic(chainID, vals)
-	check := keys.GenCommit(chainID, 123, nil, vals, []byte("foo"), []byte("params"), 0, len(keys))
+	check := keys.GenCommit(chainID, 123, nil, vals, []byte("foo"), []byte("params"), []byte("res"), 0, len(keys))
 	for i := 0; i < b.N; i++ {
 		err := cert.Certify(check)
 		if err != nil {

--- a/lite/provider_test.go
+++ b/lite/provider_test.go
@@ -58,7 +58,7 @@ func checkProvider(t *testing.T, p lite.Provider, chainID, app string) {
 		// (10, 0), (10, 1), (10, 1), (10, 2), (10, 2), ...
 		vals := keys.ToValidators(10, int64(count/2))
 		h := int64(20 + 10*i)
-		commits[i] = keys.GenFullCommit(chainID, h, nil, vals, appHash, []byte("params"), 0, 5)
+		commits[i] = keys.GenFullCommit(chainID, h, nil, vals, appHash, []byte("params"), []byte("results"), 0, 5)
 	}
 
 	// check provider is empty
@@ -129,7 +129,7 @@ func TestCacheGetsBestHeight(t *testing.T) {
 	for i := 0; i < count; i++ {
 		vals := keys.ToValidators(10, int64(count/2))
 		h := int64(10 * (i + 1))
-		fc := keys.GenFullCommit(chainID, h, nil, vals, appHash, []byte("params"), 0, 5)
+		fc := keys.GenFullCommit(chainID, h, nil, vals, appHash, []byte("params"), []byte("results"), 0, 5)
 		err := p2.StoreCommit(fc)
 		require.NoError(err)
 	}

--- a/lite/static_test.go
+++ b/lite/static_test.go
@@ -44,7 +44,7 @@ func TestStaticCert(t *testing.T) {
 
 	for _, tc := range cases {
 		check := tc.keys.GenCommit(chainID, tc.height, nil, tc.vals,
-			[]byte("foo"), []byte("params"), tc.first, tc.last)
+			[]byte("foo"), []byte("params"), []byte("results"), tc.first, tc.last)
 		err := cert.Certify(check)
 		if tc.proper {
 			assert.Nil(err, "%+v", err)

--- a/rpc/client/httpclient.go
+++ b/rpc/client/httpclient.go
@@ -152,6 +152,15 @@ func (c *HTTP) Block(height *int64) (*ctypes.ResultBlock, error) {
 	return result, nil
 }
 
+func (c *HTTP) BlockResults(height *int64) (*ctypes.ResultBlockResults, error) {
+	result := new(ctypes.ResultBlockResults)
+	_, err := c.rpc.Call("block_results", map[string]interface{}{"height": height}, result)
+	if err != nil {
+		return nil, errors.Wrap(err, "Block Result")
+	}
+	return result, nil
+}
+
 func (c *HTTP) Commit(height *int64) (*ctypes.ResultCommit, error) {
 	result := new(ctypes.ResultCommit)
 	_, err := c.rpc.Call("commit", map[string]interface{}{"height": height}, result)

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -45,6 +45,7 @@ type ABCIClient interface {
 // signatures and prove anything about the chain
 type SignClient interface {
 	Block(height *int64) (*ctypes.ResultBlock, error)
+	BlockResults(height *int64) (*ctypes.ResultBlockResults, error)
 	Commit(height *int64) (*ctypes.ResultCommit, error)
 	Validators(height *int64) (*ctypes.ResultValidators, error)
 	Tx(hash []byte, prove bool) (*ctypes.ResultTx, error)

--- a/rpc/client/localclient.go
+++ b/rpc/client/localclient.go
@@ -100,6 +100,10 @@ func (Local) Block(height *int64) (*ctypes.ResultBlock, error) {
 	return core.Block(height)
 }
 
+func (Local) BlockResults(height *int64) (*ctypes.ResultBlockResults, error) {
+	return core.BlockResults(height)
+}
+
 func (Local) Commit(height *int64) (*ctypes.ResultCommit, error) {
 	return core.Commit(height)
 }

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -168,17 +168,15 @@ func TestAppCalls(t *testing.T) {
 		assert.EqualValues(apph, block.BlockMeta.Header.Height)
 
 		// now check the results
-		blockResults, err := c.BlockResults(&apph)
+		blockResults, err := c.BlockResults(&txh)
 		require.Nil(err, "%d: %+v", i, err)
-		assert.Equal(apph, blockResults.Height)
-		if assert.Equal(1, len(blockResults.Results)) {
+		assert.Equal(txh, blockResults.Height)
+		if assert.Equal(1, len(blockResults.Results.DeliverTx)) {
 			// check success code
-			assert.EqualValues(0, blockResults.Results[0].Code)
+			assert.EqualValues(0, blockResults.Results.DeliverTx[0].Code)
 		}
 
 		// check blockchain info, now that we know there is info
-		// TODO: is this commented somewhere that they are returned
-		// in order of descending height???
 		info, err := c.BlockchainInfo(apph, apph)
 		require.Nil(err, "%d: %+v", i, err)
 		assert.True(info.LastHeight >= apph)

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -155,7 +155,6 @@ func TestAppCalls(t *testing.T) {
 		}
 
 		// make sure we can lookup the tx with proof
-		// ptx, err := c.Tx(bres.Hash, true)
 		ptx, err := c.Tx(bres.Hash, true)
 		require.Nil(err, "%d: %+v", i, err)
 		assert.EqualValues(txh, ptx.Height)
@@ -167,6 +166,15 @@ func TestAppCalls(t *testing.T) {
 		appHash := block.BlockMeta.Header.AppHash
 		assert.True(len(appHash) > 0)
 		assert.EqualValues(apph, block.BlockMeta.Header.Height)
+
+		// now check the results
+		blockResults, err := c.BlockResults(&apph)
+		require.Nil(err, "%d: %+v", i, err)
+		assert.Equal(apph, blockResults.Height)
+		if assert.Equal(1, len(blockResults.Results)) {
+			// check success code
+			assert.EqualValues(0, blockResults.Results[0].Code)
+		}
 
 		// check blockchain info, now that we know there is info
 		// TODO: is this commented somewhere that they are returned

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Get block headers for minHeight <= height <= maxHeight.
+// Block headers are returned in descending order (highest first).
 //
 // ```shell
 // curl 'localhost:46657/blockchain?minHeight=10&maxHeight=10'
@@ -314,11 +315,10 @@ func Commit(heightPtr *int64) (*ctypes.ResultCommit, error) {
 }
 
 // BlockResults gets ABCIResults at a given height.
-// If no height is provided, it will fetch the latest block.
+// If no height is provided, it will fetch results for the latest block.
 //
-// Results are for the tx of the last block with the same index.
-// Thus response.results[5] is the results of executing
-// getBlock(h-1).Txs[5]
+// Results are for the height of the block containing the txs.
+// Thus response.results[5] is the results of executing getBlock(h).Txs[5]
 //
 // ```shell
 // curl 'localhost:46657/block_results?height=10'
@@ -364,7 +364,7 @@ func BlockResults(heightPtr *int64) (*ctypes.ResultBlockResults, error) {
 
 	// load the results
 	state := consensusState.GetState()
-	results, err := state.LoadResults(height)
+	results, err := state.LoadABCIResponses(height)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -193,7 +193,8 @@ func BlockchainInfo(minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, e
 // }
 // ```
 func Block(heightPtr *int64) (*ctypes.ResultBlock, error) {
-	height, _, err := getHeight(blockStore, heightPtr)
+	storeHeight := blockStore.Height()
+	height, err := getHeight(storeHeight, heightPtr)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,8 @@ func Block(heightPtr *int64) (*ctypes.ResultBlock, error) {
 // }
 // ```
 func Commit(heightPtr *int64) (*ctypes.ResultCommit, error) {
-	height, storeHeight, err := getHeight(blockStore, heightPtr)
+	storeHeight := blockStore.Height()
+	height, err := getHeight(storeHeight, heightPtr)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +329,8 @@ func Commit(heightPtr *int64) (*ctypes.ResultCommit, error) {
 // }
 // ```
 func BlockResults(heightPtr *int64) (*ctypes.ResultBlockResults, error) {
-	height, _, err := getHeight(blockStore, heightPtr)
+	storeHeight := blockStore.Height()
+	height, err := getHeight(storeHeight, heightPtr)
 	if err != nil {
 		return nil, err
 	}
@@ -346,18 +349,16 @@ func BlockResults(heightPtr *int64) (*ctypes.ResultBlockResults, error) {
 	return res, nil
 }
 
-func getHeight(blockStore types.BlockStore, heightPtr *int64) (reqHeight int64, storeHeight int64, err error) {
-	storeHeight = blockStore.Height()
+func getHeight(storeHeight int64, heightPtr *int64) (int64, error) {
 	if heightPtr != nil {
-		reqHeight = *heightPtr
-		if reqHeight <= 0 {
-			return 0, 0, fmt.Errorf("Height must be greater than 0")
+		height := *heightPtr
+		if height <= 0 {
+			return 0, fmt.Errorf("Height must be greater than 0")
 		}
-		if reqHeight > storeHeight {
-			return 0, 0, fmt.Errorf("Height must be less than or equal to the current blockchain height")
+		if height > storeHeight {
+			return 0, fmt.Errorf("Height must be less than or equal to the current blockchain height")
 		}
-	} else {
-		reqHeight = blockStore.Height()
+		return height, nil
 	}
-	return reqHeight, storeHeight, nil
+	return storeHeight, nil
 }

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -43,12 +43,11 @@ import (
 // }
 // ```
 func Validators(heightPtr *int64) (*ctypes.ResultValidators, error) {
-	if heightPtr == nil {
-		blockHeight, validators := consensusState.GetValidators()
-		return &ctypes.ResultValidators{blockHeight, validators}, nil
+	height, _, err := getHeight(blockStore, heightPtr)
+	if err != nil {
+		return nil, err
 	}
 
-	height := *heightPtr
 	state := consensusState.GetState()
 	validators, err := state.LoadValidators(height)
 	if err != nil {

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -43,7 +43,8 @@ import (
 // }
 // ```
 func Validators(heightPtr *int64) (*ctypes.ResultValidators, error) {
-	height, _, err := getHeight(blockStore, heightPtr)
+	storeHeight := blockStore.Height()
+	height, err := getHeight(storeHeight, heightPtr)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -17,6 +17,7 @@ var Routes = map[string]*rpc.RPCFunc{
 	"blockchain":           rpc.NewRPCFunc(BlockchainInfo, "minHeight,maxHeight"),
 	"genesis":              rpc.NewRPCFunc(Genesis, ""),
 	"block":                rpc.NewRPCFunc(Block, "height"),
+	"block_results":        rpc.NewRPCFunc(BlockResults, "height"),
 	"commit":               rpc.NewRPCFunc(Commit, "height"),
 	"tx":                   rpc.NewRPCFunc(Tx, "hash,prove"),
 	"tx_search":            rpc.NewRPCFunc(TxSearch, "query,prove"),

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tendermint/go-wire/data"
 	cstypes "github.com/tendermint/tendermint/consensus/types"
 	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -34,8 +35,8 @@ type ResultCommit struct {
 }
 
 type ResultBlockResults struct {
-	Height  int64             `json:"height"`
-	Results types.ABCIResults `json:"results"`
+	Height  int64                `json:"height"`
+	Results *state.ABCIResponses `json:"results"`
 }
 
 // NewResultCommit is a helper to initialize the ResultCommit with

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -33,6 +33,11 @@ type ResultCommit struct {
 	CanonicalCommit bool `json:"canonical"`
 }
 
+type ResultBlockResults struct {
+	Height  int64             `json:"height"`
+	Results types.ABCIResults `json:"results"`
+}
+
 // NewResultCommit is a helper to initialize the ResultCommit with
 // the embedded struct
 func NewResultCommit(header *types.Header, commit *types.Commit,

--- a/state/errors.go
+++ b/state/errors.go
@@ -41,6 +41,10 @@ type (
 	ErrNoConsensusParamsForHeight struct {
 		Height int64
 	}
+
+	ErrNoResultsForHeight struct {
+		Height int64
+	}
 )
 
 func (e ErrUnknownBlock) Error() string {
@@ -68,4 +72,8 @@ func (e ErrNoValSetForHeight) Error() string {
 
 func (e ErrNoConsensusParamsForHeight) Error() string {
 	return cmn.Fmt("Could not find consensus params for height #%d", e.Height)
+}
+
+func (e ErrNoResultsForHeight) Error() string {
+	return cmn.Fmt("Could not find results for height #%d", e.Height)
 }

--- a/state/errors.go
+++ b/state/errors.go
@@ -42,7 +42,7 @@ type (
 		Height int64
 	}
 
-	ErrNoResultsForHeight struct {
+	ErrNoABCIResponsesForHeight struct {
 		Height int64
 	}
 )
@@ -74,6 +74,6 @@ func (e ErrNoConsensusParamsForHeight) Error() string {
 	return cmn.Fmt("Could not find consensus params for height #%d", e.Height)
 }
 
-func (e ErrNoResultsForHeight) Error() string {
+func (e ErrNoABCIResponsesForHeight) Error() string {
 	return cmn.Fmt("Could not find results for height #%d", e.Height)
 }

--- a/state/execution.go
+++ b/state/execution.go
@@ -242,7 +242,7 @@ func (s *State) MakeBlock(height int64, txs []types.Tx, commit *types.Commit) (*
 	block.LastBlockID = s.LastBlockID
 	block.ValidatorsHash = s.Validators.Hash()
 	block.AppHash = s.AppHash
-	block.ConsensusHash = s.LastConsensusParams.Hash()
+	block.ConsensusHash = s.ConsensusParams.Hash()
 	block.LastResultsHash = s.LastResultsHash
 
 	return block, block.MakePartSet(s.ConsensusParams.BlockGossip.BlockPartSizeBytes)
@@ -279,8 +279,8 @@ func (s *State) validateBlock(b *types.Block) error {
 	if !bytes.Equal(b.AppHash, s.AppHash) {
 		return fmt.Errorf("Wrong Block.Header.AppHash.  Expected %X, got %v", s.AppHash, b.AppHash)
 	}
-	if !bytes.Equal(b.ConsensusHash, s.LastConsensusParams.Hash()) {
-		return fmt.Errorf("Wrong Block.Header.ConsensusHash.  Expected %X, got %v", s.LastConsensusParams.Hash(), b.ConsensusHash)
+	if !bytes.Equal(b.ConsensusHash, s.ConsensusParams.Hash()) {
+		return fmt.Errorf("Wrong Block.Header.ConsensusHash.  Expected %X, got %v", s.ConsensusParams.Hash(), b.ConsensusHash)
 	}
 	if !bytes.Equal(b.LastResultsHash, s.LastResultsHash) {
 		return fmt.Errorf("Wrong Block.Header.LastResultsHash.  Expected %X, got %v", s.LastResultsHash, b.LastResultsHash)

--- a/state/execution.go
+++ b/state/execution.go
@@ -241,6 +241,7 @@ func (s *State) MakeBlock(height int64, txs []types.Tx, commit *types.Commit) (*
 	block.ValidatorsHash = s.Validators.Hash()
 	block.AppHash = s.AppHash
 	block.ConsensusHash = s.LastConsensusParams.Hash()
+	block.ResultsHash = s.LastResultHash
 
 	return block, block.MakePartSet(s.ConsensusParams.BlockGossip.BlockPartSizeBytes)
 }
@@ -278,6 +279,9 @@ func (s *State) validateBlock(b *types.Block) error {
 	}
 	if !bytes.Equal(b.ConsensusHash, s.LastConsensusParams.Hash()) {
 		return fmt.Errorf("Wrong Block.Header.ConsensusHash.  Expected %X, got %v", s.LastConsensusParams.Hash(), b.ConsensusHash)
+	}
+	if !bytes.Equal(b.ResultsHash, s.LastResultHash) {
+		return fmt.Errorf("Wrong Block.Header.ResultsHash.  Expected %X, got %v", s.LastResultHash, b.ResultsHash)
 	}
 
 	// Validate block LastCommit.

--- a/state/execution.go
+++ b/state/execution.go
@@ -243,7 +243,7 @@ func (s *State) MakeBlock(height int64, txs []types.Tx, commit *types.Commit) (*
 	block.ValidatorsHash = s.Validators.Hash()
 	block.AppHash = s.AppHash
 	block.ConsensusHash = s.LastConsensusParams.Hash()
-	block.ResultsHash = s.LastResultHash
+	block.LastResultsHash = s.LastResultsHash
 
 	return block, block.MakePartSet(s.ConsensusParams.BlockGossip.BlockPartSizeBytes)
 }
@@ -282,8 +282,8 @@ func (s *State) validateBlock(b *types.Block) error {
 	if !bytes.Equal(b.ConsensusHash, s.LastConsensusParams.Hash()) {
 		return fmt.Errorf("Wrong Block.Header.ConsensusHash.  Expected %X, got %v", s.LastConsensusParams.Hash(), b.ConsensusHash)
 	}
-	if !bytes.Equal(b.ResultsHash, s.LastResultHash) {
-		return fmt.Errorf("Wrong Block.Header.ResultsHash.  Expected %X, got %v", s.LastResultHash, b.ResultsHash)
+	if !bytes.Equal(b.LastResultsHash, s.LastResultsHash) {
+		return fmt.Errorf("Wrong Block.Header.LastResultsHash.  Expected %X, got %v", s.LastResultsHash, b.LastResultsHash)
 	}
 
 	// Validate block LastCommit.

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -67,6 +67,12 @@ func TestValidateBlock(t *testing.T) {
 	block.ConsensusHash = []byte("wrong consensus hash")
 	err = state.ValidateBlock(block)
 	require.Error(t, err)
+
+	// wrong results hash fails
+	block = makeBlock(state, 1)
+	block.ResultsHash = []byte("wrong results hash")
+	err = state.ValidateBlock(block)
+	require.Error(t, err)
 }
 
 func TestApplyBlock(t *testing.T) {

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -73,6 +73,12 @@ func TestValidateBlock(t *testing.T) {
 	block.LastResultsHash = []byte("wrong results hash")
 	err = state.ValidateBlock(block)
 	require.Error(t, err)
+
+	// wrong validators hash fails
+	block = makeBlock(state, 1)
+	block.ValidatorsHash = []byte("wrong validators hash")
+	err = state.ValidateBlock(block)
+	require.Error(t, err)
 }
 
 func TestApplyBlock(t *testing.T) {

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -70,7 +70,7 @@ func TestValidateBlock(t *testing.T) {
 
 	// wrong results hash fails
 	block = makeBlock(state, 1)
-	block.ResultsHash = []byte("wrong results hash")
+	block.LastResultsHash = []byte("wrong results hash")
 	err = state.ValidateBlock(block)
 	require.Error(t, err)
 }

--- a/state/state.go
+++ b/state/state.go
@@ -8,13 +8,10 @@ import (
 	"time"
 
 	abci "github.com/tendermint/abci/types"
-	"github.com/tendermint/go-wire/data"
-	"golang.org/x/crypto/ripemd160"
 
 	cmn "github.com/tendermint/tmlibs/common"
 	dbm "github.com/tendermint/tmlibs/db"
 	"github.com/tendermint/tmlibs/log"
-	"github.com/tendermint/tmlibs/merkle"
 
 	wire "github.com/tendermint/go-wire"
 
@@ -79,9 +76,9 @@ type State struct {
 	LastHeightConsensusParamsChanged int64
 
 	// Store LastABCIResults along with hash
-	LastResults        ABCIResults // TODO: remove??
-	LastResultHash     []byte      // this is the one for the next block to propose
-	LastLastResultHash []byte      // this verifies the last block?
+	LastResults        types.ABCIResults // TODO: remove??
+	LastResultHash     []byte            // this is the one for the next block to propose
+	LastLastResultHash []byte            // this verifies the last block?
 
 	// The latest AppHash we've received from calling abci.Commit()
 	AppHash []byte
@@ -311,8 +308,8 @@ func (s *State) saveConsensusParamsInfo() {
 	s.db.SetSync(calcConsensusParamsKey(nextHeight), paramsInfo.Bytes())
 }
 
-// LoadResults loads the ABCIResults for a given height.
-func (s *State) LoadResults(height int64) (ABCIResults, error) {
+// LoadResults loads the types.ABCIResults for a given height.
+func (s *State) LoadResults(height int64) (types.ABCIResults, error) {
 	resInfo := s.loadResults(height)
 	if resInfo == nil {
 		return nil, ErrNoResultsForHeight{height}
@@ -320,13 +317,13 @@ func (s *State) LoadResults(height int64) (ABCIResults, error) {
 	return resInfo, nil
 }
 
-func (s *State) loadResults(height int64) ABCIResults {
+func (s *State) loadResults(height int64) types.ABCIResults {
 	buf := s.db.Get(calcResultsKey(height))
 	if len(buf) == 0 {
 		return nil
 	}
 
-	v := new(ABCIResults)
+	v := new(types.ABCIResults)
 	err := wire.ReadBinaryBytes(buf, v)
 	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
@@ -396,7 +393,7 @@ func (s *State) SetBlockAndValidators(header *types.Header, blockPartsHeader typ
 		header.Time,
 		nextValSet,
 		nextParams,
-		NewResults(abciResponses.DeliverTx))
+		types.NewResults(abciResponses.DeliverTx))
 	return nil
 }
 
@@ -404,7 +401,7 @@ func (s *State) setBlockAndValidators(height int64,
 	newTxs int64, blockID types.BlockID, blockTime time.Time,
 	valSet *types.ValidatorSet,
 	params types.ConsensusParams,
-	results ABCIResults) {
+	results types.ABCIResults) {
 
 	s.LastBlockHeight = height
 	s.LastBlockTotalTx += newTxs
@@ -451,64 +448,6 @@ func NewABCIResponses(block *types.Block) *ABCIResponses {
 // Bytes serializes the ABCIResponse using go-wire
 func (a *ABCIResponses) Bytes() []byte {
 	return wire.BinaryBytes(*a)
-}
-
-//-----------------------------------------------------------------------------
-
-// ABCIResult is just the essential info to prove
-// success/failure of a DeliverTx
-type ABCIResult struct {
-	Code uint32     `json:"code"`
-	Data data.Bytes `json:"data"`
-}
-
-// Hash creates a canonical json hash of the ABCIResult
-func (a ABCIResult) Hash() []byte {
-	// stupid canonical json output, easy to check in any language
-	bs := fmt.Sprintf(`{"code":%d,"data":"%s"}`, a.Code, a.Data)
-	var hasher = ripemd160.New()
-	hasher.Write([]byte(bs))
-	return hasher.Sum(nil)
-}
-
-// ABCIResults wraps the deliver tx results to return a proof
-type ABCIResults []ABCIResult
-
-// NewResults creates ABCIResults from ResponseDeliverTx
-func NewResults(del []*abci.ResponseDeliverTx) ABCIResults {
-	res := make(ABCIResults, len(del))
-	for i, d := range del {
-		res[i] = ABCIResult{
-			Code: d.Code,
-			Data: d.Data,
-		}
-	}
-	return res
-}
-
-// Bytes serializes the ABCIResponse using go-wire
-func (a ABCIResults) Bytes() []byte {
-	return wire.BinaryBytes(a)
-}
-
-// Hash returns a merkle hash of all results
-func (a ABCIResults) Hash() []byte {
-	return merkle.SimpleHashFromHashables(a.toHashables())
-}
-
-// ProveResult returns a merkle proof of one result from the set
-func (a ABCIResults) ProveResult(i int) merkle.SimpleProof {
-	_, proofs := merkle.SimpleProofsFromHashables(a.toHashables())
-	return *proofs[i]
-}
-
-func (a ABCIResults) toHashables() []merkle.Hashable {
-	l := len(a)
-	hashables := make([]merkle.Hashable, l)
-	for i := 0; i < l; i++ {
-		hashables[i] = a[i]
-	}
-	return hashables
 }
 
 //-----------------------------------------------------------------------------

--- a/state/state.go
+++ b/state/state.go
@@ -79,8 +79,9 @@ type State struct {
 	LastHeightConsensusParamsChanged int64
 
 	// Store LastABCIResults along with hash
-	LastResults    ABCIResults // TODO: remove??
-	LastResultHash []byte
+	LastResults        ABCIResults // TODO: remove??
+	LastResultHash     []byte      // this is the one for the next block to propose
+	LastLastResultHash []byte      // this verifies the last block?
 
 	// The latest AppHash we've received from calling abci.Commit()
 	AppHash []byte
@@ -155,6 +156,9 @@ func (s *State) Copy() *State {
 		LastHeightConsensusParamsChanged: s.LastHeightConsensusParamsChanged,
 
 		AppHash: s.AppHash,
+
+		LastResults:    s.LastResults,
+		LastResultHash: s.LastResultHash,
 
 		logger: s.logger,
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -75,7 +75,7 @@ type State struct {
 	LastHeightConsensusParamsChanged int64
 
 	// Merkle root of the results from executing prev block
-	LastResultHash []byte
+	LastResultsHash []byte
 
 	// The latest AppHash we've received from calling abci.Commit()
 	AppHash []byte
@@ -151,7 +151,7 @@ func (s *State) Copy() *State {
 
 		AppHash: s.AppHash,
 
-		LastResultHash: s.LastResultHash,
+		LastResultsHash: s.LastResultsHash,
 
 		logger: s.logger,
 	}
@@ -377,7 +377,7 @@ func (s *State) setBlockAndValidators(height int64,
 	s.LastConsensusParams = s.ConsensusParams
 	s.ConsensusParams = params
 
-	s.LastResultHash = resultsHash
+	s.LastResultsHash = resultsHash
 }
 
 // GetValidators returns the last and current validator sets.
@@ -387,9 +387,9 @@ func (s *State) GetValidators() (last *types.ValidatorSet, current *types.Valida
 
 //------------------------------------------------------------------------
 
-// ABCIResponses retains the deterministic components of the responses
+// ABCIResponses retains the responses
 // of the various ABCI calls during block processing.
-// It is persisted to disk before calling Commit.
+// It is persisted to disk for each height before calling Commit.
 type ABCIResponses struct {
 	DeliverTx []*abci.ResponseDeliverTx
 	EndBlock  *abci.ResponseEndBlock

--- a/state/state.go
+++ b/state/state.go
@@ -71,7 +71,6 @@ type State struct {
 	// Consensus parameters used for validating blocks.
 	// Changes returned by EndBlock and updated after Commit.
 	ConsensusParams                  types.ConsensusParams
-	LastConsensusParams              types.ConsensusParams
 	LastHeightConsensusParamsChanged int64
 
 	// Merkle root of the results from executing prev block
@@ -146,7 +145,6 @@ func (s *State) Copy() *State {
 		LastHeightValidatorsChanged: s.LastHeightValidatorsChanged,
 
 		ConsensusParams:                  s.ConsensusParams,
-		LastConsensusParams:              s.LastConsensusParams,
 		LastHeightConsensusParamsChanged: s.LastHeightConsensusParamsChanged,
 
 		AppHash: s.AppHash,
@@ -374,7 +372,6 @@ func (s *State) setBlockAndValidators(height int64,
 	s.LastValidators = s.Validators.Copy()
 	s.Validators = valSet
 
-	s.LastConsensusParams = s.ConsensusParams
 	s.ConsensusParams = params
 
 	s.LastResultsHash = resultsHash
@@ -501,7 +498,6 @@ func MakeGenesisState(db dbm.DB, genDoc *types.GenesisDoc) (*State, error) {
 		LastHeightValidatorsChanged: 1,
 
 		ConsensusParams:                  *genDoc.ConsensusParams,
-		LastConsensusParams:              types.ConsensusParams{},
 		LastHeightConsensusParamsChanged: 1,
 
 		AppHash: genDoc.AppHash,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -422,7 +422,6 @@ func TestLessThanOneThirdOfVotingPowerPerBlockEnforced(t *testing.T) {
 		height := state.LastBlockHeight + 1
 		block := makeBlock(state, height)
 		abciResponses := &ABCIResponses{
-			Height:   height,
 			EndBlock: &abci.ResponseEndBlock{ValidatorUpdates: tc.valUpdatesFn(state.Validators)},
 		}
 		err := state.SetBlockAndValidators(block.Header, types.PartSetHeader{}, abciResponses)
@@ -512,7 +511,6 @@ func makeHeaderPartsResponsesValPowerChange(state *State, height int64,
 
 	block := makeBlock(state, height)
 	abciResponses := &ABCIResponses{
-		Height:   height,
 		EndBlock: &abci.ResponseEndBlock{ValidatorUpdates: []*abci.Validator{}},
 	}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -279,6 +279,40 @@ func TestConsensusParamsChangesSaveLoad(t *testing.T) {
 	}
 }
 
+func TestABCIResults(t *testing.T) {
+	a := ABCIResult{Code: 0, Data: nil}
+	b := ABCIResult{Code: 0, Data: []byte{}}
+	c := ABCIResult{Code: 0, Data: []byte("one")}
+	d := ABCIResult{Code: 14, Data: nil}
+	e := ABCIResult{Code: 14, Data: []byte("foo")}
+	f := ABCIResult{Code: 14, Data: []byte("bar")}
+
+	// nil and []byte{} should produce same hash
+	assert.Equal(t, a.Hash(), b.Hash())
+
+	// a and b should be the same, don't go in results
+	results := ABCIResults{a, c, d, e, f}
+
+	// make sure each result hashes properly
+	var last []byte
+	for i, res := range results {
+		h := res.Hash()
+		assert.NotEqual(t, last, h, "%d", i)
+		last = h
+	}
+
+	// make sure that we can get a root hash from results
+	// and verify proofs
+	root := results.Hash()
+	assert.NotEmpty(t, root)
+
+	for i, res := range results {
+		proof := results.ProveResult(i)
+		valid := proof.Verify(i, len(results), res.Hash(), root)
+		assert.True(t, valid, "%d", i)
+	}
+}
+
 func makeParams(blockBytes, blockTx, blockGas, txBytes,
 	txGas, partSize int) types.ConsensusParams {
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -279,40 +279,6 @@ func TestConsensusParamsChangesSaveLoad(t *testing.T) {
 	}
 }
 
-func TestABCIResults(t *testing.T) {
-	a := ABCIResult{Code: 0, Data: nil}
-	b := ABCIResult{Code: 0, Data: []byte{}}
-	c := ABCIResult{Code: 0, Data: []byte("one")}
-	d := ABCIResult{Code: 14, Data: nil}
-	e := ABCIResult{Code: 14, Data: []byte("foo")}
-	f := ABCIResult{Code: 14, Data: []byte("bar")}
-
-	// nil and []byte{} should produce same hash
-	assert.Equal(t, a.Hash(), b.Hash())
-
-	// a and b should be the same, don't go in results
-	results := ABCIResults{a, c, d, e, f}
-
-	// make sure each result hashes properly
-	var last []byte
-	for i, res := range results {
-		h := res.Hash()
-		assert.NotEqual(t, last, h, "%d", i)
-		last = h
-	}
-
-	// make sure that we can get a root hash from results
-	// and verify proofs
-	root := results.Hash()
-	assert.NotEmpty(t, root)
-
-	for i, res := range results {
-		proof := results.ProveResult(i)
-		valid := proof.Verify(i, len(results), res.Hash(), root)
-		assert.True(t, valid, "%d", i)
-	}
-}
-
 // TestResultsSaveLoad tests saving and loading abci results.
 func TestResultsSaveLoad(t *testing.T) {
 	tearDown, _, state := setupTestCase(t)
@@ -324,17 +290,17 @@ func TestResultsSaveLoad(t *testing.T) {
 		// height is implied index+2
 		// as block 1 is created from genesis
 		added    []*abci.ResponseDeliverTx
-		expected ABCIResults
+		expected types.ABCIResults
 	}{
 		0: {
 			[]*abci.ResponseDeliverTx{},
-			ABCIResults{},
+			types.ABCIResults{},
 		},
 		1: {
 			[]*abci.ResponseDeliverTx{
 				{Code: 32, Data: []byte("Hello"), Log: "Huh?"},
 			},
-			ABCIResults{
+			types.ABCIResults{
 				{32, []byte("Hello")},
 			}},
 		2: {
@@ -346,13 +312,13 @@ func TestResultsSaveLoad(t *testing.T) {
 						abci.KVPairString("build", "stuff"),
 					}},
 			},
-			ABCIResults{
+			types.ABCIResults{
 				{383, []byte{}},
 				{0, []byte("Gotcha!")},
 			}},
 		3: {
 			nil,
-			ABCIResults{},
+			types.ABCIResults{},
 		},
 	}
 

--- a/types/block.go
+++ b/types/block.go
@@ -149,7 +149,7 @@ type Header struct {
 	LastCommitHash data.Bytes `json:"last_commit_hash"` // commit from validators from the last block
 	DataHash       data.Bytes `json:"data_hash"`        // transactions
 
-	// hashes from the app
+	// hashes from the app output from the prev block
 	ValidatorsHash data.Bytes `json:"validators_hash"` // validators for the current block
 	ConsensusHash  data.Bytes `json:"consensus_hash"`  // consensus params for current block
 	AppHash        data.Bytes `json:"app_hash"`        // state after txs from the previous block

--- a/types/block.go
+++ b/types/block.go
@@ -153,6 +153,7 @@ type Header struct {
 	ValidatorsHash data.Bytes `json:"validators_hash"` // validators for the current block
 	ConsensusHash  data.Bytes `json:"consensus_hash"`  // consensus params for current block
 	AppHash        data.Bytes `json:"app_hash"`        // state after txs from the previous block
+	ResultsHash    data.Bytes `json:"results_hash"`    // root hash of all results from the txs from the previous block
 }
 
 // Hash returns the hash of the header.
@@ -173,6 +174,7 @@ func (h *Header) Hash() data.Bytes {
 		"Validators":  h.ValidatorsHash,
 		"App":         h.AppHash,
 		"Consensus":   h.ConsensusHash,
+		"Results":     h.ResultsHash,
 	})
 }
 
@@ -192,7 +194,8 @@ func (h *Header) StringIndented(indent string) string {
 %s  Data:           %v
 %s  Validators:     %v
 %s  App:            %v
-%s  Conensus:            %v
+%s  Conensus:       %v
+%s  Results:        %v
 %s}#%v`,
 		indent, h.ChainID,
 		indent, h.Height,
@@ -205,6 +208,7 @@ func (h *Header) StringIndented(indent string) string {
 		indent, h.ValidatorsHash,
 		indent, h.AppHash,
 		indent, h.ConsensusHash,
+		indent, h.ResultsHash,
 		indent, h.Hash())
 }
 

--- a/types/block.go
+++ b/types/block.go
@@ -150,10 +150,10 @@ type Header struct {
 	DataHash       data.Bytes `json:"data_hash"`        // transactions
 
 	// hashes from the app output from the prev block
-	ValidatorsHash data.Bytes `json:"validators_hash"` // validators for the current block
-	ConsensusHash  data.Bytes `json:"consensus_hash"`  // consensus params for current block
-	AppHash        data.Bytes `json:"app_hash"`        // state after txs from the previous block
-	ResultsHash    data.Bytes `json:"results_hash"`    // root hash of all results from the txs from the previous block
+	ValidatorsHash  data.Bytes `json:"validators_hash"`   // validators for the current block
+	ConsensusHash   data.Bytes `json:"consensus_hash"`    // consensus params for current block
+	AppHash         data.Bytes `json:"app_hash"`          // state after txs from the previous block
+	LastResultsHash data.Bytes `json:"last_results_hash"` // root hash of all results from the txs from the previous block
 }
 
 // Hash returns the hash of the header.
@@ -174,7 +174,7 @@ func (h *Header) Hash() data.Bytes {
 		"Validators":  h.ValidatorsHash,
 		"App":         h.AppHash,
 		"Consensus":   h.ConsensusHash,
-		"Results":     h.ResultsHash,
+		"Results":     h.LastResultsHash,
 	})
 }
 
@@ -208,7 +208,7 @@ func (h *Header) StringIndented(indent string) string {
 		indent, h.ValidatorsHash,
 		indent, h.AppHash,
 		indent, h.ConsensusHash,
-		indent, h.ResultsHash,
+		indent, h.LastResultsHash,
 		indent, h.Hash())
 }
 

--- a/types/results.go
+++ b/types/results.go
@@ -13,14 +13,13 @@ import (
 
 //-----------------------------------------------------------------------------
 
-// ABCIResult is just the essential info to prove
-// success/failure of a DeliverTx
+// ABCIResult is the deterministic component of a ResponseDeliverTx.
 type ABCIResult struct {
 	Code uint32     `json:"code"`
 	Data data.Bytes `json:"data"`
 }
 
-// Hash creates a canonical json hash of the ABCIResult
+// Hash returns the canonical json hash of the ABCIResult
 func (a ABCIResult) Hash() []byte {
 	// stupid canonical json output, easy to check in any language
 	bs := fmt.Sprintf(`{"code":%d,"data":"%s"}`, a.Code, a.Data)
@@ -36,12 +35,16 @@ type ABCIResults []ABCIResult
 func NewResults(del []*abci.ResponseDeliverTx) ABCIResults {
 	res := make(ABCIResults, len(del))
 	for i, d := range del {
-		res[i] = ABCIResult{
-			Code: d.Code,
-			Data: d.Data,
-		}
+		res[i] = NewResultFromResponse(d)
 	}
 	return res
+}
+
+func NewResultFromResponse(response *abci.ResponseDeliverTx) ABCIResult {
+	return ABCIResult{
+		Code: response.Code,
+		Data: response.Data,
+	}
 }
 
 // Bytes serializes the ABCIResponse using go-wire

--- a/types/results.go
+++ b/types/results.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"fmt"
+
+	"golang.org/x/crypto/ripemd160"
+
+	abci "github.com/tendermint/abci/types"
+	wire "github.com/tendermint/go-wire"
+	"github.com/tendermint/go-wire/data"
+	"github.com/tendermint/tmlibs/merkle"
+)
+
+//-----------------------------------------------------------------------------
+
+// ABCIResult is just the essential info to prove
+// success/failure of a DeliverTx
+type ABCIResult struct {
+	Code uint32     `json:"code"`
+	Data data.Bytes `json:"data"`
+}
+
+// Hash creates a canonical json hash of the ABCIResult
+func (a ABCIResult) Hash() []byte {
+	// stupid canonical json output, easy to check in any language
+	bs := fmt.Sprintf(`{"code":%d,"data":"%s"}`, a.Code, a.Data)
+	var hasher = ripemd160.New()
+	hasher.Write([]byte(bs))
+	return hasher.Sum(nil)
+}
+
+// ABCIResults wraps the deliver tx results to return a proof
+type ABCIResults []ABCIResult
+
+// NewResults creates ABCIResults from ResponseDeliverTx
+func NewResults(del []*abci.ResponseDeliverTx) ABCIResults {
+	res := make(ABCIResults, len(del))
+	for i, d := range del {
+		res[i] = ABCIResult{
+			Code: d.Code,
+			Data: d.Data,
+		}
+	}
+	return res
+}
+
+// Bytes serializes the ABCIResponse using go-wire
+func (a ABCIResults) Bytes() []byte {
+	return wire.BinaryBytes(a)
+}
+
+// Hash returns a merkle hash of all results
+func (a ABCIResults) Hash() []byte {
+	return merkle.SimpleHashFromHashables(a.toHashables())
+}
+
+// ProveResult returns a merkle proof of one result from the set
+func (a ABCIResults) ProveResult(i int) merkle.SimpleProof {
+	_, proofs := merkle.SimpleProofsFromHashables(a.toHashables())
+	return *proofs[i]
+}
+
+func (a ABCIResults) toHashables() []merkle.Hashable {
+	l := len(a)
+	hashables := make([]merkle.Hashable, l)
+	for i := 0; i < l; i++ {
+		hashables[i] = a[i]
+	}
+	return hashables
+}

--- a/types/results.go
+++ b/types/results.go
@@ -1,10 +1,6 @@
 package types
 
 import (
-	"fmt"
-
-	"golang.org/x/crypto/ripemd160"
-
 	abci "github.com/tendermint/abci/types"
 	wire "github.com/tendermint/go-wire"
 	"github.com/tendermint/go-wire/data"
@@ -14,18 +10,15 @@ import (
 //-----------------------------------------------------------------------------
 
 // ABCIResult is the deterministic component of a ResponseDeliverTx.
+// TODO: add Tags
 type ABCIResult struct {
 	Code uint32     `json:"code"`
 	Data data.Bytes `json:"data"`
 }
 
-// Hash returns the canonical json hash of the ABCIResult
+// Hash returns the canonical hash of the ABCIResult
 func (a ABCIResult) Hash() []byte {
-	// stupid canonical json output, easy to check in any language
-	bs := fmt.Sprintf(`{"code":%d,"data":"%s"}`, a.Code, a.Data)
-	var hasher = ripemd160.New()
-	hasher.Write([]byte(bs))
-	return hasher.Sum(nil)
+	return wire.BinaryRipemd160(a)
 }
 
 // ABCIResults wraps the deliver tx results to return a proof

--- a/types/results_test.go
+++ b/types/results_test.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestABCIResults(t *testing.T) {
+	a := ABCIResult{Code: 0, Data: nil}
+	b := ABCIResult{Code: 0, Data: []byte{}}
+	c := ABCIResult{Code: 0, Data: []byte("one")}
+	d := ABCIResult{Code: 14, Data: nil}
+	e := ABCIResult{Code: 14, Data: []byte("foo")}
+	f := ABCIResult{Code: 14, Data: []byte("bar")}
+
+	// nil and []byte{} should produce same hash
+	assert.Equal(t, a.Hash(), b.Hash())
+
+	// a and b should be the same, don't go in results
+	results := ABCIResults{a, c, d, e, f}
+
+	// make sure each result hashes properly
+	var last []byte
+	for i, res := range results {
+		h := res.Hash()
+		assert.NotEqual(t, last, h, "%d", i)
+		last = h
+	}
+
+	// make sure that we can get a root hash from results
+	// and verify proofs
+	root := results.Hash()
+	assert.NotEmpty(t, root)
+
+	for i, res := range results {
+		proof := results.ProveResult(i)
+		valid := proof.Verify(i, len(results), res.Hash(), root)
+		assert.True(t, valid, "%d", i)
+	}
+}


### PR DESCRIPTION
Address issue #952 

This is now maintained in state and save to the db.

TODO:
- [x] add `LastResultsHash data.Bytes` to the header
- [x] It should be the merkle root of the `{code, data}` of the results from the previous block.
- [x] add extra methods to the `BlockStore` for storing all the results for a given block. 
- [x] Then, to prove a result, we can make one call to the blockstore to load the BlockResults and easily compute the merkle proof
- [x] Expose modifications to RPC to make it easy for users to see which transactions in a block were invalid
