### PR TITLE
Suggested changes to consensus/reactor.go

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -696,29 +696,28 @@ func (conR *ConsensusReactor) gossipVotesForHeight(logger log.Logger, rs *cstype
 			return true
 		}
 	}
-
-	if prs.Step <= cstypes.RoundStepCommit && prs.Round != -1 && prs.Round <= rs.Round {
-		// If there are POLPrevotes to send...
-		if prs.ProposalPOLRound != -1 {
-			if polPrevotes := rs.Votes.Prevotes(prs.ProposalPOLRound); polPrevotes != nil {
-				if ps.PickSendVote(polPrevotes) {
-					logger.Debug("Picked rs.Prevotes(prs.ProposalPOLRound) to send",
-						"round", prs.ProposalPOLRound)
-					return true
-				}
-			}
-		}
-
-		// If there are prevotes to send...
+	// If there are prevotes to send...
+	if prs.Step <= cstypes.RoundStepPrevoteWait && prs.Round != -1 && prs.Round <= rs.Round {
 		if ps.PickSendVote(rs.Votes.Prevotes(prs.Round)) {
 			logger.Debug("Picked rs.Prevotes(prs.Round) to send", "round", prs.Round)
 			return true
 		}
-
-		// If there are precommits to send...
+	}
+	// If there are precommits to send...
+	if prs.Step <= cstypes.RoundStepPrecommitWait && prs.Round != -1 && prs.Round <= rs.Round {
 		if ps.PickSendVote(rs.Votes.Precommits(prs.Round)) {
 			logger.Debug("Picked rs.Precommits(prs.Round) to send", "round", prs.Round)
 			return true
+		}
+	}
+	// If there are POLPrevotes to send...
+	if prs.ProposalPOLRound != -1 {
+		if polPrevotes := rs.Votes.Prevotes(prs.ProposalPOLRound); polPrevotes != nil {
+			if ps.PickSendVote(polPrevotes) {
+				logger.Debug("Picked rs.Prevotes(prs.ProposalPOLRound) to send",
+					"round", prs.ProposalPOLRound)
+				return true
+			}
 		}
 	}
 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -696,6 +696,16 @@ func (conR *ConsensusReactor) gossipVotesForHeight(logger log.Logger, rs *cstype
 			return true
 		}
 	}
+	// If there are POL prevotes to send...
+	if prs.Step <= cstypes.RoundStepPropose && prs.Round != -1 && prs.Round <= rs.Round && prs.ProposalPOLRound != -1 {
+		if polPrevotes := rs.Votes.Prevotes(prs.ProposalPOLRound); polPrevotes != nil {
+			if ps.PickSendVote(polPrevotes) {
+				logger.Debug("Picked rs.Prevotes(prs.ProposalPOLRound) to send",
+					"round", prs.ProposalPOLRound)
+				return true
+			}
+		}
+	}
 	// If there are prevotes to send...
 	if prs.Step <= cstypes.RoundStepPrevoteWait && prs.Round != -1 && prs.Round <= rs.Round {
 		if ps.PickSendVote(rs.Votes.Prevotes(prs.Round)) {
@@ -707,6 +717,13 @@ func (conR *ConsensusReactor) gossipVotesForHeight(logger log.Logger, rs *cstype
 	if prs.Step <= cstypes.RoundStepPrecommitWait && prs.Round != -1 && prs.Round <= rs.Round {
 		if ps.PickSendVote(rs.Votes.Precommits(prs.Round)) {
 			logger.Debug("Picked rs.Precommits(prs.Round) to send", "round", prs.Round)
+			return true
+		}
+	}
+	// If there are prevotes to send...Needed because of validBlock mechanism
+	if prs.Round != -1 && prs.Round <= rs.Round {
+		if ps.PickSendVote(rs.Votes.Prevotes(prs.Round)) {
+			logger.Debug("Picked rs.Prevotes(prs.Round) to send", "round", prs.Round)
 			return true
 		}
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1307,19 +1307,20 @@ func (cs *ConsensusState) addProposalBlockPart(height int64, part *types.Part, v
 		// NOTE: it's possible to receive complete proposal blocks for future rounds without having the proposal
 		cs.Logger.Info("Received complete proposal block", "height", cs.ProposalBlock.Height, "hash", cs.ProposalBlock.Hash())
 
-		// Update ValidBlock
+		// Update Valid* if we can.
 		prevotes := cs.Votes.Prevotes(cs.Round)
-		blockID, ok := prevotes.TwoThirdsMajority()
-		if ok && !blockID.IsZero() && (cs.ValidRound < cs.Round) {
-			// update valid value
+		blockID, hasTwoThirds := prevotes.TwoThirdsMajority()
+		if hasTwoThirds && !blockID.IsZero() && (cs.ValidRound < cs.Round) {
 			if cs.ProposalBlock.HashesTo(blockID.Hash) {
 				cs.ValidRound = cs.Round
 				cs.ValidBlock = cs.ProposalBlock
 				cs.ValidBlockParts = cs.ProposalBlockParts
 			}
-			//TODO: In case there is +2/3 majority in Prevotes set for some block and cs.ProposalBlock contains different block,
-			//either proposer is faulty or voting power of faulty processes is more than 1/3. We should
-			//trigger in the future accountability procedure at this point.
+			// TODO: In case there is +2/3 majority in Prevotes set for some
+			// block and cs.ProposalBlock contains different block, either
+			// proposer is faulty or voting power of faulty processes is more
+			// than 1/3. We should trigger in the future accountability
+			// procedure at this point.
 		}
 
 		if cs.Step == cstypes.RoundStepPropose && cs.isProposalComplete() {

--- a/consensus/types/state.go
+++ b/consensus/types/state.go
@@ -67,9 +67,9 @@ type RoundState struct {
 	LockedRound        int
 	LockedBlock        *types.Block
 	LockedBlockParts   *types.PartSet
-	ValidRound         int
-	ValidBlock         *types.Block
-	ValidBlockParts    *types.PartSet
+	ValidRound         int            // Last known round with POL for non-nil valid block.
+	ValidBlock         *types.Block   // Last known block of POL mentioned above.
+	ValidBlockParts    *types.PartSet // Last known block parts of POL metnioned above.
 	Votes              *HeightVoteSet
 	CommitRound        int            //
 	LastCommit         *types.VoteSet // Last precommits at Height-1


### PR DESCRIPTION
This sends votes even when the peer is in prevoteWait.  We could also get more intelligent and only send if we have 2/3, maybe.  In that case we'll need separate clauses for <= prevote and <= prevoteWait because if <= prevote, then we always went to send prevotes.

The same applies for precommits as for prevotes above.