### PR TITLE
types: PrivValidator.Save should first invoke os.MkdirAll

### DIFF
--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -225,7 +227,13 @@ func (privVal *PrivValidatorFS) save() {
 		// `@; BOOM!!!
 		cmn.PanicCrisis(err)
 	}
-	err = cmn.WriteFileAtomic(privVal.filePath, jsonBytes, 0600)
+	outFile := privVal.filePath
+	dir := filepath.Dir(outFile)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		cmn.PanicCrisis(err)
+	}
+	// We need to mkdirAll the path
+	err = cmn.WriteFileAtomic(outFile, jsonBytes, 0600)
 	if err != nil {
 		// `@; BOOM!!!
 		cmn.PanicCrisis(err)

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -220,24 +220,22 @@ func (privVal *PrivValidatorFS) Save() {
 
 func (privVal *PrivValidatorFS) save() {
 	if privVal.filePath == "" {
-		cmn.PanicSanity("Cannot save PrivValidator: filePath not set")
+		panic("Cannot save PrivValidator: filePath not set")
 	}
 	jsonBytes, err := json.Marshal(privVal)
 	if err != nil {
-		// `@; BOOM!!!
-		cmn.PanicCrisis(err)
+		panic(err)
 	}
 	outFile := privVal.filePath
 	// We need to ensure that the parent directory exists.
 	// See Issue https://github.com/tendermint/tendermint/issues/1290
 	dir := filepath.Dir(outFile)
 	if err := os.MkdirAll(dir, 0700); err != nil {
-		cmn.PanicCrisis(err)
+		panic(err)
 	}
 	err = cmn.WriteFileAtomic(outFile, jsonBytes, 0600)
 	if err != nil {
-		// `@; BOOM!!!
-		cmn.PanicCrisis(err)
+		panic(err)
 	}
 }
 

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -228,11 +228,12 @@ func (privVal *PrivValidatorFS) save() {
 		cmn.PanicCrisis(err)
 	}
 	outFile := privVal.filePath
+	// We need to ensure that the parent directory exists.
+	// See Issue https://github.com/tendermint/tendermint/issues/1290
 	dir := filepath.Dir(outFile)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		cmn.PanicCrisis(err)
 	}
-	// We need to mkdirAll the path
 	err = cmn.WriteFileAtomic(outFile, jsonBytes, 0600)
 	if err != nil {
 		// `@; BOOM!!!

--- a/types/priv_validator_test.go
+++ b/types/priv_validator_test.go
@@ -264,6 +264,11 @@ func TestPrivValidatorFSSaveDoesNotCrash(t *testing.T) {
 	defer os.RemoveAll(saveDir)
 
 	pPath := filepath.Join(saveDir, "new", "pennyroyal", "tea", "tf.json")
-	pv := &PrivValidatorFS{filePath: pPath}
+	pv := GenPrivValidatorFS(pPath)
 	pv.Save()
+
+	// Verify that the file exists and has the right content
+	parsed := LoadPrivValidatorFS(pPath)
+	require.NotNil(t, parsed, "the parsed PrivValidator should not be nil")
+	require.Equal(t, parsed, pv)
 }

--- a/types/priv_validator_test.go
+++ b/types/priv_validator_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -252,4 +254,16 @@ func clipToMS(t time.Time) time.Time {
 	million := int64(1000000)
 	nano = (nano / million) * million
 	return time.Unix(0, nano).UTC()
+}
+
+// See Issue https://github.com/tendermint/tendermint/issues/1290
+func TestPrivValidatorFSSaveDoesNotCrash(t *testing.T) {
+	saveDir, err := ioutil.TempDir("", "priv-validator")
+	require.Nil(t, err, "should have created the tempdir")
+
+	defer os.RemoveAll(saveDir)
+
+	pPath := filepath.Join(saveDir, "out-file", "tf.json")
+	pv := &PrivValidatorFS{filePath: pPath}
+	pv.Save()
 }

--- a/types/priv_validator_test.go
+++ b/types/priv_validator_test.go
@@ -263,7 +263,7 @@ func TestPrivValidatorFSSaveDoesNotCrash(t *testing.T) {
 
 	defer os.RemoveAll(saveDir)
 
-	pPath := filepath.Join(saveDir, "out-file", "tf.json")
+	pPath := filepath.Join(saveDir, "new", "pennyroyal", "tea", "tf.json")
 	pv := &PrivValidatorFS{filePath: pPath}
 	pv.Save()
 }


### PR DESCRIPTION
Fixes https://github.com/tendermint/tendermint/issues/1290

We invoked cmn.WriteFileAtomic without first checking if
the parent directory existed yet cmn.WriteFileAtomic doesn't
do it first.

This change ensures that we invoke os.MkdirAll first.

With it, we now get
```shell
tendermint testnet
Successfully initialized 4 node directories
```
instead of panicking.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [X] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [X] Wrote tests
* [ ] Updated CHANGELOG.md
