### PR TITLE
867 Using Trust Metrics

### DIFF
--- a/blockchain/reactor.go
+++ b/blockchain/reactor.go
@@ -16,6 +16,9 @@ import (
 )
 
 const (
+	// BlockchainReactorID is the name used by various services to identify the Blockchain reactor
+	BlockchainReactorID = "BLOCKCHAIN"
+
 	// BlockchainChannel is a channel for blocks and status updates (`BlockStore` height)
 	BlockchainChannel = byte(0x40)
 

--- a/blockchain/reactor_test.go
+++ b/blockchain/reactor_test.go
@@ -140,11 +140,12 @@ func (tp *bcrTestPeer) TrySend(chID byte, value interface{}) bool {
 	return true
 }
 
-func (tp *bcrTestPeer) Send(chID byte, data interface{}) bool { return tp.TrySend(chID, data) }
-func (tp *bcrTestPeer) NodeInfo() *p2p.NodeInfo               { return nil }
-func (tp *bcrTestPeer) Status() p2p.ConnectionStatus          { return p2p.ConnectionStatus{} }
-func (tp *bcrTestPeer) Key() string                           { return tp.key }
-func (tp *bcrTestPeer) IsOutbound() bool                      { return false }
-func (tp *bcrTestPeer) IsPersistent() bool                    { return true }
-func (tp *bcrTestPeer) Get(s string) interface{}              { return s }
-func (tp *bcrTestPeer) Set(string, interface{})               {}
+func (tp *bcrTestPeer) Send(chID byte, data interface{}) bool                  { return tp.TrySend(chID, data) }
+func (tp *bcrTestPeer) NodeInfo() *p2p.NodeInfo                                { return nil }
+func (tp *bcrTestPeer) Status() p2p.ConnectionStatus                           { return p2p.ConnectionStatus{} }
+func (tp *bcrTestPeer) Key() string                                            { return tp.key }
+func (tp *bcrTestPeer) IsOutbound() bool                                       { return false }
+func (tp *bcrTestPeer) IsPersistent() bool                                     { return true }
+func (tp *bcrTestPeer) Mark(reactorID string, good bool, events, severity int) {}
+func (tp *bcrTestPeer) Get(s string) interface{}                               { return s }
+func (tp *bcrTestPeer) Set(string, interface{})                                {}

--- a/blockchain/reactor_test.go
+++ b/blockchain/reactor_test.go
@@ -140,12 +140,15 @@ func (tp *bcrTestPeer) TrySend(chID byte, value interface{}) bool {
 	return true
 }
 
-func (tp *bcrTestPeer) Send(chID byte, data interface{}) bool                  { return tp.TrySend(chID, data) }
-func (tp *bcrTestPeer) NodeInfo() *p2p.NodeInfo                                { return nil }
-func (tp *bcrTestPeer) Status() p2p.ConnectionStatus                           { return p2p.ConnectionStatus{} }
-func (tp *bcrTestPeer) Key() string                                            { return tp.key }
-func (tp *bcrTestPeer) IsOutbound() bool                                       { return false }
-func (tp *bcrTestPeer) IsPersistent() bool                                     { return true }
-func (tp *bcrTestPeer) Mark(reactorID string, good bool, events, severity int) {}
-func (tp *bcrTestPeer) Get(s string) interface{}                               { return s }
-func (tp *bcrTestPeer) Set(string, interface{})                                {}
+func (tp *bcrTestPeer) Send(chID byte, data interface{}) bool { return tp.TrySend(chID, data) }
+func (tp *bcrTestPeer) NodeInfo() *p2p.NodeInfo               { return nil }
+func (tp *bcrTestPeer) Status() p2p.ConnectionStatus          { return p2p.ConnectionStatus{} }
+func (tp *bcrTestPeer) Key() string                           { return tp.key }
+func (tp *bcrTestPeer) IsOutbound() bool                      { return false }
+func (tp *bcrTestPeer) IsPersistent() bool                    { return true }
+func (tp *bcrTestPeer) MarkAsGoodNEventsWithSeverity(trustMetricID string, events int, s p2p.Severity) {
+}
+func (tp *bcrTestPeer) MarkAsBadNEventsWithSeverity(trustMetricID string, events int, s p2p.Severity) {
+}
+func (tp *bcrTestPeer) Get(s string) interface{} { return s }
+func (tp *bcrTestPeer) Set(string, interface{})  {}

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -255,6 +255,10 @@ func (br *ByzantineReactor) AddPeer(peer p2p.Peer) {
 		br.reactor.sendNewRoundStepMessages(peer)
 	}
 }
