### PR TITLE
Restart pub/sub server on service reset

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,9 +2,10 @@
 
 
 [[projects]]
+  branch = "master"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
-  revision = "50de9da05b50eb15658bb350f6ea24368a111ab7"
+  revision = "2be2f12b358dc57d70b8f501b00be450192efbc3"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -126,12 +127,14 @@
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "49d762b9817ba1c2e9d0c69183c2b4a8b8f1d934"
+  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
+  version = "v1.7.6"
 
 [[projects]]
+  branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "b4575eea38cca1123ec2dc90c26529b5c5acfcff"
+  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
@@ -169,8 +172,8 @@
 [[projects]]
   name = "github.com/spf13/cast"
   packages = ["."]
-  revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
-  version = "v1.1.0"
+  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/spf13/cobra"
@@ -206,6 +209,7 @@
   version = "v1.2.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -221,7 +225,7 @@
     "leveldb/table",
     "leveldb/util"
   ]
-  revision = "34011bf325bce385408353a30b101fe5e923eb6e"
+  revision = "c7a14d4b00e222eab6111b4cd1af829c13f53ec2"
 
 [[projects]]
   branch = "develop"
@@ -234,7 +238,7 @@
     "server",
     "types"
   ]
-  revision = "9e0e00bef42aebf6b402f66bf0f3dc607de8a6f3"
+  revision = "d5361de3001184de7cd3a0ccbae12eccde3d724e"
 
 [[projects]]
   branch = "master"
@@ -277,10 +281,10 @@
     "pubsub/query",
     "test"
   ]
-  revision = "1b9b5652a199ab0be2e781393fb275b66377309d"
-  version = "v0.7.0"
+  revision = "066fe82a927aef6f7f6431af78f0d5156cb2cdb1"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
@@ -292,7 +296,7 @@
     "ripemd160",
     "salsa20/salsa"
   ]
-  revision = "1875d0a70c90e57f11972aefd42276df65e895b9"
+  revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
 
 [[projects]]
   branch = "master"
@@ -307,12 +311,13 @@
     "netutil",
     "trace"
   ]
-  revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
+  revision = "d25186b37f34ebdbbea8f488ef055638dfab272d"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
+  revision = "dd2ff4accc098aceecb86b36eaa7829b2a17b1c9"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -332,21 +337,27 @@
     "unicode/norm",
     "unicode/rangetable"
   ]
-  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
+  revision = "df60624c1e9b9d2973e889c7a1cff73155da81c4"
 
 [[projects]]
   name = "google.golang.org/grpc"
   packages = [
     ".",
     "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
     "codes",
     "connectivity",
     "credentials",
+    "encoding",
+    "encoding/proto",
     "grpclb/grpc_lb_v1/messages",
     "grpclog",
     "internal",
@@ -355,23 +366,25 @@
     "naming",
     "peer",
     "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
     "stats",
     "status",
     "tap",
     "transport"
   ]
-  revision = "401e0e00e4bb830a10496d64cd95e068c5bf50de"
-  version = "v1.7.3"
+  revision = "8e4536a86ab602859c20df5ebfd0bd4228d08655"
+  version = "v1.10.0"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
-  version = "v2.0.0"
+  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
+  version = "v2.1.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "36505c5f341e1e80d7d55589a17727bbd9e89403624b4e02c9e8a21b1ed39d0f"
+  inputs-digest = "efb7f3f52577df7fd7410ee2a50b0c2ef74d95f032b4e3efed5b9c8b97c7edff"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -83,7 +83,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/tmlibs"
-  version = "0.7.0"
+  revision = "066fe82a927aef6f7f6431af78f0d5156cb2cdb1"
 
 [[constraint]]
   name = "google.golang.org/grpc"

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -52,6 +52,11 @@ func (b *EventBus) OnStop() {
 	b.pubsub.OnStop()
 }
 
+// OnReset restarts the pub/sub server
+func (b *EventBus) OnReset() error {
+	return b.pubsub.OnReset()
+}
+
 func (b *EventBus) Subscribe(ctx context.Context, subscriber string, query tmpubsub.Query, out chan<- interface{}) error {
 	return b.pubsub.Subscribe(ctx, subscriber, query, out)
 }


### PR DESCRIPTION
Hi fellas,

I encountered an issue when stopping/restarting a `rpc.client.Client` because of:
```golang
// Start implements Service by calling OnStart (if defined). An error will be
// returned if the service is already running or stopped. Not to start the
// stopped service, you need to call Reset.
func (bs *BaseService) Start() error { ... }
```

Therefore I used `func (bs *BaseService) Reset()` but since the `EventBus` does not implement `OnReset()` I got a `PanicSanity("The service cannot be reset")`. This is why I added this method to `EventBus`.

The reason why I want to reset the service is that once it is stopped, the pub/sub server is shutdown and cannot be restarted, so even if subscribers are still able to subscribe to new events, they are not notified.

I don't really know what kind of tests you'd like me to write or doc you want me to update so let me know what you'd like !

Cheers!