### PR TITLE
Cleanup P2P

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,18 @@ BUG FIXES:
 FEATURES:
 
 - [p2p] Allow peers with different Minor versions to connect
+- [rpc] `/net_info` includes `n_peers`
 
 IMPROVEMENTS:
 
-- [p2p] Various code comments cleanup
+- [p2p] Various code comments, cleanup, error types
+- [p2p] Change some Error logs to Debug
 
 BUG FIXES:
 
 - [p2p] Fix reconnect to persistent peer when first dial fails
 - [p2p] Validate NodeInfo.ListenAddr
+- [p2p] Only allow (MaxNumPeers - MaxNumOutboundPeers) inbound peers
 - [p2p/pex] Limit max msg size to 64kB
 
 ## 0.19.1 (April 27th, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,19 @@ BUG FIXES:
 
 ## 0.19.2 (TBD)
 
+FEATURES:
+
+- [p2p] Allow peers with different Minor versions to connect
+
+IMPROVEMENTS:
+
+- [p2p] Various code comments cleanup
+
 BUG FIXES:
 
-- Fix reconnect to persistent peer when first dial fails
+- [p2p] Fix reconnect to persistent peer when first dial fails
+- [p2p] Validate NodeInfo.ListenAddr
+- [p2p/pex] Limit max msg size to 64kB
 
 ## 0.19.1 (April 27th, 2018)
 

--- a/docs/specification/new-spec/p2p/node.md
+++ b/docs/specification/new-spec/p2p/node.md
@@ -12,7 +12,7 @@ Seeds should operate full nodes with the PEX reactor in a "crawler" mode
 that continuously explores to validate the availability of peers.
 
 Seeds should only respond with some top percentile of the best peers it knows about.
-See [reputation](TODO) for details on peer quality.
+See [the peer-exchange docs](/docs/specification/new-spec/reactors/pex/pex.md)for details on peer quality.
 
 ## New Full Node
 

--- a/docs/specification/new-spec/reactors/pex/pex.md
+++ b/docs/specification/new-spec/reactors/pex/pex.md
@@ -83,10 +83,7 @@ Connection attempts are made with exponential backoff (plus jitter). Because
 the selection process happens every `ensurePeersPeriod`, we might not end up
 dialing a peer for much longer than the backoff duration.
 
-
-TODO
-PEX: if we fail to conenct to the peer after 16 tries (with exponential backoff), we remove from address book completely.
-
+If we fail to conenct to the peer after 16 tries (with exponential backoff), we remove from address book completely.
 
 ## Select Peers to Exchange
 

--- a/docs/specification/new-spec/reactors/pex/pex.md
+++ b/docs/specification/new-spec/reactors/pex/pex.md
@@ -35,22 +35,22 @@ Peers listen on a configurable ListenAddr that they self-report in their
 NodeInfo during handshakes with other peers. Peers accept up to (MaxNumPeers -
 MinNumOutboundPeers) incoming peers.
 
-
 ## Address Book
 
 Peers are tracked via their ID (their PubKey.Address()).
-For each ID, the address book keeps the most recent IP:PORT.
 Peers are added to the address book from the PEX when they first connect to us or
 when we hear about them from other peers.
 
 The address book is arranged in sets of buckets, and distinguishes between
 vetted (old) and unvetted (new) peers. It keeps different sets of buckets for vetted and
-unvetted peers. Buckets provide randomization over peer selection.
+unvetted peers. Buckets provide randomization over peer selection. Peers are put
+in buckets according to their IP groups.
 
-A vetted peer can only be in one bucket. An unvetted peer can be in multiple buckets.
+A vetted peer can only be in one bucket. An unvetted peer can be in multiple buckets, and
+each instance of the peer can have a different IP:PORT.
 
-If there's no space in the book, we check the bucket for bad peers, which include peers we've attempted to
-dial 3 times, and then remove them from only that bucket.
+If we're trying to add a new peer but there's no space in its bucket, we'll
+remove the worst peer from that bucket to make room.
 
 ## Vetting
 

--- a/docs/specification/new-spec/reactors/pex/pex.md
+++ b/docs/specification/new-spec/reactors/pex/pex.md
@@ -21,13 +21,19 @@ When we have no peers, or have been unable to find enough peers from existing on
 we dial a randomly selected seed to get a list of peers to dial.
 
 On startup, we will also immediately dial the given list of `persisten_peers`,
-and will attempt to maintain persistent connections with them. If the connections die,
+and will attempt to maintain persistent connections with them. If the connections die, or we fail to dail,
 we will redial every 5s for a a few minutes, then switch to an exponential backoff schedule,
 and after about a day of trying, stop dialing the peer.
 
-So long as we have less than `MaxPeers`, we periodically request additional peers
+So long as we have less than `MinNumOutboundPeers`, we periodically request additional peers
 from each of our own. If sufficient time goes by and we still can't find enough peers,
 we try the seeds again.
+
+## Listening
+
+Peers listen on a configurable ListenAddr that they self-report during
+handshakes with other peers.
+
 
 ## Address Book
 
@@ -41,6 +47,9 @@ vetted (old) and unvetted (new) peers. It keeps different sets of buckets for ve
 unvetted peers. Buckets provide randomization over peer selection.
 
 A vetted peer can only be in one bucket. An unvetted peer can be in multiple buckets.
+
+If there's no space in the book, we check the bucket for bad peers, which include peers we've attempted to
+dial 3 times, and then remove them from only that bucket.
 
 ## Vetting
 
@@ -74,17 +83,9 @@ Connection attempts are made with exponential backoff (plus jitter). Because
 the selection process happens every `ensurePeersPeriod`, we might not end up
 dialing a peer for much longer than the backoff duration.
 
-.......
------------------
-TODO: put this in the right place. And add more details.
 
