### PR TITLE
Dev/ephemeral port2

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -28,7 +28,7 @@ VOLUME [ $TMHOME ]
 WORKDIR $TMHOME
 
 # p2p and rpc port
-EXPOSE 46656 46657
+EXPOSE 26656 26657
 
 ENTRYPOINT ["/usr/bin/tendermint"]
 CMD ["node", "--moniker=`hostname`"]

--- a/DOCKER/Dockerfile.develop
+++ b/DOCKER/Dockerfile.develop
@@ -27,8 +27,8 @@ RUN mkdir -p /go/src/github.com/tendermint/tendermint && \
 
 VOLUME $DATA_ROOT
 
-EXPOSE 46656
-EXPOSE 46657
+EXPOSE 26656
+EXPOSE 26657
 
 ENTRYPOINT ["tendermint"]
 

--- a/DOCKER/Dockerfile.testing
+++ b/DOCKER/Dockerfile.testing
@@ -13,6 +13,6 @@ RUN echo 'deb http://httpredir.debian.org/debian testing main non-free contrib' 
 
 VOLUME /go
 
-EXPOSE 46656
-EXPOSE 46657
+EXPOSE 26656
+EXPOSE 26657
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/abci"
-  version = "~0.11.0"
+  branch = "develop"
 
 [[constraint]]
   name = "github.com/tendermint/go-crypto"

