### PR TITLE
state: move methods to funcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 ## Roadmap
 
 BREAKING CHANGES:
-- Upgrade the header to support better proofs on validtors, results, evidence, and possibly more
 - Better support for injecting randomness
-- Pass evidence/voteInfo through ABCI
 - Upgrade consensus for more real-time use of evidence
 
 FEATURES:
@@ -32,6 +30,27 @@ BUG FIXES:
 BREAKING CHANGES:
 - [p2p] enable the Peer Exchange reactor by default
 - [types] add Timestamp field to Proposal/Vote
+- [types] add new fields to Header: TotalTxs, ConsensusParamsHash, LastResultsHash, EvidenceHash
+- [types] add Evidence to Block
+- [types] simplify ValidateBasic
+- [state] updates to support changes to the header
+- [state] Enforce <1/3 of validator set can change at a time
+
+FEATURES:
+- [state] Send indices of absent validators and addresses of byzantine validators in BeginBlock
+- [state] Historical ConsensusParams and ABCIResponses
+- [docs] Specification for the base Tendermint data structures.
+- [evidence] New evidence reactor for gossiping and managing evidence
+- [rpc] `/block_results?height=X` returns the DeliverTx results for a given height.
+
+IMPROVEMENTS:
+- [consensus] Better handling of corrupt WAL file
+
+BUG FIXES:
+- [lite] fix race
+- [state] validate block.Header.ValidatorsHash
+- [p2p] allow seed addresses to be prefixed with eg. `tcp://`
+- [cmd] fix `tendermint init` to ignore files that are there and generate files that aren't.
 
 ## 0.14.0 (December 11, 2017)
 

--- a/blockchain/reactor.go
+++ b/blockchain/reactor.go
@@ -284,7 +284,6 @@ FOR_LOOP:
 
 					bcR.store.SaveBlock(first, firstParts, second.LastCommit)
 
-					// TODO: should we be firing events? need to fire NewBlock events manually ...
 					// NOTE: we could improve performance if we
 					// didn't make the app commit to disk every block
 					// ... but we would need a way to get the hash without it persisting

--- a/blockchain/reactor_test.go
+++ b/blockchain/reactor_test.go
@@ -21,7 +21,7 @@ func makeStateAndBlockStore(logger log.Logger) (sm.State, *BlockStore) {
 	// Get State
 	stateDB := dbm.NewMemDB()
 	state, _ := sm.GetState(stateDB, config.GenesisFile())
-	sm.SaveState(stateDB, state, state.AppHash)
+	sm.SaveState(stateDB, state)
 
 	return state, blockStore
 }

