### PR TITLE
Add support for ValidBlock mechanism for the simplest case

### DIFF
--- a/consensus/types/state.go
+++ b/consensus/types/state.go
@@ -70,6 +70,9 @@ type RoundState struct {
 	LockedRound        int
 	LockedBlock        *types.Block
 	LockedBlockParts   *types.PartSet
+	ValidRound         int
+	ValidBlock         *types.Block
+	ValidBlockParts    *types.PartSet
 	Votes              *HeightVoteSet
 	CommitRound        int            //
 	LastCommit         *types.VoteSet // Last precommits at Height-1
@@ -106,6 +109,8 @@ func (rs *RoundState) StringIndented(indent string) string {
 %s  ProposalBlock: %v %v
 %s  LockedRound:   %v
 %s  LockedBlock:   %v %v
+%s  ValidRound:   %v
+%s  ValidBlock:   %v %v
 %s  Votes:         %v
 %s  LastCommit:    %v
 %s  LastValidators:%v
@@ -118,6 +123,8 @@ func (rs *RoundState) StringIndented(indent string) string {
 		indent, rs.ProposalBlockParts.StringShort(), rs.ProposalBlock.StringShort(),
 		indent, rs.LockedRound,
 		indent, rs.LockedBlockParts.StringShort(), rs.LockedBlock.StringShort(),
+		indent, rs.ValidRound,
+		indent, rs.ValidBlockParts.StringShort(), rs.ValidBlock.StringShort(),
 		indent, rs.Votes.StringIndented(indent+"    "),
 		indent, rs.LastCommit.StringShort(),
 		indent, rs.LastValidators.StringIndented(indent+"    "),


### PR DESCRIPTION
With this PR, the idea is to only cover the simplest scenario where having ValidBlock will help with the termination issue. The goal is having the following property assured: during synchronous period (after GST), in a round with a correct proposer, if some correct process locks a block v in round r, at the end of the round r, all correct processes will have lockedBlock = v or lockedBlock = nil, and validBlock = v. This ensures that in the following round, a (correct) proposer will be able to only propose v, and all correct processes will Prevote for v, and hopefully later commit a block. 

Please take a look @ebuchman @melekes. I will add tests after.   