### PR TITLE
Feature/buildprocess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ all: check build test install metalinter
 
 check: check_tools get_vendor_deps
 
+
 ########################################
 ### Build
 


### PR DESCRIPTION
Extended the Makefile check_tools with make-compatible checks:
1. Check if go exists
2. Warn if it's not the version specified for deterministic builds
3. Warn if PATH doesn't contain GOPATH/bin
Also:
- Set new build flags to help with deterministic builds
- Minor fix to evaluate static variables only once

Most changes are `make` commands, so we don't rely on external dependencies like bash.