### PR TITLE
consensus: only fsync wal after internal msgs

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -19,10 +19,6 @@ in a case of bug.
 
 **ABCI app** (name for built-in, URL for self-written if it's publicly available):
 
-
-**Merkleeyes version** (use `git rev-parse --verify HEAD`, skip if you don't use it):
-
-
 **Environment**:
 - **OS** (e.g. from /etc/os-release):
 - **Install tools**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ FEATURES
 IMPROVEMENTS
 
 - [docs] Lots of updates
+- [consensus] Only Fsync() the WAL before executing msgs from ourselves
 
 BUG FIXES
 

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -83,7 +83,7 @@ func WALWithNBlocks(numBlocks int) (data []byte, err error) {
 	numBlocksWritten := make(chan struct{})
 	wal := newByteBufferWAL(logger, NewWALEncoder(wr), int64(numBlocks), numBlocksWritten)
 	// see wal.go#103
-	wal.Save(EndHeightMessage{0})
+	wal.Write(EndHeightMessage{0})
 	consensusState.wal = wal
 
 	if err := consensusState.Start(); err != nil {
@@ -166,7 +166,7 @@ func newByteBufferWAL(logger log.Logger, enc *WALEncoder, nBlocks int64, signalS
 // Save writes message to the internal buffer except when heightToStop is
 // reached, in which case it will signal the caller via signalWhenStopsTo and
 // skip writing.
-func (w *byteBufferWAL) Save(m WALMessage) {
+func (w *byteBufferWAL) Write(m WALMessage) {
 	if w.stopped {
 		w.logger.Debug("WAL already stopped. Not writing message", "msg", m)
 		return
@@ -187,6 +187,10 @@ func (w *byteBufferWAL) Save(m WALMessage) {
 	if err != nil {
 		panic(fmt.Sprintf("failed to encode the msg %v", m))
 	}
+}
+
+func (w *byteBufferWAL) WriteSync(m WALMessage) {
+	w.Write(m)
 }
 
 func (w *byteBufferWAL) Group() *auto.Group {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -31,7 +31,7 @@ func TestNodeStartStop(t *testing.T) {
 	assert.NoError(t, err)
 	select {
 	case <-blockCh:
-	case <-time.After(5 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for the node to produce a block")
 	}
 


### PR DESCRIPTION
Fixes https://github.com/tendermint/tendermint/issues/1589

Note this means it is possible to lose votes we have seen from the network before they result in us signing and sending a message. This wouldn't result in any corruption or safety issue, but it does introduce a dependence on the network for retransmission of messages we've already seen.