### PR TITLE
Bucky/new wire api

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -224,6 +224,7 @@
   revision = "34011bf325bce385408353a30b101fe5e923eb6e"
 
 [[projects]]
+  branch = "develop"
   name = "github.com/tendermint/abci"
   packages = [
     "client",
@@ -233,7 +234,7 @@
     "server",
     "types"
   ]
-  revision = "345a5a5a34aa31ad00626266f59e4ae7652ee274"
+  revision = "9e0e00bef42aebf6b402f66bf0f3dc607de8a6f3"
 
 [[projects]]
   branch = "master"
@@ -248,17 +249,17 @@
 [[projects]]
   name = "github.com/tendermint/go-crypto"
   packages = ["."]
-  revision = "dd20358a264c772b4a83e477b0cfce4c88a7001d"
-  version = "v0.4.1"
+  revision = "c3e19f3ea26f5c3357e0bcbb799b0761ef923755"
+  version = "v0.5.0"
 
 [[projects]]
-  branch = "bucky/new-go-wire-api"
   name = "github.com/tendermint/go-wire"
   packages = [
     ".",
     "data"
   ]
-  revision = "67ee274c5f9da166622f3b6e6747003b563e3742"
+  revision = "fa721242b042ecd4c6ed1a934ee740db4f74e45c"
+  version = "v0.7.3"
 
 [[projects]]
   name = "github.com/tendermint/tmlibs"
@@ -371,6 +372,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fcb51d5eb1d869d66946fe28612ac59f75897d71faecc67c965453dc7bf81523"
+  inputs-digest = "36505c5f341e1e80d7d55589a17727bbd9e89403624b4e02c9e8a21b1ed39d0f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -252,13 +252,13 @@
   version = "v0.4.1"
 
 [[projects]]
+  branch = "bucky/new-go-wire-api"
   name = "github.com/tendermint/go-wire"
   packages = [
     ".",
     "data"
   ]
-  revision = "b6fc872b42d41158a60307db4da051dd6f179415"
-  version = "v0.7.2"
+  revision = "67ee274c5f9da166622f3b6e6747003b563e3742"
 
 [[projects]]
   name = "github.com/tendermint/tmlibs"
@@ -371,6 +371,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a65ef86e3db67769c1fa4ae1f67af8d5b95474f4b95ec799d8572e19b44b206a"
+  inputs-digest = "fcb51d5eb1d869d66946fe28612ac59f75897d71faecc67c965453dc7bf81523"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,15 +71,15 @@
 
 [[constraint]]
   name = "github.com/tendermint/abci"
-  revision = "345a5a5a34aa31ad00626266f59e4ae7652ee274"
+  branch = "develop"
 
 [[constraint]]
   name = "github.com/tendermint/go-crypto"
-  version = "0.4.1"
+  version = "0.5.0"
 
 [[constraint]]
   name = "github.com/tendermint/go-wire"
-  branch = "bucky/new-go-wire-api"
+  version = "0.7.3"
 
 [[constraint]]
   name = "github.com/tendermint/tmlibs"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -79,7 +79,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/go-wire"
-  version = "0.7.2"
+  branch = "bucky/new-go-wire-api"
 
 [[constraint]]
   name = "github.com/tendermint/tmlibs"

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -289,17 +289,17 @@ func (privVal *ByzantinePrivValidator) GetPubKey() crypto.PubKey {
 }
 
 func (privVal *ByzantinePrivValidator) SignVote(chainID string, vote *types.Vote) (err error) {
-	vote.Signature, err = privVal.Sign(types.SignBytes(chainID, vote))
+	vote.Signature, err = privVal.Sign(vote.SignBytes(chainID))
 	return err
 }
 
 func (privVal *ByzantinePrivValidator) SignProposal(chainID string, proposal *types.Proposal) (err error) {
-	proposal.Signature, _ = privVal.Sign(types.SignBytes(chainID, proposal))
+	proposal.Signature, _ = privVal.Sign(proposal.SignBytes(chainID))
 	return nil
 }
 
 func (privVal *ByzantinePrivValidator) SignHeartbeat(chainID string, heartbeat *types.Heartbeat) (err error) {
-	heartbeat.Signature, _ = privVal.Sign(types.SignBytes(chainID, heartbeat))
+	heartbeat.Signature, _ = privVal.Sign(heartbeat.SignBytes(chainID))
 	return nil
 }
 

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -287,14 +287,19 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 
 	// Get State
 	stateDB := dbm.NewDB("state", dbType, config.DBDir())
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	gdoc, err := sm.MakeGenesisDocFromFile(config.GenesisFile())
+	if err != nil {
+		cmn.Exit(err.Error())
+	}
+	state, err := sm.MakeGenesisState(gdoc)
 	if err != nil {
 		cmn.Exit(err.Error())
 	}
 
 	// Create proxyAppConn connection (consensus, mempool, query)
 	clientCreator := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
