### PR TITLE
fix memory leak

### DIFF
--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -188,8 +188,7 @@ func (c *MConnection) OnStop() {
 	if c.quit != nil {
 		close(c.quit)
 	}
-	c.conn.Close() // nolint: errcheck
-
+	_ = c.conn.Close()
 	// We can't close pong safely here because
 	// recvRoutine may write to it after we've stopped.
 	// Though it doesn't need to get closed at all,

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -168,6 +168,12 @@ func (p *peer) OnStart() error {
 func (p *peer) OnStop() {
 	p.BaseService.OnStop()
 	p.mconn.Stop() // stop everything and close the conn
+	// fixes memory leak https://github.com/cosmos/gaia/issues/108.
+	//   my theory is some object (switch?) still refers a peer even when it's
+	//   stopped, so Go can't garbage collect it. Until we find the exact place,
+	//   we should keep this. See commit message for test case that was used to
+	//   reproduce the leak.
+	p.mconn = nil
 }
 
 //---------------------------------------------------


### PR DESCRIPTION
Refs https://github.com/cosmos/gaia/issues/108

Test case:

```
func TestSwitchMemoryLeak(t *testing.T) {
        sw := MakeSwitch(config, 1, "testing", "123.123.123", initSwitchFunc)
        err := sw.Start()
        if err != nil {
                t.Error(err)
        }
        defer sw.Stop()

        // simulate remote peer
        rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519().Wrap(), Config: DefaultPeerConfig()}
        rp.Start()
        defer rp.Stop()

        p, err := newOutboundPeer(rp.Addr(), sw.reactorsByCh, sw.chDescs, sw.StopPeerForError, sw.nodeKey.PrivKey, DefaultPeerConfig(), true)
        require.Nil(t, err)
        id := p.ID()
        err = sw.addPeer(p)
        require.Nil(t, err)

        f, err := os.Create("/tmp/mem1.mprof")
        if err != nil {
                t.Fatal(err)
        }
        pprof.WriteHeapProfile(f)
        f.Close()

        fmt.Println(runtime.NumGoroutine())

        // simulate failure by closing connection
        p.CloseConn()

        npeers := sw.Peers().Size()
        for i := 0; i < 100; i++ {
                time.Sleep(250 * time.Millisecond)
                npeers = sw.Peers().Size()
                if npeers > 0 {
                        // simulate failure by closing connection
                        sw.Peers().Get(id).(*peer).CloseConn()
                }
        }

        runtime.GC()

        f, err = os.Create("/tmp/mem2.mprof")
        if err != nil {
                t.Fatal(err)
        }
        pprof.WriteHeapProfile(f)
        f.Close()

        fmt.Println(runtime.NumGoroutine())
}
```