### PR TITLE
remove Heap.Update() call when setting Proposer field

### DIFF
--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -60,13 +60,14 @@ func (valSet *ValidatorSet) IncrementAccum(times int) {
 	// Decrement the validator with most accum times times
 	for i := 0; i < times; i++ {
 		mostest := validatorsHeap.Peek().(*Validator)
-		if i == times-1 {
-			valSet.Proposer = mostest
-		}
-
 		// mind underflow
 		mostest.Accum = safeSubClip(mostest.Accum, valSet.TotalVotingPower())
-		validatorsHeap.Update(mostest, accumComparable{mostest})
+
+		if i == times-1 {
+			valSet.Proposer = mostest
+		} else {
+			validatorsHeap.Update(mostest, accumComparable{mostest})
+		}
 	}
 }
 


### PR DESCRIPTION
In the for loop of ValidatorSet.IncrementAccum(), Heap.Update() call is unnecessary when i == times - 1.
All tests of validator_set_test.go have passed.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
