### PR TITLE
Net_info should print the ID of peers

### DIFF
--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -42,6 +42,7 @@ func NetInfo() (*ctypes.ResultNetInfo, error) {
 	for _, peer := range p2pSwitch.Peers().List() {
 		peers = append(peers, ctypes.Peer{
 			NodeInfo:         peer.NodeInfo(),
+			ID:               peer.ID(),
 			IsOutbound:       peer.IsOutbound(),
 			ConnectionStatus: peer.Status(),
 		})

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -93,6 +93,7 @@ type ResultDialPeers struct {
 
 type Peer struct {
 	p2p.NodeInfo     `json:"node_info"`
+	p2p.ID           `json:"node_id"`
 	IsOutbound       bool                 `json:"is_outbound"`
 	ConnectionStatus p2p.ConnectionStatus `json:"connection_status"`
 }


### PR DESCRIPTION
It is extremely helpful for network debugging to cross-reference between /net_info and dump_consensus_state. We switched from using ip addresses to describe peers to ID()s but we should have the necessary info the responses to cross-reference