### PR TITLE
Greg/private networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ IMPROVEMENTS:
 	- propagate block parts rarest first
 - Better testing of the consensus state machine (ie. use a DSL)
 - Auto compiled serialization/deserialization code instead of go-wire reflection
+- Enabled private IPv4 address usage. (RFC1918)
 
 BUG FIXES:
 - Graceful handling/recovery for apps that have non-determinism or fail to halt

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -199,7 +199,7 @@ func (na *NetAddress) DialTimeout(timeout time.Duration) (net.Conn, error) {
 // Routable returns true if the address is routable.
 func (na *NetAddress) Routable() bool {
 	// TODO(oga) bitcoind doesn't include RFC3849 here, but should we?
-	return na.Valid() && !(na.RFC1918() || na.RFC3927() || na.RFC4862() ||
+	return na.Valid() && !(na.RFC3927() || na.RFC4862() ||
 		na.RFC4193() || na.RFC4843() || na.Local())
 }
 


### PR DESCRIPTION
Enabled the use of private IPv4 addresses. (RFC1918). This is required to run tendermint on a private network where all the nodes are on the same private network.