### PR TITLE
`unsafe_reset_all` also resets addrbook.json

### DIFF
--- a/cmd/tendermint/commands/reset_priv_validator.go
+++ b/cmd/tendermint/commands/reset_priv_validator.go
@@ -27,7 +27,7 @@ var ResetPrivValidatorCmd = &cobra.Command{
 // XXX: this is totally unsafe.
 // it's only suitable for testnets.
 func resetAll(cmd *cobra.Command, args []string) {
-	ResetAll(config.DBDir(), config.PrivValidatorFile(), logger)
+	ResetAll(config.DBDir(), config.P2P.AddrBook, config.PrivValidatorFile(), logger)
 }
 
 // XXX: this is totally unsafe.

--- a/cmd/tendermint/commands/reset_priv_validator.go
+++ b/cmd/tendermint/commands/reset_priv_validator.go
@@ -27,7 +27,7 @@ var ResetPrivValidatorCmd = &cobra.Command{
 // XXX: this is totally unsafe.
 // it's only suitable for testnets.
 func resetAll(cmd *cobra.Command, args []string) {
-	ResetAll(config.DBDir(), config.P2P.AddrBook, config.PrivValidatorFile(), logger)
+	ResetAll(config.DBDir(), config.P2P.AddrBookFile(), config.PrivValidatorFile(), logger)
 }
 
 // XXX: this is totally unsafe.
@@ -63,7 +63,7 @@ func resetFilePV(privValFile string, logger log.Logger) {
 func removeAddrBook(addrBookFile string, logger log.Logger) {
 	if err := os.Remove(addrBookFile); err == nil {
 		logger.Info("Removed existing address book", "file", addrBookFile)
-	} else {
+	} else if !os.IsNotExist(err) {
 		logger.Info("Error removing address book", "file", addrBookFile, "err", err)
 	}
 }

--- a/cmd/tendermint/commands/reset_priv_validator.go
+++ b/cmd/tendermint/commands/reset_priv_validator.go
@@ -24,17 +24,6 @@ var ResetPrivValidatorCmd = &cobra.Command{
 	Run:   resetPrivValidator,
 }
 
-// ResetAll removes the privValidator files.
-// Exported so other CLI tools can use it.
-func ResetAll(dbDir, privValFile string, logger log.Logger) {
-	resetFilePV(privValFile, logger)
-	if err := os.RemoveAll(dbDir); err != nil {
-		logger.Error("Error removing directory", "err", err)
-		return
-	}
-	logger.Info("Removed all blockchain history", "dir", dbDir)
-}
-
 // XXX: this is totally unsafe.
 // it's only suitable for testnets.
 func resetAll(cmd *cobra.Command, args []string) {
@@ -47,6 +36,18 @@ func resetPrivValidator(cmd *cobra.Command, args []string) {
 	resetFilePV(config.PrivValidatorFile(), logger)
 }
 
+// ResetAll removes the privValidator files.
+// Exported so other CLI tools can use it.
+func ResetAll(dbDir, addrBookFile, privValFile string, logger log.Logger) {
+	resetFilePV(privValFile, logger)
+	resetAddrBook(addrBookFile, logger)
+	if err := os.RemoveAll(dbDir); err != nil {
+		logger.Error("Error removing directory", "err", err)
+		return
+	}
+	logger.Info("Removed all blockchain history", "dir", dbDir)
+}
+
 func resetFilePV(privValFile string, logger log.Logger) {
 	// Get PrivValidator
 	if _, err := os.Stat(privValFile); err == nil {
@@ -57,5 +58,15 @@ func resetFilePV(privValFile string, logger log.Logger) {
 		pv := privval.GenFilePV(privValFile)
 		pv.Save()
 		logger.Info("Generated PrivValidator", "file", privValFile)
+	}
+}
+
+// Deletes the addrbook.json file. It will be generated in node.NewNode, which is executed with
+// `tendermint start`.
+func resetAddrBook(addrBookFile string, logger log.Logger) {
+	if err := os.Remove(addrBookFile); err == nil {
+		logger.Info("Cleared AddrBook to an empty state", "file", addrBookFile)
+	} else {
+		logger.Info("Failed to clear AddrBook to an empty state", "file", addrBookFile)
 	}
 }

--- a/cmd/tendermint/commands/reset_priv_validator.go
+++ b/cmd/tendermint/commands/reset_priv_validator.go
@@ -36,37 +36,34 @@ func resetPrivValidator(cmd *cobra.Command, args []string) {
 	resetFilePV(config.PrivValidatorFile(), logger)
 }
 
-// ResetAll removes the privValidator files.
+// ResetAll removes the privValidator and address book files plus all data.
 // Exported so other CLI tools can use it.
 func ResetAll(dbDir, addrBookFile, privValFile string, logger log.Logger) {
 	resetFilePV(privValFile, logger)
-	resetAddrBook(addrBookFile, logger)
-	if err := os.RemoveAll(dbDir); err != nil {
-		logger.Error("Error removing directory", "err", err)
-		return
+	removeAddrBook(addrBookFile, logger)
+	if err := os.RemoveAll(dbDir); err == nil {
+		logger.Info("Removed all blockchain history", "dir", dbDir)
+	} else {
+		logger.Error("Error removing all blockchain history", "dir", dbDir, "err", err)
 	}
-	logger.Info("Removed all blockchain history", "dir", dbDir)
 }
 
 func resetFilePV(privValFile string, logger log.Logger) {
-	// Get PrivValidator
 	if _, err := os.Stat(privValFile); err == nil {
 		pv := privval.LoadFilePV(privValFile)
 		pv.Reset()
-		logger.Info("Reset PrivValidator to genesis state", "file", privValFile)
+		logger.Info("Reset private validator file to genesis state", "file", privValFile)
 	} else {
 		pv := privval.GenFilePV(privValFile)
 		pv.Save()
-		logger.Info("Generated PrivValidator", "file", privValFile)
+		logger.Info("Generated private validator file", "file", privValFile)
 	}
 }
 
-// Deletes the addrbook.json file. It will be generated in node.NewNode, which is executed with
-// `tendermint start`.
-func resetAddrBook(addrBookFile string, logger log.Logger) {
+func removeAddrBook(addrBookFile string, logger log.Logger) {
 	if err := os.Remove(addrBookFile); err == nil {
-		logger.Info("Cleared AddrBook to an empty state", "file", addrBookFile)
+		logger.Info("Removed existing address book", "file", addrBookFile)
 	} else {
-		logger.Info("Failed to clear AddrBook to an empty state", "file", addrBookFile)
+		logger.Info("Error removing address book", "file", addrBookFile, "err", err)
 	}
 }


### PR DESCRIPTION
When executing `unsafe_reset_all` it also clear all IP addresses from
addrbook.json. This is the expected behaviour of `unsafe_reset_all`.

closes #1713