--- a/blockchain/reactor_test.go
+++ b/blockchain/reactor_test.go
@@ -32,7 +32,7 @@ func newBlockchainReactor(logger log.Logger, maxBlockHeight int64) *BlockchainRe
 	// Make the blockchainReactor itself
 	fastSync := true
 	blockExec := sm.NewBlockExecutor(dbm.NewMemDB(), log.TestingLogger(),
-		nil, nil, types.MockMempool{}, types.MockEvidencePool{})
+		types.NopEventBus{}, nil, types.MockMempool{}, types.MockEvidencePool{})
 
 	bcReactor := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
 	bcReactor.SetLogger(logger.With("module", "blockchain"))

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -266,7 +266,7 @@ func newConsensusStateWithConfigAndBlockStore(thisConfig *cfg.Config, state sm.S
 	// Make ConsensusReactor
 	stateDB := dbm.NewMemDB() // XXX !!
 	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(),
-		nil, proxyAppConnCon, mempool, evpool)
+		types.NopEventBus{}, proxyAppConnCon, mempool, evpool)
 	cs := NewConsensusState(thisConfig.Consensus, state, blockExec, blockStore, mempool, evpool)
 	cs.SetLogger(log.TestingLogger())
 	cs.SetPrivValidator(pv)

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -264,7 +264,7 @@ func newConsensusStateWithConfigAndBlockStore(thisConfig *cfg.Config, state sm.S
 	evpool := types.MockEvidencePool{}
 
 	// Make ConsensusReactor
-	stateDB := dbm.NewMemDB() // XXX !!
+	stateDB := dbm.NewMemDB()
 	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
 	cs := NewConsensusState(thisConfig.Consensus, state, blockExec, blockStore, mempool, evpool)
 	cs.SetLogger(log.TestingLogger())

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -265,8 +265,7 @@ func newConsensusStateWithConfigAndBlockStore(thisConfig *cfg.Config, state sm.S
 
 	// Make ConsensusReactor
 	stateDB := dbm.NewMemDB() // XXX !!
-	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(),
-		types.NopEventBus{}, proxyAppConnCon, mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
 	cs := NewConsensusState(thisConfig.Consensus, state, blockExec, blockStore, mempool, evpool)
 	cs.SetLogger(log.TestingLogger())
 	cs.SetPrivValidator(pv)
@@ -356,8 +355,7 @@ func randConsensusNet(nValidators int, testName string, tickerFunc func() Timeou
 	logger := consensusLogger()
 	for i := 0; i < nValidators; i++ {
 		stateDB := dbm.NewMemDB() // each state needs its own db
-		state, _ := sm.MakeGenesisState(genDoc)
-		sm.SaveState(stateDB, state)
+		state, _ := sm.LoadStateFromDBOrGenesisDoc(stateDB, genDoc)
 		thisConfig := ResetConfig(cmn.Fmt("%s_%d", testName, i))
 		for _, opt := range configOpts {
 			opt(thisConfig)
@@ -381,8 +379,7 @@ func randConsensusNetWithPeers(nValidators, nPeers int, testName string, tickerF
 	logger := consensusLogger()
 	for i := 0; i < nPeers; i++ {
 		stateDB := dbm.NewMemDB() // each state needs its own db
-		state, _ := sm.MakeGenesisState(genDoc)
-		sm.SaveState(stateDB, state)
+		state, _ := sm.LoadStateFromDBOrGenesisDoc(stateDB, genDoc)
 		thisConfig := ResetConfig(cmn.Fmt("%s_%d", testName, i))
 		ensureDir(path.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
 		var privVal types.PrivValidator

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -82,7 +82,7 @@ func (conR *ConsensusReactor) OnStop() {
 
 // SwitchToConsensus switches from fast_sync mode to consensus mode.
 // It resets the state, turns off fast_sync, and starts the consensus state-machine
-func (conR *ConsensusReactor) SwitchToConsensus(state *sm.State, blocksSynced int) {
+func (conR *ConsensusReactor) SwitchToConsensus(state sm.State, blocksSynced int) {
 	conR.Logger.Info("SwitchToConsensus")
 	conR.conS.reconstructLastCommit(state)
 	// NOTE: The line below causes broadcastNewRoundStepRoutine() to

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -301,7 +301,7 @@ func (h *Handshaker) ReplayBlocks(appHash []byte, appBlockHeight int64, proxyApp
 
 		} else if appBlockHeight == storeBlockHeight {
 			// We ran Commit, but didn't save the state, so replayBlock with mock app
-			abciResponses, err := h.state.LoadABCIResponses(storeBlockHeight)
+			abciResponses, err := sm.LoadABCIResponses(h.state.DB(), storeBlockHeight)
 			if err != nil {
 				return nil, err
 			}

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -363,14 +363,10 @@ func (h *Handshaker) replayBlocks(state sm.State, proxyApp proxy.AppConns, appBl
 
 // ApplyBlock on the proxyApp with the last block.
 func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.AppConnConsensus) (sm.State, error) {
-	mempool := types.MockMempool{}
-	evpool := types.MockEvidencePool{}
-
 	block := h.store.LoadBlock(height)
 	meta := h.store.LoadBlockMeta(height)
 
-	blockExec := sm.NewBlockExecutor(h.stateDB, h.logger,
-		types.NopEventBus{}, proxyApp, mempool, evpool)
+	blockExec := sm.NewBlockExecutor(h.stateDB, h.logger, proxyApp, types.MockMempool{}, types.MockEvidencePool{})
 
 	var err error
 	state, err = blockExec.ApplyBlock(state, meta.BlockID, block)

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -306,7 +306,7 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 
 	mempool, evpool := types.MockMempool{}, types.MockEvidencePool{}
 	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(),
-		nil, proxyApp.Consensus(),
+		types.NopEventBus{}, proxyApp.Consensus(),
 		mempool, evpool)
 
 	consensusState := NewConsensusState(csConfig, state.Copy(), blockExec,

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -305,9 +305,7 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 	}
 
 	mempool, evpool := types.MockMempool{}, types.MockEvidencePool{}
-	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(),
-		types.NopEventBus{}, proxyApp.Consensus(),
-		mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
 
 	consensusState := NewConsensusState(csConfig, state.Copy(), blockExec,
 		blockStore, mempool, evpool)

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -53,7 +53,7 @@ func init() {
 
 func startNewConsensusStateAndWaitForBlock(t *testing.T, lastBlockHeight int64, blockDB dbm.DB, stateDB dbm.DB) {
 	logger := log.TestingLogger()
-	state, _ := sm.GetState(stateDB, consensusReplayConfig.GenesisFile())
+	state, _ := sm.LoadStateFromDBOrGenesisFile(stateDB, consensusReplayConfig.GenesisFile())
 	privValidator := loadPrivValidator(consensusReplayConfig)
 	cs := newConsensusStateWithConfigAndBlockStore(consensusReplayConfig, state, privValidator, dummy.NewDummyApplication(), blockDB)
 	cs.SetLogger(logger)
@@ -394,8 +394,7 @@ func testHandshakeReplay(t *testing.T, nBlocks int, mode uint) {
 
 func applyBlock(stateDB dbm.DB, st sm.State, blk *types.Block, proxyApp proxy.AppConns) sm.State {
 	testPartSize := st.ConsensusParams.BlockPartSizeBytes
-	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(),
-		types.NopEventBus{}, proxyApp.Consensus(), mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
 
 	blkID := types.BlockID{blk.Hash(), blk.MakePartSet(testPartSize).Header()}
 	newState, err := blockExec.ApplyBlock(st, blkID, blk)

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -67,7 +67,7 @@ func WALWithNBlocks(numBlocks int) (data []byte, err error) {
 	defer eventBus.Stop()
 	mempool := types.MockMempool{}
 	evpool := types.MockEvidencePool{}
-	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), nil, proxyApp.Consensus(), mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), types.NopEventBus{}, proxyApp.Consensus(), mempool, evpool)
 	consensusState := NewConsensusState(config.Consensus, state.Copy(), blockExec, blockStore, mempool, evpool)
 	consensusState.SetLogger(logger)
 	consensusState.SetEventBus(eventBus)

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -47,13 +47,12 @@ func WALWithNBlocks(numBlocks int) (data []byte, err error) {
 	}
 	stateDB := db.NewMemDB()
 	blockStoreDB := db.NewMemDB()
-	state, err := sm.MakeGenesisState(stateDB, genDoc)
-	state.SetLogger(logger.With("module", "state"))
+	state, err := sm.MakeGenesisState(genDoc)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to make genesis state")
 	}
 	blockStore := bc.NewBlockStore(blockStoreDB)
-	handshaker := NewHandshaker(state, blockStore)
+	handshaker := NewHandshaker(stateDB, state, blockStore)
 	proxyApp := proxy.NewAppConns(proxy.NewLocalClientCreator(app), handshaker)
 	proxyApp.SetLogger(logger.With("module", "proxy"))
 	if err := proxyApp.Start(); err != nil {
@@ -68,7 +67,8 @@ func WALWithNBlocks(numBlocks int) (data []byte, err error) {
 	defer eventBus.Stop()
 	mempool := types.MockMempool{}
 	evpool := types.MockEvidencePool{}
-	consensusState := NewConsensusState(config.Consensus, state.Copy(), proxyApp.Consensus(), blockStore, mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), nil, proxyApp.Consensus(), mempool, evpool)
+	consensusState := NewConsensusState(config.Consensus, state.Copy(), blockExec, blockStore, mempool, evpool)
 	consensusState.SetLogger(logger)
 	consensusState.SetEventBus(eventBus)
 	if privValidator != nil {

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -67,7 +67,7 @@ func WALWithNBlocks(numBlocks int) (data []byte, err error) {
 	defer eventBus.Stop()
 	mempool := types.MockMempool{}
 	evpool := types.MockEvidencePool{}
-	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), types.NopEventBus{}, proxyApp.Consensus(), mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
 	consensusState := NewConsensusState(config.Consensus, state.Copy(), blockExec, blockStore, mempool, evpool)
 	consensusState.SetLogger(logger)
 	consensusState.SetEventBus(eventBus)

--- a/evidence/pool.go
+++ b/evidence/pool.go
@@ -9,22 +9,24 @@ import (
 // EvidencePool maintains a pool of valid evidence
 // in an EvidenceStore.
 type EvidencePool struct {
-	params types.EvidenceParams
 	logger log.Logger
 
-	state         types.State // TODO: update this on commit!
 	evidenceStore *EvidenceStore
+
+	chainID         string
+	lastBlockHeight int64
+	params          types.EvidenceParams
 
 	// never close
 	evidenceChan chan types.Evidence
 }
 
-func NewEvidencePool(params types.EvidenceParams, evidenceStore *EvidenceStore, state types.State) *EvidencePool {
+func NewEvidencePool(params types.EvidenceParams, evidenceStore *EvidenceStore, state *types.State) *EvidencePool {
 	evpool := &EvidencePool{
 		params:        params,
 		logger:        log.NewNopLogger(),
 		evidenceStore: evidenceStore,
-		state:         state,
+		state:         *state,
 		evidenceChan:  make(chan types.Evidence),
 	}
 	return evpool
@@ -56,7 +58,7 @@ func (evpool *EvidencePool) AddEvidence(evidence types.Evidence) (err error) {
 	// TODO: check if we already have evidence for this
 	// validator at this height so we dont get spammed
 
-	priority, err := evpool.state.VerifyEvidence(evidence)
+	priority, err := sm.VerifyEvidence(evpool.state, evidence)
 	if err != nil {
 		// TODO: if err is just that we cant find it cuz we pruned, ignore.
 		// TODO: if its actually bad evidence, punish peer

--- a/evidence/pool.go
+++ b/evidence/pool.go
@@ -21,13 +21,13 @@ type EvidencePool struct {
 	evidenceChan chan types.Evidence
 }
 
-func NewEvidencePool(params types.EvidenceParams, evidenceStore *EvidenceStore, state types.State) *EvidencePool {
+func NewEvidencePool(params types.EvidenceParams, evidenceStore *EvidenceStore) *EvidencePool {
 	evpool := &EvidencePool{
 		params:        params,
 		logger:        log.NewNopLogger(),
 		evidenceStore: evidenceStore,
-		state:         *state,
-		evidenceChan:  make(chan types.Evidence),
+		// state:         *state,
+		evidenceChan: make(chan types.Evidence),
 	}
 	return evpool
 }
@@ -58,12 +58,15 @@ func (evpool *EvidencePool) AddEvidence(evidence types.Evidence) (err error) {
 	// TODO: check if we already have evidence for this
 	// validator at this height so we dont get spammed
 
-	priority, err := sm.VerifyEvidence(evpool.state, evidence)
-	if err != nil {
-		// TODO: if err is just that we cant find it cuz we pruned, ignore.
-		// TODO: if its actually bad evidence, punish peer
-		return err
-	}
+	// TODO
+	var priority int64
+	/*
+		priority, err := sm.VerifyEvidence(evpool.state, evidence)
+		if err != nil {
+			// TODO: if err is just that we cant find it cuz we pruned, ignore.
+			// TODO: if its actually bad evidence, punish peer
+			return err
+		}*/
 
 	added := evpool.evidenceStore.AddNewEvidence(evidence, priority)
 	if !added {

--- a/evidence/pool.go
+++ b/evidence/pool.go
@@ -21,7 +21,7 @@ type EvidencePool struct {
 	evidenceChan chan types.Evidence
 }
 
-func NewEvidencePool(params types.EvidenceParams, evidenceStore *EvidenceStore, state *types.State) *EvidencePool {
+func NewEvidencePool(params types.EvidenceParams, evidenceStore *EvidenceStore, state types.State) *EvidencePool {
 	evpool := &EvidencePool{
 		params:        params,
 		logger:        log.NewNopLogger(),

--- a/evidence/pool.go
+++ b/evidence/pool.go
@@ -1,6 +1,10 @@
 package evidence
 
 import (
+	"fmt"
+	"sync"
+
+	dbm "github.com/tendermint/tmlibs/db"
 	"github.com/tendermint/tmlibs/log"
 
 	sm "github.com/tendermint/tendermint/state"
@@ -14,17 +18,21 @@ type EvidencePool struct {
 
 	evidenceStore *EvidenceStore
 
-	state  sm.State
-	params types.EvidenceParams
+	// needed to load validators to verify evidence
+	stateDB dbm.DB
+
+	// latest state
+	mtx   sync.Mutex
+	state sm.State
 
 	// never close
 	evidenceChan chan types.Evidence
 }
 
-func NewEvidencePool(params types.EvidenceParams, evidenceStore *EvidenceStore, state sm.State) *EvidencePool {
+func NewEvidencePool(stateDB dbm.DB, evidenceStore *EvidenceStore) *EvidencePool {
 	evpool := &EvidencePool{
-		state:         state,
-		params:        params,
+		stateDB:       stateDB,
+		state:         sm.LoadState(stateDB),
 		logger:        log.NewNopLogger(),
 		evidenceStore: evidenceStore,
 		evidenceChan:  make(chan types.Evidence),
@@ -52,31 +60,44 @@ func (evpool *EvidencePool) PendingEvidence() []types.Evidence {
 	return evpool.evidenceStore.PendingEvidence()
 }
 
+// State returns the current state of the evpool.
+func (evpool *EvidencePool) State() sm.State {
+	evpool.mtx.Lock()
+	defer evpool.mtx.Unlock()
+	return evpool.state
+}
+
+// Update loads the latest
+func (evpool *EvidencePool) Update(block *types.Block) {
+	evpool.mtx.Lock()
+	defer evpool.mtx.Unlock()
+
+	state := sm.LoadState(evpool.stateDB)
+	if state.LastBlockHeight != block.Height {
+		panic(fmt.Sprintf("EvidencePool.Update: loaded state with height %d when block.Height=%d", state.LastBlockHeight, block.Height))
+	}
+	evpool.state = state
+
+	// NOTE: shouldn't need the mutex
+	evpool.MarkEvidenceAsCommitted(block.Evidence.Evidence)
+}
+
 // AddEvidence checks the evidence is valid and adds it to the pool.
 // Blocks on the EvidenceChan.
 func (evpool *EvidencePool) AddEvidence(evidence types.Evidence) (err error) {
+
 	// TODO: check if we already have evidence for this
 	// validator at this height so we dont get spammed
 
-	if err := sm.VerifyEvidence(evpool.state, evidence); err != nil {
+	if err := sm.VerifyEvidence(evpool.stateDB, evpool.State(), evidence); err != nil {
 		return err
 	}
 
-	var priority int64
-	/* // Needs a db ...
-	// TODO: if err is just that we cant find it cuz we pruned, ignore.
-	// TODO: if its actually bad evidence, punish peer
-
-	valset, err := LoadValidators(s.db, ev.Height())
-	if err != nil {
-		// XXX/TODO: what do we do if we can't load the valset?
-		// eg. if we have pruned the state or height is too high?
-		return err
-	}
-	if err := VerifyEvidenceValidator(valSet, ev); err != nil {
-		return types.NewEvidenceInvalidErr(ev, err)
-	}
-	*/
+	// fetch the validator and return its voting power as its priority
+	// TODO: something better ?
+	valset, _ := sm.LoadValidators(evpool.stateDB, evidence.Height())
+	_, val := valset.GetByAddress(evidence.Address())
+	priority := val.VotingPower
 
 	added := evpool.evidenceStore.AddNewEvidence(evidence, priority)
 	if !added {

--- a/evidence/pool.go
+++ b/evidence/pool.go
@@ -27,8 +27,7 @@ func NewEvidencePool(params types.EvidenceParams, evidenceStore *EvidenceStore, 
 		params:        params,
 		logger:        log.NewNopLogger(),
 		evidenceStore: evidenceStore,
-		// state:         *state,
-		evidenceChan: make(chan types.Evidence),
+		evidenceChan:  make(chan types.Evidence),
 	}
 	return evpool
 }

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -6,24 +6,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
 	dbm "github.com/tendermint/tmlibs/db"
 )
 
-type mockState struct{}
-
-func (m mockState) VerifyEvidence(ev types.Evidence) (int64, error) {
-	err := ev.Verify("")
-	return 10, err
-}
+var mockState = sm.State{}
 
 func TestEvidencePool(t *testing.T) {
 	assert := assert.New(t)
 
 	params := types.EvidenceParams{}
 	store := NewEvidenceStore(dbm.NewMemDB())
-	state := mockState{}
-	pool := NewEvidencePool(params, store, state)
+	pool := NewEvidencePool(params, store, mockState)
 
 	goodEvidence := newMockGoodEvidence(5, 1, []byte("val1"))
 	badEvidence := MockBadEvidence{goodEvidence}

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -3,6 +3,7 @@ package evidence
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -13,14 +14,46 @@ import (
 
 var mockState = sm.State{}
 
+func initializeValidatorState(valAddr []byte, height int64) dbm.DB {
+	stateDB := dbm.NewMemDB()
+
+	// create validator set and state
+	valSet := &types.ValidatorSet{
+		Validators: []*types.Validator{
+			{Address: valAddr},
+		},
+	}
+	state := sm.State{
+		LastBlockHeight:             0,
+		LastBlockTime:               time.Now(),
+		Validators:                  valSet,
+		LastHeightValidatorsChanged: 1,
+		ConsensusParams: types.ConsensusParams{
+			EvidenceParams: types.EvidenceParams{
+				MaxAge: 1000000,
+			},
+		},
+	}
+
+	// save all states up to height
+	for i := int64(0); i < height; i++ {
+		state.LastBlockHeight = i
+		sm.SaveState(stateDB, state)
+	}
+
+	return stateDB
+}
+
 func TestEvidencePool(t *testing.T) {
 	assert := assert.New(t)
 
-	params := types.EvidenceParams{}
+	valAddr := []byte("val1")
+	height := int64(5)
+	stateDB := initializeValidatorState(valAddr, height)
 	store := NewEvidenceStore(dbm.NewMemDB())
-	pool := NewEvidencePool(params, store, mockState)
+	pool := NewEvidencePool(stateDB, store)
 
-	goodEvidence := newMockGoodEvidence(5, 1, []byte("val1"))
+	goodEvidence := newMockGoodEvidence(height, 0, valAddr)
 	badEvidence := MockBadEvidence{goodEvidence}
 
 	err := pool.AddEvidence(badEvidence)

--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -39,8 +39,7 @@ func makeAndConnectEvidenceReactors(config *cfg.Config, N int) []*EvidenceReacto
 
 		params := types.EvidenceParams{}
 		store := NewEvidenceStore(dbm.NewMemDB())
-		state := mockState{}
-		pool := NewEvidencePool(params, store, state)
+		pool := NewEvidencePool(params, store, mockState)
 		reactors[i] = NewEvidenceReactor(pool)
 		reactors[i].SetLogger(logger.With("validator", i))
 	}

--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -32,14 +32,14 @@ func evidenceLogger() log.Logger {
 }
 
 // connect N evidence reactors through N switches
-func makeAndConnectEvidenceReactors(config *cfg.Config, N int) []*EvidenceReactor {
+func makeAndConnectEvidenceReactors(config *cfg.Config, stateDBs []dbm.DB) []*EvidenceReactor {
+	N := len(stateDBs)
 	reactors := make([]*EvidenceReactor, N)
 	logger := evidenceLogger()
 	for i := 0; i < N; i++ {
 
-		params := types.EvidenceParams{}
 		store := NewEvidenceStore(dbm.NewMemDB())
-		pool := NewEvidencePool(params, store, mockState)
+		pool := NewEvidencePool(stateDBs[i], store)
 		reactors[i] = NewEvidenceReactor(pool)
 		reactors[i].SetLogger(logger.With("validator", i))
 	}
@@ -98,10 +98,10 @@ func _waitForEvidence(t *testing.T, wg *sync.WaitGroup, evs types.EvidenceList, 
 	wg.Done()
 }
 
-func sendEvidence(t *testing.T, evpool *EvidencePool, n int) types.EvidenceList {
+func sendEvidence(t *testing.T, evpool *EvidencePool, valAddr []byte, n int) types.EvidenceList {
 	evList := make([]types.Evidence, n)
 	for i := 0; i < n; i++ {
-		ev := newMockGoodEvidence(int64(i), 2, []byte("val"))
+		ev := newMockGoodEvidence(int64(i+1), 0, valAddr)
 		err := evpool.AddEvidence(ev)
 		assert.Nil(t, err)
 		evList[i] = ev
@@ -110,17 +110,28 @@ func sendEvidence(t *testing.T, evpool *EvidencePool, n int) types.EvidenceList 
 }
 
 var (
-	NUM_EVIDENCE = 1000
+	NUM_EVIDENCE = 1
 	TIMEOUT      = 120 * time.Second // ridiculously high because CircleCI is slow
 )
 
 func TestReactorBroadcastEvidence(t *testing.T) {
 	config := cfg.TestConfig()
 	N := 7
-	reactors := makeAndConnectEvidenceReactors(config, N)
 
-	// send a bunch of evidence to the first reactor's evpool
+	// create statedb for everyone
+	stateDBs := make([]dbm.DB, N)
+	valAddr := []byte("myval")
+	// we need validators saved for heights at least as high as we have evidence for
+	height := int64(NUM_EVIDENCE) + 10
+	for i := 0; i < N; i++ {
+		stateDBs[i] = initializeValidatorState(valAddr, height)
+	}
+
+	// make reactors from statedb
+	reactors := makeAndConnectEvidenceReactors(config, stateDBs)
+
+	// send a bunch of valid evidence to the first reactor's evpool
 	// and wait for them all to be received in the others
-	evList := sendEvidence(t, reactors[0].evpool, NUM_EVIDENCE)
+	evList := sendEvidence(t, reactors[0].evpool, valAddr, NUM_EVIDENCE)
 	waitForEvidence(t, evList, reactors)
 }

--- a/evidence/store_test.go
+++ b/evidence/store_test.go
@@ -113,12 +113,14 @@ func TestStorePriority(t *testing.T) {
 
 //-------------------------------------------
 const (
-	evidenceTypeMock = byte(0x01)
+	evidenceTypeMockGood = byte(0x01)
+	evidenceTypeMockBad  = byte(0x02)
 )
 
 var _ = wire.RegisterInterface(
 	struct{ types.Evidence }{},
-	wire.ConcreteType{MockGoodEvidence{}, evidenceTypeMock},
+	wire.ConcreteType{MockGoodEvidence{}, evidenceTypeMockGood},
+	wire.ConcreteType{MockBadEvidence{}, evidenceTypeMockBad},
 )
 
 type MockGoodEvidence struct {

--- a/node/node.go
+++ b/node/node.go
@@ -219,7 +219,7 @@ func NewNode(config *cfg.Config,
 	blockExecLogger := logger.With("module", "state")
 	// make block executor for consensus and blockchain reactors to execute blocks
 	blockExec := sm.NewBlockExecutor(stateDB, blockExecLogger,
-		nil, proxyApp.Consensus(),
+		types.NopEventBus{}, proxyApp.Consensus(),
 		mempool, evidencePool)
 
 	// Make BlockchainReactor

--- a/node/node.go
+++ b/node/node.go
@@ -211,7 +211,7 @@ func NewNode(config *cfg.Config,
 	}
 	evidenceLogger := logger.With("module", "evidence")
 	evidenceStore := evidence.NewEvidenceStore(evidenceDB)
-	evidencePool := evidence.NewEvidencePool(state.ConsensusParams.EvidenceParams, evidenceStore) // , state.Copy())
+	evidencePool := evidence.NewEvidencePool(state.ConsensusParams.EvidenceParams, evidenceStore, state.Copy())
 	evidencePool.SetLogger(evidenceLogger)
 	evidenceReactor := evidence.NewEvidenceReactor(evidencePool)
 	evidenceReactor.SetLogger(evidenceLogger)

--- a/node/node.go
+++ b/node/node.go
@@ -102,7 +102,8 @@ type Node struct {
 	trustMetricStore *trust.TrustMetricStore // trust metrics for all peers
 
 	// services
-	eventBus         *types.EventBus             // pub/sub for services
+	eventBus         *types.EventBus // pub/sub for services
+	stateDB          dbm.DB
 	blockStore       *bc.BlockStore              // store the blockchain to disk
 	bcReactor        *bc.BlockchainReactor       // for fast-syncing
 	mempoolReactor   *mempl.MempoolReactor       // for gossipping transactions
@@ -148,21 +149,20 @@ func NewNode(config *cfg.Config,
 		saveGenesisDoc(stateDB, genDoc)
 	}
 
-	stateLogger := logger.With("module", "state")
 	state := sm.LoadState(stateDB)
-	if state == nil {
-		state, err = sm.MakeGenesisState(stateDB, genDoc)
+	if state.IsEmpty() {
+		state, err = sm.MakeGenesisState(genDoc)
 		if err != nil {
 			return nil, err
 		}
-		state.Save()
+		sm.SaveState(stateDB, state)
 	}
-	state.SetLogger(stateLogger)
 
 	// Create the proxyApp, which manages connections (consensus, mempool, query)
-	// and sync tendermint and the app by replaying any necessary blocks
+	// and sync tendermint and the app by performing a handshake
+	// and replaying any necessary blocks
 	consensusLogger := logger.With("module", "consensus")
-	handshaker := consensus.NewHandshaker(state, blockStore)
+	handshaker := consensus.NewHandshaker(stateDB, state, blockStore)
 	handshaker.SetLogger(consensusLogger)
 	proxyApp := proxy.NewAppConns(clientCreator, handshaker)
 	proxyApp.SetLogger(logger.With("module", "proxy"))
@@ -172,7 +172,6 @@ func NewNode(config *cfg.Config,
 
 	// reload the state (it may have been updated by the handshake)
 	state = sm.LoadState(stateDB)
-	state.SetLogger(stateLogger)
 
 	// Generate node PrivKey
 	privKey := crypto.GenPrivKeyEd25519()
@@ -194,10 +193,6 @@ func NewNode(config *cfg.Config,
 		consensusLogger.Info("This node is not a validator")
 	}
 
-	// Make BlockchainReactor
-	bcReactor := bc.NewBlockchainReactor(state.Copy(), proxyApp.Consensus(), blockStore, fastSync)
-	bcReactor.SetLogger(logger.With("module", "blockchain"))
-
 	// Make MempoolReactor
 	mempoolLogger := logger.With("module", "mempool")
 	mempool := mempl.NewMempool(config.Mempool, proxyApp.Mempool(), state.LastBlockHeight)
@@ -216,14 +211,24 @@ func NewNode(config *cfg.Config,
 	}
 	evidenceLogger := logger.With("module", "evidence")
 	evidenceStore := evidence.NewEvidenceStore(evidenceDB)
-	evidencePool := evidence.NewEvidencePool(state.ConsensusParams.EvidenceParams, evidenceStore, state.Copy())
+	evidencePool := evidence.NewEvidencePool(state.ConsensusParams.EvidenceParams, evidenceStore) // , state.Copy())
 	evidencePool.SetLogger(evidenceLogger)
 	evidenceReactor := evidence.NewEvidenceReactor(evidencePool)
 	evidenceReactor.SetLogger(evidenceLogger)
 
+	blockExecLogger := logger.With("module", "state")
+	// make block executor for consensus and blockchain reactors to execute blocks
+	blockExec := sm.NewBlockExecutor(stateDB, blockExecLogger,
+		nil, proxyApp.Consensus(),
+		mempool, evidencePool)
+
+	// Make BlockchainReactor
+	bcReactor := bc.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
+	bcReactor.SetLogger(logger.With("module", "blockchain"))
+
 	// Make ConsensusReactor
 	consensusState := consensus.NewConsensusState(config.Consensus, state.Copy(),
-		proxyApp.Consensus(), blockStore, mempool, evidencePool)
+		blockExec, blockStore, mempool, evidencePool)
 	consensusState.SetLogger(consensusLogger)
 	if privValidator != nil {
 		consensusState.SetPrivValidator(privValidator)
@@ -291,7 +296,6 @@ func NewNode(config *cfg.Config,
 	eventBus.SetLogger(logger.With("module", "events"))
 
 	// services which will be publishing and/or subscribing for messages (events)
-	bcReactor.SetEventBus(eventBus)
 	consensusReactor.SetEventBus(eventBus)
 
 	// Transaction indexing
@@ -333,6 +337,7 @@ func NewNode(config *cfg.Config,
 		addrBook:         addrBook,
 		trustMetricStore: trustMetricStore,
 
+		stateDB:          stateDB,
 		blockStore:       blockStore,
 		bcReactor:        bcReactor,
 		mempoolReactor:   mempoolReactor,
@@ -429,6 +434,7 @@ func (n *Node) AddListener(l p2p.Listener) {
 // ConfigureRPC sets all variables in rpccore so they will serve
 // rpc calls from this node
 func (n *Node) ConfigureRPC() {
+	rpccore.SetStateDB(n.stateDB)
 	rpccore.SetBlockStore(n.blockStore)
 	rpccore.SetConsensusState(n.consensusState)
 	rpccore.SetMempool(n.mempoolReactor.Mempool)

--- a/node/node.go
+++ b/node/node.go
@@ -208,7 +208,7 @@ func NewNode(config *cfg.Config,
 	}
 	evidenceLogger := logger.With("module", "evidence")
 	evidenceStore := evidence.NewEvidenceStore(evidenceDB)
-	evidencePool := evidence.NewEvidencePool(state.ConsensusParams.EvidenceParams, evidenceStore, state.Copy())
+	evidencePool := evidence.NewEvidencePool(stateDB, evidenceStore)
 	evidencePool.SetLogger(evidenceLogger)
 	evidenceReactor := evidence.NewEvidenceReactor(evidencePool)
 	evidenceReactor.SetLogger(evidenceLogger)

--- a/node/node.go
+++ b/node/node.go
@@ -291,7 +291,7 @@ func NewNode(config *cfg.Config,
 	eventBus.SetLogger(logger.With("module", "events"))
 
 	// services which will be publishing and/or subscribing for messages (events)
-	blockExec.SetEventBus(eventBus)
+	// consensusReactor will set it on consensusState and blockExecutor
 	consensusReactor.SetEventBus(eventBus)
 
 	// Transaction indexing

--- a/node/node.go
+++ b/node/node.go
@@ -291,6 +291,7 @@ func NewNode(config *cfg.Config,
 	eventBus.SetLogger(logger.With("module", "events"))
 
 	// services which will be publishing and/or subscribing for messages (events)
+	blockExec.SetEventBus(eventBus)
 	consensusReactor.SetEventBus(eventBus)
 
 	// Transaction indexing

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
 	cmn "github.com/tendermint/tmlibs/common"
 )
@@ -337,7 +338,7 @@ func BlockResults(heightPtr *int64) (*ctypes.ResultBlockResults, error) {
 
 	// load the results
 	state := consensusState.GetState()
-	results, err := state.LoadABCIResponses(height)
+	results, err := sm.LoadABCIResponses(state.DB(), height)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -337,8 +337,7 @@ func BlockResults(heightPtr *int64) (*ctypes.ResultBlockResults, error) {
 	}
 
 	// load the results
-	state := consensusState.GetState()
-	results, err := sm.LoadABCIResponses(state.DB(), height)
+	results, err := sm.LoadABCIResponses(stateDB, height)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -50,8 +50,7 @@ func Validators(heightPtr *int64) (*ctypes.ResultValidators, error) {
 		return nil, err
 	}
 
-	state := consensusState.GetState()
-	validators, err := sm.LoadValidators(state.DB(), height)
+	validators, err := sm.LoadValidators(stateDB, height)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -4,6 +4,7 @@ import (
 	cm "github.com/tendermint/tendermint/consensus"
 	cstypes "github.com/tendermint/tendermint/consensus/types"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -50,7 +51,7 @@ func Validators(heightPtr *int64) (*ctypes.ResultValidators, error) {
 	}
 
 	state := consensusState.GetState()
-	validators, err := state.LoadValidators(height)
+	validators, err := sm.LoadValidators(state.DB(), height)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/core/pipe.go
+++ b/rpc/core/pipe.go
@@ -11,6 +11,7 @@ import (
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/state/txindex"
 	"github.com/tendermint/tendermint/types"
+	dbm "github.com/tendermint/tmlibs/db"
 	"github.com/tendermint/tmlibs/log"
 )
 
@@ -20,7 +21,7 @@ var subscribeTimeout = 5 * time.Second
 // These interfaces are used by RPC and must be thread safe
 
 type Consensus interface {
-	GetState() *sm.State
+	GetState() sm.State
 	GetValidators() (int64, []*types.Validator)
 	GetRoundState() *cstypes.RoundState
 }
@@ -43,6 +44,7 @@ var (
 	proxyAppQuery proxy.AppConnQuery
 
 	// interfaces defined in types and above
+	stateDB        dbm.DB
 	blockStore     types.BlockStore
 	mempool        types.Mempool
 	evidencePool   types.EvidencePool
@@ -59,6 +61,10 @@ var (
 
 	logger log.Logger
 )
+
+func SetStateDB(db dbm.DB) {
+	stateDB = db
+}
 
 func SetBlockStore(bs types.BlockStore) {
 	blockStore = bs

--- a/state/db.go
+++ b/state/db.go
@@ -18,11 +18,11 @@ func GetState(stateDB dbm.DB, genesisFile string) (*State, error) {
 	state := LoadState(stateDB)
 	if state == nil {
 		var err error
-		state, err = MakeGenesisStateFromFile(stateDB, genesisFile)
+		state, err = MakeGenesisStateFromFile(genesisFile)
 		if err != nil {
 			return nil, err
 		}
-		state.Save()
+		state.Save(stateDB, state.AppHash)
 	}
 
 	return state, nil
@@ -39,7 +39,7 @@ func loadState(db dbm.DB, key []byte) *State {
 		return nil
 	}
 
-	s := &State{db: db}
+	s := new(State)
 	r, n, err := bytes.NewReader(buf), new(int), new(error)
 	wire.ReadBinaryPtr(&s, r, 0, n, err)
 	if *err != nil {

--- a/state/db.go
+++ b/state/db.go
@@ -1,0 +1,199 @@
+package state
+
+import (
+	"bytes"
+	"fmt"
+
+	abci "github.com/tendermint/abci/types"
+	wire "github.com/tendermint/go-wire"
+	"github.com/tendermint/tendermint/types"
+	cmn "github.com/tendermint/tmlibs/common"
+	dbm "github.com/tendermint/tmlibs/db"
+)
+
+//------------------------------------------------------------------------
+
+// ABCIResponses retains the responses
+// of the various ABCI calls during block processing.
+// It is persisted to disk for each height before calling Commit.
+type ABCIResponses struct {
+	DeliverTx []*abci.ResponseDeliverTx
+	EndBlock  *abci.ResponseEndBlock
+}
+
+// NewABCIResponses returns a new ABCIResponses
+func NewABCIResponses(block *types.Block) *ABCIResponses {
+	return &ABCIResponses{
+		DeliverTx: make([]*abci.ResponseDeliverTx, block.NumTxs),
+	}
+}
+
+// Bytes serializes the ABCIResponse using go-wire
+func (a *ABCIResponses) Bytes() []byte {
+	return wire.BinaryBytes(*a)
+}
+
+func (a *ABCIResponses) ResultsHash() []byte {
+	results := types.NewResults(a.DeliverTx)
+	return results.Hash()
+}
+
+// LoadABCIResponses loads the ABCIResponses for the given height from the database.
+// This is useful for recovering from crashes where we called app.Commit and before we called
+// s.Save(). It can also be used to produce Merkle proofs of the result of txs.
+func LoadABCIResponses(db dbm.DB, height int64) (*ABCIResponses, error) {
+	buf := db.Get(calcABCIResponsesKey(height))
+	if len(buf) == 0 {
+		return nil, ErrNoABCIResponsesForHeight{height}
+	}
+
+	abciResponses := new(ABCIResponses)
+	r, n, err := bytes.NewReader(buf), new(int), new(error)
+	wire.ReadBinaryPtr(abciResponses, r, 0, n, err)
+	if *err != nil {
+		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
+		cmn.Exit(cmn.Fmt(`LoadABCIResponses: Data has been corrupted or its spec has
+                changed: %v\n`, *err))
+	}
+	// TODO: ensure that buf is completely read.
+
+	return abciResponses, nil
+}
+
+// SaveABCIResponses persists the ABCIResponses to the database.
+// This is useful in case we crash after app.Commit and before s.Save().
+// Responses are indexed by height so they can also be loaded later to produce Merkle proofs.
+func SaveABCIResponses(db dbm.DB, height int64, abciResponses *ABCIResponses) {
+	db.SetSync(calcABCIResponsesKey(height), abciResponses.Bytes())
+}
+
+//-----------------------------------------------------------------------------
+
+// ValidatorsInfo represents the latest validator set, or the last height it changed
+type ValidatorsInfo struct {
+	ValidatorSet      *types.ValidatorSet
+	LastHeightChanged int64
+}
+
+// Bytes serializes the ValidatorsInfo using go-wire
+func (valInfo *ValidatorsInfo) Bytes() []byte {
+	return wire.BinaryBytes(*valInfo)
+}
+
+// LoadValidators loads the ValidatorSet for a given height.
+// Returns ErrNoValSetForHeight if the validator set can't be found for this height.
+func LoadValidators(db dbm.DB, height int64) (*types.ValidatorSet, error) {
+	valInfo := loadValidatorsInfo(db, height)
+	if valInfo == nil {
+		return nil, ErrNoValSetForHeight{height}
+	}
+
+	if valInfo.ValidatorSet == nil {
+		valInfo = loadValidatorsInfo(db, valInfo.LastHeightChanged)
+		if valInfo == nil {
+			cmn.PanicSanity(fmt.Sprintf(`Couldn't find validators at height %d as
+                        last changed from height %d`, valInfo.LastHeightChanged, height))
+		}
+	}
+
+	return valInfo.ValidatorSet, nil
+}
+
+func loadValidatorsInfo(db dbm.DB, height int64) *ValidatorsInfo {
+	buf := db.Get(calcValidatorsKey(height))
+	if len(buf) == 0 {
+		return nil
+	}
+
+	v := new(ValidatorsInfo)
+	r, n, err := bytes.NewReader(buf), new(int), new(error)
+	wire.ReadBinaryPtr(v, r, 0, n, err)
+	if *err != nil {
+		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
+		cmn.Exit(cmn.Fmt(`LoadValidators: Data has been corrupted or its spec has changed:
+                %v\n`, *err))
+	}
+	// TODO: ensure that buf is completely read.
+
+	return v
+}
+
+// saveValidatorsInfo persists the validator set for the next block to disk.
+// It should be called from s.Save(), right before the state itself is persisted.
+// If the validator set did not change after processing the latest block,
+// only the last height for which the validators changed is persisted.
+func saveValidatorsInfo(db dbm.DB, nextHeight, changeHeight int64, valSet *types.ValidatorSet) {
+	valInfo := &ValidatorsInfo{
+		LastHeightChanged: changeHeight,
+	}
+	if changeHeight == nextHeight {
+		valInfo.ValidatorSet = valSet
+	}
+	db.SetSync(calcValidatorsKey(nextHeight), valInfo.Bytes())
+}
+
+//-----------------------------------------------------------------------------
+
+// ConsensusParamsInfo represents the latest consensus params, or the last height it changed
+type ConsensusParamsInfo struct {
+	ConsensusParams   types.ConsensusParams
+	LastHeightChanged int64
+}
+
+// Bytes serializes the ConsensusParamsInfo using go-wire
+func (params ConsensusParamsInfo) Bytes() []byte {
+	return wire.BinaryBytes(params)
+}
+
+// LoadConsensusParams loads the ConsensusParams for a given height.
+func LoadConsensusParams(db dbm.DB, height int64) (types.ConsensusParams, error) {
+	empty := types.ConsensusParams{}
+
+	paramsInfo := loadConsensusParamsInfo(db, height)
+	if paramsInfo == nil {
+		return empty, ErrNoConsensusParamsForHeight{height}
+	}
+
+	if paramsInfo.ConsensusParams == empty {
+		paramsInfo = loadConsensusParamsInfo(db, paramsInfo.LastHeightChanged)
+		if paramsInfo == nil {
+			cmn.PanicSanity(fmt.Sprintf(`Couldn't find consensus params at height %d as
+                        last changed from height %d`, paramsInfo.LastHeightChanged, height))
+		}
+	}
+
+	return paramsInfo.ConsensusParams, nil
+}
+
+func loadConsensusParamsInfo(db dbm.DB, height int64) *ConsensusParamsInfo {
+	buf := db.Get(calcConsensusParamsKey(height))
+	if len(buf) == 0 {
+		return nil
+	}
+
+	paramsInfo := new(ConsensusParamsInfo)
+	r, n, err := bytes.NewReader(buf), new(int), new(error)
+	wire.ReadBinaryPtr(paramsInfo, r, 0, n, err)
+	if *err != nil {
+		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
+		cmn.Exit(cmn.Fmt(`LoadConsensusParams: Data has been corrupted or its spec has changed:
+                %v\n`, *err))
+	}
+	// TODO: ensure that buf is completely read.
+
+	return paramsInfo
+}
+
+// saveConsensusParamsInfo persists the consensus params for the next block to disk.
+// It should be called from s.Save(), right before the state itself is persisted.
+// If the consensus params did not change after processing the latest block,
+// only the last height for which they changed is persisted.
+func saveConsensusParamsInfo(db dbm.DB, nextHeight, changeHeight int64, params types.ConsensusParams) {
+	paramsInfo := &ConsensusParamsInfo{
+		LastHeightChanged: changeHeight,
+	}
+	if changeHeight == nextHeight {
+		paramsInfo.ConsensusParams = params
+	}
+	db.SetSync(calcConsensusParamsKey(nextHeight), paramsInfo.Bytes())
+}

--- a/state/db.go
+++ b/state/db.go
@@ -36,7 +36,7 @@ func GetState(stateDB dbm.DB, genesisFile string) (State, error) {
 		if err != nil {
 			return state, err
 		}
-		SaveState(stateDB, state, state.AppHash)
+		SaveState(stateDB, state)
 	}
 
 	return state, nil
@@ -66,9 +66,7 @@ func loadState(db dbm.DB, key []byte) (state State) {
 }
 
 // SaveState persists the State, the ValidatorsInfo, and the ConsensusParamsInfo to the database.
-// It sets the given appHash on the state before persisting.
-func SaveState(db dbm.DB, s State, appHash []byte) {
-	s.AppHash = appHash
+func SaveState(db dbm.DB, s State) {
 	nextHeight := s.LastBlockHeight + 1
 	saveValidatorsInfo(db, nextHeight, s.LastHeightValidatorsChanged, s.Validators)
 	saveConsensusParamsInfo(db, nextHeight, s.LastHeightConsensusParamsChanged, s.ConsensusParams)

--- a/state/execution.go
+++ b/state/execution.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 
@@ -14,26 +13,118 @@ import (
 	"github.com/tendermint/tmlibs/log"
 )
 
-//--------------------------------------------------
-// Execute the block
+//-----------------------------------------------------------------------------
+// BlockExecutor handles block execution and state updates.
+// It exposes ApplyBlock(), which validates & executes the block, updates state w/ ABCI responses,
+// then commits and updates the mempool atomically, then saves state.
 
-// ValExecBlock executes the block and returns the responses. It does NOT mutate State.
-// + validates the block
-// + executes block.Txs on the proxyAppConn
-func (blockExec *BlockExecutor) ValExecBlock(s State, block *types.Block) (*ABCIResponses, error) {
-	if err := s.validateBlock(block); err != nil {
-		return nil, ErrInvalidBlock(err)
+// BlockExecutor provides the context and accessories for properly executing a block.
+type BlockExecutor struct {
+	db     dbm.DB
+	logger log.Logger
+
+	txEventPublisher types.TxEventPublisher
+	proxyApp         proxy.AppConnConsensus
+
+	mempool types.Mempool
+	evpool  types.EvidencePool
+}
+
+// NewBlockExecutor returns a new BlockExecutor.
+func NewBlockExecutor(db dbm.DB, logger log.Logger,
+	txEventer types.TxEventPublisher, proxyApp proxy.AppConnConsensus,
+	mempool types.Mempool, evpool types.EvidencePool) *BlockExecutor {
+	return &BlockExecutor{
+		db,
+		logger,
+		txEventer,
+		proxyApp,
+		mempool,
+		evpool,
+	}
+}
+
+// ApplyBlock validates the block against the state, executes it against the app,
+// commits it, and saves the block and state. It's the only function that needs to be called
+// from outside this package to process and commit an entire block.
+// It takes a blockID to avoid recomputing the parts hash.
+func (blockExec *BlockExecutor) ApplyBlock(s State, blockID types.BlockID, block *types.Block) (State, error) {
+
+	if err := validateBlock(s, block); err != nil {
+		return s, ErrInvalidBlock(err)
 	}
 
 	abciResponses, err := execBlockOnProxyApp(blockExec.logger, blockExec.proxyApp, block)
 	if err != nil {
-		// There was some error in proxyApp
-		// TODO Report error and wait for proxyApp to be available.
-		return nil, ErrProxyAppConn(err)
+		return s, ErrProxyAppConn(err)
 	}
 
-	return abciResponses, nil
+	fireEvents(blockExec.txEventPublisher, block, abciResponses)
+
+	fail.Fail() // XXX
+
+	// save the results before we commit
+	saveABCIResponses(blockExec.db, block.Height, abciResponses)
+
+	fail.Fail() // XXX
+
+	// update the state with the block and responses
+	s, err = updateState(s, blockID, block.Header, abciResponses)
+	if err != nil {
+		return s, fmt.Errorf("Commit failed for application: %v", err)
+	}
+
+	// lock mempool, commit state, update mempoool
+	appHash, err := blockExec.Commit(block)
+	if err != nil {
+		return s, fmt.Errorf("Commit failed for application: %v", err)
+	}
+
+	fail.Fail() // XXX
+
+	// save the state and the validators
+	SaveState(blockExec.db, s, appHash)
+
+	return s, nil
 }
+
+// Commit locks the mempool, runs the ABCI Commit message, and updates the mempool.
+// It returns the result of calling abci.Commit (the AppHash), and an error.
+// The Mempool must be locked during commit and update because state is typically reset on Commit and old txs must be replayed
+// against committed state before new txs are run in the mempool, lest they be invalid.
+func (blockExec *BlockExecutor) Commit(block *types.Block) ([]byte, error) {
+	blockExec.mempool.Lock()
+	defer blockExec.mempool.Unlock()
+
+	// Commit block, get hash back
+	res, err := blockExec.proxyApp.CommitSync()
+	if err != nil {
+		blockExec.logger.Error("Client error during proxyAppConn.CommitSync", "err", err)
+		return nil, err
+	}
+	if res.IsErr() {
+		blockExec.logger.Error("Error in proxyAppConn.CommitSync", "err", res)
+		return nil, res
+	}
+	if res.Log != "" {
+		blockExec.logger.Debug("Commit.Log: " + res.Log)
+	}
+
+	blockExec.logger.Info("Committed state", "height", block.Height, "txs", block.NumTxs, "hash", res.Data)
+
+	// Update evpool
+	blockExec.evpool.MarkEvidenceAsCommitted(block.Evidence.Evidence)
+
+	// Update mempool.
+	if err := blockExec.mempool.Update(block.Height, block.Txs); err != nil {
+		return nil, err
+	}
+
+	return res.Data, nil
+}
+
+//---------------------------------------------------------
+// Helper functions for executing blocks and updating state
 
 // Executes block's transactions on proxyAppConn.
 // Returns a list of transaction results and updates to the validator set
@@ -196,189 +287,62 @@ func changeInVotingPowerMoreOrEqualToOneThird(currentSet *types.ValidatorSet, up
 	return false, nil
 }
 
-//-----------------------------------------------------
-// Validate block
+// updateState returns a new State updated according to the header and responses.
+func updateState(s State, blockID types.BlockID, header *types.Header,
+	abciResponses *ABCIResponses) (State, error) {
 
-// MakeBlock builds a block with the given txs and commit from the current state.
-func (s State) MakeBlock(height int64, txs []types.Tx, commit *types.Commit) (*types.Block, *types.PartSet) {
-	// build base block
-	block := types.MakeBlock(height, txs, commit)
+	// copy the valset so we can apply changes from EndBlock
+	// and update s.LastValidators and s.Validators
+	prevValSet := s.Validators.Copy()
+	nextValSet := prevValSet.Copy()
 
-	// fill header with state data
-	block.ChainID = s.ChainID
-	block.TotalTxs = s.LastBlockTotalTx + block.NumTxs
-	block.LastBlockID = s.LastBlockID
-	block.ValidatorsHash = s.Validators.Hash()
-	block.AppHash = s.AppHash
-	block.ConsensusHash = s.ConsensusParams.Hash()
-	block.LastResultsHash = s.LastResultsHash
-
-	return block, block.MakePartSet(s.ConsensusParams.BlockGossip.BlockPartSizeBytes)
-}
-
-// ValidateBlock validates the block against the state.
-func (s State) ValidateBlock(block *types.Block) error {
-	return s.validateBlock(block)
-}
-
-func (s State) validateBlock(b *types.Block) error {
-	// validate internal consistency
-	if err := b.ValidateBasic(); err != nil {
-		return err
-	}
-
-	// validate basic info
-	if b.ChainID != s.ChainID {
-		return fmt.Errorf("Wrong Block.Header.ChainID. Expected %v, got %v", s.ChainID, b.ChainID)
-	}
-	if b.Height != s.LastBlockHeight+1 {
-		return fmt.Errorf("Wrong Block.Header.Height. Expected %v, got %v", s.LastBlockHeight+1, b.Height)
-	}
-	/*	TODO: Determine bounds for Time
-		See blockchain/reactor "stopSyncingDurationMinutes"
-
-		if !b.Time.After(lastBlockTime) {
-			return errors.New("Invalid Block.Header.Time")
-		}
-	*/
-
-	// validate prev block info
-	if !b.LastBlockID.Equals(s.LastBlockID) {
-		return fmt.Errorf("Wrong Block.Header.LastBlockID.  Expected %v, got %v", s.LastBlockID, b.LastBlockID)
-	}
-	newTxs := int64(len(b.Data.Txs))
-	if b.TotalTxs != s.LastBlockTotalTx+newTxs {
-		return fmt.Errorf("Wrong Block.Header.TotalTxs. Expected %v, got %v", s.LastBlockTotalTx+newTxs, b.TotalTxs)
-	}
-
-	// validate app info
-	if !bytes.Equal(b.AppHash, s.AppHash) {
-		return fmt.Errorf("Wrong Block.Header.AppHash.  Expected %X, got %v", s.AppHash, b.AppHash)
-	}
-	if !bytes.Equal(b.ConsensusHash, s.ConsensusParams.Hash()) {
-		return fmt.Errorf("Wrong Block.Header.ConsensusHash.  Expected %X, got %v", s.ConsensusParams.Hash(), b.ConsensusHash)
-	}
-	if !bytes.Equal(b.LastResultsHash, s.LastResultsHash) {
-		return fmt.Errorf("Wrong Block.Header.LastResultsHash.  Expected %X, got %v", s.LastResultsHash, b.LastResultsHash)
-	}
-	if !bytes.Equal(b.ValidatorsHash, s.Validators.Hash()) {
-		return fmt.Errorf("Wrong Block.Header.ValidatorsHash.  Expected %X, got %v", s.Validators.Hash(), b.ValidatorsHash)
-	}
-
-	// Validate block LastCommit.
-	if b.Height == 1 {
-		if len(b.LastCommit.Precommits) != 0 {
-			return errors.New("Block at height 1 (first block) should have no LastCommit precommits")
-		}
-	} else {
-		if len(b.LastCommit.Precommits) != s.LastValidators.Size() {
-			return fmt.Errorf("Invalid block commit size. Expected %v, got %v",
-				s.LastValidators.Size(), len(b.LastCommit.Precommits))
-		}
-		err := s.LastValidators.VerifyCommit(
-			s.ChainID, s.LastBlockID, b.Height-1, b.LastCommit)
+	// update the validator set with the latest abciResponses
+	lastHeightValsChanged := s.LastHeightValidatorsChanged
+	if len(abciResponses.EndBlock.ValidatorUpdates) > 0 {
+		err := updateValidators(nextValSet, abciResponses.EndBlock.ValidatorUpdates)
 		if err != nil {
-			return err
+			return s, fmt.Errorf("Error changing validator set: %v", err)
 		}
+		// change results from this height but only applies to the next height
+		lastHeightValsChanged = header.Height + 1
 	}
 
-	for _, ev := range b.Evidence.Evidence {
-		if err := VerifyEvidence(s, ev); err != nil {
-			return types.NewEvidenceInvalidErr(ev, err)
-		}
-		/* // Needs a db ...
-		valset, err := LoadValidators(s.db, ev.Height())
+	// Update validator accums and set state variables
+	nextValSet.IncrementAccum(1)
+
+	// update the params with the latest abciResponses
+	nextParams := s.ConsensusParams
+	lastHeightParamsChanged := s.LastHeightConsensusParamsChanged
+	if abciResponses.EndBlock.ConsensusParamUpdates != nil {
+		// NOTE: must not mutate s.ConsensusParams
+		nextParams = s.ConsensusParams.Update(abciResponses.EndBlock.ConsensusParamUpdates)
+		err := nextParams.Validate()
 		if err != nil {
-			// XXX/TODO: what do we do if we can't load the valset?
-			// eg. if we have pruned the state or height is too high?
-			return err
+			return s, fmt.Errorf("Error updating consensus params: %v", err)
 		}
-		if err := VerifyEvidenceValidator(valSet, ev); err != nil {
-			return types.NewEvidenceInvalidErr(ev, err)
-		}
-		*/
+		// change results from this height but only applies to the next height
+		lastHeightParamsChanged = header.Height + 1
 	}
 
-	return nil
+	// NOTE: the AppHash has not been populated.
+	// It will be filled on state.Save.
+	return State{
+		ChainID:                          s.ChainID,
+		LastBlockHeight:                  header.Height,
+		LastBlockTotalTx:                 s.LastBlockTotalTx + header.NumTxs,
+		LastBlockID:                      blockID,
+		LastBlockTime:                    header.Time,
+		Validators:                       nextValSet,
+		LastValidators:                   s.Validators.Copy(),
+		LastHeightValidatorsChanged:      lastHeightValsChanged,
+		ConsensusParams:                  nextParams,
+		LastHeightConsensusParamsChanged: lastHeightParamsChanged,
+		LastResultsHash:                  abciResponses.ResultsHash(),
+		AppHash:                          nil,
+	}, nil
 }
 
-// XXX: What's cheaper (ie. what should be checked first):
-//  evidence internal validity (ie. sig checks) or validator existed (fetch historical val set from db)
-
-// VerifyEvidence verifies the evidence fully by checking it is internally
-// consistent and sufficiently recent.
-func VerifyEvidence(s State, evidence types.Evidence) error {
-	height := s.LastBlockHeight
-
-	evidenceAge := height - evidence.Height()
-	maxAge := s.ConsensusParams.EvidenceParams.MaxAge
-	if evidenceAge > maxAge {
-		return fmt.Errorf("Evidence from height %d is too old. Min height is %d",
-			evidence.Height(), height-maxAge)
-	}
-
-	if err := evidence.Verify(s.ChainID); err != nil {
-		return err
-	}
-	return nil
-}
-
-// VerifyEvidenceValidator returns the voting power of the validator at the height of the evidence.
-// It returns an error if the validator did not exist or does not match that loaded from the historical validator set.
-func VerifyEvidenceValidator(valset *types.ValidatorSet, evidence types.Evidence) (priority int64, err error) {
-	// The address must have been an active validator at the height
-	ev := evidence
-	height, addr, idx := ev.Height(), ev.Address(), ev.Index()
-	valIdx, val := valset.GetByAddress(addr)
-	if val == nil {
-		return priority, fmt.Errorf("Address %X was not a validator at height %d", addr, height)
-	} else if idx != valIdx {
-		return priority, fmt.Errorf("Address %X was validator %d at height %d, not %d", addr, valIdx, height, idx)
-	}
-
-	priority = val.VotingPower
-	return priority, nil
-}
-
-//-----------------------------------------------------------------------------
-// ApplyBlock validates & executes the block, updates state w/ ABCI responses,
-// then commits and updates the mempool atomically, then saves state.
-
-// BlockExecutor provides the context and accessories for properly executing a block.
-type BlockExecutor struct {
-	db     dbm.DB
-	logger log.Logger
-
-	txEventPublisher types.TxEventPublisher
-	proxyApp         proxy.AppConnConsensus
-
-	mempool types.Mempool
-	evpool  types.EvidencePool
-}
-
-func NewBlockExecutor(db dbm.DB, logger log.Logger, txEventer types.TxEventPublisher, proxyApp proxy.AppConnConsensus,
-	mempool types.Mempool, evpool types.EvidencePool) *BlockExecutor {
-	return &BlockExecutor{
-		db,
-		logger,
-		txEventer,
-		proxyApp,
-		mempool,
-		evpool,
-	}
-}
-
-// ApplyBlock validates the block against the state, executes it against the app,
-// commits it, and saves the block and state. It's the only function that needs to be called
-// from outside this package to process and commit an entire block.
-// It takes a blockID to avoid recomputing the parts hash.
-func (blockExec *BlockExecutor) ApplyBlock(s State, blockID types.BlockID, block *types.Block) (State, error) {
-
-	abciResponses, err := blockExec.ValExecBlock(s, block)
-	if err != nil {
-		return s, fmt.Errorf("Exec failed for application: %v", err)
-	}
-
+func fireEvents(txEventPublisher types.TxEventPublisher, block *types.Block, abciResponses *ABCIResponses) {
 	// TODO: Fire events
 	/*
 		tx := types.Tx(req.GetDeliverTx().Tx)
@@ -389,68 +353,10 @@ func (blockExec *BlockExecutor) ApplyBlock(s State, blockID types.BlockID, block
 			Result: *txRes,
 		}})
 	*/
-
-	fail.Fail() // XXX
-
-	// save the results before we commit
-	SaveABCIResponses(blockExec.db, block.Height, abciResponses)
-
-	fail.Fail() // XXX
-
-	// update the state with the block and responses
-	s, err = s.NextState(blockID, block.Header, abciResponses)
-	if err != nil {
-		return s, fmt.Errorf("Commit failed for application: %v", err)
-	}
-
-	// lock mempool, commit state, update mempoool
-	appHash, err := blockExec.Commit(block)
-	if err != nil {
-		return s, fmt.Errorf("Commit failed for application: %v", err)
-	}
-
-	fail.Fail() // XXX
-
-	// save the state and the validators
-	s.Save(blockExec.db, appHash)
-
-	return s, nil
 }
 
-// Commit locks the mempool, runs the ABCI Commit message, and updates the mempool.
-// It returns the result of calling abci.Commit (the AppHash), and an error.
-// The Mempool must be locked during commit and update because state is typically reset on Commit and old txs must be replayed
-// against committed state before new txs are run in the mempool, lest they be invalid.
-func (blockExec *BlockExecutor) Commit(block *types.Block) ([]byte, error) {
-	blockExec.mempool.Lock()
-	defer blockExec.mempool.Unlock()
-
-	// Commit block, get hash back
-	res, err := blockExec.proxyApp.CommitSync()
-	if err != nil {
-		blockExec.logger.Error("Client error during proxyAppConn.CommitSync", "err", err)
-		return nil, err
-	}
-	if res.IsErr() {
-		blockExec.logger.Error("Error in proxyAppConn.CommitSync", "err", res)
-		return nil, res
-	}
-	if res.Log != "" {
-		blockExec.logger.Debug("Commit.Log: " + res.Log)
-	}
-
-	blockExec.logger.Info("Committed state", "height", block.Height, "txs", block.NumTxs, "hash", res.Data)
-
-	// Update evpool
-	blockExec.evpool.MarkEvidenceAsCommitted(block.Evidence.Evidence)
-
-	// Update mempool.
-	if err := blockExec.mempool.Update(block.Height, block.Txs); err != nil {
-		return nil, err
-	}
-
-	return res.Data, nil
-}
+//----------------------------------------------------------------------------------------------------
+// Execute block without state. TODO: eliminate
 
 // ExecCommitBlock executes and commits a block on the proxyApp without validating or mutating the state.
 // It returns the application root hash (result of abci.Commit).

--- a/state/execution.go
+++ b/state/execution.go
@@ -213,7 +213,7 @@ func changeInVotingPowerMoreOrEqualToOneThird(currentSet *types.ValidatorSet, up
 // Validate block
 
 // MakeBlock builds a block with the given txs and commit from the current state.
-func (s *State) MakeBlock(height int64, txs []types.Tx, commit *types.Commit) (*types.Block, *types.PartSet) {
+func (s State) MakeBlock(height int64, txs []types.Tx, commit *types.Commit) (*types.Block, *types.PartSet) {
 	// build base block
 	block := types.MakeBlock(height, txs, commit)
 
@@ -309,7 +309,7 @@ func (s State) validateBlock(b *types.Block) error {
 // It returns the priority of this evidence, or an error.
 // NOTE: return error may be ErrNoValSetForHeight, in which case the validator set
 // for the evidence height could not be loaded.
-func VerifyEvidence(s State, evidence types.Evidence) (priority int64, err error) {
+func (s State) VerifyEvidence(evidence types.Evidence) (priority int64, err error) {
 	height := s.LastBlockHeight
 	evidenceAge := height - evidence.Height()
 	maxAge := s.ConsensusParams.EvidenceParams.MaxAge

--- a/state/execution.go
+++ b/state/execution.go
@@ -56,6 +56,14 @@ func (blockExec *BlockExecutor) SetEventBus(eventBus types.BlockEventPublisher) 
 	blockExec.eventBus = eventBus
 }
 
+// ValidateBlock validates the given block against the given state.
+// If the block is invalid, it returns an error.
+// Validation does not mutate state, but does require historical information from the stateDB,
+// ie. to verify evidence from a validator at an old height.
+func (blockExec *BlockExecutor) ValidateBlock(s State, block *types.Block) error {
+	return validateBlock(blockExec.db, s, block)
+}
+
 // ApplyBlock validates the block against the state, executes it against the app,
 // fires the relevent events, commits the app, and saves the new state and responses.
 // It's the only function that needs to be called
@@ -63,7 +71,7 @@ func (blockExec *BlockExecutor) SetEventBus(eventBus types.BlockEventPublisher) 
 // It takes a blockID to avoid recomputing the parts hash.
 func (blockExec *BlockExecutor) ApplyBlock(s State, blockID types.BlockID, block *types.Block) (State, error) {
 
-	if err := validateBlock(s, block); err != nil {
+	if err := blockExec.ValidateBlock(s, block); err != nil {
 		return s, ErrInvalidBlock(err)
 	}
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -65,7 +65,7 @@ func (blockExec *BlockExecutor) ValidateBlock(s State, block *types.Block) error
 }
 
 // ApplyBlock validates the block against the state, executes it against the app,
-// fires the relevent events, commits the app, and saves the new state and responses.
+// fires the relevant events, commits the app, and saves the new state and responses.
 // It's the only function that needs to be called
 // from outside this package to process and commit an entire block.
 // It takes a blockID to avoid recomputing the parts hash.

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -32,8 +32,7 @@ func TestApplyBlock(t *testing.T) {
 
 	state, stateDB := state(), dbm.NewMemDB()
 
-	blockExec := NewBlockExecutor(stateDB, log.TestingLogger(),
-		types.NopEventBus{}, proxyApp.Consensus(),
+	blockExec := NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(),
 		types.MockMempool{}, types.MockEvidencePool{})
 
 	block := makeBlock(state, 1)
@@ -55,14 +54,6 @@ func TestBeginBlockAbsentValidators(t *testing.T) {
 	defer proxyApp.Stop()
 
 	state := state()
-
-	// there were 2 validators
-	/*val1PrivKey := crypto.GenPrivKeyEd25519()
-	val2PrivKey := crypto.GenPrivKeyEd25519()
-	lastValidators := types.NewValidatorSet([]*types.Validator{
-		types.NewValidator(val1PrivKey.PubKey(), 10),
-		types.NewValidator(val2PrivKey.PubKey(), 5),
-	})*/
 
 	prevHash := state.LastBlockID.Hash
 	prevParts := types.PartSetHeader{}

--- a/state/state.go
+++ b/state/state.go
@@ -91,7 +91,7 @@ func (s State) Bytes() []byte {
 
 // IsEmpty returns true if the State is equal to the empty State.
 func (s State) IsEmpty() bool {
-	return s.LastBlockHeight == 0 // XXX can't compare to Empty
+	return s.Validators == nil // XXX can't compare to Empty
 }
 
 // GetValidators returns the last and current validator sets.

--- a/state/state.go
+++ b/state/state.go
@@ -4,10 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"sync"
 	"time"
-
-	abci "github.com/tendermint/abci/types"
 
 	cmn "github.com/tendermint/tmlibs/common"
 	dbm "github.com/tendermint/tmlibs/db"
@@ -44,9 +41,7 @@ func calcABCIResponsesKey(height int64) []byte {
 // but the fields should only be changed by calling state.SetBlockAndValidators.
 // NOTE: not goroutine-safe.
 type State struct {
-	// mtx for writing to db
-	mtx sync.Mutex
-	db  dbm.DB
+	db dbm.DB
 
 	// Immutable
 	ChainID string
@@ -80,6 +75,10 @@ type State struct {
 	AppHash []byte
 
 	logger log.Logger
+}
+
+func (s *State) DB() dbm.DB {
+	return s.db
 }
 
 // GetState loads the most recent state from the database,
@@ -157,150 +156,13 @@ func (s *State) Copy() *State {
 
 // Save persists the State to the database.
 func (s *State) Save() {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
-	s.saveValidatorsInfo()
-	s.saveConsensusParamsInfo()
-	s.db.SetSync(stateKey, s.Bytes())
-}
-
-// SaveABCIResponses persists the ABCIResponses to the database.
-// This is useful in case we crash after app.Commit and before s.Save().
-// Responses are indexed by height so they can also be loaded later to produce Merkle proofs.
-func (s *State) SaveABCIResponses(height int64, abciResponses *ABCIResponses) {
-	s.db.SetSync(calcABCIResponsesKey(height), abciResponses.Bytes())
-}
-
-// LoadABCIResponses loads the ABCIResponses for the given height from the database.
-// This is useful for recovering from crashes where we called app.Commit and before we called
-// s.Save(). It can also be used to produce Merkle proofs of the result of txs.
-func (s *State) LoadABCIResponses(height int64) (*ABCIResponses, error) {
-	buf := s.db.Get(calcABCIResponsesKey(height))
-	if len(buf) == 0 {
-		return nil, ErrNoABCIResponsesForHeight{height}
-	}
-
-	abciResponses := new(ABCIResponses)
-	r, n, err := bytes.NewReader(buf), new(int), new(error)
-	wire.ReadBinaryPtr(abciResponses, r, 0, n, err)
-	if *err != nil {
-		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
-		cmn.Exit(cmn.Fmt(`LoadABCIResponses: Data has been corrupted or its spec has
-                changed: %v\n`, *err))
-	}
-	// TODO: ensure that buf is completely read.
-
-	return abciResponses, nil
-}
-
-// LoadValidators loads the ValidatorSet for a given height.
-// Returns ErrNoValSetForHeight if the validator set can't be found for this height.
-func (s *State) LoadValidators(height int64) (*types.ValidatorSet, error) {
-	valInfo := s.loadValidatorsInfo(height)
-	if valInfo == nil {
-		return nil, ErrNoValSetForHeight{height}
-	}
-
-	if valInfo.ValidatorSet == nil {
-		valInfo = s.loadValidatorsInfo(valInfo.LastHeightChanged)
-		if valInfo == nil {
-			cmn.PanicSanity(fmt.Sprintf(`Couldn't find validators at height %d as
-                        last changed from height %d`, valInfo.LastHeightChanged, height))
-		}
-	}
-
-	return valInfo.ValidatorSet, nil
-}
-
-func (s *State) loadValidatorsInfo(height int64) *ValidatorsInfo {
-	buf := s.db.Get(calcValidatorsKey(height))
-	if len(buf) == 0 {
-		return nil
-	}
-
-	v := new(ValidatorsInfo)
-	r, n, err := bytes.NewReader(buf), new(int), new(error)
-	wire.ReadBinaryPtr(v, r, 0, n, err)
-	if *err != nil {
-		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
-		cmn.Exit(cmn.Fmt(`LoadValidators: Data has been corrupted or its spec has changed:
-                %v\n`, *err))
-	}
-	// TODO: ensure that buf is completely read.
-
-	return v
-}
-
-// saveValidatorsInfo persists the validator set for the next block to disk.
-// It should be called from s.Save(), right before the state itself is persisted.
-// If the validator set did not change after processing the latest block,
-// only the last height for which the validators changed is persisted.
-func (s *State) saveValidatorsInfo() {
-	changeHeight := s.LastHeightValidatorsChanged
 	nextHeight := s.LastBlockHeight + 1
-	valInfo := &ValidatorsInfo{
-		LastHeightChanged: changeHeight,
-	}
-	if changeHeight == nextHeight {
-		valInfo.ValidatorSet = s.Validators
-	}
-	s.db.SetSync(calcValidatorsKey(nextHeight), valInfo.Bytes())
-}
 
-// LoadConsensusParams loads the ConsensusParams for a given height.
-func (s *State) LoadConsensusParams(height int64) (types.ConsensusParams, error) {
-	empty := types.ConsensusParams{}
-
-	paramsInfo := s.loadConsensusParamsInfo(height)
-	if paramsInfo == nil {
-		return empty, ErrNoConsensusParamsForHeight{height}
-	}
-
-	if paramsInfo.ConsensusParams == empty {
-		paramsInfo = s.loadConsensusParamsInfo(paramsInfo.LastHeightChanged)
-		if paramsInfo == nil {
-			cmn.PanicSanity(fmt.Sprintf(`Couldn't find consensus params at height %d as
-                        last changed from height %d`, paramsInfo.LastHeightChanged, height))
-		}
-	}
-
-	return paramsInfo.ConsensusParams, nil
-}
-
-func (s *State) loadConsensusParamsInfo(height int64) *ConsensusParamsInfo {
-	buf := s.db.Get(calcConsensusParamsKey(height))
-	if len(buf) == 0 {
-		return nil
-	}
-
-	paramsInfo := new(ConsensusParamsInfo)
-	r, n, err := bytes.NewReader(buf), new(int), new(error)
-	wire.ReadBinaryPtr(paramsInfo, r, 0, n, err)
-	if *err != nil {
-		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
-		cmn.Exit(cmn.Fmt(`LoadConsensusParams: Data has been corrupted or its spec has changed:
-                %v\n`, *err))
-	}
-	// TODO: ensure that buf is completely read.
-
-	return paramsInfo
-}
-
-// saveConsensusParamsInfo persists the consensus params for the next block to disk.
-// It should be called from s.Save(), right before the state itself is persisted.
-// If the consensus params did not change after processing the latest block,
-// only the last height for which they changed is persisted.
-func (s *State) saveConsensusParamsInfo() {
-	changeHeight := s.LastHeightConsensusParamsChanged
-	nextHeight := s.LastBlockHeight + 1
-	paramsInfo := &ConsensusParamsInfo{
-		LastHeightChanged: changeHeight,
-	}
-	if changeHeight == nextHeight {
-		paramsInfo.ConsensusParams = s.ConsensusParams
-	}
-	s.db.SetSync(calcConsensusParamsKey(nextHeight), paramsInfo.Bytes())
+	// persist everything to db
+	db := s.db
+	saveValidatorsInfo(db, nextHeight, s.LastHeightValidatorsChanged, s.Validators)
+	saveConsensusParamsInfo(db, nextHeight, s.LastHeightConsensusParamsChanged, s.ConsensusParams)
+	db.SetSync(stateKey, s.Bytes())
 }
 
 // Equals returns true if the States are identical.
@@ -381,96 +243,6 @@ func (s *State) setBlockAndValidators(height int64,
 // GetValidators returns the last and current validator sets.
 func (s *State) GetValidators() (last *types.ValidatorSet, current *types.ValidatorSet) {
 	return s.LastValidators, s.Validators
-}
-
-// VerifyEvidence verifies the evidence fully by checking it is internally
-// consistent and corresponds to an existing or previous validator.
-// It returns the priority of this evidence, or an error.
-// NOTE: return error may be ErrNoValSetForHeight, in which case the validator set
-// for the evidence height could not be loaded.
-func (s *State) VerifyEvidence(evidence types.Evidence) (priority int64, err error) {
-	evidenceAge := s.LastBlockHeight - evidence.Height()
-	maxAge := s.ConsensusParams.EvidenceParams.MaxAge
-	if evidenceAge > maxAge {
-		return priority, fmt.Errorf("Evidence from height %d is too old. Min height is %d",
-			evidence.Height(), s.LastBlockHeight-maxAge)
-	}
-
-	if err := evidence.Verify(s.ChainID); err != nil {
-		return priority, err
-	}
-
-	// The address must have been an active validator at the height
-	ev := evidence
-	height, addr, idx := ev.Height(), ev.Address(), ev.Index()
-	valset, err := s.LoadValidators(height)
-	if err != nil {
-		// XXX/TODO: what do we do if we can't load the valset?
-		// eg. if we have pruned the state or height is too high?
-		return priority, err
-	}
-	valIdx, val := valset.GetByAddress(addr)
-	if val == nil {
-		return priority, fmt.Errorf("Address %X was not a validator at height %d", addr, height)
-	} else if idx != valIdx {
-		return priority, fmt.Errorf("Address %X was validator %d at height %d, not %d", addr, valIdx, height, idx)
-	}
-
-	priority = val.VotingPower
-	return priority, nil
-}
-
-//------------------------------------------------------------------------
-
-// ABCIResponses retains the responses
-// of the various ABCI calls during block processing.
-// It is persisted to disk for each height before calling Commit.
-type ABCIResponses struct {
-	DeliverTx []*abci.ResponseDeliverTx
-	EndBlock  *abci.ResponseEndBlock
-}
-
-// NewABCIResponses returns a new ABCIResponses
-func NewABCIResponses(block *types.Block) *ABCIResponses {
-	return &ABCIResponses{
-		DeliverTx: make([]*abci.ResponseDeliverTx, block.NumTxs),
-	}
-}
-
-// Bytes serializes the ABCIResponse using go-wire
-func (a *ABCIResponses) Bytes() []byte {
-	return wire.BinaryBytes(*a)
-}
-
-func (a *ABCIResponses) ResultsHash() []byte {
-	results := types.NewResults(a.DeliverTx)
-	return results.Hash()
-}
-
-//-----------------------------------------------------------------------------
-
-// ValidatorsInfo represents the latest validator set, or the last height it changed
-type ValidatorsInfo struct {
-	ValidatorSet      *types.ValidatorSet
-	LastHeightChanged int64
-}
-
-// Bytes serializes the ValidatorsInfo using go-wire
-func (valInfo *ValidatorsInfo) Bytes() []byte {
-	return wire.BinaryBytes(*valInfo)
-}
-
-//-----------------------------------------------------------------------------
-
-// ConsensusParamsInfo represents the latest consensus params, or the last height it changed
-type ConsensusParamsInfo struct {
-	ConsensusParams   types.ConsensusParams
-	LastHeightChanged int64
-}
-
-// Bytes serializes the ConsensusParamsInfo using go-wire
-func (params ConsensusParamsInfo) Bytes() []byte {
-	return wire.BinaryBytes(params)
 }
 
 //------------------------------------------------------------------------

--- a/state/state.go
+++ b/state/state.go
@@ -23,7 +23,7 @@ var (
 // including the last validator set and the consensus params.
 // All fields are exposed so the struct can be easily serialized,
 // but none of them should be mutated directly.
-// Instead, use state.Copy() ro state.NextState(...).
+// Instead, use state.Copy() or state.NextState(...).
 // NOTE: not goroutine-safe.
 type State struct {
 	// Immutable

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -14,19 +14,17 @@ import (
 
 	cmn "github.com/tendermint/tmlibs/common"
 	dbm "github.com/tendermint/tmlibs/db"
-	"github.com/tendermint/tmlibs/log"
 
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/types"
 )
 
 // setupTestCase does setup common to all test cases
-func setupTestCase(t *testing.T) (func(t *testing.T), dbm.DB, *State) {
+func setupTestCase(t *testing.T) (func(t *testing.T), dbm.DB, State) {
 	config := cfg.ResetTestRoot("state_")
 	stateDB := dbm.NewDB("state", config.DBBackend, config.DBDir())
 	state, err := GetState(stateDB, config.GenesisFile())
 	assert.NoError(t, err, "expected no error on GetState")
-	state.SetLogger(log.TestingLogger())
 
 	tearDown := func(t *testing.T) {}
 
@@ -59,7 +57,7 @@ func TestStateSaveLoad(t *testing.T) {
 	assert := assert.New(t)
 
 	state.LastBlockHeight++
-	state.Save()
+	SaveState(stateDB, state, state.AppHash)
 
 	loadedState := LoadState(stateDB)
 	assert.True(state.Equals(loadedState),
@@ -69,7 +67,7 @@ func TestStateSaveLoad(t *testing.T) {
 
 // TestABCIResponsesSaveLoad tests saving and loading ABCIResponses.
 func TestABCIResponsesSaveLoad1(t *testing.T) {
-	tearDown, _, state := setupTestCase(t)
+	tearDown, stateDB, state := setupTestCase(t)
 	defer tearDown(t)
 	// nolint: vetshadow
 	assert := assert.New(t)
@@ -88,8 +86,8 @@ func TestABCIResponsesSaveLoad1(t *testing.T) {
 		},
 	}}
 
-	SaveABCIResponses(state.db, block.Height, abciResponses)
-	loadedAbciResponses, err := LoadABCIResponses(state.db, block.Height)
+	saveABCIResponses(stateDB, block.Height, abciResponses)
+	loadedAbciResponses, err := LoadABCIResponses(stateDB, block.Height)
 	assert.Nil(err)
 	assert.Equal(abciResponses, loadedAbciResponses,
 		cmn.Fmt(`ABCIResponses don't match: Got %v, Expected %v`, loadedAbciResponses,
@@ -98,7 +96,7 @@ func TestABCIResponsesSaveLoad1(t *testing.T) {
 
 // TestResultsSaveLoad tests saving and loading abci results.
 func TestABCIResponsesSaveLoad2(t *testing.T) {
-	tearDown, _, state := setupTestCase(t)
+	tearDown, stateDB, _ := setupTestCase(t)
 	defer tearDown(t)
 	// nolint: vetshadow
 	assert := assert.New(t)
@@ -142,7 +140,7 @@ func TestABCIResponsesSaveLoad2(t *testing.T) {
 	// query all before, should return error
 	for i := range cases {
 		h := int64(i + 1)
-		res, err := LoadABCIResponses(state.db, h)
+		res, err := LoadABCIResponses(stateDB, h)
 		assert.Error(err, "%d: %#v", i, res)
 	}
 
@@ -153,13 +151,13 @@ func TestABCIResponsesSaveLoad2(t *testing.T) {
 			DeliverTx: tc.added,
 			EndBlock:  &abci.ResponseEndBlock{},
 		}
-		SaveABCIResponses(state.db, h, responses)
+		saveABCIResponses(stateDB, h, responses)
 	}
 
 	// query all before, should return expected value
 	for i, tc := range cases {
 		h := int64(i + 1)
-		res, err := LoadABCIResponses(state.db, h)
+		res, err := LoadABCIResponses(stateDB, h)
 		assert.NoError(err, "%d", i)
 		assert.Equal(tc.expected.Hash(), res.ResultsHash(), "%d", i)
 	}
@@ -167,56 +165,57 @@ func TestABCIResponsesSaveLoad2(t *testing.T) {
 
 // TestValidatorSimpleSaveLoad tests saving and loading validators.
 func TestValidatorSimpleSaveLoad(t *testing.T) {
-	tearDown, _, state := setupTestCase(t)
+	tearDown, stateDB, state := setupTestCase(t)
 	defer tearDown(t)
 	// nolint: vetshadow
 	assert := assert.New(t)
 
 	// can't load anything for height 0
-	v, err := LoadValidators(state.db, 0)
+	v, err := LoadValidators(stateDB, 0)
 	assert.IsType(ErrNoValSetForHeight{}, err, "expected err at height 0")
 
 	// should be able to load for height 1
-	v, err = LoadValidators(state.db, 1)
+	v, err = LoadValidators(stateDB, 1)
 	assert.Nil(err, "expected no err at height 1")
 	assert.Equal(v.Hash(), state.Validators.Hash(), "expected validator hashes to match")
 
 	// increment height, save; should be able to load for next height
 	state.LastBlockHeight++
 	nextHeight := state.LastBlockHeight + 1
-	saveValidatorsInfo(state.db, nextHeight, state.LastHeightValidatorsChanged, state.Validators)
-	v, err = LoadValidators(state.db, nextHeight)
+	saveValidatorsInfo(stateDB, nextHeight, state.LastHeightValidatorsChanged, state.Validators)
+	v, err = LoadValidators(stateDB, nextHeight)
 	assert.Nil(err, "expected no err")
 	assert.Equal(v.Hash(), state.Validators.Hash(), "expected validator hashes to match")
 
 	// increment height, save; should be able to load for next height
 	state.LastBlockHeight += 10
 	nextHeight = state.LastBlockHeight + 1
-	saveValidatorsInfo(state.db, nextHeight, state.LastHeightValidatorsChanged, state.Validators)
-	v, err = LoadValidators(state.db, nextHeight)
+	saveValidatorsInfo(stateDB, nextHeight, state.LastHeightValidatorsChanged, state.Validators)
+	v, err = LoadValidators(stateDB, nextHeight)
 	assert.Nil(err, "expected no err")
 	assert.Equal(v.Hash(), state.Validators.Hash(), "expected validator hashes to match")
 
 	// should be able to load for next next height
-	_, err = LoadValidators(state.db, state.LastBlockHeight+2)
+	_, err = LoadValidators(stateDB, state.LastBlockHeight+2)
 	assert.IsType(ErrNoValSetForHeight{}, err, "expected err at unknown height")
 }
 
 // TestValidatorChangesSaveLoad tests saving and loading a validator set with changes.
 func TestOneValidatorChangesSaveLoad(t *testing.T) {
-	tearDown, _, state := setupTestCase(t)
+	tearDown, stateDB, state := setupTestCase(t)
 	defer tearDown(t)
 
 	// change vals at these heights
 	changeHeights := []int64{1, 2, 4, 5, 10, 15, 16, 17, 20}
 	N := len(changeHeights)
 
-	// build the validator history by running SetBlockAndValidators
+	// build the validator history by running updateState
 	// with the right validator set for each height
 	highestHeight := changeHeights[N-1] + 5
 	changeIndex := 0
 	_, val := state.Validators.GetByIndex(0)
 	power := val.VotingPower
+	var err error
 	for i := int64(1); i < highestHeight; i++ {
 		// when we get to a change height,
 		// use the next pubkey
@@ -224,11 +223,11 @@ func TestOneValidatorChangesSaveLoad(t *testing.T) {
 			changeIndex++
 			power += 1
 		}
-		header, parts, responses := makeHeaderPartsResponsesValPowerChange(state, i, power)
-		err := state.SetBlockAndValidators(header, parts, responses)
+		header, blockID, responses := makeHeaderPartsResponsesValPowerChange(state, i, power)
+		state, err = updateState(state, blockID, header, responses)
 		assert.Nil(t, err)
 		nextHeight := state.LastBlockHeight + 1
-		saveValidatorsInfo(state.db, nextHeight, state.LastHeightValidatorsChanged, state.Validators)
+		saveValidatorsInfo(stateDB, nextHeight, state.LastHeightValidatorsChanged, state.Validators)
 	}
 
 	// on each change height, increment the power by one.
@@ -246,7 +245,7 @@ func TestOneValidatorChangesSaveLoad(t *testing.T) {
 	}
 
 	for i, power := range testCases {
-		v, err := LoadValidators(state.db, int64(i+1))
+		v, err := LoadValidators(stateDB, int64(i+1))
 		assert.Nil(t, err, fmt.Sprintf("expected no err at height %d", i))
 		assert.Equal(t, v.Size(), 1, "validator set size is greater than 1: %d", v.Size())
 		_, val := v.GetByIndex(0)
@@ -260,21 +259,22 @@ func TestOneValidatorChangesSaveLoad(t *testing.T) {
 // changes.
 func TestManyValidatorChangesSaveLoad(t *testing.T) {
 	const valSetSize = 7
-	tearDown, _, state := setupTestCase(t)
+	tearDown, stateDB, state := setupTestCase(t)
 	state.Validators = genValSet(valSetSize)
-	state.Save()
+	SaveState(stateDB, state, state.AppHash)
 	defer tearDown(t)
 
 	const height = 1
 	pubkey := crypto.GenPrivKeyEd25519().PubKey()
 	// swap the first validator with a new one ^^^ (validator set size stays the same)
-	header, parts, responses := makeHeaderPartsResponsesValPubKeyChange(state, height, pubkey)
-	err := state.SetBlockAndValidators(header, parts, responses)
+	header, blockID, responses := makeHeaderPartsResponsesValPubKeyChange(state, height, pubkey)
+	var err error
+	state, err = updateState(state, blockID, header, responses)
 	require.Nil(t, err)
 	nextHeight := state.LastBlockHeight + 1
-	saveValidatorsInfo(state.db, nextHeight, state.LastHeightValidatorsChanged, state.Validators)
+	saveValidatorsInfo(stateDB, nextHeight, state.LastHeightValidatorsChanged, state.Validators)
 
-	v, err := LoadValidators(state.db, height+1)
+	v, err := LoadValidators(stateDB, height+1)
 	assert.Nil(t, err)
 	assert.Equal(t, valSetSize, v.Size())
 
@@ -296,7 +296,7 @@ func genValSet(size int) *types.ValidatorSet {
 // TestConsensusParamsChangesSaveLoad tests saving and loading consensus params
 // with changes.
 func TestConsensusParamsChangesSaveLoad(t *testing.T) {
-	tearDown, _, state := setupTestCase(t)
+	tearDown, stateDB, state := setupTestCase(t)
 	defer tearDown(t)
 
 	// change vals at these heights
@@ -312,11 +312,12 @@ func TestConsensusParamsChangesSaveLoad(t *testing.T) {
 		params[i].BlockSize.MaxBytes += i
 	}
 
-	// build the params history by running SetBlockAndValidators
+	// build the params history by running updateState
 	// with the right params set for each height
 	highestHeight := changeHeights[N-1] + 5
 	changeIndex := 0
 	cp := params[changeIndex]
+	var err error
 	for i := int64(1); i < highestHeight; i++ {
 		// when we get to a change height,
 		// use the next params
@@ -324,11 +325,12 @@ func TestConsensusParamsChangesSaveLoad(t *testing.T) {
 			changeIndex++
 			cp = params[changeIndex]
 		}
-		header, parts, responses := makeHeaderPartsResponsesParams(state, i, cp)
-		err := state.SetBlockAndValidators(header, parts, responses)
+		header, blockID, responses := makeHeaderPartsResponsesParams(state, i, cp)
+		state, err = updateState(state, blockID, header, responses)
+
 		require.Nil(t, err)
 		nextHeight := state.LastBlockHeight + 1
-		saveConsensusParamsInfo(state.db, nextHeight, state.LastHeightConsensusParamsChanged, state.ConsensusParams)
+		saveConsensusParamsInfo(stateDB, nextHeight, state.LastHeightConsensusParamsChanged, state.ConsensusParams)
 	}
 
 	// make all the test cases by using the same params until after the change
@@ -346,7 +348,7 @@ func TestConsensusParamsChangesSaveLoad(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		p, err := LoadConsensusParams(state.db, testCase.height)
+		p, err := LoadConsensusParams(stateDB, testCase.height)
 		assert.Nil(t, err, fmt.Sprintf("expected no err at height %d", testCase.height))
 		assert.Equal(t, testCase.params, p, fmt.Sprintf(`unexpected consensus params at
                 height %d`, testCase.height))
@@ -421,15 +423,15 @@ func TestLessThanOneThirdOfVotingPowerPerBlockEnforced(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tearDown, _, state := setupTestCase(t)
+		tearDown, stateDB, state := setupTestCase(t)
 		state.Validators = genValSet(tc.initialValSetSize)
-		state.Save()
+		SaveState(stateDB, state, state.AppHash)
 		height := state.LastBlockHeight + 1
 		block := makeBlock(state, height)
 		abciResponses := &ABCIResponses{
 			EndBlock: &abci.ResponseEndBlock{ValidatorUpdates: tc.valUpdatesFn(state.Validators)},
 		}
-		err := state.SetBlockAndValidators(block.Header, types.PartSetHeader{}, abciResponses)
+		state, err := updateState(state, types.BlockID{block.Hash(), types.PartSetHeader{}}, block.Header, abciResponses)
 		if tc.shouldErr {
 			assert.Error(t, err, "#%d", i)
 		} else {
@@ -489,8 +491,8 @@ func TestApplyUpdates(t *testing.T) {
 	}
 }
 
-func makeHeaderPartsResponsesValPubKeyChange(state *State, height int64,
-	pubkey crypto.PubKey) (*types.Header, types.PartSetHeader, *ABCIResponses) {
+func makeHeaderPartsResponsesValPubKeyChange(state State, height int64,
+	pubkey crypto.PubKey) (*types.Header, types.BlockID, *ABCIResponses) {
 
 	block := makeBlock(state, height)
 	abciResponses := &ABCIResponses{
@@ -508,11 +510,11 @@ func makeHeaderPartsResponsesValPubKeyChange(state *State, height int64,
 		}
 	}
 
-	return block.Header, types.PartSetHeader{}, abciResponses
+	return block.Header, types.BlockID{block.Hash(), types.PartSetHeader{}}, abciResponses
 }
 
-func makeHeaderPartsResponsesValPowerChange(state *State, height int64,
-	power int64) (*types.Header, types.PartSetHeader, *ABCIResponses) {
+func makeHeaderPartsResponsesValPowerChange(state State, height int64,
+	power int64) (*types.Header, types.BlockID, *ABCIResponses) {
 
 	block := makeBlock(state, height)
 	abciResponses := &ABCIResponses{
@@ -529,17 +531,17 @@ func makeHeaderPartsResponsesValPowerChange(state *State, height int64,
 		}
 	}
 
-	return block.Header, types.PartSetHeader{}, abciResponses
+	return block.Header, types.BlockID{block.Hash(), types.PartSetHeader{}}, abciResponses
 }
 
-func makeHeaderPartsResponsesParams(state *State, height int64,
-	params types.ConsensusParams) (*types.Header, types.PartSetHeader, *ABCIResponses) {
+func makeHeaderPartsResponsesParams(state State, height int64,
+	params types.ConsensusParams) (*types.Header, types.BlockID, *ABCIResponses) {
 
 	block := makeBlock(state, height)
 	abciResponses := &ABCIResponses{
 		EndBlock: &abci.ResponseEndBlock{ConsensusParamUpdates: types.TM2PB.ConsensusParams(&params)},
 	}
-	return block.Header, types.PartSetHeader{}, abciResponses
+	return block.Header, types.BlockID{block.Hash(), types.PartSetHeader{}}, abciResponses
 }
 
 type paramsChangeTestCase struct {
@@ -547,13 +549,13 @@ type paramsChangeTestCase struct {
 	params types.ConsensusParams
 }
 
-func makeHeaderPartsResults(state *State, height int64,
-	results []*abci.ResponseDeliverTx) (*types.Header, types.PartSetHeader, *ABCIResponses) {
+func makeHeaderPartsResults(state State, height int64,
+	results []*abci.ResponseDeliverTx) (*types.Header, types.BlockID, *ABCIResponses) {
 
 	block := makeBlock(state, height)
 	abciResponses := &ABCIResponses{
 		DeliverTx: results,
 		EndBlock:  &abci.ResponseEndBlock{},
 	}
-	return block.Header, types.PartSetHeader{}, abciResponses
+	return block.Header, types.BlockID{block.Hash(), types.PartSetHeader{}}, abciResponses
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -57,7 +57,7 @@ func TestStateSaveLoad(t *testing.T) {
 	assert := assert.New(t)
 
 	state.LastBlockHeight++
-	SaveState(stateDB, state, state.AppHash)
+	SaveState(stateDB, state)
 
 	loadedState := LoadState(stateDB)
 	assert.True(state.Equals(loadedState),
@@ -261,7 +261,7 @@ func TestManyValidatorChangesSaveLoad(t *testing.T) {
 	const valSetSize = 7
 	tearDown, stateDB, state := setupTestCase(t)
 	state.Validators = genValSet(valSetSize)
-	SaveState(stateDB, state, state.AppHash)
+	SaveState(stateDB, state)
 	defer tearDown(t)
 
 	const height = 1
@@ -425,7 +425,7 @@ func TestLessThanOneThirdOfVotingPowerPerBlockEnforced(t *testing.T) {
 	for i, tc := range testCases {
 		tearDown, stateDB, state := setupTestCase(t)
 		state.Validators = genValSet(tc.initialValSetSize)
-		SaveState(stateDB, state, state.AppHash)
+		SaveState(stateDB, state)
 		height := state.LastBlockHeight + 1
 		block := makeBlock(state, height)
 		abciResponses := &ABCIResponses{

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -23,8 +23,8 @@ import (
 func setupTestCase(t *testing.T) (func(t *testing.T), dbm.DB, State) {
 	config := cfg.ResetTestRoot("state_")
 	stateDB := dbm.NewDB("state", config.DBBackend, config.DBDir())
-	state, err := GetState(stateDB, config.GenesisFile())
-	assert.NoError(t, err, "expected no error on GetState")
+	state, err := LoadStateFromDBOrGenesisFile(stateDB, config.GenesisFile())
+	assert.NoError(t, err, "expected no error on LoadStateFromDBOrGenesisFile")
 
 	tearDown := func(t *testing.T) {}
 

--- a/state/validation.go
+++ b/state/validation.go
@@ -1,0 +1,136 @@
+package state
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/tendermint/tendermint/types"
+)
+
+//-----------------------------------------------------
+// Validate block
+
+// ValidateBlock validates the block against the state.
+func ValidateBlock(s State, block *types.Block) error {
+	return validateBlock(s, block)
+}
+
+func validateBlock(s State, b *types.Block) error {
+	// validate internal consistency
+	if err := b.ValidateBasic(); err != nil {
+		return err
+	}
+
+	// validate basic info
+	if b.ChainID != s.ChainID {
+		return fmt.Errorf("Wrong Block.Header.ChainID. Expected %v, got %v", s.ChainID, b.ChainID)
+	}
+	if b.Height != s.LastBlockHeight+1 {
+		return fmt.Errorf("Wrong Block.Header.Height. Expected %v, got %v", s.LastBlockHeight+1, b.Height)
+	}
+	/*	TODO: Determine bounds for Time
+		See blockchain/reactor "stopSyncingDurationMinutes"
+
+		if !b.Time.After(lastBlockTime) {
+			return errors.New("Invalid Block.Header.Time")
+		}
+	*/
+
+	// validate prev block info
+	if !b.LastBlockID.Equals(s.LastBlockID) {
+		return fmt.Errorf("Wrong Block.Header.LastBlockID.  Expected %v, got %v", s.LastBlockID, b.LastBlockID)
+	}
+	newTxs := int64(len(b.Data.Txs))
+	if b.TotalTxs != s.LastBlockTotalTx+newTxs {
+		return fmt.Errorf("Wrong Block.Header.TotalTxs. Expected %v, got %v", s.LastBlockTotalTx+newTxs, b.TotalTxs)
+	}
+
+	// validate app info
+	if !bytes.Equal(b.AppHash, s.AppHash) {
+		return fmt.Errorf("Wrong Block.Header.AppHash.  Expected %X, got %v", s.AppHash, b.AppHash)
+	}
+	if !bytes.Equal(b.ConsensusHash, s.ConsensusParams.Hash()) {
+		return fmt.Errorf("Wrong Block.Header.ConsensusHash.  Expected %X, got %v", s.ConsensusParams.Hash(), b.ConsensusHash)
+	}
+	if !bytes.Equal(b.LastResultsHash, s.LastResultsHash) {
+		return fmt.Errorf("Wrong Block.Header.LastResultsHash.  Expected %X, got %v", s.LastResultsHash, b.LastResultsHash)
+	}
+	if !bytes.Equal(b.ValidatorsHash, s.Validators.Hash()) {
+		return fmt.Errorf("Wrong Block.Header.ValidatorsHash.  Expected %X, got %v", s.Validators.Hash(), b.ValidatorsHash)
+	}
+
+	// Validate block LastCommit.
+	if b.Height == 1 {
+		if len(b.LastCommit.Precommits) != 0 {
+			return errors.New("Block at height 1 (first block) should have no LastCommit precommits")
+		}
+	} else {
+		if len(b.LastCommit.Precommits) != s.LastValidators.Size() {
+			return fmt.Errorf("Invalid block commit size. Expected %v, got %v",
+				s.LastValidators.Size(), len(b.LastCommit.Precommits))
+		}
+		err := s.LastValidators.VerifyCommit(
+			s.ChainID, s.LastBlockID, b.Height-1, b.LastCommit)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, ev := range b.Evidence.Evidence {
+		if err := VerifyEvidence(s, ev); err != nil {
+			return types.NewEvidenceInvalidErr(ev, err)
+		}
+		/* // Needs a db ...
+		valset, err := LoadValidators(s.db, ev.Height())
+		if err != nil {
+			// XXX/TODO: what do we do if we can't load the valset?
+			// eg. if we have pruned the state or height is too high?
+			return err
+		}
+		if err := VerifyEvidenceValidator(valSet, ev); err != nil {
+			return types.NewEvidenceInvalidErr(ev, err)
+		}
+		*/
+	}
+
+	return nil
+}
+
+// XXX: What's cheaper (ie. what should be checked first):
+//  evidence internal validity (ie. sig checks) or validator existed (fetch historical val set from db)
+
+// VerifyEvidence verifies the evidence fully by checking it is internally
+// consistent and sufficiently recent.
+func VerifyEvidence(s State, evidence types.Evidence) error {
+	height := s.LastBlockHeight
+
+	evidenceAge := height - evidence.Height()
+	maxAge := s.ConsensusParams.EvidenceParams.MaxAge
+	if evidenceAge > maxAge {
+		return fmt.Errorf("Evidence from height %d is too old. Min height is %d",
+			evidence.Height(), height-maxAge)
+	}
+
+	if err := evidence.Verify(s.ChainID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// VerifyEvidenceValidator returns the voting power of the validator at the height of the evidence.
+// It returns an error if the validator did not exist or does not match that loaded from the historical validator set.
+func VerifyEvidenceValidator(valset *types.ValidatorSet, evidence types.Evidence) (priority int64, err error) {
+	// The address must have been an active validator at the height
+	ev := evidence
+	height, addr, idx := ev.Height(), ev.Address(), ev.Index()
+	valIdx, val := valset.GetByAddress(addr)
+	if val == nil {
+		return priority, fmt.Errorf("Address %X was not a validator at height %d", addr, height)
+	} else if idx != valIdx {
+		return priority, fmt.Errorf("Address %X was validator %d at height %d, not %d", addr, valIdx, height, idx)
+	}
+
+	priority = val.VotingPower
+	return priority, nil
+}

--- a/state/validation.go
+++ b/state/validation.go
@@ -12,11 +12,6 @@ import (
 //-----------------------------------------------------
 // Validate block
 
-// ValidateBlock validates the block against the state.
-func _ValidateBlock(s State, block *types.Block) error {
-	return validateBlock(dbm.NewMemDB(), s, block)
-}
-
 func validateBlock(stateDB dbm.DB, s State, b *types.Block) error {
 	// validate internal consistency
 	if err := b.ValidateBasic(); err != nil {

--- a/state/validation.go
+++ b/state/validation.go
@@ -6,17 +6,18 @@ import (
 	"fmt"
 
 	"github.com/tendermint/tendermint/types"
+	dbm "github.com/tendermint/tmlibs/db"
 )
 
 //-----------------------------------------------------
 // Validate block
 
 // ValidateBlock validates the block against the state.
-func ValidateBlock(s State, block *types.Block) error {
-	return validateBlock(s, block)
+func _ValidateBlock(s State, block *types.Block) error {
+	return validateBlock(dbm.NewMemDB(), s, block)
 }
 
-func validateBlock(s State, b *types.Block) error {
+func validateBlock(stateDB dbm.DB, s State, b *types.Block) error {
 	// validate internal consistency
 	if err := b.ValidateBasic(); err != nil {
 		return err

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -1,0 +1,64 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func _TestValidateBlock(t *testing.T) {
+	state := state()
+
+	// proper block must pass
+	block := makeBlock(state, 1)
+	err := ValidateBlock(state, block)
+	require.NoError(t, err)
+
+	// wrong chain fails
+	block = makeBlock(state, 1)
+	block.ChainID = "not-the-real-one"
+	err = ValidateBlock(state, block)
+	require.Error(t, err)
+
+	// wrong height fails
+	block = makeBlock(state, 1)
+	block.Height += 10
+	err = ValidateBlock(state, block)
+	require.Error(t, err)
+
+	// wrong total tx fails
+	block = makeBlock(state, 1)
+	block.TotalTxs += 10
+	err = ValidateBlock(state, block)
+	require.Error(t, err)
+
+	// wrong blockid fails
+	block = makeBlock(state, 1)
+	block.LastBlockID.PartsHeader.Total += 10
+	err = ValidateBlock(state, block)
+	require.Error(t, err)
+
+	// wrong app hash fails
+	block = makeBlock(state, 1)
+	block.AppHash = []byte("wrong app hash")
+	err = ValidateBlock(state, block)
+	require.Error(t, err)
+
+	// wrong consensus hash fails
+	block = makeBlock(state, 1)
+	block.ConsensusHash = []byte("wrong consensus hash")
+	err = ValidateBlock(state, block)
+	require.Error(t, err)
+
+	// wrong results hash fails
+	block = makeBlock(state, 1)
+	block.LastResultsHash = []byte("wrong results hash")
+	err = ValidateBlock(state, block)
+	require.Error(t, err)
+
+	// wrong validators hash fails
+	block = makeBlock(state, 1)
+	block.ValidatorsHash = []byte("wrong validators hash")
+	err = ValidateBlock(state, block)
+	require.Error(t, err)
+}

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -4,61 +4,65 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tmlibs/db"
+	"github.com/tendermint/tmlibs/log"
 )
 
-func _TestValidateBlock(t *testing.T) {
+func TestValidateBlock(t *testing.T) {
 	state := state()
+
+	blockExec := NewBlockExecutor(dbm.NewMemDB(), log.TestingLogger(), nil, nil, nil)
 
 	// proper block must pass
 	block := makeBlock(state, 1)
-	err := ValidateBlock(state, block)
+	err := blockExec.ValidateBlock(state, block)
 	require.NoError(t, err)
 
 	// wrong chain fails
 	block = makeBlock(state, 1)
 	block.ChainID = "not-the-real-one"
-	err = ValidateBlock(state, block)
+	err = blockExec.ValidateBlock(state, block)
 	require.Error(t, err)
 
 	// wrong height fails
 	block = makeBlock(state, 1)
 	block.Height += 10
-	err = ValidateBlock(state, block)
+	err = blockExec.ValidateBlock(state, block)
 	require.Error(t, err)
 
 	// wrong total tx fails
 	block = makeBlock(state, 1)
 	block.TotalTxs += 10
-	err = ValidateBlock(state, block)
+	err = blockExec.ValidateBlock(state, block)
 	require.Error(t, err)
 
 	// wrong blockid fails
 	block = makeBlock(state, 1)
 	block.LastBlockID.PartsHeader.Total += 10
-	err = ValidateBlock(state, block)
+	err = blockExec.ValidateBlock(state, block)
 	require.Error(t, err)
 
 	// wrong app hash fails
 	block = makeBlock(state, 1)
 	block.AppHash = []byte("wrong app hash")
-	err = ValidateBlock(state, block)
+	err = blockExec.ValidateBlock(state, block)
 	require.Error(t, err)
 
 	// wrong consensus hash fails
 	block = makeBlock(state, 1)
 	block.ConsensusHash = []byte("wrong consensus hash")
-	err = ValidateBlock(state, block)
+	err = blockExec.ValidateBlock(state, block)
 	require.Error(t, err)
 
 	// wrong results hash fails
 	block = makeBlock(state, 1)
 	block.LastResultsHash = []byte("wrong results hash")
-	err = ValidateBlock(state, block)
+	err = blockExec.ValidateBlock(state, block)
 	require.Error(t, err)
 
 	// wrong validators hash fails
 	block = makeBlock(state, 1)
 	block.ValidatorsHash = []byte("wrong validators hash")
-	err = ValidateBlock(state, block)
+	err = blockExec.ValidateBlock(state, block)
 	require.Error(t, err)
 }

--- a/types/events.go
+++ b/types/events.go
@@ -175,6 +175,13 @@ func QueryForEvent(eventType string) tmpubsub.Query {
 	return tmquery.MustParse(fmt.Sprintf("%s='%s'", EventTypeKey, eventType))
 }
 
+// BlockEventPublisher publishes all block related events
+type BlockEventPublisher interface {
+	PublishEventNewBlock(block EventDataNewBlock) error
+	PublishEventNewBlockHeader(header EventDataNewBlockHeader) error
+	PublishEventTx(EventDataTx) error
+}
+
 type TxEventPublisher interface {
 	PublishEventTx(EventDataTx) error
 }

--- a/types/services.go
+++ b/types/services.go
@@ -71,15 +71,6 @@ type BlockStore interface {
 }
 
 //------------------------------------------------------
-// state
-
-// State defines the stateful interface used to verify evidence.
-// UNSTABLE
-type State interface {
-	VerifyEvidence(Evidence) (priority int64, err error)
-}
-
-//------------------------------------------------------
 // evidence pool
 
 // EvidencePool defines the EvidencePool interface used by the ConsensusState.

--- a/types/services.go
+++ b/types/services.go
@@ -78,7 +78,7 @@ type BlockStore interface {
 type EvidencePool interface {
 	PendingEvidence() []Evidence
 	AddEvidence(Evidence) error
-	MarkEvidenceAsCommitted([]Evidence)
+	Update(*Block)
 }
 
 // MockMempool is an empty implementation of a Mempool, useful for testing.
@@ -86,6 +86,6 @@ type EvidencePool interface {
 type MockEvidencePool struct {
 }
 
-func (m MockEvidencePool) PendingEvidence() []Evidence        { return nil }
-func (m MockEvidencePool) AddEvidence(Evidence) error         { return nil }
-func (m MockEvidencePool) MarkEvidenceAsCommitted([]Evidence) {}
+func (m MockEvidencePool) PendingEvidence() []Evidence { return nil }
+func (m MockEvidencePool) AddEvidence(Evidence) error  { return nil }
+func (m MockEvidencePool) Update(*Block)               {}


### PR DESCRIPTION
State is no longer mutable.

Move all methods mutating methods to be functions that return a new State.

Introduce `BlockExecutor` to handle `ApplyBlock`  