+func (br *ByzantineReactor) MarkPeer(peer p2p.Peer, good bool, events, severity int) {
+	// Does not currently mark during a test
+	return
+}
 func (br *ByzantineReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 	br.reactor.RemovePeer(peer, reason)
 }

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -238,6 +238,7 @@ func NewByzantineReactor(conR *ConsensusReactor) *ByzantineReactor {
 	}
 }
 
+func (br *ByzantineReactor) GetID() string                         { return "ByzantineReactor" }
 func (br *ByzantineReactor) SetSwitch(s *p2p.Switch)               { br.reactor.SetSwitch(s) }
 func (br *ByzantineReactor) GetChannels() []*p2p.ChannelDescriptor { return br.reactor.GetChannels() }
 func (br *ByzantineReactor) AddPeer(peer p2p.Peer) {
@@ -254,10 +255,6 @@ func (br *ByzantineReactor) AddPeer(peer p2p.Peer) {
 	if !br.reactor.fastSync {
 		br.reactor.sendNewRoundStepMessages(peer)
 	}
-}
-func (br *ByzantineReactor) MarkPeer(peer p2p.Peer, good bool, events, severity int) {
-	// Does not currently mark during a test
-	return
 }
 func (br *ByzantineReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 	br.reactor.RemovePeer(peer, reason)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -21,6 +21,9 @@ import (
 )
 
 const (
+	// ConsensusReactorID is the name used by various services to identify the Consensus reactor
+	ConsensusReactorID = "CONSENSUS"
+
 	StateChannel       = byte(0x20)
 	DataChannel        = byte(0x21)
 	VoteChannel        = byte(0x22)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -195,7 +195,7 @@ func (conR *ConsensusReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) 
 	_, msg, err := DecodeMessage(msgBytes)
 	if err != nil {
 		conR.Logger.Error("Error decoding message", "src", src, "chId", chID, "msg", msg, "err", err, "bytes", msgBytes)
-		src.Mark(conR.GetID(), false, 1, p2p.PeerMarkBad)
+		src.MarkAsBadNEventsWithSeverity(conR.GetID(), 1, p2p.PeerMarkBad)
 		return
 	}
 	conR.Logger.Debug("Receive", "src", src, "chId", chID, "msg", msg)

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -96,7 +96,7 @@ func (memR *MempoolReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) {
 	switch msg := msg.(type) {
 	case *TxMessage:
 		success := func(*abci.Response) {
-			src.Mark(memR.GetID(), true, 1, p2p.PeerMarkCorrect)
+			src.MarkAsGoodNEventsWithSeverity(memR.GetID(), 1, p2p.PeerMarkCorrect)
 		}
 		err := memR.Mempool.CheckTx(msg.Tx, success)
 		if err != nil {

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -17,6 +17,9 @@ import (
 )
 
 const (
+	// MempoolReactorID is the name used by various services to identify the Mempool reactor
+	MempoolReactorID = "MEMPOOL"
+
 	MempoolChannel = byte(0x30)
 
 	maxMempoolMessageSize      = 1048576 // 1MB TODO make it configurable

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -64,18 +64,39 @@ func (memR *MempoolReactor) GetChannels() []*p2p.ChannelDescriptor {
 // It starts a broadcast routine ensuring all txs are forwarded to the given peer.
 func (memR *MempoolReactor) AddPeer(peer p2p.Peer) {
 	// Getting the peer metric initializes it in the store
-	tms := memR.Switch.MetricStore()
-	tm := tms.GetPeerTrustMetric(peer.String(), MempoolReactorID)
+	if memR.Switch != nil {
+		if tms := memR.Switch.MetricStore(); tms != nil {
+			_ = tms.GetPeerTrustMetric(peer.Key(), MempoolReactorID)
+		}
+	}
 
 	go memR.broadcastTxRoutine(peer)
 }
 
 // MarkPeer implements Reactor.
 // It updates a peer's metric with good or bad events taking place within this reactor
-func (memR *MempoolReactor) MarkPeer(peer Peer, good bool, events int) {
-	tms := memR.Switch.MetricStore()
-	tm := tms.GetPeerTrustMetric(peer.String(), MempoolReactorID)
+func (memR *MempoolReactor) MarkPeer(peer p2p.Peer, good bool, events, severity int) {
+	if memR.Switch == nil {
+		return
+	}
 
+	tms := memR.Switch.MetricStore()
+	if tms == nil {
+		return
+	}
+
+	// Modify the number of events based on severity
+	num := events
+	switch severity {
+	case p2p.Fatal, p2p.Good:
+		num *= 10
+	case p2p.Bad, p2p.Correct:
+		// These result in events * 1
+	case p2p.Neutral:
+		num *= 0
+	}
+
+	tm := tms.GetPeerTrustMetric(peer.Key(), MempoolReactorID)
 	if good {
 		tm.GoodEvents(events)
 	} else {
@@ -87,9 +108,12 @@ func (memR *MempoolReactor) MarkPeer(peer Peer, good bool, events int) {
 func (memR *MempoolReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 	// broadcast routine checks if peer is gone and returns
 
-	tms := memR.Switch.MetricStore()
-	// Pause tracking of this peer
-	tms.PeerDisconnected(peer.String(), MempoolReactorID)
+	if memR.Switch != nil {
+		if tms := memR.Switch.MetricStore(); tms != nil {
+			// Pause tracking of this peer
+			tms.PeerDisconnected(peer.Key(), MempoolReactorID)
+		}
+	}
 }
 
 // Receive implements Reactor.
@@ -108,6 +132,7 @@ func (memR *MempoolReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) {
 		if err != nil {
 			memR.Logger.Info("Could not check tx", "tx", msg.Tx, "err", err)
 		}
+		memR.MarkPeer(src, true, 1, p2p.Correct)
 		// broadcasting happens from go routines per peer
 	default:
 		memR.Logger.Error(fmt.Sprintf("Unknown message type %v", reflect.TypeOf(msg)))

--- a/node/node.go
+++ b/node/node.go
@@ -221,9 +221,9 @@ func NewNode(config *cfg.Config,
 
 	sw := p2p.NewSwitch(config.P2P)
 	sw.SetLogger(p2pLogger)
-	sw.AddReactor("MEMPOOL", mempoolReactor)
-	sw.AddReactor("BLOCKCHAIN", bcReactor)
-	sw.AddReactor("CONSENSUS", consensusReactor)
+	sw.AddReactor(MempoolReactorID, mempoolReactor)
+	sw.AddReactor(BlockchainReactorID, bcReactor)
+	sw.AddReactor(ConsensusReactorID, consensusReactor)
 
 	// Optionally, start the pex reactor
 	var addrBook *p2p.AddrBook
@@ -242,7 +242,7 @@ func NewNode(config *cfg.Config,
 
 		pexReactor := p2p.NewPEXReactor(addrBook)
 		pexReactor.SetLogger(p2pLogger)
-		sw.AddReactor("PEX", pexReactor)
+		sw.AddReactor(PexReactorID, pexReactor)
 	}
 
 	// Filter peers by addr or pubkey with an ABCI query.

--- a/node/node.go
+++ b/node/node.go
@@ -95,10 +95,9 @@ type Node struct {
 	privValidator types.PrivValidator // local node's validator key
 
 	// network
-	privKey          crypto.PrivKeyEd25519   // local node's p2p key
-	sw               *p2p.Switch             // p2p connections
-	addrBook         *p2p.AddrBook           // known peers
-	trustMetricStore *trust.TrustMetricStore // trust metrics for all peers
+	privKey  crypto.PrivKeyEd25519 // local node's p2p key
+	sw       *p2p.Switch           // p2p connections
+	addrBook *p2p.AddrBook         // known peers
 
 	// services
 	eventBus         *types.EventBus             // pub/sub for services
@@ -227,7 +226,6 @@ func NewNode(config *cfg.Config,
 
 	// Optionally, start the pex reactor
 	var addrBook *p2p.AddrBook
-	var trustMetricStore *trust.TrustMetricStore
 	if config.P2P.PexReactor {
 		addrBook = p2p.NewAddrBook(config.P2P.AddrBookFile(), config.P2P.AddrBookStrict)
 		addrBook.SetLogger(p2pLogger.With("book", config.P2P.AddrBookFile()))
@@ -237,8 +235,9 @@ func NewNode(config *cfg.Config,
 		if err != nil {
 			return nil, err
 		}
-		trustMetricStore = trust.NewTrustMetricStore(trustHistoryDB, trust.DefaultConfig())
+		trustMetricStore := trust.NewTrustMetricStore(trustHistoryDB, trust.DefaultConfig())
 		trustMetricStore.SetLogger(p2pLogger)
+		sw.SetMetricStore(trustMetricStore)
 
 		pexReactor := p2p.NewPEXReactor(addrBook)
 		pexReactor.SetLogger(p2pLogger)
@@ -313,10 +312,9 @@ func NewNode(config *cfg.Config,
 		genesisDoc:    genDoc,
 		privValidator: privValidator,
 
-		privKey:          privKey,
-		sw:               sw,
-		addrBook:         addrBook,
-		trustMetricStore: trustMetricStore,
+		privKey:  privKey,
+		sw:       sw,
+		addrBook: addrBook,
 
 		blockStore:       blockStore,
 		bcReactor:        bcReactor,

--- a/p2p/pex_reactor.go
+++ b/p2p/pex_reactor.go
@@ -117,7 +117,7 @@ func (r *PEXReactor) AddPeer(p Peer) {
 		addr, err := NewNetAddressString(p.NodeInfo().ListenAddr)
 		if err != nil {
 			// peer gave us a bad ListenAddr
-			p.Mark(r.GetID(), false, 1, PeerMarkBad)
+			p.MarkAsBadNEventsWithSeverity(r.GetID(), 1, PeerMarkBad)
 			r.Logger.Error("Error in AddPeer: invalid peer address", "addr", p.NodeInfo().ListenAddr, "err", err)
 			return
 		}
@@ -149,7 +149,7 @@ func (r *PEXReactor) Receive(chID byte, src Peer, msgBytes []byte) {
 	if r.ReachedMaxMsgCountForPeer(srcAddrStr) {
 		r.Logger.Error("Maximum number of messages reached for peer", "peer", srcAddrStr)
 		// TODO remove src from peers?
-		src.Mark(r.GetID(), false, 1, PeerMarkFatal)
+		src.MarkAsBadNEventsWithSeverity(r.GetID(), 1, PeerMarkFatal)
 		return
 	}
 
@@ -295,12 +295,12 @@ func (r *PEXReactor) ensurePeers() {
 				r.book.MarkAttempt(picked)
 				// Negatively mark the peer that provided the address
 				if peer != nil {
-					peer.Mark(r.GetID(), false, 1, PeerMarkBad)
+					peer.MarkAsBadNEventsWithSeverity(r.GetID(), 1, PeerMarkBad)
 				}
 			}
 			// Positively mark the peer that provided the dialed address
 			if peer != nil {
-				peer.Mark(r.GetID(), true, 1, PeerMarkGood)
+				peer.MarkAsGoodNEventsWithSeverity(r.GetID(), 1, PeerMarkGood)
 			}
 		}(item)
 	}

--- a/p2p/pex_reactor.go
+++ b/p2p/pex_reactor.go
@@ -12,6 +12,9 @@ import (
 )
 
 const (
+	// PexReactorID is the name used by various services to identify the PEX reactor
+	PexReactorID = "PEX"
+
 	// PexChannel is a channel for PEX messages
 	PexChannel = byte(0x00)
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -31,13 +31,22 @@ const (
 	reconnectBackOffBaseSeconds = 3
 )
 
+// The following constants modify the number of events sent to a metric based on severity
+const (
+	Fatal = iota
+	Bad
+	Neutral
+	Correct
+	Good
+)
+
 type Reactor interface {
 	cmn.Service // Start, Stop
 
 	SetSwitch(*Switch)
 	GetChannels() []*ChannelDescriptor
 	AddPeer(peer Peer)
-	MarkPeer(peer Peer, good bool, events int)
+	MarkPeer(peer Peer, good bool, events, severity int)
 	RemovePeer(peer Peer, reason interface{})
 	Receive(chID byte, peer Peer, msgBytes []byte) // CONTRACT: msgBytes are not nil
 }

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -11,6 +11,7 @@ import (
 
 	crypto "github.com/tendermint/go-crypto"
 	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/p2p/trust"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
@@ -36,6 +37,7 @@ type Reactor interface {
 	SetSwitch(*Switch)
 	GetChannels() []*ChannelDescriptor
 	AddPeer(peer Peer)
+	MarkPeer(peer Peer, good bool, events int)
 	RemovePeer(peer Peer, reason interface{})
 	Receive(chID byte, peer Peer, msgBytes []byte) // CONTRACT: msgBytes are not nil
 }
@@ -80,6 +82,7 @@ type Switch struct {
 	chDescs      []*ChannelDescriptor
 	reactorsByCh map[byte]Reactor
 	peers        *PeerSet
+	metricStore  *trust.TrustMetricStore // trust metrics for all peers
 	dialing      *cmn.CMap
 	nodeInfo     *NodeInfo             // our node info
 	nodePrivKey  crypto.PrivKeyEd25519 // our node privkey
@@ -179,6 +182,18 @@ func (sw *Switch) SetNodeInfo(nodeInfo *NodeInfo) {
 // NOTE: Not goroutine safe.
 func (sw *Switch) NodeInfo() *NodeInfo {
 	return sw.nodeInfo
+}
+
+// MetricStore - Returns the switch's TrustMetricStore.
+// NOTE: Not goroutine safe.
+func (sw *Switch) MetricStore() *trust.TrustMetricStore {
+	return sw.metricStore
+}
+
+// SetMetricStore - Sets the switch's TrustMetricStore for allowing all reactors to access the metrics.
+// NOTE: Not goroutine safe.
+func (sw *Switch) SetMetricStore(tms *trust.TrustMetricStore) {
+	sw.metricStore = tms
 }
 
 // SetNodePrivKey sets the switch's private key for authenticated encryption.

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -66,6 +66,11 @@ func (tr *TestReactor) AddPeer(peer Peer) {
 	tr.peersAdded = append(tr.peersAdded, peer)
 }
 
+func (tr *TestReactor) MarkPeer(peer Peer, good bool, events, severity int) {
+	// Does not currently mark during a test
+	return
+}
+
 func (tr *TestReactor) RemovePeer(peer Peer, reason interface{}) {
 	tr.mtx.Lock()
 	defer tr.mtx.Unlock()

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -56,6 +56,10 @@ func NewTestReactor(channels []*ChannelDescriptor, logMessages bool) *TestReacto
 	return tr
 }
 
+func (tr *TestReactor) GetID() string {
+	return "TestReactor"
+}
+
 func (tr *TestReactor) GetChannels() []*ChannelDescriptor {
 	return tr.channels
 }
@@ -64,11 +68,6 @@ func (tr *TestReactor) AddPeer(peer Peer) {
 	tr.mtx.Lock()
 	defer tr.mtx.Unlock()
 	tr.peersAdded = append(tr.peersAdded, peer)
-}
-
-func (tr *TestReactor) MarkPeer(peer Peer, good bool, events, severity int) {
-	// Does not currently mark during a test
-	return
 }
 
 func (tr *TestReactor) RemovePeer(peer Peer, reason interface{}) {

--- a/p2p/trust/store.go
+++ b/p2p/trust/store.go
@@ -115,13 +115,13 @@ func (tms *TrustMetricStore) GetPeerTrustMetric(peer, reactor string) *TrustMetr
 }
 
 // PeerDisconnected pauses the trust metric associated with the peer identified by the key
-func (tms *TrustMetricStore) PeerDisconnected(key string) {
+func (tms *TrustMetricStore) PeerDisconnected(peer, reactor string) {
 	tms.mtx.Lock()
 	defer tms.mtx.Unlock()
 
 	// If the peer that disconnected had metrics, pause them
-	for _, peers := range tms.reactorPeerMetrics {
-		if tm, ok := peers[key]; ok {
+	if peers, ok := tms.reactorPeerMetrics[reactor]; ok {
+		if tm, found := peers[peer]; found {
 			tm.Pause()
 		}
 	}

--- a/p2p/trust/store.go
+++ b/p2p/trust/store.go
@@ -141,9 +141,6 @@ func (tms *TrustMetricStore) SaveToDB() {
 // addPeerTrustMetric takes an existing trust metric and associates it with a peer and reactor ID.
 // This version of the method assumes the mutex has already been acquired
 func (tms *TrustMetricStore) addPeerTrustMetric(peer, reactor string, tm *TrustMetric) {
-	if peer == "" || reactor == "" || tm == nil {
-		return
-	}
 	// Check if we have a peer/metric map for this reactor yet
 	if _, ok := tms.reactorPeerMetrics[reactor]; !ok {
 		tms.reactorPeerMetrics[reactor] = make(map[string]*TrustMetric)
@@ -181,14 +178,14 @@ func (tms *TrustMetricStore) loadFromDB() bool {
 
 	// If history data exists in the file,
 	// load it into trust metric
-	for reactor, peers := range history {
-		for peer, data := range peers {
+	for reactorID, peerKeys := range history {
+		for pk, data := range peerKeys {
 			tm := NewMetricWithConfig(tms.config)
 
 			tm.Start()
 			tm.Init(data)
 			// Load the peer trust metric into the store
-			tms.addPeerTrustMetric(peer, reactor, tm)
+			tms.addPeerTrustMetric(pk, reactorID, tm)
 
 		}
 	}
@@ -201,12 +198,12 @@ func (tms *TrustMetricStore) saveToDB() {
 
 	history := make(map[string]map[string]MetricHistoryJSON)
 
-	for reactor, peers := range tms.reactorPeerMetrics {
-		history[reactor] = make(map[string]MetricHistoryJSON)
+	for reactorID, peerKeys := range tms.reactorPeerMetrics {
+		history[reactorID] = make(map[string]MetricHistoryJSON)
 
-		for peer, tm := range peers {
+		for pk, tm := range peerKeys {
 			// Add an entry for the metric
-			history[reactor][peer] = tm.HistoryJSON()
+			history[reactorID][pk] = tm.HistoryJSON()
 		}
 	}
 

--- a/p2p/trust/store_test.go
+++ b/p2p/trust/store_test.go
@@ -143,7 +143,7 @@ func TestTrustMetricStorePeerScore(t *testing.T) {
 	if second > first {
 		t.Errorf("A greater number of bad events should lower the trust score")
 	}
-	store.PeerDisconnected(key)
+	store.PeerDisconnected(key, "TestReactorID")
 
 	// We will remember our experiences with this peer
 	tm = store.GetPeerTrustMetric(key, "TestReactorID")


### PR DESCRIPTION
https://github.com/tendermint/tendermint/issues/867

This branch contains the work toward integrating the trust metric implementation with all the reactors within Tendermint. The reference to the trust metric store is now within the Switch, so all reactors can reach the trust metrics.

I've run into a roadblock though; some of the code (examples below) that needs to be able to punish peers for bad behavior cannot reach the reactor, and cannot mark peers.

https://github.com/tendermint/tendermint/blob/a1a5cb59a70e3075dbfc58614d2f1b83d5ad2a8b/consensus/types/height_vote_set.go#L119

https://github.com/tendermint/tendermint/blob/a1a5cb59a70e3075dbfc58614d2f1b83d5ad2a8b/blockchain/pool.go#L220

 I was hoping we could discuss the best solution to this current limitation within this PR. Thank you.