### PR TITLE
Fix race when mutating MConnConfig

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
-	tmconn "github.com/tendermint/tendermint/p2p/conn"
 )
 
 const (
@@ -304,9 +302,8 @@ type P2PConfig struct {
 	AllowDuplicateIP bool `mapstructure:"allow_duplicate_ip"`
 
 	// Peer connection configuration.
-	HandshakeTimeout time.Duration      `mapstructure:"handshake_timeout"`
-	DialTimeout      time.Duration      `mapstructure:"dial_timeout"`
-	MConfig          tmconn.MConnConfig `mapstructure:"connection"`
+	HandshakeTimeout time.Duration `mapstructure:"handshake_timeout"`
+	DialTimeout      time.Duration `mapstructure:"dial_timeout"`
 
 	// Testing params.
 	// Force dial to fail
@@ -332,7 +329,6 @@ func DefaultP2PConfig() *P2PConfig {
 		AllowDuplicateIP:        true, // so non-breaking yet
 		HandshakeTimeout:        20 * time.Second,
 		DialTimeout:             3 * time.Second,
-		MConfig:                 tmconn.DefaultMConnConfig(),
 		TestDialFail:            false,
 		TestFuzz:                false,
 		TestFuzzConfig:          DefaultFuzzConnConfig(),

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -102,6 +102,7 @@ type peer struct {
 
 func newPeer(
 	pc peerConn,
+	mConfig tmconn.MConnConfig,
 	nodeInfo NodeInfo,
 	reactorsByCh map[byte]Reactor,
 	chDescs []*tmconn.ChannelDescriptor,
@@ -120,7 +121,7 @@ func newPeer(
 		reactorsByCh,
 		chDescs,
 		onPeerError,
-		pc.config.MConfig,
+		mConfig,
 	)
 	p.BaseService = *cmn.NewBaseService(nil, "Peer", p)
 

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -27,7 +27,7 @@ func TestPeerBasic(t *testing.T) {
 	rp.Start()
 	defer rp.Stop()
 
-	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), cfg)
+	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), cfg, tmconn.DefaultMConnConfig())
 	require.Nil(err)
 
 	err = p.Start()
@@ -53,7 +53,7 @@ func TestPeerSend(t *testing.T) {
 	rp.Start()
 	defer rp.Stop()
 
-	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), config)
+	p, err := createOutboundPeerAndPerformHandshake(rp.Addr(), config, tmconn.DefaultMConnConfig())
 	require.Nil(err)
 
 	err = p.Start()
@@ -65,7 +65,11 @@ func TestPeerSend(t *testing.T) {
 	assert.True(p.Send(testCh, []byte("Asylum")))
 }
 
-func createOutboundPeerAndPerformHandshake(addr *NetAddress, config *config.P2PConfig) (*peer, error) {
+func createOutboundPeerAndPerformHandshake(
+	addr *NetAddress,
+	config *config.P2PConfig,
+	mConfig tmconn.MConnConfig,
+) (*peer, error) {
 	chDescs := []*tmconn.ChannelDescriptor{
 		{ID: testCh, Priority: 1},
 	}
@@ -86,7 +90,7 @@ func createOutboundPeerAndPerformHandshake(addr *NetAddress, config *config.P2PC
 		return nil, err
 	}
 
-	p := newPeer(pc, nodeInfo, reactorsByCh, chDescs, func(p Peer, r interface{}) {})
+	p := newPeer(pc, mConfig, nodeInfo, reactorsByCh, chDescs, func(p Peer, r interface{}) {})
 	p.SetLogger(log.TestingLogger().With("peer", addr))
 	return p, nil
 }


### PR DESCRIPTION
Instead of mutating the passed in MConnConfig part of P2PConfig we just use the default and override the values, the same as before as it was always the default version. This is yet another good reason to not embed information and access to config structs in our components and will go away with the ongoing refactoring in #1325.

