### PR TITLE
return an error if we fail to parse external IP

### DIFF
--- a/p2p/upnp/upnp.go
+++ b/p2p/upnp/upnp.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -324,12 +325,17 @@ func (n *upnpNAT) getExternalIPAddress() (info statusInfo, err error) {
 	return
 }
 
+// GetExternalAddress returns an external IP. If GetExternalIPAddress action
+// fails or IP returned is invalid, GetExternalAddress returns an error.
 func (n *upnpNAT) GetExternalAddress() (addr net.IP, err error) {
 	info, err := n.getExternalIPAddress()
 	if err != nil {
 		return
 	}
 	addr = net.ParseIP(info.externalIpAddress)
+	if addr == nil {
+		err = fmt.Errorf("Failed to parse IP: %v", info.externalIpAddress)
+	}
 	return
 }
 


### PR DESCRIPTION
```
I[06-08|11:51:57.234] Getting UPNP external address                module=p2p
I[06-08|11:51:58.867] Got UPNP external address                    module=p2p address=
```

Fixes #1717

```
I[06-08|11:51:56.952] Starting multiAppConn                        module=proxy impl=multiAppConn
I[06-08|11:51:56.952] Starting localClient                         module=abci-client connection=query impl=localClient
I[06-08|11:51:56.952] Starting localClient                         module=abci-client connection=mempool impl=localClient
I[06-08|11:51:56.952] Starting localClient                         module=abci-client connection=consensus impl=localClient
I[06-08|11:51:56.952] ABCI Handshake                               module=consensus appHeight=0 appHash=
I[06-08|11:51:56.952] ABCI Replay Blocks                           module=consensus appHeight=0 storeHeight=0 stateHeight=0
I[06-08|11:51:57.053] Completed ABCI Handshake - Tendermint and App are synced module=consensus appHeight=0 appHash=
I[06-08|11:51:57.053] This node is a validator                     module=consensus addr=6816B5D9BAC32A3CDF07884D9D3D2650694C371D pubKey=PubKeyEd25519{27A40CD032DD2467342D0CF27C5EC92052D966FEC714B6CF2F3BF3146AFD0D51}
I[06-08|11:51:57.234] Starting Node                                module=main impl=Node
I[06-08|11:51:57.234] Starting EventBus                            module=events impl=EventBus
I[06-08|11:51:57.234] Local listener                               module=p2p ip=:: port=46656
I[06-08|11:51:57.234] Getting UPNP external address                module=p2p
I[06-08|11:51:58.867] Got UPNP external address                    module=p2p address=
I[06-08|11:51:58.867] Starting DefaultListener                     module=p2p impl=Listener(@<nil>:46656)
I[06-08|11:51:58.867] P2P Node ID                                  module=main ID=3629b516392e494ae717ac4c6a1ea7eb0fe421c3 file=/home/tpb/.tendermint/config/node_key.json
I[06-08|11:51:58.868] Add our address to book                      module=p2p book=/home/tpb/.tendermint/config/addrbook.json addr=null
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x89fb86]

goroutine 1 [running]:
github.com/tendermint/tendermint/p2p.(*NetAddress).String(0x0, 0xc96e24, 0x17)
	/home/tpb/code/go/src/github.com/tendermint/tendermint/p2p/netaddress.go:171 +0x26
github.com/tendermint/tendermint/p2p/pex.(*addrBook).AddOurAddress(0xc420190620, 0x0)
	/home/tpb/code/go/src/github.com/tendermint/tendermint/p2p/pex/addrbook.go:160 +0x116
github.com/tendermint/tendermint/node.(*Node).OnStart(0xc420286d00, 0xc4201b8010, 0xd)
	/home/tpb/code/go/src/github.com/tendermint/tendermint/node/node.go:402 +0x547
github.com/tendermint/tendermint/vendor/github.com/tendermint/tmlibs/common.(*BaseService).Start(0xc420286d00, 0xe51c40, 0xc42000bd40)
	/home/tpb/code/go/src/github.com/tendermint/tendermint/vendor/github.com/tendermint/tmlibs/common/service.go:130 +0x3bd
github.com/tendermint/tendermint/cmd/tendermint/commands.NewRunNodeCmd.func1(0xc42022e000, 0xc4200acdc0, 0x0, 0x1, 0x0, 0x0)
	/home/tpb/code/go/src/github.com/tendermint/tendermint/cmd/tendermint/commands/run_node.go:58 +0xfe
github.com/tendermint/tendermint/vendor/github.com/spf13/cobra.(*Command).execute(0xc42022e000, 0xc4200acda0, 0x1, 0x1, 0xc42022e000, 0xc4200acda0)
	/home/tpb/code/go/src/github.com/tendermint/tendermint/vendor/github.com/spf13/cobra/command.go:762 +0x468
github.com/tendermint/tendermint/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x1289280, 0xbbdda0, 0xc420015e01, 0xc4201bc640)
	/home/tpb/code/go/src/github.com/tendermint/tendermint/vendor/github.com/spf13/cobra/command.go:852 +0x30a
github.com/tendermint/tendermint/vendor/github.com/spf13/cobra.(*Command).Execute(0x1289280, 0xc4201bc640, 0xc420015e98)
	/home/tpb/code/go/src/github.com/tendermint/tendermint/vendor/github.com/spf13/cobra/command.go:800 +0x2b
github.com/tendermint/tendermint/vendor/github.com/tendermint/tmlibs/cli.Executor.Execute(0x1289280, 0xde5798, 0x2, 0xc4200332c0)
	/home/tpb/code/go/src/github.com/tendermint/tendermint/vendor/github.com/tendermint/tmlibs/cli/setup.go:89 +0x4e
main.main()
	/home/tpb/code/go/src/github.com/tendermint/tendermint/cmd/tendermint/main.go:45 +0x24d
```

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
