### PR TITLE
fix typo on block header

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -215,7 +215,7 @@ func (h *Header) StringIndented(indent string) string {
 %s  Data:           %v
 %s  Validators:     %v
 %s  App:            %v
-%s  Conensus:       %v
+%s  Consensus:       %v
 %s  Results:        %v
 %s  Evidence:       %v
 %s}#%v`,


### PR DESCRIPTION
Found a typo in block header while the tendermint node was streaming blocks.
This is my first commit, so please let me know if there is anything else I should do.