### PR TITLE
privVal: Improve SocketClient network code

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -305,7 +305,6 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "netutil",
     "trace"
   ]
   revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
@@ -373,6 +372,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fe167dd9055ba9a4016e7bdad88da263372bca7ebdcebf5c81c609f396e605a3"
+  inputs-digest = "ed9db0be72a900f4812675f683db20eff9d64ef4511dc00ad29a810da65909c2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,10 +90,6 @@
   name = "google.golang.org/grpc"
   version = "1.7.3"
 
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/net"
-
 [prune]
   go-tests = true
   unused-packages = true

--- a/cmd/priv_val_server/main.go
+++ b/cmd/priv_val_server/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 
+	crypto "github.com/tendermint/go-crypto"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 
@@ -36,7 +37,7 @@ func main() {
 		*chainID,
 		*addr,
 		privVal,
-		nil,
+		crypto.GenPrivKeyEd25519(),
 	)
 	err := rs.Start()
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -183,7 +183,7 @@ func NewNode(config *cfg.Config,
 			pvsc    = priv_val.NewSocketClient(
 				logger.With("module", "priv_val"),
 				config.PrivValidatorListenAddr,
-				&privKey,
+				privKey,
 			)
 		)
 

--- a/types/priv_validator/socket_tcp.go
+++ b/types/priv_validator/socket_tcp.go
@@ -1,0 +1,66 @@
+package types
+
+import (
+	"net"
+	"time"
+)
+
+// timeoutError can be used to check if an error returned from the netp package
+// was due to a timeout.
+type timeoutError interface {
+	Timeout() bool
+}
+
+// tcpTimeoutListener implements net.Listener.
+var _ net.Listener = (*tcpTimeoutListener)(nil)
+
+// tcpTimeoutListener wraps a *net.TCPListener to standardise protocol timeouts
+// and potentially other tuning parameters.
+type tcpTimeoutListener struct {
+	*net.TCPListener
+
+	acceptDeadline time.Duration
+	connDeadline   time.Duration
+	period         time.Duration
+}
+
+// newTCPTimeoutListener returns an instance of tcpTimeoutListener.
+func newTCPTimeoutListener(
+	ln net.Listener,
+	acceptDeadline, connDeadline time.Duration,
+	period time.Duration,
+) tcpTimeoutListener {
+	return tcpTimeoutListener{
+		TCPListener:    ln.(*net.TCPListener),
+		acceptDeadline: acceptDeadline,
+		connDeadline:   connDeadline,
+		period:         period,
+	}
+}
+
+// Accept implements net.Listener.
+func (ln tcpTimeoutListener) Accept() (net.Conn, error) {
+	err := ln.SetDeadline(time.Now().Add(ln.acceptDeadline))
+	if err != nil {
+		return nil, err
+	}
+
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tc.SetDeadline(time.Now().Add(ln.connDeadline)); err != nil {
+		return nil, err
+	}
+
+	if err := tc.SetKeepAlive(true); err != nil {
+		return nil, err
+	}
+
+	if err := tc.SetKeepAlivePeriod(ln.period); err != nil {
+		return nil, err
+	}
+
+	return tc, nil
+}

--- a/types/priv_validator/socket_tcp_test.go
+++ b/types/priv_validator/socket_tcp_test.go
@@ -1,0 +1,64 @@
+package types
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestTCPTimeoutListenerAcceptDeadline(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ln = newTCPTimeoutListener(ln, time.Millisecond, time.Second, time.Second)
+
+	_, err = ln.Accept()
+	opErr, ok := err.(*net.OpError)
+	if !ok {
+		t.Fatalf("have %v, want *net.OpError", err)
+	}
+
+	if have, want := opErr.Op, "accept"; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func TestTCPTimeoutListenerConnDeadline(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ln = newTCPTimeoutListener(ln, time.Second, time.Millisecond, time.Second)
+
+	donec := make(chan struct{})
+	go func(ln net.Listener) {
+		defer close(donec)
+
+		c, err := ln.Accept()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(2 * time.Millisecond)
+
+		_, err = c.Write([]byte("foo"))
+		opErr, ok := err.(*net.OpError)
+		if !ok {
+			t.Fatalf("have %v, want *net.OpError", err)
+		}
+
+		if have, want := opErr.Op, "write"; have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+	}(ln)
+
+	_, err = net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	<-donec
+}


### PR DESCRIPTION
Follow-up to feedback from #1286, this change simplifies the connection handling in the SocketClient and makes the communication via TCP more robust. It introduces the tcpTimeoutListener to encapsulate accept and i/o timeout handling as well as connection keep-alive, this type could likely be upgraded to handle more fine-grained tuning of the tcp stack (linger, nodelay, etc.) according to the properties we desire. The same methods should be applied to the RemoteSigner which will be overhauled when the priv_val_server is fleshed out.

* require private key
* simplify connect logic
* break out conn upgrades to `tcpTimeoutListener`
* extend test coverage and simplify component setup

***

Belongs to #1255 with the original issue being #1307 