-	proxyApp := proxy.NewAppConns(clientCreator, NewHandshaker(stateDB, state, blockStore))
+	proxyApp := proxy.NewAppConns(clientCreator,
+		NewHandshaker(stateDB, state, blockStore, gdoc.AppState))
 	err = proxyApp.Start()
 	if err != nil {
 		cmn.Exit(cmn.Fmt("Error starting proxy app conns: %v", err))

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -362,7 +362,7 @@ func testHandshakeReplay(t *testing.T, nBlocks int, mode uint) {
 	}
 
 	// now start the app using the handshake - it should sync
-	handshaker := NewHandshaker(stateDB, state, store)
+	handshaker := NewHandshaker(stateDB, state, store, nil)
 	proxyApp := proxy.NewAppConns(clientCreator2, handshaker)
 	if err := proxyApp.Start(); err != nil {
 		t.Fatalf("Error starting proxy app connections: %v", err)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1269,7 +1269,7 @@ func (cs *ConsensusState) defaultSetProposal(proposal *types.Proposal) error {
 	}
 
 	// Verify signature
-	if !cs.Validators.GetProposer().PubKey.VerifyBytes(types.SignBytes(cs.state.ChainID, proposal), proposal.Signature) {
+	if !cs.Validators.GetProposer().PubKey.VerifyBytes(proposal.SignBytes(cs.state.ChainID), proposal.Signature) {
 		return ErrInvalidProposalSignature
 	}
 

--- a/consensus/types/height_vote_set.go
+++ b/consensus/types/height_vote_set.go
@@ -218,5 +218,5 @@ func (hvs *HeightVoteSet) SetPeerMaj23(round int, type_ byte, peerID p2p.ID, blo
 	if voteSet == nil {
 		return nil // something we don't know about yet
 	}
-	return voteSet.SetPeerMaj23(peerID, blockID)
+	return voteSet.SetPeerMaj23(types.P2PID(peerID), blockID)
 }

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -52,7 +52,7 @@ func WALWithNBlocks(numBlocks int) (data []byte, err error) {
 		return nil, errors.Wrap(err, "failed to make genesis state")
 	}
 	blockStore := bc.NewBlockStore(blockStoreDB)
-	handshaker := NewHandshaker(stateDB, state, blockStore)
+	handshaker := NewHandshaker(stateDB, state, blockStore, genDoc.AppState)
 	proxyApp := proxy.NewAppConns(proxy.NewLocalClientCreator(app), handshaker)
 	proxyApp.SetLogger(logger.With("module", "proxy"))
 	if err := proxyApp.Start(); err != nil {

--- a/lite/helpers.go
+++ b/lite/helpers.go
@@ -102,7 +102,7 @@ func makeVote(header *types.Header, vals *types.ValidatorSet, key crypto.PrivKey
 		BlockID:          types.BlockID{Hash: header.Hash()},
 	}
 	// Sign it
-	signBytes := types.SignBytes(header.ChainID, vote)
+	signBytes := vote.SignBytes(header.ChainID)
 	vote.Signature = key.Sign(signBytes)
 	return vote
 }

--- a/node/node.go
+++ b/node/node.go
@@ -162,7 +162,7 @@ func NewNode(config *cfg.Config,
 	// and sync tendermint and the app by performing a handshake
 	// and replaying any necessary blocks
 	consensusLogger := logger.With("module", "consensus")
-	handshaker := cs.NewHandshaker(stateDB, state, blockStore)
+	handshaker := cs.NewHandshaker(stateDB, state, blockStore, genDoc.AppState)
 	handshaker.SetLogger(consensusLogger)
 	proxyApp := proxy.NewAppConns(clientCreator, handshaker)
 	proxyApp.SetLogger(logger.With("module", "proxy"))

--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -187,7 +187,6 @@ func argsToJson(args map[string]interface{}) error {
 			continue
 		}
 
-		// Pass everything else to go-wire
 		data, err := json.Marshal(v)
 		if err != nil {
 			return err

--- a/state/state.go
+++ b/state/state.go
@@ -86,7 +86,11 @@ func (s State) Equals(s2 State) bool {
 
 // Bytes serializes the State using go-wire.
 func (s State) Bytes() []byte {
-	return wire.BinaryBytes(s)
+	bz, err := wire.MarshalBinary(s)
+	if err != nil {
+		panic(err)
+	}
+	return bz
 }
 
 // IsEmpty returns true if the State is equal to the empty State.

--- a/state/store.go
+++ b/state/store.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"bytes"
 	"fmt"
 
 	abci "github.com/tendermint/abci/types"
@@ -70,12 +69,11 @@ func loadState(db dbm.DB, key []byte) (state State) {
 		return state
 	}
 
-	r, n, err := bytes.NewReader(buf), new(int), new(error)
-	wire.ReadBinaryPtr(&state, r, 0, n, err)
-	if *err != nil {
+	err := wire.UnmarshalBinary(buf, &state)
+	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
 		cmn.Exit(cmn.Fmt(`LoadState: Data has been corrupted or its spec has changed:
-                %v\n`, *err))
+                %v\n`, err))
 	}
 	// TODO: ensure that buf is completely read.
 
@@ -113,7 +111,11 @@ func NewABCIResponses(block *types.Block) *ABCIResponses {
 
 // Bytes serializes the ABCIResponse using go-wire
 func (a *ABCIResponses) Bytes() []byte {
-	return wire.BinaryBytes(*a)
+	bz, err := wire.MarshalBinary(*a)
+	if err != nil {
+		panic(err)
+	}
+	return bz
 }
 
 func (a *ABCIResponses) ResultsHash() []byte {
@@ -131,12 +133,11 @@ func LoadABCIResponses(db dbm.DB, height int64) (*ABCIResponses, error) {
 	}
 
 	abciResponses := new(ABCIResponses)
-	r, n, err := bytes.NewReader(buf), new(int), new(error)
-	wire.ReadBinaryPtr(abciResponses, r, 0, n, err)
-	if *err != nil {
+	err := wire.UnmarshalBinary(buf, abciResponses)
+	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
 		cmn.Exit(cmn.Fmt(`LoadABCIResponses: Data has been corrupted or its spec has
-                changed: %v\n`, *err))
+                changed: %v\n`, err))
 	}
 	// TODO: ensure that buf is completely read.
 
@@ -160,7 +161,11 @@ type ValidatorsInfo struct {
 
 // Bytes serializes the ValidatorsInfo using go-wire
 func (valInfo *ValidatorsInfo) Bytes() []byte {
-	return wire.BinaryBytes(*valInfo)
+	bz, err := wire.MarshalBinary(*valInfo)
+	if err != nil {
+		panic(err)
+	}
+	return bz
 }
 
 // LoadValidators loads the ValidatorSet for a given height.
@@ -189,12 +194,11 @@ func loadValidatorsInfo(db dbm.DB, height int64) *ValidatorsInfo {
 	}
 
 	v := new(ValidatorsInfo)
-	r, n, err := bytes.NewReader(buf), new(int), new(error)
-	wire.ReadBinaryPtr(v, r, 0, n, err)
-	if *err != nil {
+	err := wire.UnmarshalBinary(buf, v)
+	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
 		cmn.Exit(cmn.Fmt(`LoadValidators: Data has been corrupted or its spec has changed:
-                %v\n`, *err))
+                %v\n`, err))
 	}
 	// TODO: ensure that buf is completely read.
 
@@ -225,7 +229,11 @@ type ConsensusParamsInfo struct {
 
 // Bytes serializes the ConsensusParamsInfo using go-wire
 func (params ConsensusParamsInfo) Bytes() []byte {
-	return wire.BinaryBytes(params)
+	bz, err := wire.MarshalBinary(params)
+	if err != nil {
+		panic(err)
+	}
+	return bz
 }
 
 // LoadConsensusParams loads the ConsensusParams for a given height.
@@ -255,12 +263,11 @@ func loadConsensusParamsInfo(db dbm.DB, height int64) *ConsensusParamsInfo {
 	}
 
 	paramsInfo := new(ConsensusParamsInfo)
-	r, n, err := bytes.NewReader(buf), new(int), new(error)
-	wire.ReadBinaryPtr(paramsInfo, r, 0, n, err)
-	if *err != nil {
+	err := wire.UnmarshalBinary(buf, paramsInfo)
+	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
 		cmn.Exit(cmn.Fmt(`LoadConsensusParams: Data has been corrupted or its spec has changed:
-                %v\n`, *err))
+                %v\n`, err))
 	}
 	// TODO: ensure that buf is completely read.
 

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -67,10 +67,8 @@ func (txi *TxIndex) Get(hash []byte) (*types.TxResult, error) {
 		return nil, nil
 	}
 
-	r := bytes.NewReader(rawBytes)
-	var n int
-	var err error
-	txResult := wire.ReadBinary(&types.TxResult{}, r, 0, &n, &err).(*types.TxResult)
+	txResult := new(types.TxResult)
+	err := wire.UnmarshalBinary(rawBytes, txResult)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading TxResult: %v", err)
 	}
@@ -93,7 +91,10 @@ func (txi *TxIndex) AddBatch(b *txindex.Batch) error {
 		}
 
 		// index tx by hash
-		rawBytes := wire.BinaryBytes(result)
+		rawBytes, err := wire.MarshalBinary(result)
+		if err != nil {
+			return err
+		}
 		storeBatch.Set(hash, rawBytes)
 	}
 
@@ -115,7 +116,10 @@ func (txi *TxIndex) Index(result *types.TxResult) error {
 	}
 
 	// index tx by hash
-	rawBytes := wire.BinaryBytes(result)
+	rawBytes, err := wire.MarshalBinary(result)
+	if err != nil {
+		return err
+	}
 	b.Set(hash, rawBytes)
 
 	b.Write()

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -68,7 +68,7 @@ func (txi *TxIndex) Get(hash []byte) (*types.TxResult, error) {
 	}
 
 	txResult := new(types.TxResult)
-	err := wire.UnmarshalBinary(rawBytes, txResult)
+	err := wire.UnmarshalBinary(rawBytes, &txResult)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading TxResult: %v", err)
 	}

--- a/types/block.go
+++ b/types/block.go
@@ -252,7 +252,8 @@ type Commit struct {
 	bitArray       *cmn.BitArray
 }
 
-// FirstPrecommit returns the first non-nil precommit in the commit
+// FirstPrecommit returns the first non-nil precommit in the commit.
+// If all precommits are nil, it returns an empty precommit with height 0.
 func (commit *Commit) FirstPrecommit() *Vote {
 	if len(commit.Precommits) == 0 {
 		return nil
@@ -266,7 +267,9 @@ func (commit *Commit) FirstPrecommit() *Vote {
 			return precommit
 		}
 	}
-	return nil
+	return &Vote{
+		Type: VoteTypePrecommit,
+	}
 }
 
 // Height returns the height of the commit

--- a/types/block.go
+++ b/types/block.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	wire "github.com/tendermint/go-wire"
+	wire "github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/merkle"
 	"golang.org/x/crypto/ripemd160"