-AddrBook: If there's no space in the book, we check the bucket for bad peers, which include peers we've attempted to
-dial 3 times, and then remove them from only that bucket.
-
+TODO
 PEX: if we fail to conenct to the peer after 16 tries (with exponential backoff), we remove from address book completely.
-
------------------
-.......
 
 
 ## Select Peers to Exchange

--- a/docs/specification/new-spec/reactors/pex/pex.md
+++ b/docs/specification/new-spec/reactors/pex/pex.md
@@ -31,8 +31,9 @@ we try the seeds again.
 
 ## Listening
 
-Peers listen on a configurable ListenAddr that they self-report during
-handshakes with other peers.
+Peers listen on a configurable ListenAddr that they self-report in their
+NodeInfo during handshakes with other peers. Peers accept up to (MaxNumPeers -
+MinNumOutboundPeers) incoming peers.
 
 
 ## Address Book

--- a/docs/specification/new-spec/reactors/pex/pex.md
+++ b/docs/specification/new-spec/reactors/pex/pex.md
@@ -20,9 +20,9 @@ Peer discovery begins with a list of seeds.
 When we have no peers, or have been unable to find enough peers from existing ones,
 we dial a randomly selected seed to get a list of peers to dial.
 
-On startup, we will also immediately dial the given list of `persisten_peers`,
-and will attempt to maintain persistent connections with them. If the connections die, or we fail to dail,
-we will redial every 5s for a a few minutes, then switch to an exponential backoff schedule,
+On startup, we will also immediately dial the given list of `persistent_peers`,
+and will attempt to maintain persistent connections with them. If the connections die, or we fail to dial,
+we will redial every 5s for a few minutes, then switch to an exponential backoff schedule,
 and after about a day of trying, stop dialing the peer.
 
 So long as we have less than `MinNumOutboundPeers`, we periodically request additional peers
@@ -84,7 +84,7 @@ Connection attempts are made with exponential backoff (plus jitter). Because
 the selection process happens every `ensurePeersPeriod`, we might not end up
 dialing a peer for much longer than the backoff duration.
 
-If we fail to conenct to the peer after 16 tries (with exponential backoff), we remove from address book completely.
+If we fail to connect to the peer after 16 tries (with exponential backoff), we remove from address book completely.
 
 ## Select Peers to Exchange
 