--- a/benchmarks/simu/counter.go
+++ b/benchmarks/simu/counter.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	wsc := rpcclient.NewWSClient("127.0.0.1:46657", "/websocket")
+	wsc := rpcclient.NewWSClient("127.0.0.1:26657", "/websocket")
 	err := wsc.Start()
 	if err != nil {
 		cmn.Exit(err.Error())

--- a/cmd/priv_val_server/main.go
+++ b/cmd/priv_val_server/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	var (
-		addr        = flag.String("addr", ":46659", "Address of client to connect to")
+		addr        = flag.String("addr", ":26659", "Address of client to connect to")
 		chainID     = flag.String("chain-id", "mychain", "chain id")
 		privValPath = flag.String("priv", "", "priv val file path")
 

--- a/cmd/tendermint/commands/lite.go
+++ b/cmd/tendermint/commands/lite.go
@@ -35,7 +35,7 @@ var (
 
 func init() {
 	LiteCmd.Flags().StringVar(&listenAddr, "laddr", "tcp://localhost:8888", "Serve the proxy on the given address")
-	LiteCmd.Flags().StringVar(&nodeAddr, "node", "tcp://localhost:46657", "Connect to a Tendermint node at this address")
+	LiteCmd.Flags().StringVar(&nodeAddr, "node", "tcp://localhost:26657", "Connect to a Tendermint node at this address")
 	LiteCmd.Flags().StringVar(&chainID, "chain-id", "tendermint", "Specify the Tendermint chain ID")
 	LiteCmd.Flags().StringVar(&home, "home-dir", ".tendermint-lite", "Specify the home directory")
 }

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -46,10 +46,10 @@ func init() {
 	TestnetFilesCmd.Flags().BoolVar(&populatePersistentPeers, "populate-persistent-peers", true,
 		"Update config of each node with the list of persistent peers build using either hostname-prefix or starting-ip-address")
 	TestnetFilesCmd.Flags().StringVar(&hostnamePrefix, "hostname-prefix", "node",
-		"Hostname prefix (node results in persistent peers list ID0@node0:46656, ID1@node1:46656, ...)")
+		"Hostname prefix (node results in persistent peers list ID0@node0:26656, ID1@node1:26656, ...)")
 	TestnetFilesCmd.Flags().StringVar(&startingIPAddress, "starting-ip-address", "",
-		"Starting IP address (192.168.0.1 results in persistent peers list ID0@192.168.0.1:46656, ID1@192.168.0.2:46656, ...)")
-	TestnetFilesCmd.Flags().IntVar(&p2pPort, "p2p-port", 46656,
+		"Starting IP address (192.168.0.1 results in persistent peers list ID0@192.168.0.1:26656, ID1@192.168.0.2:26656, ...)")
+	TestnetFilesCmd.Flags().IntVar(&p2pPort, "p2p-port", 26656,
 		"P2P Port")
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -151,7 +151,7 @@ func DefaultBaseConfig() BaseConfig {
 		PrivValidator:     defaultPrivValPath,
 		NodeKey:           defaultNodeKeyPath,
 		Moniker:           defaultMoniker,
-		ProxyApp:          "tcp://127.0.0.1:46658",
+		ProxyApp:          "tcp://127.0.0.1:26658",
 		ABCI:              "socket",
 		LogLevel:          DefaultPackageLogLevels(),
 		ProfListenAddress: "",
@@ -228,7 +228,7 @@ type RPCConfig struct {
 // DefaultRPCConfig returns a default configuration for the RPC server
 func DefaultRPCConfig() *RPCConfig {
 	return &RPCConfig{
-		ListenAddress:     "tcp://0.0.0.0:46657",
+		ListenAddress:     "tcp://0.0.0.0:26657",
 		GRPCListenAddress: "",
 		Unsafe:            false,
 	}
@@ -316,7 +316,7 @@ type P2PConfig struct {
 // DefaultP2PConfig returns a default configuration for the peer-to-peer layer
 func DefaultP2PConfig() *P2PConfig {
 	return &P2PConfig{
-		ListenAddress:           "tcp://0.0.0.0:46656",
+		ListenAddress:           "tcp://0.0.0.0:26656",
 		AddrBook:                defaultAddrBookPath,
 		AddrBookStrict:          true,
 		MaxNumPeers:             50,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: node0
     image: "tendermint/localnode"
     ports:
-      - "46656-46657:46656-46657"
+      - "26656-26657:26656-26657"
     environment:
       - ID=0
       - LOG=$${LOG:-tendermint.log}
@@ -19,7 +19,7 @@ services:
     container_name: node1
     image: "tendermint/localnode"
     ports:
-      - "46659-46660:46656-46657"
+      - "26659-26660:26656-26657"
     environment:
       - ID=1
       - LOG=$${LOG:-tendermint.log}
@@ -36,7 +36,7 @@ services:
       - ID=2
       - LOG=$${LOG:-tendermint.log}
     ports:
-      - "46661-46662:46656-46657"
+      - "26661-26662:26656-26657"
     volumes:
       - ./build:/tendermint:Z
     networks:
@@ -50,7 +50,7 @@ services:
       - ID=3
       - LOG=$${LOG:-tendermint.log}
     ports:
-      - "46663-46664:46656-46657"
+      - "26663-26664:26656-26657"
     volumes:
       - ./build:/tendermint:Z
     networks:

--- a/docs/abci-cli.md
+++ b/docs/abci-cli.md
@@ -41,7 +41,7 @@ Now run `abci-cli` to see the list of commands:
 
     Flags:
           --abci string      socket or grpc (default "socket")
-          --address string   address of application socket (default "tcp://127.0.0.1:46658")
+          --address string   address of application socket (default "tcp://127.0.0.1:26658")
       -h, --help             help for abci-cli
       -v, --verbose          print the command and results as if it were a console session
 

--- a/docs/deploy-testnets.md
+++ b/docs/deploy-testnets.md
@@ -26,12 +26,12 @@ Here are the steps to setting up a testnet manually:
     `tendermint node --proxy_app=kvstore --p2p.persistent_peers=< peer addresses >`
     on each node, where `< peer addresses >` is a comma separated list
     of the IP:PORT combination for each node. The default port for
-    Tendermint is `46656`. Thus, if the IP addresses of your nodes were
+    Tendermint is `26656`. Thus, if the IP addresses of your nodes were
     `192.168.0.1, 192.168.0.2, 192.168.0.3, 192.168.0.4`, the command
     would look like:
 
 
-    tendermint node --proxy_app=kvstore --p2p.persistent_peers=96663a3dd0d7b9d17d4c8211b191af259621c693@192.168.0.1:46656, 429fcf25974313b95673f58d77eacdd434402665@192.168.0.2:46656, 0491d373a8e0fcf1023aaf18c51d6a1d0d4f31bd@192.168.0.3:46656, f9baeaa15fedf5e1ef7448dd60f46c01f1a9e9c4@192.168.0.4:46656
+    tendermint node --proxy_app=kvstore --p2p.persistent_peers=96663a3dd0d7b9d17d4c8211b191af259621c693@192.168.0.1:26656, 429fcf25974313b95673f58d77eacdd434402665@192.168.0.2:26656, 0491d373a8e0fcf1023aaf18c51d6a1d0d4f31bd@192.168.0.3:26656, f9baeaa15fedf5e1ef7448dd60f46c01f1a9e9c4@192.168.0.4:26656
 
 After a few seconds, all the nodes should connect to each other and
 start making blocks! For more information, see the Tendermint Networks

--- a/docs/examples/getting-started.md
+++ b/docs/examples/getting-started.md
@@ -85,7 +85,7 @@ I[01-06|01:45:15.624] Committed state                              module=state 
 Check the status with:
 
 ```
-curl -s localhost:46657/status
+curl -s localhost:26657/status
 ```
 
 ### Sending Transactions
@@ -93,25 +93,25 @@ curl -s localhost:46657/status
 With the kvstore app running, we can send transactions:
 
 ```
-curl -s 'localhost:46657/broadcast_tx_commit?tx="abcd"'
+curl -s 'localhost:26657/broadcast_tx_commit?tx="abcd"'
 ```
 
 and check that it worked with:
 
 ```
-curl -s 'localhost:46657/abci_query?data="abcd"'
+curl -s 'localhost:26657/abci_query?data="abcd"'
 ```
 
 We can send transactions with a key and value too:
 
 ```
-curl -s 'localhost:46657/broadcast_tx_commit?tx="name=satoshi"'
+curl -s 'localhost:26657/broadcast_tx_commit?tx="name=satoshi"'
 ```
 
 and query the key:
 
 ```
-curl -s 'localhost:46657/abci_query?data="name"'
+curl -s 'localhost:26657/abci_query?data="name"'
 ```
 
 where the value is returned in hex.
@@ -134,10 +134,10 @@ This will install `go` and other dependencies, get the Tendermint source code, t
 Next, `cd` into `docs/examples`. Each command below should be run from each node, in sequence:
 
 ```
-tendermint node --home ./node0 --proxy_app=kvstore --p2p.persistent_peers="167b80242c300bf0ccfb3ced3dec60dc2a81776e@IP1:46656,3c7a5920811550c04bf7a0b2f1e02ab52317b5e6@IP2:46656,303a1a4312c30525c99ba66522dd81cca56a361a@IP3:46656,b686c2a7f4b1b46dca96af3a0f31a6a7beae0be4@IP4:46656"
-tendermint node --home ./node1 --proxy_app=kvstore --p2p.persistent_peers="167b80242c300bf0ccfb3ced3dec60dc2a81776e@IP1:46656,3c7a5920811550c04bf7a0b2f1e02ab52317b5e6@IP2:46656,303a1a4312c30525c99ba66522dd81cca56a361a@IP3:46656,b686c2a7f4b1b46dca96af3a0f31a6a7beae0be4@IP4:46656"
-tendermint node --home ./node2 --proxy_app=kvstore --p2p.persistent_peers="167b80242c300bf0ccfb3ced3dec60dc2a81776e@IP1:46656,3c7a5920811550c04bf7a0b2f1e02ab52317b5e6@IP2:46656,303a1a4312c30525c99ba66522dd81cca56a361a@IP3:46656,b686c2a7f4b1b46dca96af3a0f31a6a7beae0be4@IP4:46656"
-tendermint node --home ./node3 --proxy_app=kvstore --p2p.persistent_peers="167b80242c300bf0ccfb3ced3dec60dc2a81776e@IP1:46656,3c7a5920811550c04bf7a0b2f1e02ab52317b5e6@IP2:46656,303a1a4312c30525c99ba66522dd81cca56a361a@IP3:46656,b686c2a7f4b1b46dca96af3a0f31a6a7beae0be4@IP4:46656"
+tendermint node --home ./node0 --proxy_app=kvstore --p2p.persistent_peers="167b80242c300bf0ccfb3ced3dec60dc2a81776e@IP1:26656,3c7a5920811550c04bf7a0b2f1e02ab52317b5e6@IP2:26656,303a1a4312c30525c99ba66522dd81cca56a361a@IP3:26656,b686c2a7f4b1b46dca96af3a0f31a6a7beae0be4@IP4:26656"
+tendermint node --home ./node1 --proxy_app=kvstore --p2p.persistent_peers="167b80242c300bf0ccfb3ced3dec60dc2a81776e@IP1:26656,3c7a5920811550c04bf7a0b2f1e02ab52317b5e6@IP2:26656,303a1a4312c30525c99ba66522dd81cca56a361a@IP3:26656,b686c2a7f4b1b46dca96af3a0f31a6a7beae0be4@IP4:26656"
+tendermint node --home ./node2 --proxy_app=kvstore --p2p.persistent_peers="167b80242c300bf0ccfb3ced3dec60dc2a81776e@IP1:26656,3c7a5920811550c04bf7a0b2f1e02ab52317b5e6@IP2:26656,303a1a4312c30525c99ba66522dd81cca56a361a@IP3:26656,b686c2a7f4b1b46dca96af3a0f31a6a7beae0be4@IP4:26656"
+tendermint node --home ./node3 --proxy_app=kvstore --p2p.persistent_peers="167b80242c300bf0ccfb3ced3dec60dc2a81776e@IP1:26656,3c7a5920811550c04bf7a0b2f1e02ab52317b5e6@IP2:26656,303a1a4312c30525c99ba66522dd81cca56a361a@IP3:26656,b686c2a7f4b1b46dca96af3a0f31a6a7beae0be4@IP4:26656"
 ```
 
 Note that after the third node is started, blocks will start to stream in

--- a/docs/examples/node0/config/config.toml
+++ b/docs/examples/node0/config/config.toml
@@ -5,7 +5,7 @@
 
 # TCP or UNIX socket address of the ABCI application,
 # or the name of an ABCI application compiled in with the Tendermint binary
-proxy_app = "tcp://127.0.0.1:46658"
+proxy_app = "tcp://127.0.0.1:26658"
 
 # A custom human readable name for this node
 moniker = "alpha"
@@ -51,7 +51,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:46657"
+laddr = "tcp://0.0.0.0:26657"
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
@@ -64,7 +64,7 @@ unsafe = false
 [p2p]
 
 # Address to listen for incoming connections
-laddr = "tcp://0.0.0.0:46656"
+laddr = "tcp://0.0.0.0:26656"
 
 # Comma separated list of seed nodes to connect to
 seeds = ""

--- a/docs/examples/node1/config/config.toml
+++ b/docs/examples/node1/config/config.toml
@@ -5,7 +5,7 @@
 
 # TCP or UNIX socket address of the ABCI application,
 # or the name of an ABCI application compiled in with the Tendermint binary
-proxy_app = "tcp://127.0.0.1:46658"
+proxy_app = "tcp://127.0.0.1:26658"
 
 # A custom human readable name for this node
 moniker = "bravo"
@@ -51,7 +51,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:46657"
+laddr = "tcp://0.0.0.0:26657"
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
@@ -64,7 +64,7 @@ unsafe = false
 [p2p]
 
 # Address to listen for incoming connections
-laddr = "tcp://0.0.0.0:46656"
+laddr = "tcp://0.0.0.0:26656"
 
 # Comma separated list of seed nodes to connect to
 seeds = ""

--- a/docs/examples/node2/config/config.toml
+++ b/docs/examples/node2/config/config.toml
@@ -5,7 +5,7 @@
 
 # TCP or UNIX socket address of the ABCI application,
 # or the name of an ABCI application compiled in with the Tendermint binary
-proxy_app = "tcp://127.0.0.1:46658"
+proxy_app = "tcp://127.0.0.1:26658"
 
 # A custom human readable name for this node
 moniker = "charlie"
@@ -51,7 +51,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:46657"
+laddr = "tcp://0.0.0.0:26657"
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
@@ -64,7 +64,7 @@ unsafe = false
 [p2p]
 
 # Address to listen for incoming connections
-laddr = "tcp://0.0.0.0:46656"
+laddr = "tcp://0.0.0.0:26656"
 
 # Comma separated list of seed nodes to connect to
 seeds = ""

--- a/docs/examples/node3/config/config.toml
+++ b/docs/examples/node3/config/config.toml
@@ -5,7 +5,7 @@
 
 # TCP or UNIX socket address of the ABCI application,
 # or the name of an ABCI application compiled in with the Tendermint binary
-proxy_app = "tcp://127.0.0.1:46658"
+proxy_app = "tcp://127.0.0.1:26658"
 
 # A custom human readable name for this node
 moniker = "delta"
@@ -51,7 +51,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:46657"
+laddr = "tcp://0.0.0.0:26657"
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
@@ -64,7 +64,7 @@ unsafe = false
 [p2p]
 
 # Address to listen for incoming connections
-laddr = "tcp://0.0.0.0:46656"
+laddr = "tcp://0.0.0.0:26656"
 
 # Comma separated list of seed nodes to connect to
 seeds = ""

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,14 +67,14 @@ details, see [the guide on using Tendermint](./using-tendermint.html).
 You should see Tendermint making blocks! We can get the status of our
 Tendermint node as follows:
 
-    curl -s localhost:46657/status
+    curl -s localhost:26657/status
 
 The `-s` just silences `curl`. For nicer output, pipe the result into a
 tool like [jq](https://stedolan.github.io/jq/) or `json_pp`.
 
 Now let's send some transactions to the kvstore.
 
-    curl -s 'localhost:46657/broadcast_tx_commit?tx="abcd"'
+    curl -s 'localhost:26657/broadcast_tx_commit?tx="abcd"'
 
 Note the single quote (`'`) around the url, which ensures that the
 double quotes (`"`) are not escaped by bash. This command sent a
@@ -110,7 +110,7 @@ like:
 We can confirm that our transaction worked and the value got stored by
 querying the app:
 
-    curl -s 'localhost:46657/abci_query?data="abcd"'
+    curl -s 'localhost:26657/abci_query?data="abcd"'
 
 The result should look like:
 
@@ -136,12 +136,12 @@ human-readable](https://github.com/tendermint/abci/issues/32).
 
 Now let's try setting a different key and value:
 
-    curl -s 'localhost:46657/broadcast_tx_commit?tx="name=satoshi"'
+    curl -s 'localhost:26657/broadcast_tx_commit?tx="name=satoshi"'
 
 Now if we query for `name`, we should get `satoshi`, or `c2F0b3NoaQ==`
 in base64:
 
-    curl -s 'localhost:46657/abci_query?data="name"'
+    curl -s 'localhost:26657/abci_query?data="name"'
 
 Try some other transactions and queries to make sure everything is
 working!
@@ -186,12 +186,12 @@ Once again, you can see the blocks streaming by. Let's send some
 transactions. Since we have set `serial=on`, the first transaction must
 be the number `0`:
 
-    curl localhost:46657/broadcast_tx_commit?tx=0x00
+    curl localhost:26657/broadcast_tx_commit?tx=0x00
 
 Note the empty (hence successful) response. The next transaction must be
 the number `1`. If instead, we try to send a `5`, we get an error:
 
-    > curl localhost:46657/broadcast_tx_commit?tx=0x05
+    > curl localhost:26657/broadcast_tx_commit?tx=0x05
     {
       "jsonrpc": "2.0",
       "id": "",
@@ -211,7 +211,7 @@ the number `1`. If instead, we try to send a `5`, we get an error:
 
 But if we send a `1`, it works again:
 
-    > curl localhost:46657/broadcast_tx_commit?tx=0x01
+    > curl localhost:26657/broadcast_tx_commit?tx=0x01
     {
       "jsonrpc": "2.0",
       "id": "",
@@ -258,8 +258,8 @@ Once again, you should see blocks streaming by - but now, our
 application is written in javascript! Try sending some transactions, and
 like before - the results should be the same:
 
-    curl localhost:46657/broadcast_tx_commit?tx=0x00 # ok
-    curl localhost:46657/broadcast_tx_commit?tx=0x05 # invalid nonce
-    curl localhost:46657/broadcast_tx_commit?tx=0x01 # ok
+    curl localhost:26657/broadcast_tx_commit?tx=0x00 # ok
+    curl localhost:26657/broadcast_tx_commit?tx=0x05 # invalid nonce
+    curl localhost:26657/broadcast_tx_commit?tx=0x01 # ok
 
 Neat, eh?

--- a/docs/how-to-read-logs.md
+++ b/docs/how-to-read-logs.md
@@ -22,10 +22,10 @@ and perform UPNP discover in order to detect the IP address.
     I[10-04|13:54:27.374] Starting EventSwitch                         module=types impl=EventSwitch
     I[10-04|13:54:27.375] This node is a validator                     module=consensus
     I[10-04|13:54:27.379] Starting Node                                module=main impl=Node
-    I[10-04|13:54:27.381] Local listener                               module=p2p ip=:: port=46656
+    I[10-04|13:54:27.381] Local listener                               module=p2p ip=:: port=26656
     I[10-04|13:54:27.382] Getting UPNP external address                module=p2p
     I[10-04|13:54:30.386] Could not perform UPNP discover              module=p2p err="write udp4 0.0.0.0:38238->239.255.255.250:1900: i/o timeout"
-    I[10-04|13:54:30.386] Starting DefaultListener                     module=p2p impl=Listener(@10.0.2.15:46656)
+    I[10-04|13:54:30.386] Starting DefaultListener                     module=p2p impl=Listener(@10.0.2.15:26656)
     I[10-04|13:54:30.387] Starting P2P Switch                          module=p2p impl="P2P Switch"
     I[10-04|13:54:30.387] Starting MempoolReactor                      module=mempool impl=MempoolReactor
     I[10-04|13:54:30.387] Starting BlockchainReactor                   module=blockchain impl=BlockchainReactor
@@ -46,8 +46,8 @@ Next we replay all the messages from the WAL.
 
 "Started node" message signals that everything is ready for work.
 
-    I[10-04|13:54:30.391] Starting RPC HTTP server on tcp socket 0.0.0.0:46657 module=rpc-server
-    I[10-04|13:54:30.392] Started node                                 module=main nodeInfo="NodeInfo{id: DF22D7C92C91082324A1312F092AA1DA197FA598DBBFB6526E, moniker: anonymous, network: test-chain-3MNw2N [remote , listen 10.0.2.15:46656], version: 0.11.0-10f361fc ([wire_version=0.6.2 p2p_version=0.5.0 consensus_version=v1/0.2.2 rpc_version=0.7.0/3 tx_index=on rpc_addr=tcp://0.0.0.0:46657])}"
+    I[10-04|13:54:30.391] Starting RPC HTTP server on tcp socket 0.0.0.0:26657 module=rpc-server
+    I[10-04|13:54:30.392] Started node                                 module=main nodeInfo="NodeInfo{id: DF22D7C92C91082324A1312F092AA1DA197FA598DBBFB6526E, moniker: anonymous, network: test-chain-3MNw2N [remote , listen 10.0.2.15:26656], version: 0.11.0-10f361fc ([wire_version=0.6.2 p2p_version=0.5.0 consensus_version=v1/0.2.2 rpc_version=0.7.0/3 tx_index=on rpc_addr=tcp://0.0.0.0:26657])}"
 
 Next follows a standard block creation cycle, where we enter a new
 round, propose a block, receive more than 2/3 of prevotes, then

--- a/docs/indexing-transactions.md
+++ b/docs/indexing-transactions.md
@@ -66,7 +66,7 @@ Tendermint will throw a warning if you try to use any of the above keys.
 You can query the transaction results by calling `/tx_search` RPC
 endpoint:
 
-    curl "localhost:46657/tx_search?query=\"account.name='igor'\"&prove=true"
+    curl "localhost:26657/tx_search?query=\"account.name='igor'\"&prove=true"
 
 Check out [API docs](https://tendermint.github.io/slate/?shell#txsearch)
 for more information on query syntax and other options.

--- a/docs/spec/p2p/config.md
+++ b/docs/spec/p2p/config.md
@@ -12,14 +12,14 @@ and upon incoming connection shares some peers and disconnects.
 
 ## Seeds
 
-`--p2p.seeds “1.2.3.4:466656,2.3.4.5:4444”`
+`--p2p.seeds “1.2.3.4:26656,2.3.4.5:4444”`
 
 Dials these seeds when we need more peers. They should return a list of peers and then disconnect.
 If we already have enough peers in the address book, we may never need to dial them.
 
 ## Persistent Peers
 
-`--p2p.persistent_peers “1.2.3.4:46656,2.3.4.5:466656”`
+`--p2p.persistent_peers “1.2.3.4:26656,2.3.4.5:26656”`
 
 Dial these peers and auto-redial them if the connection fails.
 These are intended to be trusted persistent peers that can help
@@ -32,7 +32,7 @@ and that the node may not be able to keep the connection persistent.
 
 ## Private Persistent Peers
 
-`--p2p.private_persistent_peers “1.2.3.4:46656,2.3.4.5:466656”`
+`--p2p.private_persistent_peers “1.2.3.4:26656,2.3.4.5:26656”`
 
 These are persistent peers that we do not add to the address book or
 gossip to other peers. They stay private to us.

--- a/docs/spec/reactors/mempool/messages.md
+++ b/docs/spec/reactors/mempool/messages.md
@@ -31,7 +31,7 @@ It can be posted via `broadcast_commit`, `broadcast_sync` or
 wait before returning (sync makes sure CheckTx passes, commit
 makes sure it was included in a signed block).
 
-Request (`POST http://gaia.zone:46657/`):
+Request (`POST http://gaia.zone:26657/`):
 
 ```json
 {

--- a/docs/specification/block-structure.rst
+++ b/docs/specification/block-structure.rst
@@ -129,7 +129,7 @@ For example, a precommit vote might have the following ``sign-bytes``:
 
 .. code:: json
 
-    {"chain_id":"my_chain","vote":{"block_hash":"611801F57B4CE378DF1A3FFF1216656E89209A99","block_parts_header":{"hash":"B46697379DBE0774CC2C3B656083F07CA7E0F9CE","total":123},"height":1234,"round":1,"type":2}}
+    {"chain_id":"my_chain","vote":{"block_hash":"611801F57B4CE378DF1A3FFF1216656E89209A99","block_parts_header":{"hash":"B26697379DBE0774CC2C3B656083F07CA7E0F9CE","total":123},"height":1234,"round":1,"type":2}}
 
 Block Hash
 ~~~~~~~~~~

--- a/docs/specification/configuration.rst
+++ b/docs/specification/configuration.rst
@@ -24,7 +24,7 @@ like the file below, however, double check by inspecting the
 
     # TCP or UNIX socket address of the ABCI application,
     # or the name of an ABCI application compiled in with the Tendermint binary
-    proxy_app = "tcp://127.0.0.1:46658"
+    proxy_app = "tcp://127.0.0.1:26658"
 
     # A custom human readable name for this node
     moniker = "anonymous"
@@ -70,7 +70,7 @@ like the file below, however, double check by inspecting the
     [rpc]
 
     # TCP or UNIX socket address for the RPC server to listen on
-    laddr = "tcp://0.0.0.0:46657"
+    laddr = "tcp://0.0.0.0:26657"
 
     # TCP or UNIX socket address for the gRPC server to listen on
     # NOTE: This server only supports /broadcast_tx_commit
@@ -83,7 +83,7 @@ like the file below, however, double check by inspecting the
     [p2p]
 
     # Address to listen for incoming connections
-    laddr = "tcp://0.0.0.0:46656"
+    laddr = "tcp://0.0.0.0:26656"
 
     # Comma separated list of seed nodes to connect to
     seeds = ""

--- a/docs/terraform-and-ansible.md
+++ b/docs/terraform-and-ansible.md
@@ -80,7 +80,7 @@ which as you'll see below, executes
 soon be modifying this role and running it again, this first execution
 allows us to get each `node_info.id` that corresponds to each
 `node_info.listen_addr`. (This part will be automated in the future). In
-your browser (or using `curl`), for every droplet, go to IP:46657/status
+your browser (or using `curl`), for every droplet, go to IP:26657/status
 and note the two just mentioned `node_info` fields. Notice that blocks
 aren't being created (`latest_block_height` should be zero and not
 increasing).
@@ -103,7 +103,7 @@ for each node. The resulting file should look something like:
     User={{service}}
     Group={{service}}
     PermissionsStartOnly=true
-    ExecStart=/usr/bin/tendermint node --proxy_app=kvstore --p2p.persistent_peers=167b80242c300bf0ccfb3ced3dec60dc2a81776e@165.227.41.206:46656,3c7a5920811550c04bf7a0b2f1e02ab52317b5e6@165.227.43.146:46656,303a1a4312c30525c99ba66522dd81cca56a361a@159.89.115.32:46656,b686c2a7f4b1b46dca96af3a0f31a6a7beae0be4@159.89.119.125:46656
+    ExecStart=/usr/bin/tendermint node --proxy_app=kvstore --p2p.persistent_peers=167b80242c300bf0ccfb3ced3dec60dc2a81776e@165.227.41.206:26656,3c7a5920811550c04bf7a0b2f1e02ab52317b5e6@165.227.43.146:26656,303a1a4312c30525c99ba66522dd81cca56a361a@159.89.115.32:26656,b686c2a7f4b1b46dca96af3a0f31a6a7beae0be4@159.89.119.125:26656
     ExecReload=/bin/kill -HUP $MAINPID
     KillSignal=SIGTERM
 

--- a/docs/using-tendermint.md
+++ b/docs/using-tendermint.md
@@ -34,7 +34,7 @@ To run a Tendermint node, use
     tendermint node
 
 By default, Tendermint will try to connect to an ABCI application on
-[127.0.0.1:46658](127.0.0.1:46658). If you have the `kvstore` ABCI app
+[127.0.0.1:26658](127.0.0.1:26658). If you have the `kvstore` ABCI app
 installed, run it in another window. If you don't, kill Tendermint and
 run an in-process version of the `kvstore` app:
 
@@ -59,17 +59,17 @@ on, for instance:
 To send a transaction, use `curl` to make requests to the Tendermint RPC
 server, for example:
 
-    curl http://localhost:46657/broadcast_tx_commit?tx=\"abcd\"
+    curl http://localhost:26657/broadcast_tx_commit?tx=\"abcd\"
 
 We can see the chain's status at the `/status` end-point:
 
-    curl http://localhost:46657/status | json_pp
+    curl http://localhost:26657/status | json_pp
 
 and the `latest_app_hash` in particular:
 
-    curl http://localhost:46657/status | json_pp | grep latest_app_hash
+    curl http://localhost:26657/status | json_pp | grep latest_app_hash
 
-Visit http://localhost:46657> in your browser to see the list of other
+Visit http://localhost:26657> in your browser to see the list of other
 endpoints. Some take no arguments (like `/status`), while others specify
 the argument name and use `_` as a placeholder.
 
@@ -82,30 +82,30 @@ With `GET`:
 
 To send a UTF8 string byte array, quote the value of the tx pramater:
 
-    curl 'http://localhost:46657/broadcast_tx_commit?tx="hello"'
+    curl 'http://localhost:26657/broadcast_tx_commit?tx="hello"'
 
 which sends a 5 byte transaction: "h e l l o" \[68 65 6c 6c 6f\].
 
 Note the URL must be wrapped with single quoes, else bash will ignore
 the double quotes. To avoid the single quotes, escape the double quotes:
 
-    curl http://localhost:46657/broadcast_tx_commit?tx=\"hello\"
+    curl http://localhost:26657/broadcast_tx_commit?tx=\"hello\"
 
 Using a special character:
 
-    curl 'http://localhost:46657/broadcast_tx_commit?tx="€5"'
+    curl 'http://localhost:26657/broadcast_tx_commit?tx="€5"'
 
 sends a 4 byte transaction: "€5" (UTF8) \[e2 82 ac 35\].
 
 To send as raw hex, omit quotes AND prefix the hex string with `0x`:
 
-    curl http://localhost:46657/broadcast_tx_commit?tx=0x01020304
+    curl http://localhost:26657/broadcast_tx_commit?tx=0x01020304
 
 which sends a 4 byte transaction: \[01 02 03 04\].
 
 With `POST` (using `json`), the raw hex must be `base64` encoded:
 
-    curl --data-binary '{"jsonrpc":"2.0","id":"anything","method":"broadcast_tx_commit","params": {"tx": "AQIDBA=="}}' -H 'content-type:text/plain;' http://localhost:46657
+    curl --data-binary '{"jsonrpc":"2.0","id":"anything","method":"broadcast_tx_commit","params": {"tx": "AQIDBA=="}}' -H 'content-type:text/plain;' http://localhost:26657
 
 which sends the same 4 byte transaction: \[01 02 03 04\].
 
@@ -303,12 +303,12 @@ persistent connections with.
 
 For example,
 
-    tendermint node --p2p.seeds "f9baeaa15fedf5e1ef7448dd60f46c01f1a9e9c4@1.2.3.4:46656,0491d373a8e0fcf1023aaf18c51d6a1d0d4f31bd@5.6.7.8:46656"
+    tendermint node --p2p.seeds "f9baeaa15fedf5e1ef7448dd60f46c01f1a9e9c4@1.2.3.4:26656,0491d373a8e0fcf1023aaf18c51d6a1d0d4f31bd@5.6.7.8:26656"
 
 Alternatively, you can use the `/dial_seeds` endpoint of the RPC to
 specify seeds for a running node to connect to:
 
-    curl 'localhost:46657/dial_seeds?seeds=\["f9baeaa15fedf5e1ef7448dd60f46c01f1a9e9c4@1.2.3.4:46656","0491d373a8e0fcf1023aaf18c51d6a1d0d4f31bd@5.6.7.8:46656"\]'
+    curl 'localhost:26657/dial_seeds?seeds=\["f9baeaa15fedf5e1ef7448dd60f46c01f1a9e9c4@1.2.3.4:26656","0491d373a8e0fcf1023aaf18c51d6a1d0d4f31bd@5.6.7.8:26656"\]'
 
 Note, with PeX enabled, you
 should not need seeds after the first start.
@@ -319,8 +319,8 @@ maintain a persistent connection with each, you can use the
 `config.toml` or the `/dial_peers` RPC endpoint to do it without
 stopping Tendermint core instance.
 
-    tendermint node --p2p.persistent_peers "429fcf25974313b95673f58d77eacdd434402665@10.11.12.13:46656,96663a3dd0d7b9d17d4c8211b191af259621c693@10.11.12.14:46656"
-    curl 'localhost:46657/dial_peers?persistent=true&peers=\["429fcf25974313b95673f58d77eacdd434402665@10.11.12.13:46656","96663a3dd0d7b9d17d4c8211b191af259621c693@10.11.12.14:46656"\]'
+    tendermint node --p2p.persistent_peers "429fcf25974313b95673f58d77eacdd434402665@10.11.12.13:26656,96663a3dd0d7b9d17d4c8211b191af259621c693@10.11.12.14:26656"
+    curl 'localhost:26657/dial_peers?persistent=true&peers=\["429fcf25974313b95673f58d77eacdd434402665@10.11.12.13:26656","96663a3dd0d7b9d17d4c8211b191af259621c693@10.11.12.14:26656"\]'
 
 ### Adding a Non-Validator
 

--- a/networks/local/README.md
+++ b/networks/local/README.md
@@ -32,9 +32,9 @@ To start a 4 node testnet run:
 make localnet-start
 ```
 
-The nodes bind their RPC servers to ports 46657, 46660, 46662, and 46664 on the host.
+The nodes bind their RPC servers to ports 26657, 26660, 26662, and 26664 on the host.
 This file creates a 4-node network using the localnode image.
-The nodes of the network expose their P2P and RPC endpoints to the host machine on ports 46656-46657, 46659-46660, 46661-46662, and 46663-46664 respectively.
+The nodes of the network expose their P2P and RPC endpoints to the host machine on ports 26656-26657, 26659-26660, 26661-26662, and 26663-26664 respectively.
 
 To update the binary, just rebuild it and restart the nodes:
 

--- a/networks/local/localnode/Dockerfile
+++ b/networks/local/localnode/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update && \
 
 VOLUME [ /tendermint ]
 WORKDIR /tendermint
-EXPOSE 46656 46657
+EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
 CMD ["node", "--proxy_app", "kvstore"]
 STOPSIGNAL SIGTERM

--- a/networks/remote/integration.sh
+++ b/networks/remote/integration.sh
@@ -90,10 +90,10 @@ ansible-playbook -i inventory/digital_ocean.py -l sentrynet config.yml -e BINARY
 sleep 10
 
 # get each nodes ID then populate the ansible file
-id0=`curl $ip0:46657/status | jq .result.node_info.id`
-id1=`curl $ip1:46657/status | jq .result.node_info.id`
-id2=`curl $ip2:46657/status | jq .result.node_info.id`
-id3=`curl $ip3:46657/status | jq .result.node_info.id`
+id0=`curl $ip0:26657/status | jq .result.node_info.id`
+id1=`curl $ip1:26657/status | jq .result.node_info.id`
+id2=`curl $ip2:26657/status | jq .result.node_info.id`
+id3=`curl $ip3:26657/status | jq .result.node_info.id`
 
 id0=$(strip $id0)
 id1=$(strip $id1)
@@ -115,7 +115,7 @@ Restart=on-failure
 User={{service}}
 Group={{service}}
 PermissionsStartOnly=true
-ExecStart=/usr/bin/tendermint node --proxy_app=kvstore --p2p.persistent_peers=$id0@$ip0:46656,$id1@$ip1:46656,$id2@$ip2:46656,$id3@$ip3:46656
+ExecStart=/usr/bin/tendermint node --proxy_app=kvstore --p2p.persistent_peers=$id0@$ip0:26656,$id1@$ip1:26656,$id2@$ip2:26656,$id3@$ip3:26656
 ExecReload=/bin/kill -HUP \$MAINPID
 KillSignal=SIGTERM
 

--- a/p2p/peer_set_test.go
+++ b/p2p/peer_set_test.go
@@ -22,7 +22,7 @@ func randPeer(ip net.IP) *peer {
 	p := &peer{
 		nodeInfo: NodeInfo{
 			ID:         nodeKey.ID(),
-			ListenAddr: cmn.Fmt("%v.%v.%v.%v:46656", rand.Int()%256, rand.Int()%256, rand.Int()%256, rand.Int()%256),
+			ListenAddr: cmn.Fmt("%v.%v.%v.%v:26656", rand.Int()%256, rand.Int()%256, rand.Int()%256, rand.Int()%256),
 		},
 	}
 

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -35,7 +35,7 @@ func CreateRandomPeer(outbound bool) *peer {
 func CreateRoutableAddr() (addr string, netAddr *NetAddress) {
 	for {
 		var err error
-		addr = cmn.Fmt("%X@%v.%v.%v.%v:46656", cmn.RandBytes(20), cmn.RandInt()%256, cmn.RandInt()%256, cmn.RandInt()%256, cmn.RandInt()%256)
+		addr = cmn.Fmt("%X@%v.%v.%v.%v:26656", cmn.RandBytes(20), cmn.RandInt()%256, cmn.RandInt()%256, cmn.RandInt()%256, cmn.RandInt()%256)
 		netAddr, err = NewNetAddressString(addr)
 		if err != nil {
 			panic(err)

--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -10,11 +10,11 @@ import (
 // Query the application for some information.
 //
 // ```shell
-// curl 'localhost:46657/abci_query?path=""&data="abcd"&trusted=false'
+// curl 'localhost:26657/abci_query?path=""&data="abcd"&trusted=false'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // result, err := client.ABCIQuery("", "abcd", true)
 // ```
 //
@@ -64,11 +64,11 @@ func ABCIQuery(path string, data cmn.HexBytes, height int64, trusted bool) (*cty
 // Get some info about the application.
 //
 // ```shell
-// curl 'localhost:46657/abci_info'
+// curl 'localhost:26657/abci_info'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // info, err := client.ABCIInfo()
 // ```
 //

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -13,11 +13,11 @@ import (
 // Block headers are returned in descending order (highest first).
 //
 // ```shell
-// curl 'localhost:46657/blockchain?minHeight=10&maxHeight=10'
+// curl 'localhost:26657/blockchain?minHeight=10&maxHeight=10'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // info, err := client.BlockchainInfo(10, 10)
 // ```
 //
@@ -97,11 +97,11 @@ func BlockchainInfo(minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, e
 // If no height is provided, it will fetch the latest block.
 //
 // ```shell
-// curl 'localhost:46657/block?height=10'
+// curl 'localhost:26657/block?height=10'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // info, err := client.Block(10)
 // ```
 //
@@ -209,11 +209,11 @@ func Block(heightPtr *int64) (*ctypes.ResultBlock, error) {
 // If no height is provided, it will fetch the commit for the latest block.
 //
 // ```shell
-// curl 'localhost:46657/commit?height=11'
+// curl 'localhost:26657/commit?height=11'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // info, err := client.Commit(11)
 // ```
 //
@@ -303,11 +303,11 @@ func Commit(heightPtr *int64) (*ctypes.ResultCommit, error) {
 // Thus response.results[5] is the results of executing getBlock(h).Txs[5]
 //
 // ```shell
-// curl 'localhost:46657/block_results?height=10'
+// curl 'localhost:26657/block_results?height=10'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // info, err := client.BlockResults(10)
 // ```
 //

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -12,11 +12,11 @@ import (
 // If no height is provided, it will fetch the current validator set.
 //
 // ```shell
-// curl 'localhost:46657/validators'
+// curl 'localhost:26657/validators'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // state, err := client.Validators()
 // ```
 //
@@ -61,11 +61,11 @@ func Validators(heightPtr *int64) (*ctypes.ResultValidators, error) {
 // UNSTABLE
 //
 // ```shell
-// curl 'localhost:46657/dump_consensus_state'
+// curl 'localhost:26657/dump_consensus_state'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // state, err := client.DumpConsensusState()
 // ```
 //
@@ -153,7 +153,7 @@ func Validators(heightPtr *int64) (*ctypes.ResultValidators, error) {
 //     },
 //     "peers": [
 //       {
-//         "node_address": "30ad1854af22506383c3f0e57fb3c7f90984c5e8@172.16.63.221:46656",
+//         "node_address": "30ad1854af22506383c3f0e57fb3c7f90984c5e8@172.16.63.221:26656",
 //         "peer_state": {
 //           "round_state": {
 //             "height": 7185,
@@ -216,11 +216,11 @@ func DumpConsensusState() (*ctypes.ResultDumpConsensusState, error) {
 // UNSTABLE
 //
 // ```shell
-// curl 'localhost:46657/consensus_state'
+// curl 'localhost:26657/consensus_state'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // state, err := client.ConsensusState()
 // ```
 //

--- a/rpc/core/doc.go
+++ b/rpc/core/doc.go
@@ -11,7 +11,7 @@ Tendermint RPC is built using [our own RPC library](https://github.com/tendermin
 
 ## Configuration
 
-Set the `laddr` config parameter under `[rpc]` table in the `$TMHOME/config/config.toml` file or the `--rpc.laddr` command-line flag to the desired protocol://host:port setting.  Default: `tcp://0.0.0.0:46657`.
+Set the `laddr` config parameter under `[rpc]` table in the `$TMHOME/config/config.toml` file or the `--rpc.laddr` command-line flag to the desired protocol://host:port setting.  Default: `tcp://0.0.0.0:26657`.
 
 ## Arguments
 
@@ -20,7 +20,7 @@ Arguments which expect strings or byte arrays may be passed as quoted strings, l
 ## URI/HTTP
 
 ```bash
-curl 'localhost:46657/broadcast_tx_sync?tx="abc"'
+curl 'localhost:26657/broadcast_tx_sync?tx="abc"'
 ```
 
 > Response:
@@ -43,7 +43,7 @@ The first entry in the result-array (`96`) is the method this response correlate
 
 ## JSONRPC/HTTP
 
-JSONRPC requests can be POST'd to the root RPC endpoint via HTTP (e.g. `http://localhost:46657/`).
+JSONRPC requests can be POST'd to the root RPC endpoint via HTTP (e.g. `http://localhost:26657/`).
 
 ```json
 {
@@ -56,7 +56,7 @@ JSONRPC requests can be POST'd to the root RPC endpoint via HTTP (e.g. `http://l
 
 ## JSONRPC/websockets
 
-JSONRPC requests can be made via websocket. The websocket endpoint is at `/websocket`, e.g. `localhost:46657/websocket`.  Asynchronous RPC functions like event `subscribe` and `unsubscribe` are only available via websockets.
+JSONRPC requests can be made via websocket. The websocket endpoint is at `/websocket`, e.g. `localhost:26657/websocket`.  Asynchronous RPC functions like event `subscribe` and `unsubscribe` are only available via websockets.
 
 
 ## More Examples
@@ -68,7 +68,7 @@ See the various bash tests using curl in `test/`, and examples using the `Go` AP
 An HTTP Get request to the root RPC endpoint shows a list of available endpoints.
 
 ```bash
-curl 'localhost:46657'
+curl 'localhost:26657'
 ```
 
 > Response:

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -52,7 +52,7 @@ import (
 // import "github.com/tendermint/tendermint/libs/pubsub/query"
 // import "github.com/tendermint/tendermint/types"
 //
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // ctx, cancel := context.WithTimeout(context.Background(), timeout)
 // defer cancel()
 // query := query.MustParse("tm.event = 'Tx' AND tx.height = 3")
@@ -114,7 +114,7 @@ func Subscribe(wsCtx rpctypes.WSRPCContext, query string) (*ctypes.ResultSubscri
 // Unsubscribe from events via WebSocket.
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // err := client.Unsubscribe("test-client", query)
 // ```
 //
@@ -153,7 +153,7 @@ func Unsubscribe(wsCtx rpctypes.WSRPCContext, query string) (*ctypes.ResultUnsub
 // Unsubscribe from all events via WebSocket.
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // err := client.UnsubscribeAll("test-client")
 // ```
 //

--- a/rpc/core/health.go
+++ b/rpc/core/health.go
@@ -8,11 +8,11 @@ import (
 // case of an error.
 //
 // ```shell
-// curl 'localhost:46657/health'
+// curl 'localhost:26657/health'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // result, err := client.Health()
 // ```
 //

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -19,11 +19,11 @@ import (
 // Returns right away, with no response
 //
 // ```shell
-// curl 'localhost:46657/broadcast_tx_async?tx="123"'
+// curl 'localhost:26657/broadcast_tx_async?tx="123"'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // result, err := client.BroadcastTxAsync("123")
 // ```
 //
@@ -59,11 +59,11 @@ func BroadcastTxAsync(tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 // Returns with the response from CheckTx.
 //
 // ```shell
-// curl 'localhost:46657/broadcast_tx_sync?tx="456"'
+// curl 'localhost:26657/broadcast_tx_sync?tx="456"'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // result, err := client.BroadcastTxSync("456")
 // ```
 //
@@ -112,11 +112,11 @@ func BroadcastTxSync(tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 // will contain a non-OK ABCI code.
 //
 // ```shell
-// curl 'localhost:46657/broadcast_tx_commit?tx="789"'
+// curl 'localhost:26657/broadcast_tx_commit?tx="789"'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // result, err := client.BroadcastTxCommit("789")
 // ```
 //
@@ -212,11 +212,11 @@ func BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
 // Get unconfirmed transactions (maximum ?limit entries) including their number.
 //
 // ```shell
-// curl 'localhost:46657/unconfirmed_txs'
+// curl 'localhost:26657/unconfirmed_txs'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // result, err := client.UnconfirmedTxs()
 // ```
 //
@@ -250,11 +250,11 @@ func UnconfirmedTxs(limit int) (*ctypes.ResultUnconfirmedTxs, error) {
 // Get number of unconfirmed transactions.
 //
 // ```shell
-// curl 'localhost:46657/num_unconfirmed_txs'
+// curl 'localhost:26657/num_unconfirmed_txs'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // result, err := client.UnconfirmedTxs()
 // ```
 //

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -9,11 +9,11 @@ import (
 // Get network info.
 //
 // ```shell
-// curl 'localhost:46657/net_info'
+// curl 'localhost:26657/net_info'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // info, err := client.NetInfo()
 // ```
 //
@@ -26,7 +26,7 @@ import (
 //		"n_peers": 0,
 // 		"peers": [],
 // 		"listeners": [
-// 			"Listener(@10.0.2.15:46656)"
+// 			"Listener(@10.0.2.15:26656)"
 // 		],
 // 		"listening": true
 // 	},
@@ -88,11 +88,11 @@ func UnsafeDialPeers(peers []string, persistent bool) (*ctypes.ResultDialPeers, 
 // Get genesis file.
 //
 // ```shell
-// curl 'localhost:46657/genesis'
+// curl 'localhost:26657/genesis'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // genesis, err := client.Genesis()
 // ```
 //

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -14,11 +14,11 @@ import (
 // hash, app hash, block height and time.
 //
 // ```shell
-// curl 'localhost:46657/status'
+// curl 'localhost:26657/status'
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // result, err := client.Status()
 // ```
 //
@@ -31,7 +31,7 @@ import (
 //  "result": {
 //    "node_info": {
 //      "id": "562dd7f579f0ecee8c94a11a3c1e378c1876f433",
-//      "listen_addr": "192.168.1.2:46656",
+//      "listen_addr": "192.168.1.2:26656",
 //      "network": "test-chain-I6zScH",
 //      "version": "0.19.0",
 //      "channels": "4020212223303800",
@@ -42,7 +42,7 @@ import (
 //        "consensus_version=v1/0.2.2",
 //        "rpc_version=0.7.0/3",
 //        "tx_index=on",
-//        "rpc_addr=tcp://0.0.0.0:46657"
+//        "rpc_addr=tcp://0.0.0.0:26657"
 //      ]
 //    },
 //    "sync_info": {

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -16,11 +16,11 @@ import (
 // place.
 //
 // ```shell
-// curl "localhost:46657/tx?hash=0x2B8EC32BA2579B3B8606E42C06DE2F7AFA2556EF"
+// curl "localhost:26657/tx?hash=0x2B8EC32BA2579B3B8606E42C06DE2F7AFA2556EF"
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // tx, err := client.Tx([]byte("2B8EC32BA2579B3B8606E42C06DE2F7AFA2556EF"), true)
 // ```
 //
@@ -110,11 +110,11 @@ func Tx(hash []byte, prove bool) (*ctypes.ResultTx, error) {
 // list of transactions (maximum ?per_page entries) and the total count.
 //
 // ```shell
-// curl "localhost:46657/tx_search?query=\"account.owner='Ivan'\"&prove=true"
+// curl "localhost:26657/tx_search?query=\"account.owner='Ivan'\"&prove=true"
 // ```
 //
 // ```go
-// client := client.NewHTTP("tcp://0.0.0.0:46657", "/websocket")
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // q, err := tmquery.New("account.owner='Ivan'")
 // tx, err := client.TxSearch(q, true)
 // ```

--- a/test/app/counter_test.sh
+++ b/test/app/counter_test.sh
@@ -50,7 +50,7 @@ function sendTx() {
 	fi
 	set -u
 	if [[ "$GRPC_BROADCAST_TX" == "" ]]; then
-		RESPONSE=$(curl -s localhost:46657/broadcast_tx_commit?tx=0x"$TX")
+		RESPONSE=$(curl -s localhost:26657/broadcast_tx_commit?tx=0x"$TX")
 		IS_ERR=$(echo "$RESPONSE" | jq 'has("error")')
 		ERROR=$(echo "$RESPONSE" | jq '.error')
 		ERROR=$(echo "$ERROR" | tr -d '"') # remove surrounding quotes

--- a/test/app/kvstore_test.sh
+++ b/test/app/kvstore_test.sh
@@ -15,7 +15,7 @@ TESTNAME=$1
 KEY="abcd"
 VALUE="dcba"
 echo $(toHex $KEY=$VALUE)
-curl -s 127.0.0.1:46657/broadcast_tx_commit?tx=$(toHex $KEY=$VALUE)
+curl -s 127.0.0.1:26657/broadcast_tx_commit?tx=$(toHex $KEY=$VALUE)
 echo $?
 echo ""
 
@@ -56,7 +56,7 @@ set -e
 echo "... testing query with /abci_query 2"
 
 # we should be able to look up the key
-RESPONSE=`curl -s "127.0.0.1:46657/abci_query?path=\"\"&data=$(toHex $KEY)&prove=false"`
+RESPONSE=`curl -s "127.0.0.1:26657/abci_query?path=\"\"&data=$(toHex $KEY)&prove=false"`
 RESPONSE=`echo $RESPONSE | jq .result.response.log`
 
 set +e
@@ -69,7 +69,7 @@ fi
 set -e
 
 # we should not be able to look up the value
-RESPONSE=`curl -s "127.0.0.1:46657/abci_query?path=\"\"&data=$(toHex $VALUE)&prove=false"`
+RESPONSE=`curl -s "127.0.0.1:26657/abci_query?path=\"\"&data=$(toHex $VALUE)&prove=false"`
 RESPONSE=`echo $RESPONSE | jq .result.response.log`
 set +e
 A=`echo $RESPONSE | grep 'exists'`

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -34,5 +34,5 @@ RUN go install ./cmd/tendermint
 # expose the volume for debugging
 VOLUME $REPO
 
-EXPOSE 46656
-EXPOSE 46657
+EXPOSE 26656
+EXPOSE 26657

--- a/test/p2p/README.md
+++ b/test/p2p/README.md
@@ -21,10 +21,10 @@ docker network create --driver bridge --subnet 172.57.0.0/16 my_testnet
 This gives us a new network with IP addresses in the rage `172.57.0.0 - 172.57.255.255`.
 Peers on the network can have any IP address in this range. 
 For our four node network, let's pick `172.57.0.101 - 172.57.0.104`.
-Since we use Tendermint's default listening port of 46656, our list of seed nodes will look like:
+Since we use Tendermint's default listening port of 26656, our list of seed nodes will look like:
 
 ```
-172.57.0.101:46656,172.57.0.102:46656,172.57.0.103:46656,172.57.0.104:46656
+172.57.0.101:26656,172.57.0.102:26656,172.57.0.103:26656,172.57.0.104:26656
 ```
 
 Now we can start up the peers. We already have config files setup in `test/p2p/data/`.
@@ -38,7 +38,7 @@ for i in $(seq 1 4); do
 	  --name local_testnet_$i \
 	  --entrypoint tendermint \
 	  -e TMHOME=/go/src/github.com/tendermint/tendermint/test/p2p/data/mach$i/core \
-	  tendermint_tester node --p2p.persistent_peers 172.57.0.101:46656,172.57.0.102:46656,172.57.0.103:46656,172.57.0.104:46656 --proxy_app=kvstore
+	  tendermint_tester node --p2p.persistent_peers 172.57.0.101:26656,172.57.0.102:26656,172.57.0.103:26656,172.57.0.104:26656 --proxy_app=kvstore
 done
 ```
 
@@ -47,7 +47,7 @@ If you now run `docker ps`, you'll see your containers!
 We can confirm they are making blocks by checking the `/status` message using `curl` and `jq` to pretty print the output json:
 
 ```
-curl 172.57.0.101:46657/status | jq . 
+curl 172.57.0.101:26657/status | jq . 
 ```
 
 

--- a/test/p2p/atomic_broadcast/test.sh
+++ b/test/p2p/atomic_broadcast/test.sh
@@ -14,7 +14,7 @@ N=$1
 echo ""
 # run the test on each of them
 for i in $(seq 1 "$N"); do
-    addr=$(test/p2p/ip.sh "$i"):46657
+    addr=$(test/p2p/ip.sh "$i"):26657
 
     # current state
     HASH1=$(curl -s "$addr/status" | jq .result.sync_info.latest_app_hash)
@@ -37,7 +37,7 @@ for i in $(seq 1 "$N"); do
     minHeight=$h2
     for j in $(seq 1 "$N"); do
         if [[ "$i" != "$j" ]]; then
-            addrJ=$(test/p2p/ip.sh "$j"):46657
+            addrJ=$(test/p2p/ip.sh "$j"):26657
 
             h=$(curl -s "$addrJ/status" | jq .result.sync_info.latest_block_height)
             while [ "$h" -lt "$minHeight" ]; do
@@ -57,7 +57,7 @@ for i in $(seq 1 "$N"); do
     # check we get the same new hash on all other nodes
     for j in $(seq 1 "$N"); do
         if [[ "$i" != "$j" ]]; then
-            addrJ=$(test/p2p/ip.sh "$j"):46657
+            addrJ=$(test/p2p/ip.sh "$j"):26657
             HASH3=$(curl -s "$addrJ/status" | jq .result.sync_info.latest_app_hash)
 
             if [[ "$HASH2" != "$HASH3" ]]; then

--- a/test/p2p/basic/test.sh
+++ b/test/p2p/basic/test.sh
@@ -16,7 +16,7 @@ MAX_SLEEP=60
 # wait for everyone to come online
 echo "Waiting for nodes to come online"
 for i in `seq 1 $N`; do
-	addr=$(test/p2p/ip.sh $i):46657
+	addr=$(test/p2p/ip.sh $i):26657
 	curl -s $addr/status > /dev/null
 	ERR=$?
 	COUNT=0
@@ -36,7 +36,7 @@ done
 echo ""
 # wait for each of them to sync up
 for i in `seq 1 $N`; do
-	addr=$(test/p2p/ip.sh $i):46657
+	addr=$(test/p2p/ip.sh $i):26657
 	N_1=$(($N - 1))
 
 	# - assert everyone has N-1 other peers

--- a/test/p2p/fast_sync/check_peer.sh
+++ b/test/p2p/fast_sync/check_peer.sh
@@ -10,9 +10,9 @@ ID=$1
 #
 ###########################################
 
-addr=$(test/p2p/ip.sh $ID):46657
+addr=$(test/p2p/ip.sh $ID):26657
 peerID=$(( $(($ID % 4)) + 1  )) # 1->2 ... 3->4 ... 4->1
-peer_addr=$(test/p2p/ip.sh $peerID):46657
+peer_addr=$(test/p2p/ip.sh $peerID):26657
 
 # get another peer's height
 h1=`curl -s $peer_addr/status | jq .result.sync_info.latest_block_height`

--- a/test/p2p/fast_sync/test_peer.sh
+++ b/test/p2p/fast_sync/test_peer.sh
@@ -23,9 +23,9 @@ set +e # circle sigh :(
 	set -e
 
 	# restart peer - should have an empty blockchain
-	PERSISTENT_PEERS="$(test/p2p/ip_plus_id.sh 1 $DOCKER_IMAGE):46656"
+	PERSISTENT_PEERS="$(test/p2p/ip_plus_id.sh 1 $DOCKER_IMAGE):26656"
 	for j in `seq 2 $N`; do
-		PERSISTENT_PEERS="$PERSISTENT_PEERS,$(test/p2p/ip_plus_id.sh $j $DOCKER_IMAGE):46656"
+		PERSISTENT_PEERS="$PERSISTENT_PEERS,$(test/p2p/ip_plus_id.sh $j $DOCKER_IMAGE):26656"
 	done
 	bash test/p2p/peer.sh $DOCKER_IMAGE $NETWORK_NAME $ID $PROXY_APP "--p2p.persistent_peers $PERSISTENT_PEERS --p2p.pex --rpc.unsafe"
 

--- a/test/p2p/kill_all/check_peers.sh
+++ b/test/p2p/kill_all/check_peers.sh
@@ -9,7 +9,7 @@ MAX_ATTEMPTS_TO_CATCH_UP=120
 echo "Waiting for nodes to come online"
 set +e
 for i in $(seq 1 "$NUM_OF_PEERS"); do
-	addr=$(test/p2p/ip.sh "$i"):46657
+	addr=$(test/p2p/ip.sh "$i"):26657
 	curl -s "$addr/status" > /dev/null
 	ERR=$?
 	while [ "$ERR" != 0 ]; do
@@ -22,7 +22,7 @@ done
 set -e
 
 # get the first peer's height
-addr=$(test/p2p/ip.sh 1):46657
+addr=$(test/p2p/ip.sh 1):26657
 h1=$(curl -s "$addr/status" | jq .result.sync_info.latest_block_height)
 echo "1st peer is on height $h1"
 
@@ -32,7 +32,7 @@ for i in $(seq 2 "$NUM_OF_PEERS"); do
 	hi=0
 
 	while [[ $hi -le $h1 ]] ; do
-		addr=$(test/p2p/ip.sh "$i"):46657
+		addr=$(test/p2p/ip.sh "$i"):26657
 		hi=$(curl -s "$addr/status" | jq .result.sync_info.latest_block_height)
 
 		echo "... peer $i is on height $hi"

--- a/test/p2p/persistent_peers.sh
+++ b/test/p2p/persistent_peers.sh
@@ -6,8 +6,8 @@ DOCKER_IMAGE=$2
 
 cd "$GOPATH/src/github.com/tendermint/tendermint"
 
-persistent_peers="$(test/p2p/ip_plus_id.sh 1 $DOCKER_IMAGE):46656"
+persistent_peers="$(test/p2p/ip_plus_id.sh 1 $DOCKER_IMAGE):26656"
 for i in $(seq 2 $N); do
-	persistent_peers="$persistent_peers,$(test/p2p/ip_plus_id.sh $i $DOCKER_IMAGE):46656"
+	persistent_peers="$persistent_peers,$(test/p2p/ip_plus_id.sh $i $DOCKER_IMAGE):26656"
 done
 echo "$persistent_peers"

--- a/test/p2p/pex/check_peer.sh
+++ b/test/p2p/pex/check_peer.sh
@@ -4,7 +4,7 @@ set -u
 ID=$1
 N=$2
 
-addr=$(test/p2p/ip.sh "$ID"):46657
+addr=$(test/p2p/ip.sh "$ID"):26657
 
 echo "2. wait until peer $ID connects to other nodes using pex reactor"
 peers_count="0"

--- a/test/p2p/pex/dial_peers.sh
+++ b/test/p2p/pex/dial_peers.sh
@@ -8,7 +8,7 @@ cd "$GOPATH/src/github.com/tendermint/tendermint"
 
 echo "Waiting for nodes to come online"
 for i in $(seq 1 "$N"); do
-	addr=$(test/p2p/ip.sh "$i"):46657
+	addr=$(test/p2p/ip.sh "$i"):26657
 	curl -s "$addr/status" > /dev/null
 	ERR=$?
 	while [ "$ERR" != 0 ]; do
@@ -20,4 +20,4 @@ for i in $(seq 1 "$N"); do
 done
 
 IP=$(test/p2p/ip.sh 1)
-curl "$IP:46657/dial_peers?persistent=true&peers=\\[$PEERS\\]"
+curl "$IP:26657/dial_peers?persistent=true&peers=\\[$PEERS\\]"

--- a/test/p2p/pex/test_dial_peers.sh
+++ b/test/p2p/pex/test_dial_peers.sh
@@ -23,9 +23,9 @@ set -e
 # NOTE we re-use the same network for all tests
 bash test/p2p/local_testnet_start.sh $DOCKER_IMAGE $NETWORK_NAME $N $PROXY_APP ""
 
-PERSISTENT_PEERS="\"$(test/p2p/ip_plus_id.sh 1 $DOCKER_IMAGE):46656\""
+PERSISTENT_PEERS="\"$(test/p2p/ip_plus_id.sh 1 $DOCKER_IMAGE):26656\""
 for i in $(seq 2 $N); do
-	PERSISTENT_PEERS="$PERSISTENT_PEERS,\"$(test/p2p/ip_plus_id.sh $i $DOCKER_IMAGE):46656\""
+	PERSISTENT_PEERS="$PERSISTENT_PEERS,\"$(test/p2p/ip_plus_id.sh $i $DOCKER_IMAGE):26656\""
 done
 echo "$PERSISTENT_PEERS"
 

--- a/test/persist/test_failure_indices.sh
+++ b/test/persist/test_failure_indices.sh
@@ -82,7 +82,7 @@ for failIndex in $(seq $failsStart $failsEnd); do
     echo "* Test FailIndex $failIndex"
     # test failure at failIndex
 
-    bash $(dirname $0)/txs.sh "localhost:46657" &
+    bash $(dirname $0)/txs.sh "localhost:26657" &
     start_procs 1 "$failIndex"
 
     # tendermint should already have exited when it hits the fail index

--- a/test/persist/test_simple.sh
+++ b/test/persist/test_simple.sh
@@ -27,7 +27,7 @@ function send_txs(){
     for i in `seq 1 5`; do
         for j in `seq 1 100`; do
             tx=`head -c 8 /dev/urandom | hexdump -ve '1/1 "%.2X"'`
-            curl -s 127.0.0.1:46657/broadcast_tx_async?tx=0x$tx &> /dev/null
+            curl -s 127.0.0.1:26657/broadcast_tx_async?tx=0x$tx &> /dev/null
         done
         sleep 1
     done
@@ -41,7 +41,7 @@ kill_procs
 start_procs 2
 
 # wait for node to handshake and make a new block
-addr="localhost:46657"
+addr="localhost:26657"
 curl -s $addr/status > /dev/null
 ERR=$?
 i=0

--- a/test/persist/txs.sh
+++ b/test/persist/txs.sh
@@ -2,7 +2,7 @@
 set -u
 
 # wait till node is up, send txs
-ADDR=$1 #="127.0.0.1:46657"
+ADDR=$1 #="127.0.0.1:26657"
 curl -s $ADDR/status > /dev/null
 ERR=$?
 while [ "$ERR" != 0 ]; do


### PR DESCRIPTION
This moves all ports of the form 466xx to 266xx. This is done to address cosmos/cosmos-sdk#932. Essentially the problem was the default ports used by tendermint are in the ephemeral port range.

This requires tendermint/abci#253