### PR TITLE
Collapse PeerConfig into P2PConfig

### DIFF
--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -83,7 +83,7 @@ type MConnection struct {
 	onReceive     receiveCbFunc
 	onError       errorCbFunc
 	errored       uint32
-	config        *MConnConfig
+	config        MConnConfig
 
 	quit       chan struct{}
 	flushTimer *cmn.ThrottleTimer // flush writes as necessary but throttled.
@@ -121,8 +121,8 @@ func (cfg *MConnConfig) maxPacketMsgTotalSize() int {
 }
 
 // DefaultMConnConfig returns the default config.
-func DefaultMConnConfig() *MConnConfig {
-	return &MConnConfig{
+func DefaultMConnConfig() MConnConfig {
+	return MConnConfig{
 		SendRate:                defaultSendRate,
 		RecvRate:                defaultRecvRate,
 		MaxPacketMsgPayloadSize: maxPacketMsgPayloadSizeDefault,
@@ -143,7 +143,7 @@ func NewMConnection(conn net.Conn, chDescs []*ChannelDescriptor, onReceive recei
 }
 
 // NewMConnectionWithConfig wraps net.Conn and creates multiplex connection with a config
-func NewMConnectionWithConfig(conn net.Conn, chDescs []*ChannelDescriptor, onReceive receiveCbFunc, onError errorCbFunc, config *MConnConfig) *MConnection {
+func NewMConnectionWithConfig(conn net.Conn, chDescs []*ChannelDescriptor, onReceive receiveCbFunc, onError errorCbFunc, config MConnConfig) *MConnection {
 	if config.PongTimeout >= config.PingInterval {
 		panic("pongTimeout must be less than pingInterval (otherwise, next ping will reset pong timer)")
 	}

--- a/p2p/fuzz.go
+++ b/p2p/fuzz.go
@@ -5,14 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tendermint/tendermint/config"
 	cmn "github.com/tendermint/tmlibs/common"
-)
-
-const (
-	// FuzzModeDrop is a mode in which we randomly drop reads/writes, connections or sleep
-	FuzzModeDrop = iota
-	// FuzzModeDelay is a mode in which we randomly sleep
-	FuzzModeDelay
 )
 
 // FuzzedConnection wraps any net.Conn and depending on the mode either delays
@@ -24,37 +18,17 @@ type FuzzedConnection struct {
 	start  <-chan time.Time
 	active bool
 
-	config *FuzzConnConfig
-}
-
-// FuzzConnConfig is a FuzzedConnection configuration.
-type FuzzConnConfig struct {
-	Mode         int
-	MaxDelay     time.Duration
-	ProbDropRW   float64
-	ProbDropConn float64
-	ProbSleep    float64
-}
-
-// DefaultFuzzConnConfig returns the default config.
-func DefaultFuzzConnConfig() *FuzzConnConfig {
-	return &FuzzConnConfig{
-		Mode:         FuzzModeDrop,
-		MaxDelay:     3 * time.Second,
-		ProbDropRW:   0.2,
-		ProbDropConn: 0.00,
-		ProbSleep:    0.00,
-	}
+	config *config.FuzzConnConfig
 }
 
 // FuzzConn creates a new FuzzedConnection. Fuzzing starts immediately.
 func FuzzConn(conn net.Conn) net.Conn {
-	return FuzzConnFromConfig(conn, DefaultFuzzConnConfig())
+	return FuzzConnFromConfig(conn, config.DefaultFuzzConnConfig())
 }
 
 // FuzzConnFromConfig creates a new FuzzedConnection from a config. Fuzzing
 // starts immediately.
-func FuzzConnFromConfig(conn net.Conn, config *FuzzConnConfig) net.Conn {
+func FuzzConnFromConfig(conn net.Conn, config *config.FuzzConnConfig) net.Conn {
 	return &FuzzedConnection{
 		conn:   conn,
 		start:  make(<-chan time.Time),
@@ -66,12 +40,16 @@ func FuzzConnFromConfig(conn net.Conn, config *FuzzConnConfig) net.Conn {
 // FuzzConnAfter creates a new FuzzedConnection. Fuzzing starts when the
 // duration elapses.
 func FuzzConnAfter(conn net.Conn, d time.Duration) net.Conn {
-	return FuzzConnAfterFromConfig(conn, d, DefaultFuzzConnConfig())
+	return FuzzConnAfterFromConfig(conn, d, config.DefaultFuzzConnConfig())
 }
 
 // FuzzConnAfterFromConfig creates a new FuzzedConnection from a config.
 // Fuzzing starts when the duration elapses.
-func FuzzConnAfterFromConfig(conn net.Conn, d time.Duration, config *FuzzConnConfig) net.Conn {
+func FuzzConnAfterFromConfig(
+	conn net.Conn,
+	d time.Duration,
+	config *config.FuzzConnConfig,
+) net.Conn {
 	return &FuzzedConnection{
 		conn:   conn,
 		start:  time.After(d),
@@ -81,7 +59,7 @@ func FuzzConnAfterFromConfig(conn net.Conn, d time.Duration, config *FuzzConnCon
 }
 
 // Config returns the connection's config.
-func (fc *FuzzedConnection) Config() *FuzzConnConfig {
+func (fc *FuzzedConnection) Config() *config.FuzzConnConfig {
 	return fc.config
 }
 
@@ -136,7 +114,7 @@ func (fc *FuzzedConnection) fuzz() bool {
 	}
 
 	switch fc.config.Mode {
-	case FuzzModeDrop:
+	case config.FuzzModeDrop:
 		// randomly drop the r/w, drop the conn, or sleep
 		r := cmn.RandFloat64()
 		if r <= fc.config.ProbDropRW {
@@ -149,7 +127,7 @@ func (fc *FuzzedConnection) fuzz() bool {
 		} else if r < fc.config.ProbDropRW+fc.config.ProbDropConn+fc.config.ProbSleep {
 			time.Sleep(fc.randomDuration())
 		}
-	case FuzzModeDelay:
+	case config.FuzzModeDelay:
 		// sleep a bit
 		time.Sleep(fc.randomDuration())
 	}

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	crypto "github.com/tendermint/go-crypto"
-	tmconn "github.com/tendermint/tendermint/p2p/conn"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
+
+	"github.com/tendermint/tendermint/config"
+	tmconn "github.com/tendermint/tendermint/p2p/conn"
 )
 
 const testCh = 0x01
@@ -21,11 +23,11 @@ func TestPeerBasic(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	// simulate remote peer
-	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: DefaultPeerConfig()}
+	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: cfg}
 	rp.Start()
 	defer rp.Stop()
 
-	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), DefaultPeerConfig())
+	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), cfg)
 	require.Nil(err)
 
 	err = p.Start()
@@ -44,7 +46,7 @@ func TestPeerBasic(t *testing.T) {
 func TestPeerSend(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
-	config := DefaultPeerConfig()
+	config := cfg
 
 	// simulate remote peer
 	rp := &remotePeer{PrivKey: crypto.GenPrivKeyEd25519(), Config: config}
@@ -63,7 +65,7 @@ func TestPeerSend(t *testing.T) {
 	assert.True(p.Send(testCh, []byte("Asylum")))
 }
 
-func createOutboundPeerAndPerformHandshake(addr *NetAddress, config *PeerConfig) (*peer, error) {
+func createOutboundPeerAndPerformHandshake(addr *NetAddress, config *config.P2PConfig) (*peer, error) {
 	chDescs := []*tmconn.ChannelDescriptor{
 		{ID: testCh, Priority: 1},
 	}
@@ -91,7 +93,7 @@ func createOutboundPeerAndPerformHandshake(addr *NetAddress, config *PeerConfig)
 
 type remotePeer struct {
 	PrivKey    crypto.PrivKey
-	Config     *PeerConfig
+	Config     *config.P2PConfig
 	addr       *NetAddress
 	quit       chan struct{}
 	channels   cmn.HexBytes

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -13,21 +13,22 @@ import (
 	"github.com/stretchr/testify/require"
 
 	crypto "github.com/tendermint/go-crypto"
-	cfg "github.com/tendermint/tendermint/config"
-	"github.com/tendermint/tendermint/p2p"
-	"github.com/tendermint/tendermint/p2p/conn"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
+
+	"github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/p2p/conn"
 )
 
 var (
-	config *cfg.P2PConfig
+	cfg *config.P2PConfig
 )
 
 func init() {
-	config = cfg.DefaultP2PConfig()
-	config.PexReactor = true
-	config.AllowDuplicateIP = true
+	cfg = config.DefaultP2PConfig()
+	cfg.PexReactor = true
+	cfg.AllowDuplicateIP = true
 }
 
 func TestPEXReactorBasic(t *testing.T) {
@@ -84,7 +85,7 @@ func TestPEXReactorRunning(t *testing.T) {
 
 	// create switches
 	for i := 0; i < N; i++ {
-		switches[i] = p2p.MakeSwitch(config, i, "testing", "123.123.123", func(i int, sw *p2p.Switch) *p2p.Switch {
+		switches[i] = p2p.MakeSwitch(cfg, i, "testing", "123.123.123", func(i int, sw *p2p.Switch) *p2p.Switch {
 			books[i] = NewAddrBook(filepath.Join(dir, fmt.Sprintf("addrbook%d.json", i)), false)
 			books[i].SetLogger(logger.With("pex", i))
 			sw.SetAddrBook(books[i])
@@ -212,7 +213,7 @@ func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 
 	// 1. create seed
 	seed := p2p.MakeSwitch(
-		config,
+		cfg,
 		0,
 		"127.0.0.1",
 		"123.123.123",
@@ -242,7 +243,7 @@ func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 
 	// 2. create usual peer with only seed configured.
 	peer := p2p.MakeSwitch(
-		config,
+		cfg,
 		1,
 		"127.0.0.1",
 		"123.123.123",
@@ -428,7 +429,7 @@ func assertPeersWithTimeout(
 	}
 }
 
-func createReactor(config *PEXReactorConfig) (r *PEXReactor, book *addrBook) {
+func createReactor(conf *PEXReactorConfig) (r *PEXReactor, book *addrBook) {
 	// directory to store address book
 	dir, err := ioutil.TempDir("", "pex_reactor")
 	if err != nil {
@@ -437,7 +438,7 @@ func createReactor(config *PEXReactorConfig) (r *PEXReactor, book *addrBook) {
 	book = NewAddrBook(filepath.Join(dir, "addrbook.json"), true)
 	book.SetLogger(log.TestingLogger())
 
-	r = NewPEXReactor(book, config)
+	r = NewPEXReactor(book, conf)
 	r.SetLogger(log.TestingLogger())
 	return
 }
@@ -450,7 +451,7 @@ func teardownReactor(book *addrBook) {
 }
 
 func createSwitchAndAddReactors(reactors ...p2p.Reactor) *p2p.Switch {
-	sw := p2p.MakeSwitch(config, 0, "127.0.0.1", "123.123.123", func(i int, sw *p2p.Switch) *p2p.Switch { return sw })
+	sw := p2p.MakeSwitch(cfg, 0, "127.0.0.1", "123.123.123", func(i int, sw *p2p.Switch) *p2p.Switch { return sw })
 	sw.SetLogger(log.TestingLogger())
 	for _, r := range reactors {
 		sw.AddReactor(r.String(), r)

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -8,7 +8,7 @@ import (
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/p2p/conn"
 )
 
@@ -56,7 +56,7 @@ const TEST_HOST = "localhost"
 // If connect==Connect2Switches, the switches will be fully connected.
 // initSwitch defines how the i'th switch should be initialized (ie. with what reactors).
 // NOTE: panics if any switch fails to start.
-func MakeConnectedSwitches(cfg *cfg.P2PConfig, n int, initSwitch func(int, *Switch) *Switch, connect func([]*Switch, int, int)) []*Switch {
+func MakeConnectedSwitches(cfg *config.P2PConfig, n int, initSwitch func(int, *Switch) *Switch, connect func([]*Switch, int, int)) []*Switch {
 	switches := make([]*Switch, n)
 	for i := 0; i < n; i++ {
 		switches[i] = MakeSwitch(cfg, i, TEST_HOST, "123.123.123", initSwitch)
@@ -104,7 +104,7 @@ func Connect2Switches(switches []*Switch, i, j int) {
 }
 
 func (sw *Switch) addPeerWithConnection(conn net.Conn) error {
-	pc, err := newInboundPeerConn(conn, sw.peerConfig, sw.nodeKey.PrivKey)
+	pc, err := newInboundPeerConn(conn, sw.config, sw.nodeKey.PrivKey)
 	if err != nil {
 		if err := conn.Close(); err != nil {
 			sw.Logger.Error("Error closing connection", "err", err)
@@ -131,7 +131,7 @@ func StartSwitches(switches []*Switch) error {
 	return nil
 }
 
-func MakeSwitch(cfg *cfg.P2PConfig, i int, network, version string, initSwitch func(int, *Switch) *Switch) *Switch {
+func MakeSwitch(cfg *config.P2PConfig, i int, network, version string, initSwitch func(int, *Switch) *Switch) *Switch {
 	// new switch, add reactors
 	// TODO: let the config be passed in?
 	nodeKey := &NodeKey{


### PR DESCRIPTION
As both configs are concerned with the p2p packaage and PeerConfig is only used inside of the package there is no good reason to keep the couple of fields separate, therefore it is collapsed into the more general P2PConifg. This is a stepping stone towards a setup where the components inside of p2p do not have any knowledge about the config.

follow-up to #1325