--- a/node/node.go
+++ b/node/node.go
@@ -100,7 +100,6 @@ type Node struct {
 	// network
 	sw       *p2p.Switch  // p2p connections
 	addrBook pex.AddrBook // known peers
-	// trustMetricStore *trust.TrustMetricStore // trust metrics for all peers
 
 	// services
 	eventBus         *types.EventBus // pub/sub for services

--- a/node/node.go
+++ b/node/node.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 
 	abci "github.com/tendermint/abci/types"
 	amino "github.com/tendermint/go-amino"
@@ -280,14 +279,6 @@ func NewNode(config *cfg.Config,
 		addrBook = pex.NewAddrBook(config.P2P.AddrBookFile(), config.P2P.AddrBookStrict)
 		addrBook.SetLogger(p2pLogger.With("book", config.P2P.AddrBookFile()))
 
-		var seeds []string
-		if config.P2P.Seeds != "" {
-			seeds = strings.Split(config.P2P.Seeds, ",")
-		}
-		var privatePeerIDs []string
-		if config.P2P.PrivatePeerIDs != "" {
-			privatePeerIDs = strings.Split(config.P2P.PrivatePeerIDs, ",")
-		}
 		// TODO persistent peers ? so we can have their DNS addrs saved
 		pexReactor := pex.NewPEXReactor(addrBook,
 			&pex.PEXReactorConfig{

--- a/node/node.go
+++ b/node/node.go
@@ -274,11 +274,11 @@ func NewNode(config *cfg.Config,
 	// if auth_enc=false.
 	//
 	// If PEX is on, it should handle dialing the seeds. Otherwise the switch does it.
+	// Note we currently use the addrBook regardless at least for AddOurAddress
 	var addrBook pex.AddrBook
+	addrBook = pex.NewAddrBook(config.P2P.AddrBookFile(), config.P2P.AddrBookStrict)
+	addrBook.SetLogger(p2pLogger.With("book", config.P2P.AddrBookFile()))
 	if config.P2P.PexReactor {
-		addrBook = pex.NewAddrBook(config.P2P.AddrBookFile(), config.P2P.AddrBookStrict)
-		addrBook.SetLogger(p2pLogger.With("book", config.P2P.AddrBookFile()))
-
 		// TODO persistent peers ? so we can have their DNS addrs saved
 		pexReactor := pex.NewPEXReactor(addrBook,
 			&pex.PEXReactorConfig{

--- a/node/node.go
+++ b/node/node.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 
 	abci "github.com/tendermint/abci/types"
 	amino "github.com/tendermint/go-amino"
@@ -21,7 +22,6 @@ import (
 	mempl "github.com/tendermint/tendermint/mempool"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/p2p/pex"
-	"github.com/tendermint/tendermint/p2p/trust"
 	"github.com/tendermint/tendermint/proxy"
 	rpccore "github.com/tendermint/tendermint/rpc/core"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
@@ -99,9 +99,9 @@ type Node struct {
 	privValidator types.PrivValidator // local node's validator key
 
 	// network
-	sw               *p2p.Switch             // p2p connections
-	addrBook         pex.AddrBook            // known peers
-	trustMetricStore *trust.TrustMetricStore // trust metrics for all peers
+	sw       *p2p.Switch  // p2p connections
+	addrBook pex.AddrBook // known peers
+	// trustMetricStore *trust.TrustMetricStore // trust metrics for all peers
 
 	// services
 	eventBus         *types.EventBus // pub/sub for services
@@ -262,20 +262,33 @@ func NewNode(config *cfg.Config,
 	sw.AddReactor("EVIDENCE", evidenceReactor)
 
 	// Optionally, start the pex reactor
+	//
+	// TODO:
+	//
+	// We need to set Seeds and PersistentPeers on the switch,
+	// since it needs to be able to use these (and their DNS names)
+	// even if the PEX is off. We can include the DNS name in the NetAddress,
+	// but it would still be nice to have a clear list of the current "PersistentPeers"
+	// somewhere that we can return with net_info.
+	//
+	// Let's assume we always have IDs ... and we just dont authenticate them
+	// if auth_enc=false.
+	//
+	// If PEX is on, it should handle dialing the seeds. Otherwise the switch does it.
 	var addrBook pex.AddrBook
-	var trustMetricStore *trust.TrustMetricStore
 	if config.P2P.PexReactor {
 		addrBook = pex.NewAddrBook(config.P2P.AddrBookFile(), config.P2P.AddrBookStrict)
 		addrBook.SetLogger(p2pLogger.With("book", config.P2P.AddrBookFile()))
 
-		// Get the trust metric history data
-		trustHistoryDB, err := dbProvider(&DBContext{"trusthistory", config})
-		if err != nil {
-			return nil, err
+		var seeds []string
+		if config.P2P.Seeds != "" {
+			seeds = strings.Split(config.P2P.Seeds, ",")
 		}
-		trustMetricStore = trust.NewTrustMetricStore(trustHistoryDB, trust.DefaultConfig())
-		trustMetricStore.SetLogger(p2pLogger)
-
+		var privatePeerIDs []string
+		if config.P2P.PrivatePeerIDs != "" {
+			privatePeerIDs = strings.Split(config.P2P.PrivatePeerIDs, ",")
+		}
+		// TODO persistent peers ? so we can have their DNS addrs saved
 		pexReactor := pex.NewPEXReactor(addrBook,
 			&pex.PEXReactorConfig{
 				Seeds:          cmn.SplitAndTrim(config.P2P.Seeds, ",", " "),
@@ -355,9 +368,8 @@ func NewNode(config *cfg.Config,
 		genesisDoc:    genDoc,
 		privValidator: privValidator,
 
-		sw:               sw,
-		addrBook:         addrBook,
-		trustMetricStore: trustMetricStore,
+		sw:       sw,
+		addrBook: addrBook,
 
 		stateDB:          stateDB,
 		blockStore:       blockStore,

--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -18,3 +18,31 @@ type ErrSwitchAuthenticationFailure struct {
 func (e ErrSwitchAuthenticationFailure) Error() string {
 	return fmt.Sprintf("Failed to authenticate peer. Dialed %v, but got peer with ID %s", e.Dialed, e.Got)
 }
+
+//-------------------------------------------------------------------
+
+type ErrNetAddressNoID struct {
+	Addr string
+}
+
+func (e ErrNetAddressNoID) Error() string {
+	return fmt.Errorf("Address (%s) does not contain ID", e.Addr)
+}
+
+type ErrNetAddressInvalid struct {
+	Addr string
+	Err  error
+}
+
+func (e ErrNetAddressInvalid) Error() string {
+	return fmt.Errorf("Invalid address (%s): %v", e.Addr, e.Err)
+}
+
+type ErrNetAddressLookup struct {
+	Addr string
+	Err  error
+}
+
+func (e ErrNetAddressLookup) Error() string {
+	return fmt.Errorf("Error looking up host (%s): %v", e.Addr, e.Err)
+}

--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -26,7 +26,7 @@ type ErrNetAddressNoID struct {
 }
 
 func (e ErrNetAddressNoID) Error() string {
-	return fmt.Errorf("Address (%s) does not contain ID", e.Addr)
+	return fmt.Sprintf("Address (%s) does not contain ID", e.Addr)
 }
 
 type ErrNetAddressInvalid struct {
@@ -35,7 +35,7 @@ type ErrNetAddressInvalid struct {
 }
 
 func (e ErrNetAddressInvalid) Error() string {
-	return fmt.Errorf("Invalid address (%s): %v", e.Addr, e.Err)
+	return fmt.Sprintf("Invalid address (%s): %v", e.Addr, e.Err)
 }
 
 type ErrNetAddressLookup struct {
@@ -44,5 +44,5 @@ type ErrNetAddressLookup struct {
 }
 
 func (e ErrNetAddressLookup) Error() string {
-	return fmt.Errorf("Error looking up host (%s): %v", e.Addr, e.Err)
+	return fmt.Sprintf("Error looking up host (%s): %v", e.Addr, e.Err)
 }

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -22,7 +22,9 @@ type NetAddress struct {
 	ID   ID     `json:"id"`
 	IP   net.IP `json:"ip"`
 	Port uint16 `json:"port"`
-	Name string `json:"name"` // optional DNS name
+
+	// TODO:
+	// Name string `json:"name"` // optional DNS name
 
 	// memoize .String()
 	str string

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -19,11 +19,13 @@ import (
 // NetAddress defines information about a peer on the network
 // including its ID, IP address, and port.
 type NetAddress struct {
-	ID   ID
-	IP   net.IP
-	Port uint16
-	Name string // optional DNS name
-	str  string
+	ID   ID     `json:"id"`
+	IP   net.IP `json:"ip"`
+	Port uint16 `json:"port"`
+	Name string `json:"name"` // optional DNS name
+
+	// memoize .String()
+	str string
 }
 
 // IDAddressString returns id@hostPort.
@@ -57,10 +59,11 @@ func NewNetAddress(id ID, addr net.Addr) *NetAddress {
 // NewNetAddressString returns a new NetAddress using the provided address in
 // the form of "ID@IP:Port".
 // Also resolves the host if host is not an IP.
+// Errors are of type ErrNetAddressXxx where Xxx is in (NoID, Invalid, Lookup)
 func NewNetAddressString(addr string) (*NetAddress, error) {
 	spl := strings.Split(addr, "@")
 	if len(spl) < 2 {
-		return nil, fmt.Errorf("Address (%s) does not contain ID", addr)
+		return nil, ErrNetAddressNoID{addr}
 	}
 	return NewNetAddressStringWithOptionalID(addr)
 }
@@ -77,11 +80,12 @@ func NewNetAddressStringWithOptionalID(addr string) (*NetAddress, error) {
 		idStr := spl[0]
 		idBytes, err := hex.DecodeString(idStr)
 		if err != nil {
-			return nil, cmn.ErrorWrap(err, fmt.Sprintf("Address (%s) contains invalid ID", addrWithoutProtocol))
+			return nil, ErrNetAddressInvalid{addrWithoutProtocol, err}
 		}
 		if len(idBytes) != IDByteLength {
-			return nil, fmt.Errorf("Address (%s) contains ID of invalid length (%d). Should be %d hex-encoded bytes",
-				addrWithoutProtocol, len(idBytes), IDByteLength)
+			return nil, ErrNetAddressInvalid{
+				addrWithoutProtocol,
+				fmt.Errorf("invalid hex length - got %d, expected %d", len(idBytes), IDByteLength)}
 		}
 
 		id, addrWithoutProtocol = ID(idStr), spl[1]
@@ -89,7 +93,7 @@ func NewNetAddressStringWithOptionalID(addr string) (*NetAddress, error) {
 
 	host, portStr, err := net.SplitHostPort(addrWithoutProtocol)
 	if err != nil {
-		return nil, err
+		return nil, ErrNetAddressInvalid{addrWithoutProtocol, err}
 	}
 
 	ip := net.ParseIP(host)
@@ -97,7 +101,7 @@ func NewNetAddressStringWithOptionalID(addr string) (*NetAddress, error) {
 		if len(host) > 0 {
 			ips, err := net.LookupIP(host)
 			if err != nil {
-				return nil, err
+				return nil, ErrNetAddressLookup{host, err}
 			}
 			ip = ips[0]
 		}
@@ -105,7 +109,7 @@ func NewNetAddressStringWithOptionalID(addr string) (*NetAddress, error) {
 
 	port, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
-		return nil, err
+		return nil, ErrNetAddressInvalid{portStr, err}
 	}
 
 	na := NewNetAddressIPPort(ip, uint16(port))
@@ -121,7 +125,7 @@ func NewNetAddressStrings(addrs []string) ([]*NetAddress, []error) {
 	for _, addr := range addrs {
 		netAddr, err := NewNetAddressString(addr)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("Error in address %s: %v", addr, err))
+			errs = append(errs, err)
 		} else {
 			netAddrs = append(netAddrs, netAddr)
 		}

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -22,6 +22,7 @@ type NetAddress struct {
 	ID   ID
 	IP   net.IP
 	Port uint16
+	Name string // optional DNS name
 	str  string
 }
 

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -57,7 +57,7 @@ func (info NodeInfo) Validate() error {
 	}
 
 	// ensure ListenAddr is good
-	netAddr, err := NewNetAddressString(IDAddressString(info.ID, info.ListenAddr))
+	_, err := NewNetAddressString(IDAddressString(info.ID, info.ListenAddr))
 	if err != nil {
 		return err
 	}

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -56,7 +56,7 @@ func (info NodeInfo) Validate() error {
 }
 
 // CompatibleWith checks if two NodeInfo are compatible with eachother.
-// CONTRACT: two nodes are compatible if the major/minor versions match and network match
+// CONTRACT: two nodes are compatible if the major version matches and network match
 // and they have at least one channel in common.
 func (info NodeInfo) CompatibleWith(other NodeInfo) error {
 	iMajor, iMinor, _, iErr := splitVersion(info.Version)
@@ -77,9 +77,9 @@ func (info NodeInfo) CompatibleWith(other NodeInfo) error {
 		return fmt.Errorf("Peer is on a different major version. Got %v, expected %v", oMajor, iMajor)
 	}
 
-	// minor version must match
+	// minor version can differ
 	if iMinor != oMinor {
-		return fmt.Errorf("Peer is on a different minor version. Got %v, expected %v", oMinor, iMinor)
+		// ok
 	}
 
 	// nodes must be on the same network

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -58,11 +58,7 @@ func (info NodeInfo) Validate() error {
 
 	// ensure ListenAddr is good
 	_, err := NewNetAddressString(IDAddressString(info.ID, info.ListenAddr))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // CompatibleWith checks if two NodeInfo are compatible with eachother.

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -221,7 +221,11 @@ func (a *addrBook) PickAddress(biasTowardsNewAddrs int) *p2p.NetAddress {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
-	if a.size() == 0 {
+	bookSize := a.size()
+	if bookSize <= 0 {
+		if bookSize < 0 {
+			a.Logger.Error("Addrbook size less than 0", "nNew", a.nNew, "nOld", a.nOld)
+		}
 		return nil
 	}
 	if biasTowardsNewAddrs > 100 {
@@ -301,7 +305,10 @@ func (a *addrBook) GetSelection() []*p2p.NetAddress {
 	defer a.mtx.Unlock()
 
 	bookSize := a.size()
-	if bookSize == 0 {
+	if bookSize <= 0 {
+		if bookSize < 0 {
+			a.Logger.Error("Addrbook size less than 0", "nNew", a.nNew, "nOld", a.nOld)
+		}
 		return nil
 	}
 
@@ -344,7 +351,10 @@ func (a *addrBook) GetSelectionWithBias(biasTowardsNewAddrs int) []*p2p.NetAddre
 	defer a.mtx.Unlock()
 
 	bookSize := a.size()
-	if bookSize == 0 {
+	if bookSize <= 0 {
+		if bookSize < 0 {
+			a.Logger.Error("Addrbook size less than 0", "nNew", a.nNew, "nOld", a.nOld)
+		}
 		return nil
 	}
 
@@ -609,10 +619,7 @@ func (a *addrBook) pickOldest(bucketType byte, bucketIdx int) *knownAddress {
 // adds the address to a "new" bucket. if its already in one,
 // it only adds it probabilistically
 func (a *addrBook) addAddress(addr, src *p2p.NetAddress) error {
-	if addr == nil {
-		return ErrAddrBookNilAddr{addr, src}
-	}
-	if src == nil {
+	if addr == nil || src == nil {
 		return ErrAddrBookNilAddr{addr, src}
 	}
 

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -496,7 +496,7 @@ func (a *addrBook) getBucket(bucketType byte, bucketIdx int) map[string]*knownAd
 func (a *addrBook) addToNewBucket(ka *knownAddress, bucketIdx int) {
 	// Sanity check
 	if ka.isOld() {
-		a.Logger.Error("Failed Sanity Check! Cant add old address to new bucket", "ka", knownAddress, "bucket", bucketIdx)
+		a.Logger.Error("Failed Sanity Check! Cant add old address to new bucket", "ka", ka, "bucket", bucketIdx)
 		return
 	}
 
@@ -679,8 +679,6 @@ func (a *addrBook) moveToOld(ka *knownAddress) {
 		return
 	}
 
-	// Remember one of the buckets in which ka is in.
-	freedBucket := ka.Buckets[0]
 	// Remove from all (new) buckets.
 	a.removeFromAllBuckets(ka)
 	// It's officially old now.

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -626,8 +626,8 @@ func (a *addrBook) addAddress(addr, src *p2p.NetAddress) error {
 
 	ka := a.addrLookup[addr.ID]
 	if ka != nil {
-		// Already old.
-		if ka.isOld() {
+		// If its already old and the addr is the same, ignore it.
+		if ka.isOld() && ka.Addr.Equals(addr) {
 			return nil
 		}
 		// Already in max new buckets.

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -623,7 +623,7 @@ func (a *addrBook) addAddress(addr, src *p2p.NetAddress) error {
 	}
 	// TODO: we should track ourAddrs by ID and by IP:PORT and refuse both.
 	if _, ok := a.ourAddrs[addr.String()]; ok {
-		return ErrAddrBookSelf
+		return ErrAddrBookSelf{addr}
 	}
 
 	ka := a.addrLookup[addr.ID]

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -295,6 +295,7 @@ func (a *addrBook) MarkBad(addr *p2p.NetAddress) {
 
 // GetSelection implements AddrBook.
 // It randomly selects some addresses (old & new). Suitable for peer-exchange protocols.
+// Must never return a nil address.
 func (a *addrBook) GetSelection() []*p2p.NetAddress {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
@@ -332,6 +333,7 @@ func (a *addrBook) GetSelection() []*p2p.NetAddress {
 
 // GetSelectionWithBias implements AddrBook.
 // It randomly selects some addresses (old & new). Suitable for peer-exchange protocols.
+// Must never return a nil address.
 //
 // Each address is picked randomly from an old or new bucket according to the
 // biasTowardsNewAddrs argument, which must be between [0, 100] (or else is truncated to

--- a/p2p/pex/errors.go
+++ b/p2p/pex/errors.go
@@ -30,12 +30,3 @@ type ErrAddrBookNilAddr struct {
 func (err ErrAddrBookNilAddr) Error() string {
 	return fmt.Sprintf("Cannot add a nil address. Got (addr, src) = (%v, %v)", err.Addr, err.Src)
 }
-
-type ErrAddrBookFull struct {
-	Addr *p2p.NetAddress
-	Size int
-}
-
-func (err ErrAddrBookFull) Error() string {
-	return fmt.Sprintf("Can't add new address (%v), addr book is full (%d)", err.Addr, err.Size)
-}

--- a/p2p/pex/errors.go
+++ b/p2p/pex/errors.go
@@ -1,0 +1,41 @@
+package pex
+
+import (
+	"fmt"
+
+	"github.com/tendermint/tendermint/p2p"
+)
+
+type ErrAddrBookNonRoutable struct {
+	Addr *p2p.NetAddress
+}
+
+func (err ErrAddrBookNonRoutable) Error() string {
+	return fmt.Sprintf("Cannot add non-routable address %v", err.Addr)
+}
+
+type ErrAddrBookSelf struct {
+	Addr *p2p.NetAddress
+}
+
+func (err ErrAddrBookSelf) Error() string {
+	return fmt.Sprintf("Cannot add ourselves with address %v", err.Addr)
+}
+
+type ErrAddrBookNilAddr struct {
+	Addr *p2p.NetAddress
+	Src  *p2p.NetAddress
+}
+
+func (err ErrAddrBookNilAddr) Error() string {
+	return fmt.Sprintf("Cannot add a nil address. Got (addr, src) = (%v, %v)", err.Addr, err.Src)
+}
+
+type ErrAddrBookFull struct {
+	Addr *p2p.NetAddress
+	Size int
+}
+
+func (err ErrAddrBookFull) Error() string {
+	return fmt.Sprintf("Can't add new address (%v), addr book is full (%d)", err.Addr, err.Size)
+}

--- a/p2p/pex/known_address.go
+++ b/p2p/pex/known_address.go
@@ -106,7 +106,6 @@ func (ka *knownAddress) removeBucketRef(bucketIdx int) int {
    All addresses that meet these criteria are assumed to be worthless and not
    worth keeping hold of.
 
-   XXX: so a good peer needs us to call MarkGood before the conditions above are reached!
 */
 func (ka *knownAddress) isBad() bool {
 	// Is Old --> good
@@ -115,14 +114,15 @@ func (ka *knownAddress) isBad() bool {
 	}
 
 	// Has been attempted in the last minute --> good
-	if ka.LastAttempt.Before(time.Now().Add(-1 * time.Minute)) {
+	if ka.LastAttempt.After(time.Now().Add(-1 * time.Minute)) {
 		return false
 	}
 
+	// TODO: From the future?
+
 	// Too old?
-	// XXX: does this mean if we've kept a connection up for this long we'll disconnect?!
-	// and shouldn't it be .Before ?
-	if ka.LastAttempt.After(time.Now().Add(-1 * numMissingDays * time.Hour * 24)) {
+	// TODO: should be a timestamp of last seen, not just last attempt
+	if ka.LastAttempt.Before(time.Now().Add(-1 * numMissingDays * time.Hour * 24)) {
 		return true
 	}
 
@@ -132,7 +132,6 @@ func (ka *knownAddress) isBad() bool {
 	}
 
 	// Hasn't succeeded in too long?
-	// XXX: does this mean if we've kept a connection up for this long we'll disconnect?!
 	if ka.LastSuccess.Before(time.Now().Add(-1*minBadDays*time.Hour*24)) &&
 		ka.Attempts >= maxFailures {
 		return true

--- a/p2p/pex/params.go
+++ b/p2p/pex/params.go
@@ -50,6 +50,6 @@ const (
 	minGetSelection = 32
 
 	// max addresses returned by GetSelection
-	// NOTE: this must match "maxPexMessageSize"
+	// NOTE: this must match "maxMsgSize"
 	maxGetSelection = 250
 )

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -20,10 +20,14 @@ const (
 	// PexChannel is a channel for PEX messages
 	PexChannel = byte(0x00)
 
-	// TODO: make smaller. Should match the maxGetSelection
-	// this is basically the amplification factor since a request
-	// msg is like 1 byte ... it can cause us to send msgs of this size!
-	maxPexMessageSize = 1048576 // 1MB
+	// over-estimate of max NetAddress size
+	// hexID (40) + IP (16) + Port (2) + Name (100) ...
+	// NOTE: dont use massive DNS name ..
+	maxAddressSize = 256
+
+	// NOTE: amplificaiton factor!
+	// small request results in up to maxPexMessageSize response
+	maxPexMessageSize = maxAddressSize * maxGetSelection
 
 	// ensure we have enough peers
 	defaultEnsurePeersPeriod   = 30 * time.Second

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -31,7 +31,7 @@ const (
 
 	// ensure we have enough peers
 	defaultEnsurePeersPeriod   = 30 * time.Second
-	defaultMinNumOutboundPeers = 10
+	defaultMinNumOutboundPeers = p2p.DefaultMinNumOutboundPeers
 
 	// Seed/Crawler constants
 

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -126,9 +126,7 @@ func (r *PEXReactor) OnStart() error {
 	}
 
 	// return err if user provided a bad seed address
-	// NOTE: only if its an invalid address.
-	// If we simply fail to resovle a DNS name,
-	// we shouldn't exit here ...
+	// or a host name that we cant resolve
 	if err := r.checkSeeds(); err != nil {
 		return err
 	}
@@ -500,9 +498,6 @@ func (r *PEXReactor) checkSeeds() error {
 	if lSeeds == 0 {
 		return nil
 	}
-	// TODO: don't exit the program if we simply cant resolve a DNS name.
-	// But if names or addresses are incorrectly speficied (ie. invalid),
-	// then we should return an err that causes an exit
 	_, errs := p2p.NewNetAddressStrings(r.config.Seeds)
 	for _, err := range errs {
 		if err != nil {

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -20,7 +20,10 @@ const (
 	// PexChannel is a channel for PEX messages
 	PexChannel = byte(0x00)
 
-	maxMsgSize = 1048576 // 1MB
+	// TODO: make smaller. Should match the maxGetSelection
+	// this is basically the amplification factor since a request
+	// msg is like 1 byte ... it can cause us to send msgs of this size!
+	maxPexMessageSize = 1048576 // 1MB
 
 	// ensure we have enough peers
 	defaultEnsurePeersPeriod   = 30 * time.Second
@@ -61,13 +64,19 @@ type PEXReactor struct {
 
 	book              AddrBook
 	config            *PEXReactorConfig
-	ensurePeersPeriod time.Duration
+	ensurePeersPeriod time.Duration // TODO: should go in the config
 
 	// maps to prevent abuse
 	requestsSent         *cmn.CMap // ID->struct{}: unanswered send requests
 	lastReceivedRequests *cmn.CMap // ID->time.Time: last time peer requested from us
 
 	attemptsToDial sync.Map // address (string) -> {number of attempts (int), last time dialed (time.Time)}
+}
+
+func (pexR *PEXReactor) minReceiveRequestInterval() time.Duration {
+	// NOTE: must be less than ensurePeersPeriod, otherwise we'll request
+	// peers too quickly from others and they'll think we're bad!
+	return pexR.ensurePeersPeriod / 3
 }
 
 // PEXReactorConfig holds reactor specific configuration data.
@@ -113,6 +122,9 @@ func (r *PEXReactor) OnStart() error {
 	}
 
 	// return err if user provided a bad seed address
+	// NOTE: only if its an invalid address.
+	// If we simply fail to resovle a DNS name,
+	// we shouldn't exit here ...
 	if err := r.checkSeeds(); err != nil {
 		return err
 	}
@@ -195,6 +207,10 @@ func (r *PEXReactor) Receive(chID byte, src Peer, msgBytes []byte) {
 		}
 
 		// Seeds disconnect after sending a batch of addrs
+		// NOTE: this is a prime candidate for amplification attacks
+		// so it's important we
+		// 1) restrict how frequently peers can request
+		// 2) limit the output size
 		if r.config.SeedMode {
 			r.SendAddrs(src, r.book.GetSelectionWithBias(biasToSelectNewPeers))
 			r.Switch.StopPeerGracefully(src)
@@ -213,6 +229,7 @@ func (r *PEXReactor) Receive(chID byte, src Peer, msgBytes []byte) {
 	}
 }
 
+// enforces a minimum amount of time between requests
 func (r *PEXReactor) receiveRequest(src Peer) error {
 	id := string(src.ID())
 	v := r.lastReceivedRequests.Get(id)
@@ -232,8 +249,14 @@ func (r *PEXReactor) receiveRequest(src Peer) error {
 	}
 
 	now := time.Now()
-	if now.Sub(lastReceived) < r.ensurePeersPeriod/3 {
-		return fmt.Errorf("Peer (%v) is sending too many PEX requests. Disconnecting", src.ID())
+	minInterval := r.minReceiveRequestInterval()
+	if now.Sub(lastReceived) < minInterval {
+		return fmt.Errorf("Peer (%v) send next PEX request too soon. lastReceived: %v, now: %v, minInterval: %v. Disconnecting",
+			src.ID(),
+			lastReceived,
+			now,
+			minInterval,
+		)
 	}
 	r.lastReceivedRequests.Set(id, now)
 	return nil
@@ -264,7 +287,11 @@ func (r *PEXReactor) ReceiveAddrs(addrs []*p2p.NetAddress, src Peer) error {
 
 	srcAddr := src.NodeInfo().NetAddress()
 	for _, netAddr := range addrs {
+		// TODO: make sure correct nodes never send nil and return error
+		//   if a netAddr == nil
 		if netAddr != nil && !isAddrPrivate(netAddr, r.config.PrivatePeerIDs) {
+			// TODO: Should we moe the list of private peers into the AddrBook so AddAddress
+			// can do the check for us, and we don't have to worry about checking before calling ?
 			err := r.book.AddAddress(netAddr, srcAddr)
 			if err != nil {
 				r.Logger.Error("Failed to add new address", "err", err)
@@ -360,6 +387,9 @@ func (r *PEXReactor) ensurePeers() {
 		if connected := r.Switch.Peers().Has(try.ID); connected {
 			continue
 		}
+		// TODO: consider moving some checks from toDial into here
+		// so we don't even consider dialing peers that we want to wait
+		// before dialling again, or have dialled too many times already
 		r.Logger.Info("Will dial address", "addr", try)
 		toDial[try.ID] = try
 	}
@@ -387,13 +417,17 @@ func (r *PEXReactor) ensurePeers() {
 	}
 }
 
-func (r *PEXReactor) dialPeer(addr *p2p.NetAddress) {
-	var attempts int
-	var lastDialed time.Time
-	if lAttempts, attempted := r.attemptsToDial.Load(addr.DialString()); attempted {
-		attempts = lAttempts.(_attemptsToDial).number
-		lastDialed = lAttempts.(_attemptsToDial).lastDialed
+func (r *PEXReactor) dialAttemptsInfo(addr *p2p.NetAddress) (attempts int, lastDialed time.Time) {
+	_attempts, ok := r.attemptsToDial.Load(addr.DialString())
+	if !ok {
+		return
 	}
+	atd := _attempts.(_attemptsToDial)
+	return atd.number, atd.lastDialed
+}
+
+func (r *PEXReactor) dialPeer(addr *p2p.NetAddress) {
+	attempts, lastDialed := r.dialAttemptsInfo(addr)
 
 	if attempts > maxAttemptsToDial {
 		r.Logger.Error("Reached max attempts to dial", "addr", addr, "attempts", attempts)
@@ -439,6 +473,9 @@ func (r *PEXReactor) checkSeeds() error {
 	if lSeeds == 0 {
 		return nil
 	}
+	// TODO: don't exit the program if we simply cant resolve a DNS name.
+	// But if names or addresses are incorrectly speficied (ie. invalid),
+	// then we should return an err that causes an exit
 	_, errs := p2p.NewNetAddressStrings(r.config.Seeds)
 	for _, err := range errs {
 		if err != nil {

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -181,16 +181,19 @@ func (r *PEXReactor) AddPeer(p Peer) {
 		// add to book. dont RequestAddrs right away because
 		// we don't trust inbound as much - let ensurePeersRoutine handle it.
 		err := r.book.AddAddress(addr, src)
-		if err != nil {
-			switch err.(type) {
-			case ErrAddrBookNilAddr:
-				r.Logger.Error("Failed to add new address", "err", err)
-			default:
-				// non-routable, self, full book, etc.
-				r.Logger.Debug("Failed to add new address", "err", err)
-			}
-		}
+		r.logErrAddrBook(err)
+	}
+}
 
+func (r *PEXReactor) logErrAddrBook(err error) {
+	if err != nil {
+		switch err.(type) {
+		case ErrAddrBookNilAddr:
+			r.Logger.Error("Failed to add new address", "err", err)
+		default:
+			// non-routable, self, full book, etc.
+			r.Logger.Debug("Failed to add new address", "err", err)
+		}
 	}
 }
 
@@ -313,15 +316,7 @@ func (r *PEXReactor) ReceiveAddrs(addrs []*p2p.NetAddress, src Peer) error {
 		}
 
 		err := r.book.AddAddress(netAddr, srcAddr)
-		if err != nil {
-			switch err.(type) {
-			case ErrAddrBookNilAddr:
-				r.Logger.Error("Failed to add new address", "err", err)
-			default:
-				// Could be non-routable, self, or full book. But not worth logging an Error
-				r.Logger.Debug("Failed to add new address", "err", err)
-			}
-		}
+		r.logErrAddrBook(err)
 	}
 	return nil
 }

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -26,8 +26,8 @@ const (
 	maxAddressSize = 256
 
 	// NOTE: amplificaiton factor!
-	// small request results in up to maxPexMessageSize response
-	maxPexMessageSize = maxAddressSize * maxGetSelection
+	// small request results in up to maxMsgSize response
+	maxMsgSize = maxAddressSize * maxGetSelection
 
 	// ensure we have enough peers
 	defaultEnsurePeersPeriod   = 30 * time.Second

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -260,6 +260,7 @@ func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 	sw.stopAndRemovePeer(peer, reason)
 
 	if peer.IsPersistent() {
+		// NOTE: this is the self-reported addr, not the original we dialed
 		go sw.reconnectToPeer(peer.NodeInfo().NetAddress())
 	}
 }
@@ -351,6 +352,7 @@ func (sw *Switch) IsDialing(id ID) bool {
 }
 
 // DialPeersAsync dials a list of peers asynchronously in random order (optionally, making them persistent).
+// Used to dial peers from config on startup or from unsafe-RPC (trusted sources).
 // TODO: remove addrBook arg since it's now set on the switch
 func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent bool) error {
 	netAddrs, errs := NewNetAddressStrings(peers)

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -351,6 +351,7 @@ func (sw *Switch) IsDialing(id ID) bool {
 }
 
 // DialPeersAsync dials a list of peers asynchronously in random order (optionally, making them persistent).
+// TODO: remove addrBook arg since it's now set on the switch
 func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent bool) error {
 	netAddrs, errs := NewNetAddressStrings(peers)
 	// only log errors, dial correct addresses
@@ -360,7 +361,10 @@ func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent b
 
 	ourAddr := sw.nodeInfo.NetAddress()
 
-	// TODO: move this out of here ?
+	// TODO: this code feels like it's in the wrong place.
+	// The integration tests depend on the addrBook being saved
+	// right away but maybe we can change that. Recall that
+	// the addrBook is only written to disk every 2min
 	if addrBook != nil {
 		// add peers to `addrBook`
 		for _, netAddr := range netAddrs {

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -26,6 +26,10 @@ const (
 	// ie. 3**10 = 16hrs
 	reconnectBackOffAttempts    = 10
 	reconnectBackOffBaseSeconds = 3
+
+	// keep at least this many outbound peers
+	// TODO: move to config
+	DefaultMinNumOutboundPeers = 10
 )
 
 //-----------------------------------------------------------------------------
@@ -458,7 +462,8 @@ func (sw *Switch) listenerRoutine(l Listener) {
 		}
 
 		// ignore connection if we already have enough
-		maxPeers := sw.config.MaxNumPeers
+		// leave room for MinNumOutboundPeers
+		maxPeers := sw.config.MaxNumPeers - DefaultMinNumOutboundPeers
 		if maxPeers <= sw.peers.Size() {
 			sw.Logger.Info("Ignoring inbound connection: already have enough peers", "address", inConn.RemoteAddr().String(), "numPeers", sw.peers.Size(), "max", maxPeers)
 			continue

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -401,7 +401,7 @@ func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent b
 			sw.randomSleep(0)
 			err := sw.DialPeerWithAddress(addr, persistent)
 			if err != nil {
-				switch err.(type) {
+				switch err {
 				case ErrSwitchConnectToSelf, ErrSwitchDuplicatePeer:
 					sw.Logger.Debug("Error dialing peer", "err", err)
 				default:

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -49,6 +49,8 @@ func CreateRoutableAddr() (addr string, netAddr *NetAddress) {
 //------------------------------------------------------------------
 // Connects switches via arbitrary net.Conn. Used for testing.
 
+const TEST_HOST = "localhost"
+
 // MakeConnectedSwitches returns n switches, connected according to the connect func.
 // If connect==Connect2Switches, the switches will be fully connected.
 // initSwitch defines how the i'th switch should be initialized (ie. with what reactors).
@@ -56,7 +58,7 @@ func CreateRoutableAddr() (addr string, netAddr *NetAddress) {
 func MakeConnectedSwitches(cfg *cfg.P2PConfig, n int, initSwitch func(int, *Switch) *Switch, connect func([]*Switch, int, int)) []*Switch {
 	switches := make([]*Switch, n)
 	for i := 0; i < n; i++ {
-		switches[i] = MakeSwitch(cfg, i, "testing", "123.123.123", initSwitch)
+		switches[i] = MakeSwitch(cfg, i, TEST_HOST, "123.123.123", initSwitch)
 	}
 
 	if err := StartSwitches(switches); err != nil {

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -47,6 +47,8 @@ func NetInfo() (*ctypes.ResultNetInfo, error) {
 			ConnectionStatus: peer.Status(),
 		})
 	}
+	// TODO: should we include "num_peers" field for convenience ?
+	// Let's also include the PersistentPeers and Seeds in here.
 	return &ctypes.ResultNetInfo{
 		Listening: listening,
 		Listeners: listeners,

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -23,6 +23,7 @@ import (
 // {
 // 	"error": "",
 // 	"result": {
+//		"n_peers": 0,
 // 		"peers": [],
 // 		"listeners": [
 // 			"Listener(@10.0.2.15:46656)"
@@ -47,11 +48,13 @@ func NetInfo() (*ctypes.ResultNetInfo, error) {
 			ConnectionStatus: peer.Status(),
 		})
 	}
-	// TODO: should we include "num_peers" field for convenience ?
-	// Let's also include the PersistentPeers and Seeds in here.
+	// TODO: Should we include PersistentPeers and Seeds in here?
+	// PRO: useful info
+	// CON: privacy
 	return &ctypes.ResultNetInfo{
 		Listening: listening,
 		Listeners: listeners,
+		NPeers:    len(peers),
 		Peers:     peers,
 	}, nil
 }

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -100,6 +100,7 @@ func (s *ResultStatus) TxIndexEnabled() bool {
 type ResultNetInfo struct {
 	Listening bool     `json:"listening"`
 	Listeners []string `json:"listeners"`
+	NPeers    int      `json:"n_peers"`
 	Peers     []Peer   `json:"peers"`
 }
 


### PR DESCRIPTION
Replaces https://github.com/tendermint/tendermint/pull/1344

- reduce max pex msg size
- validate nodeInfo.ListenAddr
- clarify maxNumPeers (closes #1501) and update pex spec
- remove trust metric
- more explicit errors for addrbook.AddAddress and NewNetAddressFromString
- give NetAddress json tags in prep for using it in NodeInfo
- allow nodes to differ by minor version
- some cleanup
- a bunch of new comments/notes/todos
- a little #1476


<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG.md
