### PR TITLE
do not return an error if we fail to lookup IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ IMPROVEMENTS:
 - [all] renamed `dummy` (`persistent_dummy`) to `kvstore`
   (`persistent_kvstore`) (name "dummy" is deprecated and will not work in
   release after this one)
+- [p2p] do not fail instantly if we can't resolve IPs of seeds or persistent peers
 
 FEATURES:
 - [config] added the `--p2p.private_peer_ids` flag and `PrivatePeerIDs` config variable (see config for description)

--- a/p2p/netaddress_test.go
+++ b/p2p/netaddress_test.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,11 +32,11 @@ func TestNewNetAddressString(t *testing.T) {
 		{"127.0.0.1:8080", "127.0.0.1:8080", true},
 		{"tcp://127.0.0.1:8080", "127.0.0.1:8080", true},
 		{"udp://127.0.0.1:8080", "127.0.0.1:8080", true},
-		{"udp//127.0.0.1:8080", "", false},
+		// {"udp//127.0.0.1:8080", "", false},
 		// {"127.0.0:8080", false},
 		{"notahost", "", false},
 		{"127.0.0.1:notapath", "", false},
-		{"notahost:8080", "", false},
+		// {"notahost:8080", "", false},
 		{"8082", "", false},
 		{"127.0.0:8080000", "", false},
 
@@ -128,4 +129,26 @@ func TestNetAddressReachabilityTo(t *testing.T) {
 
 		assert.Equal(t.reachability, addr.ReachabilityTo(other))
 	}
+}
+
+func TestDial(t *testing.T) {
+	addr, err := NewNetAddressString("notresolvable:8800")
+
+	assert.NoError(t, err)
+
+	conn, err := addr.Dial()
+
+	assert.Nil(t, conn)
+	assert.Error(t, err, IPNotSetError)
+}
+
+func TestDialTimeout(t *testing.T) {
+	addr, err := NewNetAddressString("notresolvable:8800")
+
+	assert.NoError(t, err)
+
+	conn, err := addr.DialTimeout(1 * time.Second)
+
+	assert.Nil(t, conn)
+	assert.Error(t, err, IPNotSetError)
 }


### PR DESCRIPTION
So we don't fail when e.g. checking seeds (see
pex/pex_reactor.go#checkSeeds)

If there is no IP, Dial/DialTimeout will return an error.

Refs #1230

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG.md
