### PR TITLE
Update godep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,9 +2,10 @@
 
 
 [[projects]]
+  branch = "master"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
-  revision = "50de9da05b50eb15658bb350f6ea24368a111ab7"
+  revision = "2be2f12b358dc57d70b8f501b00be450192efbc3"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -19,10 +20,10 @@
   revision = "95f809107225be108efcf10a3509e4ea6ceef3c4"
 
 [[projects]]
-  branch = "master"
   name = "github.com/fortytw2/leaktest"
   packages = ["."]
-  revision = "3b724c3d7b8729a35bf4e577f71653aec6e53513"
+  revision = "a5ef70473c97b71626b9abeda80ee92ba2a7de9e"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
@@ -96,6 +97,7 @@
     ".",
     "hcl/ast",
     "hcl/parser",
+    "hcl/printer",
     "hcl/scanner",
     "hcl/strconv",
     "hcl/token",
@@ -103,7 +105,7 @@
     "json/scanner",
     "json/token"
   ]
-  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
+  revision = "f40e974e75af4e271d97ce0fc917af5898ae7bda"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -126,12 +128,14 @@
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "49d762b9817ba1c2e9d0c69183c2b4a8b8f1d934"
+  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
+  version = "v1.7.6"
 
 [[projects]]
+  branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "b4575eea38cca1123ec2dc90c26529b5c5acfcff"
+  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
@@ -169,8 +173,8 @@
 [[projects]]
   name = "github.com/spf13/cast"
   packages = ["."]
-  revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
-  version = "v1.1.0"
+  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/spf13/cobra"
@@ -193,8 +197,8 @@
 [[projects]]
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
-  version = "v1.0.0"
+  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
+  version = "v1.0.2"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -206,6 +210,7 @@
   version = "v1.2.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -221,10 +226,10 @@
     "leveldb/table",
     "leveldb/util"
   ]
-  revision = "34011bf325bce385408353a30b101fe5e923eb6e"
+  revision = "169b1b37be738edb2813dab48c97a549bcf99bb5"
 
 [[projects]]
-  branch = "develop"
+  branch = "release/v0.10.1"
   name = "github.com/tendermint/abci"
   packages = [
     "client",
@@ -234,7 +239,7 @@
     "server",
     "types"
   ]
-  revision = "9e0e00bef42aebf6b402f66bf0f3dc607de8a6f3"
+  revision = "4600f19d9f7577ac8b20011d93147a9e1f6e6e97"
 
 [[projects]]
   branch = "master"
@@ -278,10 +283,11 @@
     "pubsub/query",
     "test"
   ]
-  revision = "1b9b5652a199ab0be2e781393fb275b66377309d"
-  version = "v0.7.0"
+  revision = "24da7009c3d8c019b40ba4287495749e3160caca"
+  version = "v0.7.1"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
@@ -293,7 +299,7 @@
     "ripemd160",
     "salsa20/salsa"
   ]
-  revision = "1875d0a70c90e57f11972aefd42276df65e895b9"
+  revision = "88942b9c40a4c9d203b82b3731787b672d6e809b"
 
 [[projects]]
   branch = "master"
@@ -307,12 +313,13 @@
     "lex/httplex",
     "trace"
   ]
-  revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
+  revision = "6078986fec03a1dcc236c34816c71b0e05018fda"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
+  revision = "91ee8cde435411ca3f1cd365e8f20131aed4d0a1"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -332,12 +339,14 @@
     "unicode/norm",
     "unicode/rangetable"
   ]
-  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
+  revision = "f8c8703595236ae70fdf8789ecb656ea0bcdcf46"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -360,18 +369,18 @@
     "tap",
     "transport"
   ]
-  revision = "401e0e00e4bb830a10496d64cd95e068c5bf50de"
-  version = "v1.7.3"
+  revision = "5b3c4e850e90a4cf6a20ebd46c8b32a0a3afcb9e"
+  version = "v1.7.5"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
-  version = "v2.0.0"
+  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
+  version = "v2.1.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ed9db0be72a900f4812675f683db20eff9d64ef4511dc00ad29a810da65909c2"
+  inputs-digest = "d5b407cf2d84cde15d42282d06c0afa4e75e133e969e61261b478542e33e2ef2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -229,7 +229,6 @@
   revision = "169b1b37be738edb2813dab48c97a549bcf99bb5"
 
 [[projects]]
-  branch = "release/v0.10.2"
   name = "github.com/tendermint/abci"
   packages = [
     "client",
@@ -239,7 +238,8 @@
     "server",
     "types"
   ]
-  revision = "8fc21cdcd93bee6a0eb2b2fe345b55082e6c6767"
+  revision = "46686763ba8ea595ede16530ed4a40fb38f49f94"
+  version = "v0.10.2"
 
 [[projects]]
   branch = "master"
@@ -381,6 +381,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4357422364b30c09987968b41d0b955313a6917c30d61851a465af6b7e647197"
+  inputs-digest = "4dca5dbd2d280d093d7c8fc423606ab86d6ad1b241b076a7716c2093b5a09231"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -229,6 +229,7 @@
   revision = "169b1b37be738edb2813dab48c97a549bcf99bb5"
 
 [[projects]]
