### PR TITLE
Fix Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ test/logs
 coverage.txt
 docs/_build
 docs/tools
+*.log
 
 scripts/wal2json/wal2json
 scripts/cutWALUntil/cutWALUntil

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,9 @@ Run `bash scripts/glide/status.sh` to get a list of vendored dependencies that m
 
 If you are a [Vagrant](https://www.vagrantup.com/) user, all you have to do to get started hacking Tendermint is:
 
+In case you installed Vagrant in 2017, you might need to run
+`vagrant box update` to upgrade to the latest `ubuntu/xenial64`.
+
 ```
 vagrant up
 vagrant ssh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,17 +42,17 @@ Run `bash scripts/glide/status.sh` to get a list of vendored dependencies that m
 
 ## Vagrant
 
-If you are a [Vagrant](https://www.vagrantup.com/) user, all you have to do to get started hacking Tendermint is:
+If you are a [Vagrant](https://www.vagrantup.com/) user, you can get started hacking Tendermint with the commands below.
 
-In case you installed Vagrant in 2017, you might need to run
+NOTE: In case you installed Vagrant in 2017, you might need to run
 `vagrant box update` to upgrade to the latest `ubuntu/xenial64`.
 
 ```
 vagrant up
 vagrant ssh
-cd ~/go/src/github.com/tendermint/tendermint
 make test
 ```
+
 
 ## Testing
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,6 @@ Vagrant.configure("2") do |config|
 
     # install base requirements
     apt-get update
-    apt-get upgrade -y
     apt-get install -y --no-install-recommends wget curl jq \
         make shellcheck bsdmainutils psmisc
     apt-get install -y docker-ce golang-1.9-go

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure("2") do |config|
     apt-get install -y docker-ce golang-1.9-go
     apt-get install -y language-pack-en
 
+    # cleanup
     apt-get autoremove -y
 
     # needed for docker
@@ -44,7 +45,7 @@ Vagrant.configure("2") do |config|
     chown vagrant:vagrant /home/vagrant/.bash_profile
 
     # get all deps and tools, ready to install/test
-    source /home/vagrant/.bash_profile
-    cd /home/vagrant/go/src/github.com/tendermint/tendermint && make get_tools && make get_vendor_deps
+    su - vagrant  -c 'source /home/vagrant/.bash_profile'
+    su - vagrant -c 'cd /home/vagrant/go/src/github.com/tendermint/tendermint && make get_tools && make get_vendor_deps'
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,7 @@ Vagrant.configure("2") do |config|
     echo 'export PATH=$PATH:/usr/lib/go-1.9/bin:/home/vagrant/go/bin' >> /home/vagrant/.bash_profile
     echo 'export GOPATH=/home/vagrant/go' >> /home/vagrant/.bash_profile
     echo 'export LC_ALL=en_US.UTF-8' >> /home/vagrant/.bash_profile
+    echo 'cd go/src/github.com/tendermint/tendermint' >> /home/vagrant/.bash_profile
 
     mkdir -p /home/vagrant/go/bin
     mkdir -p /home/vagrant/go/src/github.com/tendermint

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,29 +21,31 @@ Vagrant.configure("2") do |config|
 
     # install base requirements
     apt-get update
+    apt-get upgrade -y
     apt-get install -y --no-install-recommends wget curl jq \
         make shellcheck bsdmainutils psmisc
     apt-get install -y docker-ce golang-1.9-go
+    apt-get install -y language-pack-en
+
+    apt-get autoremove -y
 
     # needed for docker
-    usermod -a -G docker ubuntu
+    usermod -a -G docker vagrant
 
-    # use "EOF" not EOF to avoid variable substitution of $PATH
-    cat << "EOF" >> /home/ubuntu/.bash_profile
-export PATH=$PATH:/usr/lib/go-1.9/bin:/home/ubuntu/go/bin
-export GOPATH=/home/ubuntu/go
-export LC_ALL=en_US.UTF-8
-cd go/src/github.com/tendermint/tendermint
-EOF
+    # set env variables
+    echo 'export PATH=$PATH:/usr/lib/go-1.9/bin:/home/vagrant/go/bin' >> /home/vagrant/.bash_profile
+    echo 'export GOPATH=/home/vagrant/go' >> /home/vagrant/.bash_profile
+    echo 'export LC_ALL=en_US.UTF-8' >> /home/vagrant/.bash_profile
 
-    mkdir -p /home/ubuntu/go/bin
-    mkdir -p /home/ubuntu/go/src/github.com/tendermint
-    ln -s /vagrant /home/ubuntu/go/src/github.com/tendermint/tendermint
+    mkdir -p /home/vagrant/go/bin
+    mkdir -p /home/vagrant/go/src/github.com/tendermint
+    ln -s /vagrant /home/vagrant/go/src/github.com/tendermint/tendermint
 
-    chown -R ubuntu:ubuntu /home/ubuntu/go
-    chown ubuntu:ubuntu /home/ubuntu/.bash_profile
+    chown -R vagrant:vagrant /home/vagrant/go
+    chown vagrant:vagrant /home/vagrant/.bash_profile
 
     # get all deps and tools, ready to install/test
-    su - ubuntu -c 'cd /home/ubuntu/go/src/github.com/tendermint/tendermint && make get_tools && make get_vendor_deps'
+    source /home/vagrant/.bash_profile
+    cd /home/vagrant/go/src/github.com/tendermint/tendermint && make get_tools && make get_vendor_deps
   SHELL
 end


### PR DESCRIPTION
If you get an error, please run `vagrant box update`.

According to Vagrant policies the user should be `vagrant` and if a box uses a different user it is a shitty box. It seems that the ubuntu box was upgraded in the 2018 version to use `vagrant`.

So if `vagrant box list` gives you something with 2017, you should run `vagrant box update` and it should work.