### PR TITLE
docs: add 'On Determinism'

### DIFF
--- a/docs/determinism.rst
+++ b/docs/determinism.rst
@@ -1,0 +1,8 @@
+On Determinism
+==============
+
+Arguably, the most difficult part of blockchain programming is determinism - that is, ensuring that sources of indeterminism do not creep into the design of such systems.
+
+See `this issue <https://github.com/tendermint/abci/issues/56>`__ for more information on the potential sources of indeterminism.
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ Tendermint 201
    :maxdepth: 2
 
    specification.rst
+   determinism.rst
 
 * For a deeper dive, see `this thesis <https://atrium.lib.uoguelph.ca/xmlui/handle/10214/9769>`__.
 * There is also the `original whitepaper <https://tendermint.com/static/docs/tendermint.pdf>`__, though it is now quite outdated.


### PR DESCRIPTION
This is, admittedly, a half-measure but it gets the ball rolling on having a place to discuss determinism.

closes https://github.com/tendermint/abci/issues/56

