### PR TITLE
Split CMD's param on space

### DIFF
--- a/networks/local/localnode/Dockerfile
+++ b/networks/local/localnode/Dockerfile
@@ -9,7 +9,7 @@ VOLUME [ /tendermint ]
 WORKDIR /tendermint
 EXPOSE 46656 46657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
-CMD ["node", "--proxy_app dummy"]
+CMD ["node", "--proxy_app", "dummy"]
 STOPSIGNAL SIGTERM
 
 COPY wrapper.sh /usr/bin/wrapper.sh


### PR DESCRIPTION
This is to avoid "ERROR: unknown flag: --proxy_app dummy" message when kicking "docker-compose up"

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
