### PR TITLE
Remove unnecessary bytes.Compare() call

### DIFF
--- a/types/validator.go
+++ b/types/validator.go
@@ -45,9 +45,10 @@ func (v *Validator) CompareAccum(other *Validator) *Validator {
 	} else if v.Accum < other.Accum {
 		return other
 	} else {
-		if bytes.Compare(v.Address, other.Address) < 0 {
+		result := bytes.Compare(v.Address, other.Address)
+		if result < 0 {
 			return v
-		} else if bytes.Compare(v.Address, other.Address) > 0 {
+		} else if result > 0 {
 			return other
 		} else {
 			cmn.PanicSanity("Cannot compare identical validators")


### PR DESCRIPTION
It's a simple patch.
bytes.Compare(v.Address, other.Address) doesn't need to be called two times.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
