### PR TITLE
Introduce local option for peerconfig

### DIFF
--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -135,7 +135,7 @@ func TestReactorRecordsBlockParts(t *testing.T) {
 	reactor := NewConsensusReactor(css[0], false) // so we dont start the consensus states
 	reactor.SetEventBus(css[0].eventBus)
 	reactor.SetLogger(log.TestingLogger())
-	sw := p2p.MakeSwitch(cfg.DefaultP2PConfig(), 1, "testing", "123.123.123", func(i int, sw *p2p.Switch) *p2p.Switch { return sw })
+	sw := p2p.MakeSwitch(cfg.DefaultP2PConfig(), nil, 1, "testing", "123.123.123", func(i int, sw *p2p.Switch) *p2p.Switch { return sw })
 	reactor.SetSwitch(sw)
 	err := reactor.Start()
 	require.NoError(t, err)
@@ -186,7 +186,7 @@ func TestReactorRecordsVotes(t *testing.T) {
 	reactor := NewConsensusReactor(css[0], false) // so we dont start the consensus states
 	reactor.SetEventBus(css[0].eventBus)
 	reactor.SetLogger(log.TestingLogger())
-	sw := p2p.MakeSwitch(cfg.DefaultP2PConfig(), 1, "testing", "123.123.123", func(i int, sw *p2p.Switch) *p2p.Switch { return sw })
+	sw := p2p.MakeSwitch(cfg.DefaultP2PConfig(), nil, 1, "testing", "123.123.123", func(i int, sw *p2p.Switch) *p2p.Switch { return sw })
 	reactor.SetSwitch(sw)
 	err := reactor.Start()
 	require.NoError(t, err)

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -127,6 +127,7 @@ type PeerConfig struct {
 	DialFail   bool            `mapstructure:"dial_fail"` // for testing
 	Fuzz       bool            `mapstructure:"fuzz"`      // fuzz connection (for testing)
 	FuzzConfig *FuzzConnConfig `mapstructure:"fuzz_config"`
+	Local      bool            `mapstructure:"local"` // for testing on local loopback
 }
 
 // DefaultPeerConfig returns the default config.
@@ -139,6 +140,7 @@ func DefaultPeerConfig() *PeerConfig {
 		DialFail:         false,
 		Fuzz:             false,
 		FuzzConfig:       DefaultFuzzConnConfig(),
+		Local:            false,
 	}
 }
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -341,6 +341,11 @@ func (sw *Switch) SetAddrBook(addrBook AddrBook) {
 	sw.addrBook = addrBook
 }
 
+// SetPeerConfig sets the PeerConfig used for peer setup.
+func (sw *Switch) SetPeerConfig(config *PeerConfig) {
+	sw.peerConfig = config
+}
+
 // MarkPeerAsGood marks the given peer as good when it did something useful
 // like contributed to consensus.
 func (sw *Switch) MarkPeerAsGood(peer Peer) {
@@ -530,6 +535,11 @@ func (sw *Switch) addOutboundPeerWithConfig(addr *NetAddress, config *PeerConfig
 func (sw *Switch) addPeer(pc peerConn) error {
 
 	addr := pc.conn.RemoteAddr()
+
+	if pc.config.Local {
+		addr = pc.conn.LocalAddr()
+	}
+
 	if err := sw.FilterConnByAddr(addr); err != nil {
 		return err
 	}

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -151,8 +151,8 @@ func assertMsgReceivedWithTimeout(t *testing.T, msgBytes []byte, channel byte, r
 }
 
 func TestConnAddrFilter(t *testing.T) {
-	s1 := MakeSwitch(config, 1, "testing", "123.123.123", initSwitchFunc)
-	s2 := MakeSwitch(config, 1, "testing", "123.123.123", initSwitchFunc)
+	s1 := MakeSwitch(config, nil, 1, "testing", "123.123.123", initSwitchFunc)
+	s2 := MakeSwitch(config, nil, 1, "testing", "123.123.123", initSwitchFunc)
 	defer s1.Stop()
 	defer s2.Stop()
 
@@ -180,7 +180,7 @@ func TestConnAddrFilter(t *testing.T) {
 }
 
 func TestSwitchFiltersOutItself(t *testing.T) {
-	s1 := MakeSwitch(config, 1, "127.0.0.2", "123.123.123", initSwitchFunc)
+	s1 := MakeSwitch(config, nil, 1, "127.0.0.2", "123.123.123", initSwitchFunc)
 	// addr := s1.NodeInfo().NetAddress()
 
 	// // add ourselves like we do in node.go#427
@@ -213,8 +213,8 @@ func assertNoPeersAfterTimeout(t *testing.T, sw *Switch, timeout time.Duration) 
 }
 
 func TestConnIDFilter(t *testing.T) {
-	s1 := MakeSwitch(config, 1, "testing", "123.123.123", initSwitchFunc)
-	s2 := MakeSwitch(config, 1, "testing", "123.123.123", initSwitchFunc)
+	s1 := MakeSwitch(config, nil, 1, "testing", "123.123.123", initSwitchFunc)
+	s2 := MakeSwitch(config, nil, 1, "testing", "123.123.123", initSwitchFunc)
 	defer s1.Stop()
 	defer s2.Stop()
 
@@ -250,7 +250,7 @@ func TestConnIDFilter(t *testing.T) {
 func TestSwitchStopsNonPersistentPeerOnError(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
-	sw := MakeSwitch(config, 1, "testing", "123.123.123", initSwitchFunc)
+	sw := MakeSwitch(config, nil, 1, "testing", "123.123.123", initSwitchFunc)
 	err := sw.Start()
 	if err != nil {
 		t.Error(err)
@@ -280,7 +280,7 @@ func TestSwitchStopsNonPersistentPeerOnError(t *testing.T) {
 func TestSwitchReconnectsToPersistentPeer(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
-	sw := MakeSwitch(config, 1, "testing", "123.123.123", initSwitchFunc)
+	sw := MakeSwitch(config, nil, 1, "testing", "123.123.123", initSwitchFunc)
 	err := sw.Start()
 	if err != nil {
 		t.Error(err)

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -58,9 +58,12 @@ const TEST_HOST = "localhost"
 // initSwitch defines how the i'th switch should be initialized (ie. with what reactors).
 // NOTE: panics if any switch fails to start.
 func MakeConnectedSwitches(cfg *cfg.P2PConfig, n int, initSwitch func(int, *Switch) *Switch, connect func([]*Switch, int, int)) []*Switch {
+	peerConfig := DefaultPeerConfig()
+	peerConfig.Local = true
+
 	switches := make([]*Switch, n)
 	for i := 0; i < n; i++ {
-		switches[i] = MakeSwitch(cfg, i, TEST_HOST, "123.123.123", initSwitch)
+		switches[i] = MakeSwitch(cfg, peerConfig, i, TEST_HOST, "123.123.123", initSwitch)
 	}
 
 	if err := StartSwitches(switches); err != nil {
@@ -134,7 +137,13 @@ func StartSwitches(switches []*Switch) error {
 
 var listenAddrSuffix uint32 = 1
 
-func MakeSwitch(cfg *cfg.P2PConfig, i int, network, version string, initSwitch func(int, *Switch) *Switch) *Switch {
+func MakeSwitch(
+	cfg *cfg.P2PConfig,
+	peerConfig *PeerConfig,
+	i int,
+	network, version string,
+	initSwitch func(int, *Switch) *Switch,
+) *Switch {
 	// new switch, add reactors
 	// TODO: let the config be passed in?
 	nodeKey := &NodeKey{
@@ -155,5 +164,10 @@ func MakeSwitch(cfg *cfg.P2PConfig, i int, network, version string, initSwitch f
 	}
 	sw.SetNodeInfo(ni)
 	sw.SetNodeKey(nodeKey)
+
+	if peerConfig != nil {
+		sw.SetPeerConfig(peerConfig)
+	}
+
 	return sw
 }


### PR DESCRIPTION
In line with other options we use for testing in the peerConfig we add the Local flag which signals to use the LocalAddr from the connection instead of the RemoteAddr. We require this as we piggyback on the loopback (127.0.0/8) addresses to simulate multiple peers.
