### PR TITLE
docker: update usergroup for alpine 3.7

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -13,8 +13,8 @@ ENV DATA_ROOT /tendermint
 ENV TMHOME $DATA_ROOT
 
 # Set user right away for determinism
-RUN addgroup tmuser && \
-    adduser -S -G tmuser tmuser
+RUN addgroup -g 1000 -S tmuser && \
+    adduser -u 1000 -S tmuser -G tmuser
 
 # Create directory for persistence and give our user ownership
 RUN mkdir -p $DATA_ROOT && \

--- a/DOCKER/Dockerfile.develop
+++ b/DOCKER/Dockerfile.develop
@@ -3,8 +3,8 @@ FROM alpine:3.7
 ENV DATA_ROOT /tendermint
 ENV TMHOME $DATA_ROOT
 
-RUN addgroup tmuser && \
-    adduser -S -G tmuser tmuser
+RUN addgroup -g 1000 tmuser && \
+    adduser -u 1000 -S tmuser -G tmuser
 
 RUN mkdir -p $DATA_ROOT && \
     chown -R tmuser:tmuser $DATA_ROOT


### PR DESCRIPTION
Fixes #1398 

For Alpine 3.7 it looks like this is the recommended command (see referenced Alpine issue).

I'm still confused about the issue though.
On Ubuntu I'm getting the error mentioned in the issue with Tendermint's official docker images for 0.17.1 and 0.18.0, but if I clone tendermint's repo and do *make build_develop* I'm unable to repro the issue.
If I do *make build* (which pull the 0.17.1 binary) the resulting image doesn't work at all (I get a "standard_init_linux.go:195: exec user process caused "no such file or directory"" error as if there was a CGO issue with the binary).

If someone can explain this weirdness I'd be very interested in understanding it.

Note: the only command impacted is *tendermint init*, not other tendermint commands (since it's because of the filesystem)