@@ -515,9 +515,13 @@ type hasher struct {
 }
 
 func (h hasher) Hash() []byte {
-	hasher, n, err := ripemd160.New(), new(int), new(error)
-	wire.WriteBinary(h.item, hasher, n, err)
-	if *err != nil {
+	hasher := ripemd160.New()
+	bz, err := wire.MarshalBinary(h.item)
+	if err != nil {
+		panic(err)
+	}
+	_, err = hasher.Write(bz)
+	if err != nil {
 		panic(err)
 	}
 	return hasher.Sum(nil)

--- a/types/canonical_json.go
+++ b/types/canonical_json.go
@@ -3,11 +3,11 @@ package types
 import (
 	"time"
 
-	wire "github.com/tendermint/go-wire"
+	wire "github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
-// canonical json is go-wire's json for structs with fields in alphabetical order
+// canonical json is wire's json for structs with fields in alphabetical order
 
 // TimeFormat is used for generating the sigs
 const TimeFormat = wire.RFC3339Millis
@@ -114,7 +114,7 @@ func CanonicalHeartbeat(heartbeat *Heartbeat) CanonicalJSONHeartbeat {
 }
 
 func CanonicalTime(t time.Time) string {
-	// note that sending time over go-wire resets it to
+	// note that sending time over wire resets it to
 	// local time, we need to force UTC here, so the
 	// signatures match
 	return t.UTC().Format(TimeFormat)

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -80,13 +80,13 @@ func (evl EvidenceList) Has(evidence Evidence) bool {
 //-------------------------------------------
 
 const (
-	wireTypeEvidenceDuplicateVote = "com.tendermint.types.evidence.duplicate_vote"
+	evidenceTypeDuplicateVote = byte(0x01)
 )
 
-func init() {
-	wire.RegisterInterface((*Evidence)(nil), nil)
-	wire.RegisterConcrete(&DuplicateVoteEvidence{}, wireTypeEvidenceDuplicateVote, nil)
-}
+var _ = wire.RegisterInterface(
+	struct{ Evidence }{},
+	wire.ConcreteType{&DuplicateVoteEvidence{}, evidenceTypeDuplicateVote},
+)
 
 //-------------------------------------------
 

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/tendermint/go-crypto"
-	wire "github.com/tendermint/go-wire"
+	wire "github.com/tendermint/tendermint/wire"
 	"github.com/tendermint/tmlibs/merkle"
 )
 
@@ -80,13 +80,13 @@ func (evl EvidenceList) Has(evidence Evidence) bool {
 //-------------------------------------------
 
 const (
-	evidenceTypeDuplicateVote = byte(0x01)
+	wireTypeEvidenceDuplicateVote = "com.tendermint.types.evidence.duplicate_vote"
 )
 
-var _ = wire.RegisterInterface(
-	struct{ Evidence }{},
-	wire.ConcreteType{&DuplicateVoteEvidence{}, evidenceTypeDuplicateVote},
-)
+func init() {
+	wire.RegisterInterface((*Evidence)(nil), nil)
+	wire.RegisterConcrete(&DuplicateVoteEvidence{}, wireTypeEvidenceDuplicateVote, nil)
+}
 
 //-------------------------------------------
 

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -148,10 +148,10 @@ func (dve *DuplicateVoteEvidence) Verify(chainID string) error {
 	}
 
 	// Signatures must be valid
-	if !dve.PubKey.VerifyBytes(SignBytes(chainID, dve.VoteA), dve.VoteA.Signature) {
+	if !dve.PubKey.VerifyBytes(dve.VoteA.SignBytes(chainID), dve.VoteA.Signature) {
 		return fmt.Errorf("DuplicateVoteEvidence Error verifying VoteA: %v", ErrVoteInvalidSignature)
 	}
-	if !dve.PubKey.VerifyBytes(SignBytes(chainID, dve.VoteB), dve.VoteB.Signature) {
+	if !dve.PubKey.VerifyBytes(dve.VoteB.SignBytes(chainID), dve.VoteB.Signature) {
 		return fmt.Errorf("DuplicateVoteEvidence Error verifying VoteB: %v", ErrVoteInvalidSignature)
 	}
 

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -22,7 +22,7 @@ func makeVote(val *PrivValidatorFS, chainID string, valIndex int, height int64, 
 		Type:             byte(step),
 		BlockID:          blockID,
 	}
-	sig := val.PrivKey.Sign(SignBytes(chainID, v))
+	sig := val.PrivKey.Sign(v.SignBytes(chainID))
 	v.Signature = sig
 	return v
 
@@ -41,7 +41,7 @@ func TestEvidence(t *testing.T) {
 
 	vote1 := makeVote(val, chainID, 0, 10, 2, 1, blockID)
 	badVote := makeVote(val, chainID, 0, 10, 2, 1, blockID)
-	badVote.Signature = val2.PrivKey.Sign(SignBytes(chainID, badVote))
+	badVote.Signature = val2.PrivKey.Sign(badVote.SignBytes(chainID))
 
 	cases := []voteData{
 		{vote1, makeVote(val, chainID, 0, 10, 2, 1, blockID2), true}, // different block ids

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	crypto "github.com/tendermint/go-crypto"
+	"github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
@@ -33,7 +34,7 @@ type GenesisDoc struct {
 
 // SaveAs is a utility method for saving GenensisDoc as a JSON file.
 func (genDoc *GenesisDoc) SaveAs(file string) error {
-	genDocBytes, err := json.Marshal(genDoc)
+	genDocBytes, err := wire.MarshalJSON(genDoc)
 	if err != nil {
 		return err
 	}
@@ -89,7 +90,7 @@ func (genDoc *GenesisDoc) ValidateAndComplete() error {
 // GenesisDocFromJSON unmarshalls JSON data into a GenesisDoc.
 func GenesisDocFromJSON(jsonBlob []byte) (*GenesisDoc, error) {
 	genDoc := GenesisDoc{}
-	err := json.Unmarshal(jsonBlob, &genDoc)
+	err := wire.UnmarshalJSON(jsonBlob, &genDoc)
 	if err != nil {
 		return nil, err
 	}

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 
 	crypto "github.com/tendermint/go-crypto"
-	"github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
@@ -34,7 +33,7 @@ type GenesisDoc struct {
 
 // SaveAs is a utility method for saving GenensisDoc as a JSON file.
 func (genDoc *GenesisDoc) SaveAs(file string) error {
-	genDocBytes, err := wire.MarshalJSON(genDoc)
+	genDocBytes, err := json.Marshal(genDoc)
 	if err != nil {
 		return err
 	}
@@ -90,7 +89,7 @@ func (genDoc *GenesisDoc) ValidateAndComplete() error {
 // GenesisDocFromJSON unmarshalls JSON data into a GenesisDoc.
 func GenesisDocFromJSON(jsonBlob []byte) (*GenesisDoc, error) {
 	genDoc := GenesisDoc{}
-	err := wire.UnmarshalJSON(jsonBlob, &genDoc)
+	err := json.Unmarshal(jsonBlob, &genDoc)
 	if err != nil {
 		return nil, err
 	}

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -1,12 +1,12 @@
 package types
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	crypto "github.com/tendermint/go-crypto"
-	wire "github.com/tendermint/tendermint/wire"
 )
 
 func TestGenesis(t *testing.T) {
@@ -42,7 +42,7 @@ func TestGenesis(t *testing.T) {
 		ChainID:    "abc",
 		Validators: []GenesisValidator{{crypto.GenPrivKeyEd25519().PubKey(), 10, "myval"}},
 	}
-	genDocBytes, err = wire.MarshalJSON(baseGenDoc)
+	genDocBytes, err = json.Marshal(baseGenDoc)
 	assert.NoError(t, err, "error marshalling genDoc")
 
 	// test base gendoc and check consensus params were filled
@@ -51,14 +51,14 @@ func TestGenesis(t *testing.T) {
 	assert.NotNil(t, genDoc.ConsensusParams, "expected consensus params to be filled in")
 
 	// create json with consensus params filled
-	genDocBytes, err = wire.MarshalJSON(genDoc)
+	genDocBytes, err = json.Marshal(genDoc)
 	assert.NoError(t, err, "error marshalling genDoc")
 	genDoc, err = GenesisDocFromJSON(genDocBytes)
 	assert.NoError(t, err, "expected no error for valid genDoc json")
 
 	// test with invalid consensus params
 	genDoc.ConsensusParams.BlockSize.MaxBytes = 0
-	genDocBytes, err = wire.MarshalJSON(genDoc)
+	genDocBytes, err = json.Marshal(genDoc)
 	assert.NoError(t, err, "error marshalling genDoc")
 	genDoc, err = GenesisDocFromJSON(genDocBytes)
 	assert.Error(t, err, "expected error for genDoc json with block size of 0")

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -1,12 +1,12 @@
 package types
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	crypto "github.com/tendermint/go-crypto"
+	wire "github.com/tendermint/tendermint/wire"
 )
 
 func TestGenesis(t *testing.T) {
@@ -28,17 +28,21 @@ func TestGenesis(t *testing.T) {
 		assert.Error(t, err, "expected error for empty genDoc json")
 	}
 
+	/* TODO WIRE enable json ...
 	// test a good one by raw json
 	genDocBytes := []byte(`{"genesis_time":"0001-01-01T00:00:00Z","chain_id":"test-chain-QDKdJr","consensus_params":null,"validators":[{"pub_key":{"type":"ed25519","data":"961EAB8752E51A03618502F55C2B6E09C38C65635C64CCF3173ED452CF86C957"},"power":10,"name":""}],"app_hash":"","app_state":{"account_owner": "Bob"}}`)
 	_, err := GenesisDocFromJSON(genDocBytes)
 	assert.NoError(t, err, "expected no error for good genDoc json")
+	*/
+	var genDocBytes []byte
+	var err error
 
 	// create a base gendoc from struct
 	baseGenDoc := &GenesisDoc{
 		ChainID:    "abc",
 		Validators: []GenesisValidator{{crypto.GenPrivKeyEd25519().PubKey(), 10, "myval"}},
 	}
-	genDocBytes, err = json.Marshal(baseGenDoc)
+	genDocBytes, err = wire.MarshalJSON(baseGenDoc)
 	assert.NoError(t, err, "error marshalling genDoc")
 
 	// test base gendoc and check consensus params were filled
@@ -47,14 +51,14 @@ func TestGenesis(t *testing.T) {
 	assert.NotNil(t, genDoc.ConsensusParams, "expected consensus params to be filled in")
 
 	// create json with consensus params filled
-	genDocBytes, err = json.Marshal(genDoc)
+	genDocBytes, err = wire.MarshalJSON(genDoc)
 	assert.NoError(t, err, "error marshalling genDoc")
 	genDoc, err = GenesisDocFromJSON(genDocBytes)
 	assert.NoError(t, err, "expected no error for valid genDoc json")
 
 	// test with invalid consensus params
 	genDoc.ConsensusParams.BlockSize.MaxBytes = 0
-	genDocBytes, err = json.Marshal(genDoc)
+	genDocBytes, err = wire.MarshalJSON(genDoc)
 	assert.NoError(t, err, "error marshalling genDoc")
 	genDoc, err = GenesisDocFromJSON(genDocBytes)
 	assert.Error(t, err, "expected error for genDoc json with block size of 0")

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -28,14 +28,10 @@ func TestGenesis(t *testing.T) {
 		assert.Error(t, err, "expected error for empty genDoc json")
 	}
 
-	/* TODO WIRE enable json ...
 	// test a good one by raw json
 	genDocBytes := []byte(`{"genesis_time":"0001-01-01T00:00:00Z","chain_id":"test-chain-QDKdJr","consensus_params":null,"validators":[{"pub_key":{"type":"ed25519","data":"961EAB8752E51A03618502F55C2B6E09C38C65635C64CCF3173ED452CF86C957"},"power":10,"name":""}],"app_hash":"","app_state":{"account_owner": "Bob"}}`)
 	_, err := GenesisDocFromJSON(genDocBytes)
 	assert.NoError(t, err, "expected no error for good genDoc json")
-	*/
-	var genDocBytes []byte
-	var err error
 
 	// create a base gendoc from struct
 	baseGenDoc := &GenesisDoc{

--- a/types/heartbeat.go
+++ b/types/heartbeat.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/tendermint/go-crypto"
-	"github.com/tendermint/go-wire"
+	"github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 

--- a/types/heartbeat.go
+++ b/types/heartbeat.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/tendermint/go-crypto"
 	"github.com/tendermint/go-wire"
@@ -23,13 +22,17 @@ type Heartbeat struct {
 	Signature        crypto.Signature `json:"signature"`
 }
 
-// WriteSignBytes writes the Heartbeat for signing.
+// SignBytes returns the Heartbeat bytes for signing.
 // It panics if the Heartbeat is nil.
-func (heartbeat *Heartbeat) WriteSignBytes(chainID string, w io.Writer, n *int, err *error) {
-	wire.WriteJSON(CanonicalJSONOnceHeartbeat{
+func (heartbeat *Heartbeat) SignBytes(chainID string) []byte {
+	bz, err := wire.MarshalJSON(CanonicalJSONOnceHeartbeat{
 		chainID,
 		CanonicalHeartbeat(heartbeat),
-	}, w, n, err)
+	})
+	if err != nil {
+		panic(err)
+	}
+	return bz
 }
 
 // Copy makes a copy of the Heartbeat.

--- a/types/heartbeat_test.go
+++ b/types/heartbeat_test.go
@@ -25,13 +25,14 @@ func TestHeartbeatString(t *testing.T) {
 	require.Contains(t, nilHb.String(), "nil", "expecting a string and no panic")
 
 	hb := &Heartbeat{ValidatorIndex: 1, Height: 11, Round: 2}
-	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) {<nil>}}")
+	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) <nil>}")
 
 	var key crypto.PrivKeyEd25519
 	hb.Signature = key.Sign([]byte("Tendermint"))
-	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) {/FF41E371B9BF.../}}")
+	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) /FF41E371B9BF.../}")
 }
 
+/* TODO WIRE make json work
 func TestHeartbeatWriteSignBytes(t *testing.T) {
 
 	hb := &Heartbeat{ValidatorIndex: 1, Height: 10, Round: 1}
@@ -48,3 +49,4 @@ func TestHeartbeatWriteSignBytes(t *testing.T) {
 		require.Equal(t, string(bz), "null")
 	})
 }
+*/

--- a/types/heartbeat_test.go
+++ b/types/heartbeat_test.go
@@ -25,11 +25,11 @@ func TestHeartbeatString(t *testing.T) {
 	require.Contains(t, nilHb.String(), "nil", "expecting a string and no panic")
 
 	hb := &Heartbeat{ValidatorIndex: 1, Height: 11, Round: 2}
-	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) <nil>}")
+	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) {<nil>}}")
 
 	var key crypto.PrivKeyEd25519
 	hb.Signature = key.Sign([]byte("Tendermint"))
-	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) /FF41E371B9BF.../}")
+	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) {/FF41E371B9BF.../}}")
 }
 
 /* TODO WIRE make json work

--- a/types/heartbeat_test.go
+++ b/types/heartbeat_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,23 +33,18 @@ func TestHeartbeatString(t *testing.T) {
 }
 
 func TestHeartbeatWriteSignBytes(t *testing.T) {
-	var n int
-	var err error
-	buf := new(bytes.Buffer)
 
 	hb := &Heartbeat{ValidatorIndex: 1, Height: 10, Round: 1}
-	hb.WriteSignBytes("0xdeadbeef", buf, &n, &err)
-	require.Equal(t, buf.String(), `{"chain_id":"0xdeadbeef","heartbeat":{"height":10,"round":1,"sequence":0,"validator_address":"","validator_index":1}}`)
+	bz := hb.SignBytes("0xdeadbeef")
+	require.Equal(t, string(bz), `{"chain_id":"0xdeadbeef","heartbeat":{"height":10,"round":1,"sequence":0,"validator_address":"","validator_index":1}}`)
 
-	buf.Reset()
 	plainHb := &Heartbeat{}
-	plainHb.WriteSignBytes("0xdeadbeef", buf, &n, &err)
-	require.Equal(t, buf.String(), `{"chain_id":"0xdeadbeef","heartbeat":{"height":0,"round":0,"sequence":0,"validator_address":"","validator_index":0}}`)
+	bz = plainHb.SignBytes("0xdeadbeef")
+	require.Equal(t, string(bz), `{"chain_id":"0xdeadbeef","heartbeat":{"height":0,"round":0,"sequence":0,"validator_address":"","validator_index":0}}`)
 
 	require.Panics(t, func() {
-		buf.Reset()
 		var nilHb *Heartbeat
-		nilHb.WriteSignBytes("0xdeadbeef", buf, &n, &err)
-		require.Equal(t, buf.String(), "null")
+		bz := nilHb.SignBytes("0xdeadbeef")
+		require.Equal(t, string(bz), "null")
 	})
 }

--- a/types/heartbeat_test.go
+++ b/types/heartbeat_test.go
@@ -32,7 +32,6 @@ func TestHeartbeatString(t *testing.T) {
 	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) {/FF41E371B9BF.../}}")
 }
 
-/* TODO WIRE make json work
 func TestHeartbeatWriteSignBytes(t *testing.T) {
 
 	hb := &Heartbeat{ValidatorIndex: 1, Height: 10, Round: 1}
@@ -49,4 +48,3 @@ func TestHeartbeatWriteSignBytes(t *testing.T) {
 		require.Equal(t, string(bz), "null")
 	})
 }
-*/

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -9,7 +9,6 @@ import (
 
 	"golang.org/x/crypto/ripemd160"
 
-	"github.com/tendermint/go-wire"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/merkle"
 )
@@ -71,10 +70,6 @@ func (psh PartSetHeader) IsZero() bool {
 
 func (psh PartSetHeader) Equals(other PartSetHeader) bool {
 	return psh.Total == other.Total && bytes.Equal(psh.Hash, other.Hash)
-}
-
-func (psh PartSetHeader) WriteSignBytes(w io.Writer, n *int, err *error) {
-	wire.WriteJSON(CanonicalPartSetHeader(psh), w, n, err)
 }
 
 //-------------------------------------

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	crypto "github.com/tendermint/go-crypto"
+	"github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
@@ -198,7 +198,7 @@ func LoadPrivValidatorFSWithSigner(filePath string, signerFunc func(PrivValidato
 		cmn.Exit(err.Error())
 	}
 	privVal := &PrivValidatorFS{}
-	err = json.Unmarshal(privValJSONBytes, &privVal)
+	err = wire.UnmarshalJSON(privValJSONBytes, &privVal)
 	if err != nil {
 		cmn.Exit(cmn.Fmt("Error reading PrivValidator from %v: %v\n", filePath, err))
 	}
@@ -219,7 +219,7 @@ func (privVal *PrivValidatorFS) save() {
 	if privVal.filePath == "" {
 		cmn.PanicSanity("Cannot save PrivValidator: filePath not set")
 	}
-	jsonBytes, err := json.Marshal(privVal)
+	jsonBytes, err := wire.MarshalJSON(privVal)
 	if err != nil {
 		// `@; BOOM!!!
 		cmn.PanicCrisis(err)
@@ -422,10 +422,10 @@ func (pvs PrivValidatorsByAddress) Swap(i, j int) {
 // returns true if the only difference in the votes is their timestamp.
 func checkVotesOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (time.Time, bool) {
 	var lastVote, newVote CanonicalJSONOnceVote
-	if err := json.Unmarshal(lastSignBytes, &lastVote); err != nil {
+	if err := wire.UnmarshalJSON(lastSignBytes, &lastVote); err != nil {
 		panic(fmt.Sprintf("LastSignBytes cannot be unmarshalled into vote: %v", err))
 	}
-	if err := json.Unmarshal(newSignBytes, &newVote); err != nil {
+	if err := wire.UnmarshalJSON(newSignBytes, &newVote); err != nil {
 		panic(fmt.Sprintf("signBytes cannot be unmarshalled into vote: %v", err))
 	}
 
@@ -438,8 +438,8 @@ func checkVotesOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (time.T
 	now := CanonicalTime(time.Now())
 	lastVote.Vote.Timestamp = now
 	newVote.Vote.Timestamp = now
-	lastVoteBytes, _ := json.Marshal(lastVote)
-	newVoteBytes, _ := json.Marshal(newVote)
+	lastVoteBytes, _ := wire.MarshalJSON(lastVote)
+	newVoteBytes, _ := wire.MarshalJSON(newVote)
 
 	return lastTime, bytes.Equal(newVoteBytes, lastVoteBytes)
 }
@@ -448,10 +448,10 @@ func checkVotesOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (time.T
 // returns true if the only difference in the proposals is their timestamp
 func checkProposalsOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (time.Time, bool) {
 	var lastProposal, newProposal CanonicalJSONOnceProposal
-	if err := json.Unmarshal(lastSignBytes, &lastProposal); err != nil {
+	if err := wire.UnmarshalJSON(lastSignBytes, &lastProposal); err != nil {
 		panic(fmt.Sprintf("LastSignBytes cannot be unmarshalled into proposal: %v", err))
 	}
-	if err := json.Unmarshal(newSignBytes, &newProposal); err != nil {
+	if err := wire.UnmarshalJSON(newSignBytes, &newProposal); err != nil {
 		panic(fmt.Sprintf("signBytes cannot be unmarshalled into proposal: %v", err))
 	}
 
@@ -464,8 +464,8 @@ func checkProposalsOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (ti
 	now := CanonicalTime(time.Now())
 	lastProposal.Proposal.Timestamp = now
 	newProposal.Proposal.Timestamp = now
-	lastProposalBytes, _ := json.Marshal(lastProposal)
-	newProposalBytes, _ := json.Marshal(newProposal)
+	lastProposalBytes, _ := wire.MarshalJSON(lastProposal)
+	newProposalBytes, _ := wire.MarshalJSON(newProposal)
 
 	return lastTime, bytes.Equal(newProposalBytes, lastProposalBytes)
 }

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -9,7 +10,6 @@ import (
 	"time"
 
 	crypto "github.com/tendermint/go-crypto"
-	"github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
@@ -198,7 +198,7 @@ func LoadPrivValidatorFSWithSigner(filePath string, signerFunc func(PrivValidato
 		cmn.Exit(err.Error())
 	}
 	privVal := &PrivValidatorFS{}
-	err = wire.UnmarshalJSON(privValJSONBytes, &privVal)
+	err = json.Unmarshal(privValJSONBytes, &privVal)
 	if err != nil {
 		cmn.Exit(cmn.Fmt("Error reading PrivValidator from %v: %v\n", filePath, err))
 	}
@@ -219,7 +219,7 @@ func (privVal *PrivValidatorFS) save() {
 	if privVal.filePath == "" {
 		cmn.PanicSanity("Cannot save PrivValidator: filePath not set")
 	}
-	jsonBytes, err := wire.MarshalJSON(privVal)
+	jsonBytes, err := json.Marshal(privVal)
 	if err != nil {
 		// `@; BOOM!!!
 		cmn.PanicCrisis(err)
@@ -422,10 +422,10 @@ func (pvs PrivValidatorsByAddress) Swap(i, j int) {
 // returns true if the only difference in the votes is their timestamp.
 func checkVotesOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (time.Time, bool) {
 	var lastVote, newVote CanonicalJSONOnceVote
-	if err := wire.UnmarshalJSON(lastSignBytes, &lastVote); err != nil {
+	if err := json.Unmarshal(lastSignBytes, &lastVote); err != nil {
 		panic(fmt.Sprintf("LastSignBytes cannot be unmarshalled into vote: %v", err))
 	}
-	if err := wire.UnmarshalJSON(newSignBytes, &newVote); err != nil {
+	if err := json.Unmarshal(newSignBytes, &newVote); err != nil {
 		panic(fmt.Sprintf("signBytes cannot be unmarshalled into vote: %v", err))
 	}
 
@@ -438,8 +438,8 @@ func checkVotesOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (time.T
 	now := CanonicalTime(time.Now())
 	lastVote.Vote.Timestamp = now
 	newVote.Vote.Timestamp = now
-	lastVoteBytes, _ := wire.MarshalJSON(lastVote)
-	newVoteBytes, _ := wire.MarshalJSON(newVote)
+	lastVoteBytes, _ := json.Marshal(lastVote)
+	newVoteBytes, _ := json.Marshal(newVote)
 
 	return lastTime, bytes.Equal(newVoteBytes, lastVoteBytes)
 }
@@ -448,10 +448,10 @@ func checkVotesOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (time.T
 // returns true if the only difference in the proposals is their timestamp
 func checkProposalsOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (time.Time, bool) {
 	var lastProposal, newProposal CanonicalJSONOnceProposal
-	if err := wire.UnmarshalJSON(lastSignBytes, &lastProposal); err != nil {
+	if err := json.Unmarshal(lastSignBytes, &lastProposal); err != nil {
 		panic(fmt.Sprintf("LastSignBytes cannot be unmarshalled into proposal: %v", err))
 	}
-	if err := wire.UnmarshalJSON(newSignBytes, &newProposal); err != nil {
+	if err := json.Unmarshal(newSignBytes, &newProposal); err != nil {
 		panic(fmt.Sprintf("signBytes cannot be unmarshalled into proposal: %v", err))
 	}
 
@@ -464,8 +464,8 @@ func checkProposalsOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (ti
 	now := CanonicalTime(time.Now())
 	lastProposal.Proposal.Timestamp = now
 	newProposal.Proposal.Timestamp = now
-	lastProposalBytes, _ := wire.MarshalJSON(lastProposal)
-	newProposalBytes, _ := wire.MarshalJSON(newProposal)
+	lastProposalBytes, _ := json.Marshal(lastProposal)
+	newProposalBytes, _ := json.Marshal(newProposal)
 
 	return lastTime, bytes.Equal(newProposalBytes, lastProposalBytes)
 }

--- a/types/priv_validator/priv_validator_test.go
+++ b/types/priv_validator/priv_validator_test.go
@@ -211,7 +211,7 @@ func TestDifferByTimestamp(t *testing.T) {
 		proposal := newProposal(height, round, block1)
 		err := privVal.SignProposal(chainID, proposal)
 		assert.NoError(t, err, "expected no error signing proposal")
-		signBytes := types.SignBytes(chainID, proposal)
+		signBytes := proposal.SignBytes(chainID)
 		sig := proposal.Signature
 		timeStamp := clipToMS(proposal.Timestamp)
 
@@ -222,7 +222,7 @@ func TestDifferByTimestamp(t *testing.T) {
 		assert.NoError(t, err, "expected no error on signing same proposal")
 
 		assert.Equal(t, timeStamp, proposal.Timestamp)
-		assert.Equal(t, signBytes, types.SignBytes(chainID, proposal))
+		assert.Equal(t, signBytes, proposal.SignBytes(chainID))
 		assert.Equal(t, sig, proposal.Signature)
 	}
 
@@ -237,7 +237,7 @@ func TestDifferByTimestamp(t *testing.T) {
 		err = privVal.SignVote("mychainid", vote)
 		assert.NoError(t, err, "expected no error signing vote")
 
-		signBytes := types.SignBytes(chainID, vote)
+		signBytes := vote.SignBytes(chainID)
 		sig := vote.Signature
 		timeStamp := clipToMS(vote.Timestamp)
 
@@ -248,7 +248,7 @@ func TestDifferByTimestamp(t *testing.T) {
 		assert.NoError(t, err, "expected no error on signing same vote")
 
 		assert.Equal(t, timeStamp, vote.Timestamp)
-		assert.Equal(t, signBytes, types.SignBytes(chainID, vote))
+		assert.Equal(t, signBytes, vote.SignBytes(chainID))
 		assert.Equal(t, sig, vote.Signature)
 	}
 }

--- a/types/priv_validator/sign_info.go
+++ b/types/priv_validator/sign_info.go
@@ -112,7 +112,7 @@ func (info *LastSignedInfo) Reset() {
 // Else it returns an error.
 func (lsi *LastSignedInfo) SignVote(signer types.Signer, chainID string, vote *types.Vote) error {
 	height, round, step := vote.Height, vote.Round, voteToStep(vote)
-	signBytes := types.SignBytes(chainID, vote)
+	signBytes := vote.SignBytes(chainID)
 
 	sameHRS, err := lsi.Verify(height, round, step)
 	if err != nil {
@@ -151,7 +151,7 @@ func (lsi *LastSignedInfo) SignVote(signer types.Signer, chainID string, vote *t
 // Else it returns an error.
 func (lsi *LastSignedInfo) SignProposal(signer types.Signer, chainID string, proposal *types.Proposal) error {
 	height, round, step := proposal.Height, proposal.Round, stepPropose
-	signBytes := types.SignBytes(chainID, proposal)
+	signBytes := proposal.SignBytes(chainID)
 
 	sameHRS, err := lsi.Verify(height, round, step)
 	if err != nil {

--- a/types/priv_validator/unencrypted.go
+++ b/types/priv_validator/unencrypted.go
@@ -61,6 +61,6 @@ func (upv *PrivValidatorUnencrypted) SignProposal(chainID string, proposal *type
 
 func (upv *PrivValidatorUnencrypted) SignHeartbeat(chainID string, heartbeat *types.Heartbeat) error {
 	var err error
-	heartbeat.Signature, err = upv.PrivKey.Sign(types.SignBytes(chainID, heartbeat))
+	heartbeat.Signature, err = upv.PrivKey.Sign(heartbeat.SignBytes(chainID))
 	return err
 }

--- a/types/priv_validator_test.go
+++ b/types/priv_validator_test.go
@@ -1,15 +1,19 @@
 package types
 
 import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	crypto "github.com/tendermint/go-crypto"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
-/* TODO WIRE make json work ...
 func TestGenLoadValidator(t *testing.T) {
 	assert := assert.New(t)
 
@@ -73,7 +77,7 @@ func TestUnmarshalValidator(t *testing.T) {
 }`, addrStr, pubStr, privStr)
 
 	val := PrivValidatorFS{}
-	err = wire.UnmarshalJSON([]byte(serialized), &val)
+	err = json.Unmarshal([]byte(serialized), &val)
 	require.Nil(err, "%+v", err)
 
 	// make sure the values match
@@ -82,11 +86,10 @@ func TestUnmarshalValidator(t *testing.T) {
 	assert.EqualValues(privKey, val.PrivKey)
 
 	// export it and make sure it is the same
-	out, err := wire.MarshalJSON(val)
+	out, err := json.Marshal(val)
 	require.Nil(err, "%+v", err)
 	assert.JSONEq(serialized, string(out))
 }
-*/
 
 func TestSignVote(t *testing.T) {
 	assert := assert.New(t)

--- a/types/priv_validator_test.go
+++ b/types/priv_validator_test.go
@@ -185,18 +185,19 @@ func TestDifferByTimestamp(t *testing.T) {
 		proposal := newProposal(height, round, block1)
 		err := privVal.SignProposal(chainID, proposal)
 		assert.NoError(t, err, "expected no error signing proposal")
-		signBytes := SignBytes(chainID, proposal)
+		signBytes := proposal.SignBytes(chainID)
 		sig := proposal.Signature
 		timeStamp := clipToMS(proposal.Timestamp)
 
 		// manipulate the timestamp. should get changed back
 		proposal.Timestamp = proposal.Timestamp.Add(time.Millisecond)
-		proposal.Signature = crypto.Signature{}
+		var emptySig crypto.Signature
+		proposal.Signature = emptySig
 		err = privVal.SignProposal("mychainid", proposal)
 		assert.NoError(t, err, "expected no error on signing same proposal")
 
 		assert.Equal(t, timeStamp, proposal.Timestamp)
-		assert.Equal(t, signBytes, SignBytes(chainID, proposal))
+		assert.Equal(t, signBytes, proposal.SignBytes(chainID))
 		assert.Equal(t, sig, proposal.Signature)
 	}
 
@@ -208,18 +209,19 @@ func TestDifferByTimestamp(t *testing.T) {
 		err := privVal.SignVote("mychainid", vote)
 		assert.NoError(t, err, "expected no error signing vote")
 
-		signBytes := SignBytes(chainID, vote)
+		signBytes := vote.SignBytes(chainID)
 		sig := vote.Signature
 		timeStamp := clipToMS(vote.Timestamp)
 
 		// manipulate the timestamp. should get changed back
 		vote.Timestamp = vote.Timestamp.Add(time.Millisecond)
-		vote.Signature = crypto.Signature{}
+		var emptySig crypto.Signature
+		vote.Signature = emptySig
 		err = privVal.SignVote("mychainid", vote)
 		assert.NoError(t, err, "expected no error on signing same vote")
 
 		assert.Equal(t, timeStamp, vote.Timestamp)
-		assert.Equal(t, signBytes, SignBytes(chainID, vote))
+		assert.Equal(t, signBytes, vote.SignBytes(chainID))
 		assert.Equal(t, sig, vote.Signature)
 	}
 }

--- a/types/priv_validator_test.go
+++ b/types/priv_validator_test.go
@@ -1,19 +1,15 @@
 package types
 
 import (
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	crypto "github.com/tendermint/go-crypto"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
+/* TODO WIRE make json work ...
 func TestGenLoadValidator(t *testing.T) {
 	assert := assert.New(t)
 
@@ -77,7 +73,7 @@ func TestUnmarshalValidator(t *testing.T) {
 }`, addrStr, pubStr, privStr)
 
 	val := PrivValidatorFS{}
-	err = json.Unmarshal([]byte(serialized), &val)
+	err = wire.UnmarshalJSON([]byte(serialized), &val)
 	require.Nil(err, "%+v", err)
 
 	// make sure the values match
@@ -86,10 +82,11 @@ func TestUnmarshalValidator(t *testing.T) {
 	assert.EqualValues(privKey, val.PrivKey)
 
 	// export it and make sure it is the same
-	out, err := json.Marshal(val)
+	out, err := wire.MarshalJSON(val)
 	require.Nil(err, "%+v", err)
 	assert.JSONEq(serialized, string(out))
 }
+*/
 
 func TestSignVote(t *testing.T) {
 	assert := assert.New(t)

--- a/types/proposal.go
+++ b/types/proposal.go
@@ -3,7 +3,6 @@ package types
 import (
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/tendermint/go-crypto"
@@ -50,10 +49,14 @@ func (p *Proposal) String() string {
 		p.POLBlockID, p.Signature, CanonicalTime(p.Timestamp))
 }
 
-// WriteSignBytes writes the Proposal bytes for signing
-func (p *Proposal) WriteSignBytes(chainID string, w io.Writer, n *int, err *error) {
-	wire.WriteJSON(CanonicalJSONOnceProposal{
+// SignBytes returns the Proposal bytes for signing
+func (p *Proposal) SignBytes(chainID string) []byte {
+	bz, err := wire.MarshalJSON(CanonicalJSONOnceProposal{
 		ChainID:  chainID,
 		Proposal: CanonicalProposal(p),
-	}, w, n, err)
+	})
+	if err != nil {
+		panic(err)
+	}
+	return bz
 }

--- a/types/proposal.go
+++ b/types/proposal.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/tendermint/go-crypto"
-	"github.com/tendermint/go-wire"
+	"github.com/tendermint/tendermint/wire"
 )
 
 var (

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	wire "github.com/tendermint/go-wire"
+	wire "github.com/tendermint/tendermint/wire"
 )
 
 var testProposal *Proposal

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func TestProposalSignable(t *testing.T) {
-	signBytes := SignBytes("test_chain_id", testProposal)
+	signBytes := testProposal.SignBytes("test_chain_id")
 	signStr := string(signBytes)
 
 	expected := `{"chain_id":"test_chain_id","proposal":{"block_parts_header":{"hash":"626C6F636B7061727473","total":111},"height":12345,"pol_block_id":{},"pol_round":-1,"round":23456,"timestamp":"2018-02-11T07:09:22.765Z"}}`
@@ -48,24 +48,25 @@ func TestProposalVerifySignature(t *testing.T) {
 	pubKey := privVal.GetPubKey()
 
 	prop := NewProposal(4, 2, PartSetHeader{777, []byte("proper")}, 2, BlockID{})
-	signBytes := SignBytes("test_chain_id", prop)
+	signBytes := prop.SignBytes("test_chain_id")
 
 	// sign it
 	signature, err := privVal.Signer.Sign(signBytes)
 	require.NoError(t, err)
 
 	// verify the same proposal
-	valid := pubKey.VerifyBytes(SignBytes("test_chain_id", prop), signature)
+	valid := pubKey.VerifyBytes(prop.SignBytes("test_chain_id"), signature)
 	require.True(t, valid)
 
 	// serialize, deserialize and verify again....
 	newProp := new(Proposal)
-	bs := wire.BinaryBytes(prop)
-	err = wire.ReadBinaryBytes(bs, &newProp)
+	bs, err := wire.MarshalBinary(prop)
+	require.NoError(t, err)
+	err = wire.UnmarshalBinary(bs, &newProp)
 	require.NoError(t, err)
 
 	// verify the transmitted proposal
-	newSignBytes := SignBytes("test_chain_id", newProp)
+	newSignBytes := newProp.SignBytes("test_chain_id")
 	require.Equal(t, string(signBytes), string(newSignBytes))
 	valid = pubKey.VerifyBytes(newSignBytes, signature)
 	require.True(t, valid)
@@ -73,14 +74,14 @@ func TestProposalVerifySignature(t *testing.T) {
 
 func BenchmarkProposalWriteSignBytes(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		SignBytes("test_chain_id", testProposal)
+		testProposal.SignBytes("test_chain_id")
 	}
 }
 
 func BenchmarkProposalSign(b *testing.B) {
 	privVal := GenPrivValidatorFS("")
 	for i := 0; i < b.N; i++ {
-		_, err := privVal.Signer.Sign(SignBytes("test_chain_id", testProposal))
+		_, err := privVal.Signer.Sign(testProposal.SignBytes("test_chain_id"))
 		if err != nil {
 			b.Error(err)
 		}
@@ -88,12 +89,12 @@ func BenchmarkProposalSign(b *testing.B) {
 }
 
 func BenchmarkProposalVerifySignature(b *testing.B) {
-	signBytes := SignBytes("test_chain_id", testProposal)
+	signBytes := testProposal.SignBytes("test_chain_id")
 	privVal := GenPrivValidatorFS("")
 	signature, _ := privVal.Signer.Sign(signBytes)
 	pubKey := privVal.GetPubKey()
 
 	for i := 0; i < b.N; i++ {
-		pubKey.VerifyBytes(SignBytes("test_chain_id", testProposal), signature)
+		pubKey.VerifyBytes(testProposal.SignBytes("test_chain_id"), signature)
 	}
 }

--- a/types/results.go
+++ b/types/results.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	abci "github.com/tendermint/abci/types"
-	wire "github.com/tendermint/go-wire"
+	wire "github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/merkle"
 )
@@ -18,7 +18,7 @@ type ABCIResult struct {
 
 // Hash returns the canonical hash of the ABCIResult
 func (a ABCIResult) Hash() []byte {
-	return merkle.SimpleHashFromBinary(a)
+	return tmHash(a)
 }
 
 // ABCIResults wraps the deliver tx results to return a proof
@@ -40,7 +40,7 @@ func NewResultFromResponse(response *abci.ResponseDeliverTx) ABCIResult {
 	}
 }
 
-// Bytes serializes the ABCIResponse using go-wire
+// Bytes serializes the ABCIResponse using wire
 func (a ABCIResults) Bytes() []byte {
 	bz, err := wire.MarshalBinary(a)
 	if err != nil {

--- a/types/results.go
+++ b/types/results.go
@@ -18,7 +18,7 @@ type ABCIResult struct {
 
 // Hash returns the canonical hash of the ABCIResult
 func (a ABCIResult) Hash() []byte {
-	return wire.BinaryRipemd160(a)
+	return merkle.SimpleHashFromBinary(a)
 }
 
 // ABCIResults wraps the deliver tx results to return a proof
@@ -42,7 +42,11 @@ func NewResultFromResponse(response *abci.ResponseDeliverTx) ABCIResult {
 
 // Bytes serializes the ABCIResponse using go-wire
 func (a ABCIResults) Bytes() []byte {
-	return wire.BinaryBytes(a)
+	bz, err := wire.MarshalBinary(a)
+	if err != nil {
+		panic(err)
+	}
+	return bz
 }
 
 // Hash returns a merkle hash of all results

--- a/types/signable.go
+++ b/types/signable.go
@@ -1,9 +1,5 @@
 package types
 
-import (
-	"github.com/tendermint/tmlibs/merkle"
-)
-
 // Signable is an interface for all signable things.
 // It typically removes signatures before serializing.
 // SignBytes returns the bytes to be signed
@@ -16,5 +12,5 @@ type Signable interface {
 
 // HashSignBytes is a convenience method for getting the hash of the bytes of a signable
 func HashSignBytes(chainID string, o Signable) []byte {
-	return merkle.SimpleHashFromBinary(o.SignBytes(chainID))
+	return tmHash(o.SignBytes(chainID))
 }

--- a/types/signable.go
+++ b/types/signable.go
@@ -1,24 +1,20 @@
 package types
 
 import (
-	"bytes"
-	"io"
-
-	cmn "github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tmlibs/merkle"
 )
 
 // Signable is an interface for all signable things.
 // It typically removes signatures before serializing.
+// SignBytes returns the bytes to be signed
+// NOTE: chainIDs are part of the SignBytes but not
+// necessarily the object themselves.
+// NOTE: Expected to panic if there is an error marshalling.
 type Signable interface {
-	WriteSignBytes(chainID string, w io.Writer, n *int, err *error)
+	SignBytes(chainID string) []byte
 }
 
-// SignBytes is a convenience method for getting the bytes to sign of a Signable.
-func SignBytes(chainID string, o Signable) []byte {
-	buf, n, err := new(bytes.Buffer), new(int), new(error)
-	o.WriteSignBytes(chainID, buf, n, err)
-	if *err != nil {
-		cmn.PanicCrisis(err)
-	}
-	return buf.Bytes()
+// HashSignBytes is a convenience method for getting the hash of the bytes of a signable
+func HashSignBytes(chainID string, o Signable) []byte {
+	return merkle.SimpleHashFromBinary(o.SignBytes(chainID))
 }

--- a/types/test_util.go
+++ b/types/test_util.go
@@ -29,7 +29,7 @@ func MakeCommit(blockID BlockID, height int64, round int,
 }
 
 func signAddVote(privVal *PrivValidatorFS, vote *Vote, voteSet *VoteSet) (signed bool, err error) {
-	vote.Signature, err = privVal.Signer.Sign(SignBytes(voteSet.ChainID(), vote))
+	vote.Signature, err = privVal.Signer.Sign(vote.SignBytes(voteSet.ChainID()))
 	if err != nil {
 		return false, err
 	}

--- a/types/tx.go
+++ b/types/tx.go
@@ -11,12 +11,12 @@ import (
 )
 
 // Tx is an arbitrary byte array.
-// NOTE: Tx has no types at this level, so when go-wire encoded it's just length-prefixed.
+// NOTE: Tx has no types at this level, so when wire encoded it's just length-prefixed.
 // Alternatively, it may make sense to add types here and let
 // []byte be type 0x1 so we can have versioned txs if need be in the future.
 type Tx []byte
 
-// Hash computes the RIPEMD160 hash of the go-wire encoded transaction.
+// Hash computes the RIPEMD160 hash of the wire encoded transaction.
 func (tx Tx) Hash() []byte {
 	return wireHasher(tx).Hash()
 }

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -69,8 +69,9 @@ func TestValidTxProof(t *testing.T) {
 
 			// read-write must also work
 			var p2 TxProof
-			bin := wire.BinaryBytes(proof)
-			err := wire.ReadBinaryBytes(bin, &p2)
+			bin, err := wire.MarshalBinary(proof)
+			assert.Nil(err)
+			err = wire.UnmarshalBinary(bin, &p2)
 			if assert.Nil(err, "%d: %d: %+v", h, i, err) {
 				assert.Nil(p2.Validate(root), "%d: %d", h, i)
 			}
@@ -96,7 +97,8 @@ func testTxProofUnchangable(t *testing.T) {
 
 	// make sure it is valid to start with
 	assert.Nil(proof.Validate(root))
-	bin := wire.BinaryBytes(proof)
+	bin, err := wire.MarshalBinary(proof)
+	assert.Nil(err)
 
 	// try mutating the data and make sure nothing breaks
 	for j := 0; j < 500; j++ {
@@ -110,7 +112,7 @@ func testTxProofUnchangable(t *testing.T) {
 // this make sure the proof doesn't deserialize into something valid
 func assertBadProof(t *testing.T, root []byte, bad []byte, good TxProof) {
 	var proof TxProof
-	err := wire.ReadBinaryBytes(bad, &proof)
+	err := wire.UnmarshalBinary(bad, &proof)
 	if err == nil {
 		err = proof.Validate(root)
 		if err == nil {

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	wire "github.com/tendermint/go-wire"
+	wire "github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 	ctest "github.com/tendermint/tmlibs/test"
 )

--- a/types/validator.go
+++ b/types/validator.go
@@ -3,10 +3,8 @@ package types
 import (
 	"bytes"
 	"fmt"
-	"io"
 
 	"github.com/tendermint/go-crypto"
-	"github.com/tendermint/go-wire"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
@@ -14,9 +12,9 @@ import (
 // NOTE: The Accum is not included in Validator.Hash();
 // make sure to update that method if changes are made here
 type Validator struct {
-	Address     Address `json:"address"`
-	PubKey      crypto.PubKey  `json:"pub_key"`
-	VotingPower int64          `json:"voting_power"`
+	Address     Address       `json:"address"`
+	PubKey      crypto.PubKey `json:"pub_key"`
+	VotingPower int64         `json:"voting_power"`
 
 	Accum int64 `json:"accum"`
 }
@@ -72,7 +70,7 @@ func (v *Validator) String() string {
 // Hash computes the unique ID of a validator with a given voting power.
 // It excludes the Accum value, which changes with every round.
 func (v *Validator) Hash() []byte {
-	return wire.BinaryRipemd160(struct {
+	return tmHash(struct {
 		Address     Address
 		PubKey      crypto.PubKey
 		VotingPower int64
@@ -81,25 +79,6 @@ func (v *Validator) Hash() []byte {
 		v.PubKey,
 		v.VotingPower,
 	})
-}
-
-//-------------------------------------
-
-var ValidatorCodec = validatorCodec{}
-
-type validatorCodec struct{}
-
-func (vc validatorCodec) Encode(o interface{}, w io.Writer, n *int, err *error) {
-	wire.WriteBinary(o.(*Validator), w, n, err)
-}
-
-func (vc validatorCodec) Decode(r io.Reader, n *int, err *error) interface{} {
-	return wire.ReadBinary(&Validator{}, r, 0, n, err)
-}
-
-func (vc validatorCodec) Compare(o1 interface{}, o2 interface{}) int {
-	cmn.PanicSanity("ValidatorCodec.Compare not implemented")
-	return 0
 }
 
 //--------------------------------------------------------------------------------

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -252,6 +252,7 @@ func (valSet *ValidatorSet) VerifyCommit(chainID string, blockID BlockID, height
 			return fmt.Errorf("Invalid commit -- not precommit @ index %v", idx)
 		}
 		_, val := valSet.GetByIndex(idx)
+		fmt.Println("IDX", idx, val)
 		// Validate signature
 		precommitSignBytes := precommit.SignBytes(chainID)
 		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -252,7 +252,6 @@ func (valSet *ValidatorSet) VerifyCommit(chainID string, blockID BlockID, height
 			return fmt.Errorf("Invalid commit -- not precommit @ index %v", idx)
 		}
 		_, val := valSet.GetByIndex(idx)
-		fmt.Println("IDX", idx, val)
 		// Validate signature
 		precommitSignBytes := precommit.SignBytes(chainID)
 		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -253,7 +253,7 @@ func (valSet *ValidatorSet) VerifyCommit(chainID string, blockID BlockID, height
 		}
 		_, val := valSet.GetByIndex(idx)
 		// Validate signature
-		precommitSignBytes := SignBytes(chainID, precommit)
+		precommitSignBytes := precommit.SignBytes(chainID)
 		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {
 			return fmt.Errorf("Invalid commit -- invalid signature: %v", precommit)
 		}
@@ -327,7 +327,7 @@ func (valSet *ValidatorSet) VerifyCommitAny(newSet *ValidatorSet, chainID string
 		seen[vi] = true
 
 		// Validate signature old school
-		precommitSignBytes := SignBytes(chainID, precommit)
+		precommitSignBytes := precommit.SignBytes(chainID)
 		if !ov.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {
 			return errors.Errorf("Invalid commit -- invalid signature: %v", precommit)
 		}

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	crypto "github.com/tendermint/go-crypto"
-	wire "github.com/tendermint/go-wire"
+	wire "github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -16,7 +16,7 @@ import (
 func randPubKey() crypto.PubKey {
 	var pubKey [32]byte
 	copy(pubKey[:], cmn.RandBytes(32))
-	return crypto.PubKeyEd25519(pubKey)
+	return crypto.PubKeyEd25519(pubKey).Wrap()
 }
 
 func randValidator_() *Validator {
@@ -299,7 +299,7 @@ func (valSet *ValidatorSet) toBytes() []byte {
 }
 
 func (valSet *ValidatorSet) fromBytes(b []byte) {
-	err := wire.UnmarshalBinary(b, valSet)
+	err := wire.UnmarshalBinary(b, &valSet)
 	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
 		panic(err)

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -16,7 +16,7 @@ import (
 func randPubKey() crypto.PubKey {
 	var pubKey [32]byte
 	copy(pubKey[:], cmn.RandBytes(32))
-	return crypto.PubKeyEd25519(pubKey).Wrap()
+	return crypto.PubKeyEd25519(pubKey)
 }
 
 func randValidator_() *Validator {
@@ -291,19 +291,17 @@ func BenchmarkValidatorSetCopy(b *testing.B) {
 }
 
 func (valSet *ValidatorSet) toBytes() []byte {
-	buf, n, err := new(bytes.Buffer), new(int), new(error)
-	wire.WriteBinary(valSet, buf, n, err)
-	if *err != nil {
-		cmn.PanicCrisis(*err)
+	bz, err := wire.MarshalBinary(valSet)
+	if err != nil {
+		panic(err)
 	}
-	return buf.Bytes()
+	return bz
 }
 
 func (valSet *ValidatorSet) fromBytes(b []byte) {
-	r, n, err := bytes.NewReader(b), new(int), new(error)
-	wire.ReadBinary(valSet, r, 0, n, err)
-	if *err != nil {
+	err := wire.UnmarshalBinary(b, valSet)
+	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
-		cmn.PanicCrisis(*err)
+		panic(err)
 	}
 }

--- a/types/vote.go
+++ b/types/vote.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/tendermint/go-crypto"
@@ -73,11 +72,15 @@ type Vote struct {
 	Signature        crypto.Signature `json:"signature"`
 }
 
-func (vote *Vote) WriteSignBytes(chainID string, w io.Writer, n *int, err *error) {
-	wire.WriteJSON(CanonicalJSONOnceVote{
+func (vote *Vote) SignBytes(chainID string) []byte {
+	bz, err := wire.MarshalJSON(CanonicalJSONOnceVote{
 		chainID,
 		CanonicalVote(vote),
-	}, w, n, err)
+	})
+	if err != nil {
+		panic(err)
+	}
+	return bz
 }
 
 func (vote *Vote) Copy() *Vote {
@@ -111,7 +114,7 @@ func (vote *Vote) Verify(chainID string, pubKey crypto.PubKey) error {
 		return ErrVoteInvalidValidatorAddress
 	}
 
-	if !pubKey.VerifyBytes(SignBytes(chainID, vote), vote.Signature) {
+	if !pubKey.VerifyBytes(vote.SignBytes(chainID), vote.Signature) {
 		return ErrVoteInvalidSignature
 	}
 	return nil

--- a/types/vote.go
+++ b/types/vote.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/tendermint/go-crypto"
-	"github.com/tendermint/go-wire"
+	"github.com/tendermint/tendermint/wire"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tendermint/tendermint/p2p"
 	cmn "github.com/tendermint/tmlibs/common"
 )
+
+type p2pID string
 
 /*
 	VoteSet helps collect signatures from validators at each height+round for a
@@ -59,7 +60,7 @@ type VoteSet struct {
 	sum           int64                  // Sum of voting power for seen votes, discounting conflicts
 	maj23         *BlockID               // First 2/3 majority seen
 	votesByBlock  map[string]*blockVotes // string(blockHash|blockParts) -> blockVotes
-	peerMaj23s    map[p2p.ID]BlockID     // Maj23 for each peer
+	peerMaj23s    map[p2pID]BlockID      // Maj23 for each peer
 }
 
 // Constructs a new VoteSet struct used to accumulate votes for given height/round.
@@ -78,7 +79,7 @@ func NewVoteSet(chainID string, height int64, round int, type_ byte, valSet *Val
 		sum:           0,
 		maj23:         nil,
 		votesByBlock:  make(map[string]*blockVotes, valSet.Size()),
-		peerMaj23s:    make(map[p2p.ID]BlockID),
+		peerMaj23s:    make(map[p2pID]BlockID),
 	}
 }
 
@@ -291,7 +292,7 @@ func (voteSet *VoteSet) addVerifiedVote(vote *Vote, blockKey string, votingPower
 // this can cause memory issues.
 // TODO: implement ability to remove peers too
 // NOTE: VoteSet must not be nil
-func (voteSet *VoteSet) SetPeerMaj23(peerID p2p.ID, blockID BlockID) error {
+func (voteSet *VoteSet) SetPeerMaj23(peerID p2pID, blockID BlockID) error {
 	if voteSet == nil {
 		cmn.PanicSanity("SetPeerMaj23() on nil VoteSet")
 	}

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -11,7 +11,11 @@ import (
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
-type p2pID string
+// UNSTABLE
+// XXX: duplicate of p2p.ID to avoid dependence between packages.
+// Perhaps we can have a minimal types package containing this (and other things?)
+// that both `types` and `p2p` import ?
+type P2PID string
 
 /*
 	VoteSet helps collect signatures from validators at each height+round for a
@@ -60,7 +64,7 @@ type VoteSet struct {
 	sum           int64                  // Sum of voting power for seen votes, discounting conflicts
 	maj23         *BlockID               // First 2/3 majority seen
 	votesByBlock  map[string]*blockVotes // string(blockHash|blockParts) -> blockVotes
-	peerMaj23s    map[p2pID]BlockID      // Maj23 for each peer
+	peerMaj23s    map[P2PID]BlockID      // Maj23 for each peer
 }
 
 // Constructs a new VoteSet struct used to accumulate votes for given height/round.
@@ -79,7 +83,7 @@ func NewVoteSet(chainID string, height int64, round int, type_ byte, valSet *Val
 		sum:           0,
 		maj23:         nil,
 		votesByBlock:  make(map[string]*blockVotes, valSet.Size()),
-		peerMaj23s:    make(map[p2pID]BlockID),
+		peerMaj23s:    make(map[P2PID]BlockID),
 	}
 }
 
@@ -292,7 +296,7 @@ func (voteSet *VoteSet) addVerifiedVote(vote *Vote, blockKey string, votingPower
 // this can cause memory issues.
 // TODO: implement ability to remove peers too
 // NOTE: VoteSet must not be nil
-func (voteSet *VoteSet) SetPeerMaj23(peerID p2pID, blockID BlockID) error {
+func (voteSet *VoteSet) SetPeerMaj23(peerID P2PID, blockID BlockID) error {
 	if voteSet == nil {
 		cmn.PanicSanity("SetPeerMaj23() on nil VoteSet")
 	}

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -42,7 +42,7 @@ func exampleVote(t byte) *Vote {
 
 func TestVoteSignable(t *testing.T) {
 	vote := examplePrecommit()
-	signBytes := SignBytes("test_chain_id", vote)
+	signBytes := vote.SignBytes("test_chain_id")
 	signStr := string(signBytes)
 
 	expected := `{"chain_id":"test_chain_id","vote":{"block_id":{"hash":"68617368","parts":{"hash":"70617274735F68617368","total":1000000}},"height":12345,"round":2,"timestamp":"2017-12-25T03:00:01.234Z","type":2}}`
@@ -77,24 +77,25 @@ func TestVoteVerifySignature(t *testing.T) {
 	pubKey := privVal.GetPubKey()
 
 	vote := examplePrecommit()
-	signBytes := SignBytes("test_chain_id", vote)
+	signBytes := vote.SignBytes("test_chain_id")
 
 	// sign it
 	signature, err := privVal.Signer.Sign(signBytes)
 	require.NoError(t, err)
 
 	// verify the same vote
-	valid := pubKey.VerifyBytes(SignBytes("test_chain_id", vote), signature)
+	valid := pubKey.VerifyBytes(vote.SignBytes("test_chain_id"), signature)
 	require.True(t, valid)
 
 	// serialize, deserialize and verify again....
 	precommit := new(Vote)
-	bs := wire.BinaryBytes(vote)
-	err = wire.ReadBinaryBytes(bs, &precommit)
+	bs, err := wire.MarshalBinary(vote)
+	require.NoError(t, err)
+	err = wire.UnmarshalBinary(bs, &precommit)
 	require.NoError(t, err)
 
 	// verify the transmitted vote
-	newSignBytes := SignBytes("test_chain_id", precommit)
+	newSignBytes := precommit.SignBytes("test_chain_id")
 	require.Equal(t, string(signBytes), string(newSignBytes))
 	valid = pubKey.VerifyBytes(newSignBytes, signature)
 	require.True(t, valid)

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	wire "github.com/tendermint/go-wire"
+	wire "github.com/tendermint/tendermint/wire"
 )
 
 func examplePrevote() *Vote {

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -1,0 +1,46 @@
+package wire
+
+import (
+	"github.com/tendermint/go-crypto"
+	"github.com/tendermint/go-wire"
+)
+
+// Expose access to a global wire codec
+// TODO: maybe introduce some Context object
+// containing logger, config, codec that can
+// be threaded through everything to avoid this global
+
+var cdc *wire.Codec
+
+func init() {
+	cdc = wire.NewCodec()
+	crypto.RegisterWire(cdc)
+}
+
+func MarshalBinary(o interface{}) ([]byte, error) {
+	return cdc.MarshalBinary(o)
+}
+
+func UnmarshalBinary(bz []byte, ptr interface{}) error {
+	return cdc.UnmarshalBinary(bz, ptr)
+}
+
+func MarshalJSON(o interface{}) ([]byte, error) {
+	return cdc.MarshalJSON(o)
+}
+
+func UnmarshalJSON(jsonBz []byte, ptr interface{}) error {
+	return cdc.UnmarshalJSON(jsonBz, ptr)
+}
+
+func RegisterInterface(ptr interface{}, opts *wire.InterfaceOptions) {
+	cdc.RegisterInterface(ptr, opts)
+}
+
+func RegisterConcrete(o interface{}, name string, opts *wire.ConcreteOptions) {
+	cdc.RegisterConcrete(o, name, opts)
+}
+
+//-------------------------------
+
+const RFC3339Millis = wire.RFC3339Millis

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -1,37 +1,42 @@
 package wire
 
 import (
-	"github.com/tendermint/go-crypto"
 	"github.com/tendermint/go-wire"
 )
 
+/*
 // Expose access to a global wire codec
 // TODO: maybe introduce some Context object
 // containing logger, config, codec that can
 // be threaded through everything to avoid this global
-
 var cdc *wire.Codec
 
 func init() {
 	cdc = wire.NewCodec()
 	crypto.RegisterWire(cdc)
 }
+*/
+
+// Just a flow through to go-wire.
+// To be used later for the global codec
 
 func MarshalBinary(o interface{}) ([]byte, error) {
-	return cdc.MarshalBinary(o)
+	return wire.MarshalBinary(o)
 }
 
 func UnmarshalBinary(bz []byte, ptr interface{}) error {
-	return cdc.UnmarshalBinary(bz, ptr)
+	return wire.UnmarshalBinary(bz, ptr)
 }
 
 func MarshalJSON(o interface{}) ([]byte, error) {
-	return cdc.MarshalJSON(o)
+	return wire.MarshalJSON(o)
 }
 
 func UnmarshalJSON(jsonBz []byte, ptr interface{}) error {
-	return cdc.UnmarshalJSON(jsonBz, ptr)
+	return wire.UnmarshalJSON(jsonBz, ptr)
 }
+
+/*
 
 func RegisterInterface(ptr interface{}, opts *wire.InterfaceOptions) {
 	cdc.RegisterInterface(ptr, opts)
@@ -44,3 +49,4 @@ func RegisterConcrete(o interface{}, name string, opts *wire.ConcreteOptions) {
 //-------------------------------
 
 const RFC3339Millis = wire.RFC3339Millis
+*/

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -36,6 +36,14 @@ func UnmarshalJSON(jsonBz []byte, ptr interface{}) error {
 	return wire.UnmarshalJSON(jsonBz, ptr)
 }
 
+type ConcreteType = wire.ConcreteType
+
+func RegisterInterface(o interface{}, ctypes ...ConcreteType) *wire.TypeInfo {
+	return wire.RegisterInterface(o, ctypes...)
+}
+
+const RFC3339Millis = wire.RFC3339Millis
+
 /*
 
 func RegisterInterface(ptr interface{}, opts *wire.InterfaceOptions) {


### PR DESCRIPTION
Start updating for new go-wire API without breaking the underlying encoding scheme.

These changes should be purely cosmetic, but should make actually upgrading later a lot more straight forward and involve less code.

Started cherry-picking commits from https://github.com/tendermint/tendermint/pull/1221.

We can just keep doing so as we please until the whole repo is using the Marshal API