### PR TITLE
Remove auth_enc config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- [p2p] remove `auth_enc` config option, peer connections are always auth
+  encrypted
+
 ## 0.19.7
 
 BREAKING:

--- a/config/config.go
+++ b/config/config.go
@@ -287,9 +287,6 @@ type P2PConfig struct {
 	// Does not work if the peer-exchange reactor is disabled.
 	SeedMode bool `mapstructure:"seed_mode"`
 
-	// Authenticated encryption
-	AuthEnc bool `mapstructure:"auth_enc"`
-
 	// Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
 	PrivatePeerIDs string `mapstructure:"private_peer_ids"`
 
@@ -310,7 +307,6 @@ func DefaultP2PConfig() *P2PConfig {
 		RecvRate:                512000, // 500 kB/s
 		PexReactor:              true,
 		SeedMode:                false,
-		AuthEnc:                 true,
 		AllowDuplicateIP:        true, // so non-breaking yet
 	}
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -165,9 +165,6 @@ pex = {{ .P2P.PexReactor }}
 # Does not work if the peer-exchange reactor is disabled.
 seed_mode = {{ .P2P.SeedMode }}
 
-# Authenticated encryption
-auth_enc = {{ .P2P.AuthEnc }}
-
 # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
 private_peer_ids = "{{ .P2P.PrivatePeerIDs }}"
 

--- a/docs/examples/node0/config/config.toml
+++ b/docs/examples/node0/config/config.toml
@@ -103,9 +103,6 @@ pex = true
 # Does not work if the peer-exchange reactor is disabled.
 seed_mode = false
 
-# Authenticated encryption
-auth_enc = true
-
 # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
 private_peer_ids = ""
 

--- a/docs/examples/node1/config/config.toml
+++ b/docs/examples/node1/config/config.toml
@@ -103,9 +103,6 @@ pex = true
 # Does not work if the peer-exchange reactor is disabled.
 seed_mode = false
 
-# Authenticated encryption
-auth_enc = true
-
 # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
 private_peer_ids = ""
 

--- a/docs/examples/node2/config/config.toml
+++ b/docs/examples/node2/config/config.toml
@@ -103,9 +103,6 @@ pex = true
 # Does not work if the peer-exchange reactor is disabled.
 seed_mode = false
 
-# Authenticated encryption
-auth_enc = true
-
 # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
 private_peer_ids = ""
 

--- a/docs/examples/node3/config/config.toml
+++ b/docs/examples/node3/config/config.toml
@@ -103,9 +103,6 @@ pex = true
 # Does not work if the peer-exchange reactor is disabled.
 seed_mode = false
 
-# Authenticated encryption
-auth_enc = true
-
 # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
 private_peer_ids = ""
 

--- a/docs/spec/p2p/peer.md
+++ b/docs/spec/p2p/peer.md
@@ -17,9 +17,6 @@ We will attempt to connect to the peer at IP:PORT, and verify,
 via authenticated encryption, that it is in possession of the private key
 corresponding to `<ID>`. This prevents man-in-the-middle attacks on the peer layer.
 
-If `auth_enc = false`, peers can use an arbitrary ID, but they must always use
-one. Authentication can then happen out-of-band of Tendermint, for instance via VPN.
-
 ## Connections
 
 All p2p connections use TCP.

--- a/docs/specification/configuration.rst
+++ b/docs/specification/configuration.rst
@@ -122,9 +122,6 @@ like the file below, however, double check by inspecting the
     # Does not work if the peer-exchange reactor is disabled.
     seed_mode = false
 
-    # Authenticated encryption
-    auth_enc = true
-
     # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
     private_peer_ids = ""
 

--- a/docs/specification/secure-p2p.rst
+++ b/docs/specification/secure-p2p.rst
@@ -65,9 +65,7 @@ are connected to at least one validator.
 Config
 ------
 
-Authenticated encryption is enabled by default. If you wish to use another
-authentication scheme or your peers are connected via VPN, you can turn it off
-by setting ``auth_enc`` to ``false`` in the config file.
+Authenticated encryption is enabled by default.
 
 Additional Reading
 ------------------

--- a/node/node.go
+++ b/node/node.go
@@ -269,9 +269,6 @@ func NewNode(config *cfg.Config,
 	// but it would still be nice to have a clear list of the current "PersistentPeers"
 	// somewhere that we can return with net_info.
 	//
-	// Let's assume we always have IDs ... and we just dont authenticate them
-	// if auth_enc=false.
-	//
 	// If PEX is on, it should handle dialing the seeds. Otherwise the switch does it.
 	// Note we currently use the addrBook regardless at least for AddOurAddress
 	addrBook := pex.NewAddrBook(config.P2P.AddrBookFile(), config.P2P.AddrBookStrict)

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -41,32 +41,10 @@ func TestPeerBasic(t *testing.T) {
 	assert.Equal(rp.ID(), p.ID())
 }
 
-func TestPeerWithoutAuthEnc(t *testing.T) {
-	assert, require := assert.New(t), require.New(t)
-
-	config := DefaultPeerConfig()
-	config.AuthEnc = false
-
-	// simulate remote peer
-	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: config}
-	rp.Start()
-	defer rp.Stop()
-
-	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), config)
-	require.Nil(err)
-
-	err = p.Start()
-	require.Nil(err)
-	defer p.Stop()
-
-	assert.True(p.IsRunning())
-}
-
 func TestPeerSend(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	config := DefaultPeerConfig()
-	config.AuthEnc = false
 
 	// simulate remote peer
 	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: config}


### PR DESCRIPTION
As we didn't hear any voices requesting this feature, we removed the
option to disable it and always have peer connection auth encrypted.

closes #1518
follow-up #1325

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG.md
