### PR TITLE
remove quotes from `tendermint version`

### DIFF
--- a/scripts/dist_build.sh
+++ b/scripts/dist_build.sh
@@ -31,7 +31,7 @@ echo "==> Building..."
 		-os="${XC_OS}" \
 		-arch="${XC_ARCH}" \
 		-osarch="!darwin/arm !solaris/amd64 !freebsd/amd64" \
-		-ldflags "-s -w -X ${GIT_IMPORT}.GitCommit='${GIT_COMMIT}'" \
+		-ldflags "-s -w -X ${GIT_IMPORT}.GitCommit=${GIT_COMMIT}" \
 		-output "build/pkg/{{.OS}}_{{.Arch}}/tendermint" \
 		-tags="${BUILD_TAGS}" \
 		github.com/tendermint/tendermint/cmd/tendermint


### PR DESCRIPTION
before:
0.14.0-'88f5f21d'

after:
0.14.0-88f5f21d

Fixes #1023