### PR TITLE
Disable slate step in CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,9 +199,6 @@ workflows:
   test-suite:
     jobs:
       - setup_dependencies
-      - build_slate:
-          requires:
-            - setup_dependencies
       - setup_abci:
           requires:
             - setup_dependencies


### PR DESCRIPTION
It's currently breaking for unknown reasons, until fixed we going to
disable it, to not block on it for unrelated PRs.

