### PR TITLE
p2p: NodeInfo.Channels is now common.HexBytes instead of []byte

### DIFF
--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	crypto "github.com/tendermint/go-crypto"
+	"github.com/tendermint/tmlibs/common"
 )
 
 const (
@@ -24,9 +25,9 @@ type NodeInfo struct {
 	ListenAddr string        `json:"listen_addr"` // accepting incoming
 
 	// Check compatibility
-	Network  string `json:"network"`  // network/chain ID
-	Version  string `json:"version"`  // major.minor.revision
-	Channels []byte `json:"channels"` // channels this node knows about
+	Network  string          `json:"network"`  // network/chain ID
+	Version  string          `json:"version"`  // major.minor.revision
+	Channels common.HexBytes `json:"channels"` // channels this node knows about
 
 	// Sanitize
 	Moniker string   `json:"moniker"` // arbitrary moniker

--- a/p2p/node_info_test.go
+++ b/p2p/node_info_test.go
@@ -1,0 +1,34 @@
+package p2p_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	crypto "github.com/tendermint/go-crypto"
+	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tmlibs/common"
+)
+
+func TestNodeInfoChannelsAreHexEncoded(t *testing.T) {
+	chb := "Tendermint"
+	ni := &p2p.NodeInfo{
+		PubKey:   crypto.GenPrivKeyEd25519().PubKey(),
+		Channels: []byte(chb),
+		Other:    []string{"test", "foo"},
+	}
+	gotBlob, err := json.Marshal(ni)
+	require.Nil(t, err, "expecting a successful json.Marshal")
+	keyBlob, err := json.Marshal(ni.PubKey)
+	require.Nil(t, err, "expecting a successful json.Marshal of the key")
+	channelsBlob, err := json.Marshal(common.HexBytes(chb))
+	require.Nil(t, err, "expecting a successful json.Marshal of the channels")
+	wantBlob := []byte(fmt.Sprintf(`{"pub_key":%s,"listen_addr":"","network":"","version":"","channels":%s,"moniker":"","other":["test","foo"]}`, keyBlob, channelsBlob))
+	require.Equal(t, wantBlob, gotBlob)
+
+	back := new(p2p.NodeInfo)
+	require.Nil(t, json.Unmarshal(gotBlob, back), "roundtrip Unmarshal should not error")
+	require.Equal(t, ni, back, "roundtrip Unmarshal should return the same object as the original")
+}


### PR DESCRIPTION
Fixes #1310

NodeInfo.Channels is now of type common.HexBytes instead of []byte.
[]byte when JSON encoded as represented as base64 bytes. However
base64 hurts readability/inspection. Therefore use common.HexBytes
which can still be assigned to []byte but are encoded as hex bytes e.g
```go
ni.Channels = []byte("foo-bar")
```

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