+  branch = "release/v0.10.2"
   name = "github.com/tendermint/abci"
   packages = [
     "client",
@@ -238,8 +239,7 @@
     "server",
     "types"
   ]
-  revision = "f3f9f792a569e80286b14f25f6a507d8bca6319f"
-  version = "v0.10.1"
+  revision = "5310e85bbbb4d89641731cbc83e49d5cc50baf08"
 
 [[projects]]
   branch = "master"
@@ -381,6 +381,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3e53ce46fe488767647c414e724b7815f71b25013cd52028abd58b02f736e7bb"
+  inputs-digest = "4357422364b30c09987968b41d0b955313a6917c30d61851a465af6b7e647197"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -229,7 +229,6 @@
   revision = "169b1b37be738edb2813dab48c97a549bcf99bb5"
 
 [[projects]]
-  branch = "release/v0.10.1"
   name = "github.com/tendermint/abci"
   packages = [
     "client",
@@ -239,7 +238,8 @@
     "server",
     "types"
   ]
-  revision = "4600f19d9f7577ac8b20011d93147a9e1f6e6e97"
+  revision = "f3f9f792a569e80286b14f25f6a507d8bca6319f"
+  version = "v0.10.1"
 
 [[projects]]
   branch = "master"
@@ -381,6 +381,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d5b407cf2d84cde15d42282d06c0afa4e75e133e969e61261b478542e33e2ef2"
+  inputs-digest = "3e53ce46fe488767647c414e724b7815f71b25013cd52028abd58b02f736e7bb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -239,7 +239,7 @@
     "server",
     "types"
   ]
-  revision = "5310e85bbbb4d89641731cbc83e49d5cc50baf08"
+  revision = "8fc21cdcd93bee6a0eb2b2fe345b55082e6c6767"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/abci"
-  branch = "release/v0.10.1"
+  version = "~0.10.1"
 
 [[constraint]]
   name = "github.com/tendermint/go-crypto"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,8 @@
 
 [[constraint]]
   name = "github.com/tendermint/abci"
-  version = "~0.10.1"
+  branch = "release/v0.10.2"
+  # version = "~0.10.1"
 
 [[constraint]]
   name = "github.com/tendermint/go-crypto"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,8 +71,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/abci"
-  branch = "release/v0.10.2"
-  # version = "~0.10.1"
+  version = "~0.10.2"
 
 [[constraint]]
   name = "github.com/tendermint/go-crypto"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,23 +35,23 @@
 
 [[constraint]]
   name = "github.com/go-kit/kit"
-  version = "0.6.0"
+  version = "~0.6.0"
 
 [[constraint]]
   name = "github.com/gogo/protobuf"
-  version = "1.0.0"
+  version = "~1.0.0"
 
 [[constraint]]
   name = "github.com/golang/protobuf"
-  version = "1.0.0"
+  version = "~1.0.0"
 
 [[constraint]]
   name = "github.com/gorilla/websocket"
-  version = "1.2.0"
+  version = "~1.2.0"
 
 [[constraint]]
   name = "github.com/pkg/errors"
-  version = "0.8.0"
+  version = "~0.8.0"
 
 [[constraint]]
   branch = "master"
@@ -59,36 +59,36 @@
 
 [[constraint]]
   name = "github.com/spf13/cobra"
-  version = "0.0.1"
+  version = "~0.0.1"
 
 [[constraint]]
   name = "github.com/spf13/viper"
-  version = "1.0.0"
+  version = "~1.0.0"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.1"
+  version = "~1.2.1"
 
 [[constraint]]
   name = "github.com/tendermint/abci"
-  branch = "develop"
+  branch = "release/v0.10.1"
 
 [[constraint]]
   name = "github.com/tendermint/go-crypto"
-  version = "0.5.0"
+  version = "~0.5.0"
 
 [[constraint]]
   name = "github.com/tendermint/go-wire"
   source = "github.com/tendermint/go-amino"
-  version = "0.7.3"
+  version = "~0.7.3"
 
 [[constraint]]
   name = "github.com/tendermint/tmlibs"
-  version = "0.7.0"
+  version = "~0.7.1"
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "1.7.3"
+  version = "~1.7.3"
 
 [prune]
   go-tests = true

--- a/version/version.go
+++ b/version/version.go
@@ -2,12 +2,12 @@ package version
 
 const Maj = "0"
 const Min = "16"
-const Fix = "0"
+const Fix = "1"
 
 var (
 	// Version is the current version of Tendermint
 	// Must be a string because scripts like dist.sh read this file.
-	Version = "0.16.0"
+	Version = "0.16.1-rc1"
 
 	// GitCommit is the current HEAD set using ldflags.
 	GitCommit string


### PR DESCRIPTION
We actually shouldn't merge this as is - I updated tmlibs and abci and not sure why the state tests are now failing. Seems to be because of a super minor mismatch in empty struct in the KI64Pair between `[]uint{}` and `[]uint(nil)`  :(

Maybe @xla or @melekes can help figure this out .

