### PR TITLE
lite: memStoreProvider GetHeightBinarySearch method + fix ValKeys.signHeaders

### DIFF
--- a/lite/helpers.go
+++ b/lite/helpers.go
@@ -78,6 +78,9 @@ func (v ValKeys) signHeader(header *types.Header, first, last int) *types.Commit
 
 	// fill in the votes we want
 	for i := first; i < last; i++ {
+		if i >= len(v) {
+			break
+		}
 		vote := makeVote(header, vset, v[i])
 		votes[vote.ValidatorIndex] = vote
 	}

--- a/lite/helpers.go
+++ b/lite/helpers.go
@@ -77,10 +77,7 @@ func (v ValKeys) signHeader(header *types.Header, first, last int) *types.Commit
 	vset := v.ToValidators(1, 0)
 
 	// fill in the votes we want
-	for i := first; i < last; i++ {
-		if i >= len(v) {
-			break
-		}
+	for i := first; i < last && i < len(v); i++ {
 		vote := makeVote(header, vset, v[i])
 		votes[vote.ValidatorIndex] = vote
 	}

--- a/lite/memprovider.go
+++ b/lite/memprovider.go
@@ -89,7 +89,7 @@ func (m *memStoreProvider) GetByHeightBinarySearch(h int64) (FullCommit, error) 
 	var midFC FullCommit
 	// Our goal is to either find:
 	//   * item ByHeight with the query
-	//   * heighest height with a height <= query
+	//   * greatest height with a height <= query
 	for low <= high {
 		mid = int(uint(low+high) >> 1) // Avoid an overflow
 		midFC = m.byHeight[mid]

--- a/lite/memprovider.go
+++ b/lite/memprovider.go
@@ -60,8 +60,8 @@ func (m *memStoreProvider) StoreCommit(fc FullCommit) error {
 
 // GetByHeight returns the FullCommit for height h or an error if the commit is not found.
 func (m *memStoreProvider) GetByHeight(h int64) (FullCommit, error) {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	if !m.sorted {
 		sort.Sort(m.byHeight)
 		m.sorted = true
@@ -77,8 +77,8 @@ func (m *memStoreProvider) GetByHeight(h int64) (FullCommit, error) {
 
 // GetByHeight returns the FullCommit for height h or an error if the commit is not found.
 func (m *memStoreProvider) GetByHeightBinarySearch(h int64) (FullCommit, error) {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	if !m.sorted {
 		sort.Sort(m.byHeight)
 		m.sorted = true

--- a/lite/performance_test.go
+++ b/lite/performance_test.go
@@ -1,4 +1,4 @@
-package lite_test
+package lite
 
 import (
 	"fmt"
@@ -6,30 +6,124 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/tendermint/tendermint/lite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	liteErr "github.com/tendermint/tendermint/lite/errors"
 )
 
+func TestMemStoreProvidergetByHeightBinaryAndLinearSameResult(t *testing.T) {
+	p := NewMemStoreProvider().(*memStoreProvider)
+
+	// Store a bunch of commits at specific heights
+	// and then ensure that:
+	//  * getByHeightLinearSearch
+	//  * getByHeightBinarySearch
+	// both return the exact same result
+
+	// 1. Non-existent height commits
+	nonExistent := []int64{-1000, -1, 0, 1, 10, 11, 17, 31, 67, 1000, 1e9}
+	ensureNonExistentCommitsAtHeight(t, "getByHeightLinearSearch", p.getByHeightLinearSearch, nonExistent)
+	ensureNonExistentCommitsAtHeight(t, "getByHeightBinarySearch", p.getByHeightBinarySearch, nonExistent)
+
+	// 2. Save some known height commits
+	knownHeights := []int64{0, 1, 7, 9, 12, 13, 18, 44, 23, 16, 1024, 100, 199, 1e9}
+	createAndStoreCommits(t, p, knownHeights)
+
+	// 3. Now check if those heights are retrieved
+	ensureExistentCommitsAtHeight(t, "getByHeightLinearSearch", p.getByHeightLinearSearch, knownHeights)
+	ensureExistentCommitsAtHeight(t, "getByHeightBinarySearch", p.getByHeightBinarySearch, knownHeights)
+
+	// 4. And now for the height probing to ensure that any height
+	// requested returns a fullCommit of height <= requestedHeight.
+	comparegetByHeightAlgorithms(t, p, 0, 0)
+	comparegetByHeightAlgorithms(t, p, 1, 1)
+	comparegetByHeightAlgorithms(t, p, 2, 1)
+	comparegetByHeightAlgorithms(t, p, 5, 1)
+	comparegetByHeightAlgorithms(t, p, 7, 7)
+	comparegetByHeightAlgorithms(t, p, 10, 9)
+	comparegetByHeightAlgorithms(t, p, 12, 12)
+	comparegetByHeightAlgorithms(t, p, 14, 13)
+	comparegetByHeightAlgorithms(t, p, 19, 18)
+	comparegetByHeightAlgorithms(t, p, 43, 23)
+	comparegetByHeightAlgorithms(t, p, 45, 44)
+	comparegetByHeightAlgorithms(t, p, 1025, 1024)
+	comparegetByHeightAlgorithms(t, p, 101, 100)
+	comparegetByHeightAlgorithms(t, p, 1e3, 199)
+	comparegetByHeightAlgorithms(t, p, 1e4, 1024)
+	comparegetByHeightAlgorithms(t, p, 1e9, 1e9)
+	comparegetByHeightAlgorithms(t, p, 1e9+1, 1e9)
+}
+
+func createAndStoreCommits(t *testing.T, p Provider, heights []int64) {
+	chainID := "cache-best-height-binary-and-linear"
+	appHash := []byte("0xdeadbeef")
+	keys := GenValKeys(len(heights) / 2)
+
+	for _, h := range heights {
+		vals := keys.ToValidators(10, int64(len(heights)/2))
+		fc := keys.GenFullCommit(chainID, h, nil, vals, appHash, []byte("params"), []byte("results"), 0, 5)
+		err := p.StoreCommit(fc)
+		require.NoError(t, err, "StoreCommit height=%d", h)
+	}
+}
+
+func comparegetByHeightAlgorithms(t *testing.T, p *memStoreProvider, ask, expect int64) {
+	algos := map[string]func(int64) (FullCommit, error){
+		"getHeightByLinearSearch": p.getByHeightLinearSearch,
+		"getHeightByBinarySearch": p.getByHeightBinarySearch,
+	}
+
+	for algo, fn := range algos {
+		fc, err := fn(ask)
+		// t.Logf("%s got=%v want=%d", algo, expect, fc.Height())
+		require.Nil(t, err, "%s: %+v", algo, err)
+		if assert.Equal(t, expect, fc.Height()) {
+			err = p.StoreCommit(fc)
+			require.Nil(t, err, "%s: %+v", algo, err)
+		}
+	}
+}
+
+var blankFullCommit FullCommit
+
+func ensureNonExistentCommitsAtHeight(t *testing.T, prefix string, fn func(int64) (FullCommit, error), data []int64) {
+	for i, qh := range data {
+		fc, err := fn(qh)
+		assert.NotNil(t, err, "#%d: %s: height=%d should return non-nil error", i, prefix, qh)
+		assert.Equal(t, fc, blankFullCommit, "#%d: %s: height=%d\ngot =%+v\nwant=%+v", i, prefix, qh, fc, blankFullCommit)
+	}
+}
+
+func ensureExistentCommitsAtHeight(t *testing.T, prefix string, fn func(int64) (FullCommit, error), data []int64) {
+	for i, qh := range data {
+		fc, err := fn(qh)
+		assert.Nil(t, err, "#%d: %s: height=%d should not return an error: %v", i, prefix, qh, err)
+		assert.NotEqual(t, fc, blankFullCommit, "#%d: %s: height=%d got a blankCommit", i, prefix, qh)
+	}
+}
+
 func BenchmarkGenCommit20(b *testing.B) {
-	keys := lite.GenValKeys(20)
+	keys := GenValKeys(20)
 	benchmarkGenCommit(b, keys)
 }
 
 func BenchmarkGenCommit100(b *testing.B) {
-	keys := lite.GenValKeys(100)
+	keys := GenValKeys(100)
 	benchmarkGenCommit(b, keys)
 }
 
 func BenchmarkGenCommitSec20(b *testing.B) {
-	keys := lite.GenSecpValKeys(20)
+	keys := GenSecpValKeys(20)
 	benchmarkGenCommit(b, keys)
 }
 
 func BenchmarkGenCommitSec100(b *testing.B) {
-	keys := lite.GenSecpValKeys(100)
+	keys := GenSecpValKeys(100)
 	benchmarkGenCommit(b, keys)
 }
 
-func benchmarkGenCommit(b *testing.B, keys lite.ValKeys) {
+func benchmarkGenCommit(b *testing.B, keys ValKeys) {
 	chainID := fmt.Sprintf("bench-%d", len(keys))
 	vals := keys.ToValidators(20, 10)
 	for i := 0; i < b.N; i++ {
@@ -42,7 +136,7 @@ func benchmarkGenCommit(b *testing.B, keys lite.ValKeys) {
 
 // this benchmarks generating one key
 func BenchmarkGenValKeys(b *testing.B) {
-	keys := lite.GenValKeys(20)
+	keys := GenValKeys(20)
 	for i := 0; i < b.N; i++ {
 		keys = keys.Extend(1)
 	}
@@ -50,7 +144,7 @@ func BenchmarkGenValKeys(b *testing.B) {
 
 // this benchmarks generating one key
 func BenchmarkGenSecpValKeys(b *testing.B) {
-	keys := lite.GenSecpValKeys(20)
+	keys := GenSecpValKeys(20)
 	for i := 0; i < b.N; i++ {
 		keys = keys.Extend(1)
 	}
@@ -66,7 +160,7 @@ func BenchmarkToValidators100(b *testing.B) {
 
 // this benchmarks constructing the validator set (.PubKey() * nodes)
 func benchmarkToValidators(b *testing.B, nodes int) {
-	keys := lite.GenValKeys(nodes)
+	keys := GenValKeys(nodes)
 	for i := 1; i <= b.N; i++ {
 		keys.ToValidators(int64(2*i), int64(i))
 	}
@@ -78,36 +172,36 @@ func BenchmarkToValidatorsSec100(b *testing.B) {
 
 // this benchmarks constructing the validator set (.PubKey() * nodes)
 func benchmarkToValidatorsSec(b *testing.B, nodes int) {
-	keys := lite.GenSecpValKeys(nodes)
+	keys := GenSecpValKeys(nodes)
 	for i := 1; i <= b.N; i++ {
 		keys.ToValidators(int64(2*i), int64(i))
 	}
 }
 
 func BenchmarkCertifyCommit20(b *testing.B) {
-	keys := lite.GenValKeys(20)
+	keys := GenValKeys(20)
 	benchmarkCertifyCommit(b, keys)
 }
 
 func BenchmarkCertifyCommit100(b *testing.B) {
-	keys := lite.GenValKeys(100)
+	keys := GenValKeys(100)
 	benchmarkCertifyCommit(b, keys)
 }
 
 func BenchmarkCertifyCommitSec20(b *testing.B) {
-	keys := lite.GenSecpValKeys(20)
+	keys := GenSecpValKeys(20)
 	benchmarkCertifyCommit(b, keys)
 }
 
 func BenchmarkCertifyCommitSec100(b *testing.B) {
-	keys := lite.GenSecpValKeys(100)
+	keys := GenSecpValKeys(100)
 	benchmarkCertifyCommit(b, keys)
 }
 
-func benchmarkCertifyCommit(b *testing.B, keys lite.ValKeys) {
+func benchmarkCertifyCommit(b *testing.B, keys ValKeys) {
 	chainID := "bench-certify"
 	vals := keys.ToValidators(20, 10)
-	cert := lite.NewStaticCertifier(chainID, vals)
+	cert := NewStaticCertifier(chainID, vals)
 	check := keys.GenCommit(chainID, 123, nil, vals, []byte("foo"), []byte("params"), []byte("res"), 0, len(keys))
 	for i := 0; i < b.N; i++ {
 		err := cert.Certify(check)
@@ -126,67 +220,73 @@ const (
 )
 
 // Lazy load the commits
-var fcs5, fcs50, fcs100, fcs500, fcs1000 []lite.FullCommit
+var fcs5, fcs50, fcs100, fcs500, fcs1000 []FullCommit
 var h5, h50, h100, h500, h1000 []int64
 var commitsOnce sync.Once
 
-func lazyGenerateFullCommits() {
+func lazyGenerateFullCommits(b *testing.B) {
+	b.Logf("Generating FullCommits")
 	commitsOnce.Do(func() {
 		fcs5, h5 = genFullCommits(nil, nil, 5)
+		b.Logf("Generated 5 FullCommits")
 		fcs50, h50 = genFullCommits(fcs5, h5, 50)
+		b.Logf("Generated 50 FullCommits")
 		fcs100, h100 = genFullCommits(fcs50, h50, 100)
+		b.Logf("Generated 100 FullCommits")
 		fcs500, h500 = genFullCommits(fcs100, h100, 500)
+		b.Logf("Generated 500 FullCommits")
 		fcs1000, h1000 = genFullCommits(fcs500, h500, 1000)
+		b.Logf("Generated 1000 FullCommits")
 	})
 }
 
 func BenchmarkMemStoreProviderGetByHeightLinearSearch5(b *testing.B) {
-	benchmarkMemStoreProviderGetByHeight(b, fcs5, h5, linearSearch)
+	benchmarkMemStoreProvidergetByHeight(b, fcs5, h5, linearSearch)
 }
 
 func BenchmarkMemStoreProviderGetByHeightLinearSearch50(b *testing.B) {
-	benchmarkMemStoreProviderGetByHeight(b, fcs50, h50, linearSearch)
+	benchmarkMemStoreProvidergetByHeight(b, fcs50, h50, linearSearch)
 }
 
 func BenchmarkMemStoreProviderGetByHeightLinearSearch100(b *testing.B) {
-	benchmarkMemStoreProviderGetByHeight(b, fcs100, h100, linearSearch)
+	benchmarkMemStoreProvidergetByHeight(b, fcs100, h100, linearSearch)
 }
 
 func BenchmarkMemStoreProviderGetByHeightLinearSearch500(b *testing.B) {
-	benchmarkMemStoreProviderGetByHeight(b, fcs500, h500, linearSearch)
+	benchmarkMemStoreProvidergetByHeight(b, fcs500, h500, linearSearch)
 }
 
 func BenchmarkMemStoreProviderGetByHeightLinearSearch1000(b *testing.B) {
-	benchmarkMemStoreProviderGetByHeight(b, fcs1000, h1000, linearSearch)
+	benchmarkMemStoreProvidergetByHeight(b, fcs1000, h1000, linearSearch)
 }
 
 func BenchmarkMemStoreProviderGetByHeightBinarySearch5(b *testing.B) {
-	benchmarkMemStoreProviderGetByHeight(b, fcs5, h5, binarySearch)
+	benchmarkMemStoreProvidergetByHeight(b, fcs5, h5, binarySearch)
 }
 
 func BenchmarkMemStoreProviderGetByHeightBinarySearch50(b *testing.B) {
-	benchmarkMemStoreProviderGetByHeight(b, fcs50, h50, binarySearch)
+	benchmarkMemStoreProvidergetByHeight(b, fcs50, h50, binarySearch)
 }
 
 func BenchmarkMemStoreProviderGetByHeightBinarySearch100(b *testing.B) {
-	benchmarkMemStoreProviderGetByHeight(b, fcs100, h100, binarySearch)
+	benchmarkMemStoreProvidergetByHeight(b, fcs100, h100, binarySearch)
 }
 
 func BenchmarkMemStoreProviderGetByHeightBinarySearch500(b *testing.B) {
-	benchmarkMemStoreProviderGetByHeight(b, fcs500, h500, binarySearch)
+	benchmarkMemStoreProvidergetByHeight(b, fcs500, h500, binarySearch)
 }
 
 func BenchmarkMemStoreProviderGetByHeightBinarySearch1000(b *testing.B) {
-	benchmarkMemStoreProviderGetByHeight(b, fcs1000, h1000, binarySearch)
+	benchmarkMemStoreProvidergetByHeight(b, fcs1000, h1000, binarySearch)
 }
 
 var rng = rand.New(rand.NewSource(10))
 
-func benchmarkMemStoreProviderGetByHeight(b *testing.B, fcs []lite.FullCommit, fHeights []int64, algo algo) {
-	lazyGenerateFullCommits()
+func benchmarkMemStoreProvidergetByHeight(b *testing.B, fcs []FullCommit, fHeights []int64, algo algo) {
+	lazyGenerateFullCommits(b)
 
 	b.StopTimer()
-	mp := lite.NewMemStoreProvider()
+	mp := NewMemStoreProvider()
 	for i, fc := range fcs {
 		if err := mp.StoreCommit(fc); err != nil {
 			b.Fatalf("FullCommit #%d: err: %v", i, err)
@@ -197,11 +297,10 @@ func benchmarkMemStoreProviderGetByHeight(b *testing.B, fcs []lite.FullCommit, f
 	// Append some non-existent heights to trigger the worst cases.
 	qHeights = append(qHeights, 19, -100, -10000, 1e7, -17, 31, -1e9)
 
-	searchFn := mp.GetByHeight
+	memP := mp.(*memStoreProvider)
+	searchFn := memP.getByHeightLinearSearch
 	if algo == binarySearch { // nolint
-		searchFn = mp.(interface {
-			GetByHeightBinarySearch(h int64) (lite.FullCommit, error)
-		}).GetByHeightBinarySearch
+		searchFn = memP.getByHeightBinarySearch
 	}
 
 	hPerm := rng.Perm(len(qHeights))
@@ -217,8 +316,8 @@ func benchmarkMemStoreProviderGetByHeight(b *testing.B, fcs []lite.FullCommit, f
 	b.ReportAllocs()
 }
 
-func genFullCommits(prevFC []lite.FullCommit, prevH []int64, want int) ([]lite.FullCommit, []int64) {
-	fcs := make([]lite.FullCommit, len(prevFC))
+func genFullCommits(prevFC []FullCommit, prevH []int64, want int) ([]FullCommit, []int64) {
+	fcs := make([]FullCommit, len(prevFC))
 	copy(fcs, prevFC)
 	heights := make([]int64, len(prevH))
 	copy(heights, prevH)
@@ -226,7 +325,7 @@ func genFullCommits(prevFC []lite.FullCommit, prevH []int64, want int) ([]lite.F
 	appHash := []byte("benchmarks")
 	chainID := "benchmarks-gen-full-commits"
 	n := want
-	keys := lite.GenValKeys(2 + (n / 3))
+	keys := GenValKeys(2 + (n / 3))
 	for i := 0; i < n; i++ {
 		vals := keys.ToValidators(10, int64(n/2))
 		h := int64(20 + 10*i)
@@ -234,4 +333,33 @@ func genFullCommits(prevFC []lite.FullCommit, prevH []int64, want int) ([]lite.F
 		heights = append(heights, h)
 	}
 	return fcs, heights
+}
+
+func TestMemStoreProviderLatestCommitAlwaysUsesSorted(t *testing.T) {
+	p := NewMemStoreProvider().(*memStoreProvider)
+	// 1. With no commits yet stored, it should return ErrCommitNotFound
+	got, err := p.LatestCommit()
+	require.Equal(t, err.Error(), liteErr.ErrCommitNotFound().Error(), "should return ErrCommitNotFound()")
+	require.Equal(t, got, blankFullCommit, "With no fullcommits, it should return a blank FullCommit")
+
+	// 2. Generate some full commits now and we'll add them unsorted.
+	genAndStoreCommitsOfHeight(t, p, 27, 100, 1, 12, 1000, 17, 91)
+	fc, err := p.LatestCommit()
+	require.Nil(t, err, "with commits saved no error expected")
+	require.NotEqual(t, fc, blankFullCommit, "with commits saved no blank FullCommit")
+	require.Equal(t, fc.Height(), int64(1000), "the latest commit i.e. the largest expected")
+}
+
+func genAndStoreCommitsOfHeight(t *testing.T, p Provider, heights ...int64) {
+	n := len(heights)
+	appHash := []byte("tests")
+	chainID := "tests-gen-full-commits"
+	keys := GenValKeys(2 + (n / 3))
+	for i := 0; i < n; i++ {
+		h := heights[i]
+		vals := keys.ToValidators(10, int64(n/2))
+		fc := keys.GenFullCommit(chainID, h, nil, vals, appHash, []byte("params"), []byte("results"), 0, 5)
+		err := p.StoreCommit(fc)
+		require.NoError(t, err, "StoreCommit height=%d", h)
+	}
 }

--- a/lite/performance_test.go
+++ b/lite/performance_test.go
@@ -198,7 +198,7 @@ func benchmarkMemStoreProviderGetByHeight(b *testing.B, fcs []lite.FullCommit, f
 	qHeights = append(qHeights, 19, -100, -10000, 1e7, -17, 31, -1e9)
 
 	searchFn := mp.GetByHeight
-	if algo == binarySearch {
+	if algo == binarySearch { // nolint
 		searchFn = mp.(interface {
 			GetByHeightBinarySearch(h int64) (lite.FullCommit, error)
 		}).GetByHeightBinarySearch

--- a/lite/provider_test.go
+++ b/lite/provider_test.go
@@ -100,13 +100,30 @@ func checkProvider(t *testing.T, p lite.Provider, chainID, app string) {
 
 }
 
+type binarySearchHeightGetter interface {
+	GetByHeightBinarySearch(h int64) (lite.FullCommit, error)
+}
+
 // this will make a get height, and if it is good, set the data as well
 func checkGetHeight(t *testing.T, p lite.Provider, ask, expect int64) {
-	fc, err := p.GetByHeight(ask)
-	require.Nil(t, err, "%+v", err)
-	if assert.Equal(t, expect, fc.Height()) {
-		err = p.StoreCommit(fc)
-		require.Nil(t, err, "%+v", err)
+	// The goal here is to test checkGetHeight using both
+	// provider.GetByHeight
+	// *memStoreProvider.GetHeightBinarySearch
+	fnMap := map[string]func(int64) (lite.FullCommit, error){
+		"getByHeight": p.GetByHeight,
+	}
+	if bshg, ok := p.(binarySearchHeightGetter); ok {
+		fnMap["getByHeightBinary"] = bshg.GetByHeightBinarySearch
+	}
+
+	for algo, fn := range fnMap {
+		fc, err := fn(ask)
+		// t.Logf("%s got=%v want=%d", algo, expect, fc.Height())
+		require.Nil(t, err, "%s: %+v", algo, err)
+		if assert.Equal(t, expect, fc.Height()) {
+			err = p.StoreCommit(fc)
+			require.Nil(t, err, "%s: %+v", algo, err)
+		}
 	}
 }
 
@@ -146,4 +163,78 @@ func TestCacheGetsBestHeight(t *testing.T) {
 	// now, query the cache for a higher value
 	checkGetHeight(t, p2, 99, 90)
 	checkGetHeight(t, cp, 99, 90)
+}
+
+var blankFullCommit lite.FullCommit
+
+func ensureNonExistentCommitsAtHeight(t *testing.T, prefix string, fn func(int64) (lite.FullCommit, error), data []int64) {
+	for i, qh := range data {
+		fc, err := fn(qh)
+		assert.NotNil(t, err, "#%d: %s: height=%d should return non-nil error", i, prefix, qh)
+		assert.Equal(t, fc, blankFullCommit, "#%d: %s: height=%d\ngot =%+v\nwant=%+v", i, prefix, qh, fc, blankFullCommit)
+	}
+}
+
+func TestMemStoreProviderGetByHeightBinaryAndLinearSameResult(t *testing.T) {
+	p := lite.NewMemStoreProvider()
+
+	// Store a bunch of commits at specific heights
+	// and then ensure that:
+	//  * GetByHeight
+	//  * GetByHeightBinarySearch
+	// both return the exact same result
+
+	// 1. Non-existent height commits
+	nonExistent := []int64{-1000, -1, 0, 1, 10, 11, 17, 31, 67, 1000, 1e9}
+	ensureNonExistentCommitsAtHeight(t, "GetByHeight", p.GetByHeight, nonExistent)
+	ensureNonExistentCommitsAtHeight(t, "GetByHeightBinarySearch", p.(binarySearchHeightGetter).GetByHeightBinarySearch, nonExistent)
+
+	// 2. Save some known height commits
+	knownHeights := []int64{0, 1, 7, 9, 12, 13, 18, 44, 23, 16, 1024, 100, 199, 1e9}
+	createAndStoreCommits(t, p, knownHeights)
+
+	// 3. Now check if those heights are retrieved
+	ensureExistentCommitsAtHeight(t, "GetByHeight", p.GetByHeight, knownHeights)
+	ensureExistentCommitsAtHeight(t, "GetByHeightBinarySearch", p.(binarySearchHeightGetter).GetByHeightBinarySearch, knownHeights)
+
+	// 4. And now for the height probing to ensure that any height
+	// requested returns a fullCommit of height <= requestedHeight.
+	checkGetHeight(t, p, 0, 0)
+	checkGetHeight(t, p, 1, 1)
+	checkGetHeight(t, p, 2, 1)
+	checkGetHeight(t, p, 5, 1)
+	checkGetHeight(t, p, 7, 7)
+	checkGetHeight(t, p, 10, 9)
+	checkGetHeight(t, p, 12, 12)
+	checkGetHeight(t, p, 14, 13)
+	checkGetHeight(t, p, 19, 18)
+	checkGetHeight(t, p, 43, 23)
+	checkGetHeight(t, p, 45, 44)
+	checkGetHeight(t, p, 1025, 1024)
+	checkGetHeight(t, p, 101, 100)
+	checkGetHeight(t, p, 1e3, 199)
+	checkGetHeight(t, p, 1e4, 1024)
+	checkGetHeight(t, p, 1e9, 1e9)
+	checkGetHeight(t, p, 1e9+1, 1e9)
+}
+
+func ensureExistentCommitsAtHeight(t *testing.T, prefix string, fn func(int64) (lite.FullCommit, error), data []int64) {
+	for i, qh := range data {
+		fc, err := fn(qh)
+		assert.Nil(t, err, "#%d: %s: height=%d should not return an error: %v", i, prefix, qh, err)
+		assert.NotEqual(t, fc, blankFullCommit, "#%d: %s: height=%d got a blankCommit", i, prefix, qh)
+	}
+}
+
+func createAndStoreCommits(t *testing.T, p lite.Provider, heights []int64) {
+	chainID := "cache-best-height-binary-and-linear"
+	appHash := []byte("0xdeadbeef")
+	keys := lite.GenValKeys(len(heights) / 2)
+
+	for _, h := range heights {
+		vals := keys.ToValidators(10, int64(len(heights)/2))
+		fc := keys.GenFullCommit(chainID, h, nil, vals, appHash, []byte("params"), []byte("results"), 0, 5)
+		err := p.StoreCommit(fc)
+		require.NoError(t, err, "StoreCommit height=%d", h)
+	}
 }


### PR DESCRIPTION
Updates #1021

* Implement a GetHeightBinarySearch method that looks for
the height using the binary search algorithm guaranteeing
worst case iteration time of O(log2(n))
whereas
worst case iteration time of O(n) for the current linear search

So if n we had 500 commits stored by height and sorted, to
trigger the worst case scenario for each, pass in
the most negative height you can find e.g. -1
Linear search: 500 iterations
Binary search: 9 iterations

with n=1000, qHeight = -1
Linear search: 1000 iterations
Binary search: 10 iterations

with n=1e6, qHeight = -1
Linear search: 1e6 iterations
Binary search: 20 iterations

Of course there are realistic expectations e.g. a max of
commits that may be saved so linear search might be useful
for very small size set because it has less preparing overhead
and only ~2 types of comparisons, but nonetheless binary search
shines as soon as we start to hit say 50 commits to search from
as you can see below:

```shell
$ go test -v -run=^$ -bench=MemStore
goos: darwin
goarch: amd64
pkg: github.com/tendermint/tendermint/lite
BenchmarkMemStoreProviderGetByHeightLinearSearch5-4     300000        6491 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightLinearSearch50-4      200000       12064 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightLinearSearch100-4      50000       32987 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightLinearSearch500-4       5000      395521 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightLinearSearch1000-4	       500     2940724 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightBinarySearch5-4     300000        6281 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightBinarySearch50-4      200000       10117 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightBinarySearch100-4     100000       18447 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightBinarySearch500-4      20000       89029 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightBinarySearch1000-4	      5000      265719 ns/op      1600 B/op       15 allocs/op
PASS
ok    github.com/tendermint/tendermint/lite 86.614s
$ go test -v -run=^$ -bench=MemStore
goos: darwin
goarch: amd64
pkg: github.com/tendermint/tendermint/lite
BenchmarkMemStoreProviderGetByHeightLinearSearch5-4     300000        6779 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightLinearSearch50-4      100000       12980 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightLinearSearch100-4      30000       43598 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightLinearSearch500-4       5000      377462 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightLinearSearch1000-4	       500     3278122 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightBinarySearch5-4     300000        7084 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightBinarySearch50-4      200000        9852 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightBinarySearch100-4     100000       19020 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightBinarySearch500-4      20000       99463 ns/op      1600 B/op       15 allocs/op
BenchmarkMemStoreProviderGetByHeightBinarySearch1000-4	      5000      259293 ns/op      1600 B/op       15 allocs/op
PASS
ok    github.com/tendermint/tendermint/lite 86.204s
```

which gives
```shell
$ benchstat old.txt new.txt
name                               old time/op    new time/op    delta
MemStoreProviderGetByHeight5-4       6.63µs ± 2%    6.68µs ± 6%   ~             (p=1.000 n=2+2)
MemStoreProviderGetByHeight50-4      12.5µs ± 4%    10.0µs ± 1%   ~             (p=0.333 n=2+2)
MemStoreProviderGetByHeight100-4     38.3µs ±14%    18.7µs ± 2%   ~             (p=0.333 n=2+2)
MemStoreProviderGetByHeight500-4      386µs ± 2%      94µs ± 6%   ~             (p=0.333 n=2+2)
MemStoreProviderGetByHeight1000-4    3.11ms ± 5%    0.26ms ± 1%   ~             (p=0.333 n=2+2)
```

If need be we can make a hybrid algorithm that switches between the
linear and binary search depending on the number of items.
This is reminiscent of Python's TimSort algorithm.