### PR TITLE
rename default user from ubuntu to vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,24 +26,24 @@ Vagrant.configure("2") do |config|
     apt-get install -y docker-ce golang-1.9-go
 
     # needed for docker
-    usermod -a -G docker ubuntu
+    usermod -a -G docker vagrant
 
     # use "EOF" not EOF to avoid variable substitution of $PATH
-    cat << "EOF" >> /home/ubuntu/.bash_profile
-export PATH=$PATH:/usr/lib/go-1.9/bin:/home/ubuntu/go/bin
-export GOPATH=/home/ubuntu/go
+    cat << "EOF" >> /home/vagrant/.bash_profile
+export PATH=$PATH:/usr/lib/go-1.9/bin:/home/vagrant/go/bin
+export GOPATH=/home/vagrant/go
 export LC_ALL=en_US.UTF-8
 cd go/src/github.com/tendermint/tendermint
 EOF
 
-    mkdir -p /home/ubuntu/go/bin
-    mkdir -p /home/ubuntu/go/src/github.com/tendermint
-    ln -s /vagrant /home/ubuntu/go/src/github.com/tendermint/tendermint
+    mkdir -p /home/vagrant/go/bin
+    mkdir -p /home/vagrant/go/src/github.com/tendermint
+    ln -s /vagrant /home/vagrant/go/src/github.com/tendermint/tendermint
 
-    chown -R ubuntu:ubuntu /home/ubuntu/go
-    chown ubuntu:ubuntu /home/ubuntu/.bash_profile
+    chown -R vagrant:vagrant /home/vagrant/go
+    chown vagrant:vagrant /home/vagrant/.bash_profile
 
     # get all deps and tools, ready to install/test
-    su - ubuntu -c 'cd /home/ubuntu/go/src/github.com/tendermint/tendermint && make get_tools && make get_vendor_deps'
+    su - vagrant -c 'cd /home/vagrant/go/src/github.com/tendermint/tendermint && make get_tools && make get_vendor_deps'
   SHELL
 end


### PR DESCRIPTION
vagrant docs says it must be vagrant user
https://www.vagrantup.com/docs/boxes/base.html#quot-vagrant-quot-user
If box does not do that, then it's not following vagrant requirements
and should not be used.