### PR TITLE
p2p: Keep reference to connections in test peer

### DIFF
--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -140,6 +140,8 @@ func (p *remotePeer) Stop() {
 }
 
 func (p *remotePeer) accept(l net.Listener) {
+	conns := []net.Conn{}
+
 	for {
 		conn, err := l.Accept()
 		if err != nil {
@@ -160,10 +162,15 @@ func (p *remotePeer) accept(l net.Listener) {
 		if err != nil {
 			golog.Fatalf("Failed to perform handshake: %+v", err)
 		}
+
+		conns = append(conns, conn)
+
 		select {
 		case <-p.quit:
-			if err := conn.Close(); err != nil {
-				golog.Fatal(err)
+			for _, conn := range conns {
+				if err := conn.Close(); err != nil {
+					golog.Fatal(err)
+				}
 			}
 			return
 		default:


### PR DESCRIPTION
We observed non-deterministic test failures in one of our switch tests, which would happen if the GC would run between iterations of the accept loop. As we don't hold any reference to the connection the setup finalizer might get triggered and therefore the file handle closed. For the curious check the references on finalizers and the variable scoping in the spec:

https://groups.google.com/forum/#!topic/golang-nuts/xWkhGJ5PY6c
https://groups.google.com/forum/#!topic/golang-nuts/d8aF4rAob7U/discussion
https://golang.org/ref/spec#Declarations_and_scope

Fixes #1266