### PR TITLE
Release/v0.20.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/github.com/tendermint/tendermint
   docker:
-    - image: circleci/golang:1.10.0
+    - image: circleci/golang:1.10.3
   environment:
     GOBIN: /tmp/workspace/bin
 

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -35,6 +35,8 @@ in a case of bug.
 
 **Logs (you can paste a part showing an error or attach the whole file)**:
 
+**Config (you can paste only the changes you've made)**:
+
 **`/dump_consensus_state` output for consensus bugs**
 
 **Anything else do we need to know**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.20.1
+
+*June 18th, 2018*
+
+BUG FIXES
+
+[consensus] Fix #1754 where we don't make blocks when `create_empty_blocks=false`
+
 ## 0.20.0
 
 *June 6th, 2018*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 BUG FIXES
 
-[consensus] Fix #1754 where we don't make blocks when `create_empty_blocks=false`
+- [consensus] Fix #1754 where we don't make blocks when `create_empty_blocks=false`
+- [mempool] Fix #1761 where we don't process txs if `cache_size=0`
 
 ## 0.20.0
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -77,7 +77,7 @@ type Mempool struct {
 
 	// Keep a cache of already-seen txs.
 	// This reduces the pressure on the proxyApp.
-	cache *txCache
+	cache txCache
 
 	// A log of mempool txs
 	wal *auto.AutoFile
@@ -97,7 +97,11 @@ func NewMempool(config *cfg.MempoolConfig, proxyAppConn proxy.AppConnMempool, he
 		recheckCursor: nil,
 		recheckEnd:    nil,
 		logger:        log.NewNopLogger(),
-		cache:         newTxCache(config.CacheSize),
+	}
+	if config.CacheSize > 0 {
+		mempool.cache = newMapTxCache(config.CacheSize)
+	} else {
+		mempool.cache = nopTxCache{}
 	}
 	proxyAppConn.SetResponseCallback(mempool.resCb)
 	return mempool
@@ -448,40 +452,44 @@ func (memTx *mempoolTx) Height() int64 {
 
 //--------------------------------------------------------------------------------
 
-// txCache maintains a cache of transactions.
-type txCache struct {
+type txCache interface {
+	Reset()
+	Push(tx types.Tx) bool
+	Remove(tx types.Tx)
+}
+
+// mapTxCache maintains a cache of transactions.
+type mapTxCache struct {
 	mtx  sync.Mutex
 	size int
 	map_ map[string]struct{}
 	list *list.List // to remove oldest tx when cache gets too big
 }
 
-// newTxCache returns a new txCache.
-func newTxCache(cacheSize int) *txCache {
-	return &txCache{
+var _ txCache = (*mapTxCache)(nil)
+
+// newMapTxCache returns a new mapTxCache.
+func newMapTxCache(cacheSize int) *mapTxCache {
+	return &mapTxCache{
 		size: cacheSize,
 		map_: make(map[string]struct{}, cacheSize),
 		list: list.New(),
 	}
 }
 
-// Reset resets the txCache to empty.
-func (cache *txCache) Reset() {
+// Reset resets the cache to an empty state.
+func (cache *mapTxCache) Reset() {
 	cache.mtx.Lock()
 	cache.map_ = make(map[string]struct{}, cache.size)
 	cache.list.Init()
 	cache.mtx.Unlock()
 }
 
-// Push adds the given tx to the txCache. It returns false if tx is already in the cache.
-func (cache *txCache) Push(tx types.Tx) bool {
+// Push adds the given tx to the cache and returns true. It returns false if tx
+// is already in the cache.
+func (cache *mapTxCache) Push(tx types.Tx) bool {
 	cache.mtx.Lock()
 	defer cache.mtx.Unlock()
-
-	// if cache size is 0, do nothing
-	if cache.size == 0 {
-		return true
-	}
 
 	if _, exists := cache.map_[string(tx)]; exists {
 		return false
@@ -501,8 +509,16 @@ func (cache *txCache) Push(tx types.Tx) bool {
 }
 
 // Remove removes the given tx from the cache.
-func (cache *txCache) Remove(tx types.Tx) {
+func (cache *mapTxCache) Remove(tx types.Tx) {
 	cache.mtx.Lock()
 	delete(cache.map_, string(tx))
 	cache.mtx.Unlock()
 }
+
+type nopTxCache struct{}
+
+var _ txCache = (*nopTxCache)(nil)
+
+func (nopTxCache) Reset()             {}
+func (nopTxCache) Push(types.Tx) bool { return true }
+func (nopTxCache) Remove(types.Tx)    {}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -328,11 +328,11 @@ func (mem *Mempool) notifyTxsAvailable() {
 		panic("notified txs available but mempool is empty!")
 	}
 	if mem.txsAvailable != nil && !mem.notifiedTxsAvailable {
+		// channel cap is 1, so this will send once
 		select {
 		case mem.txsAvailable <- mem.height + 1:
 		default:
 		}
-
 		mem.notifiedTxsAvailable = true
 	}
 }

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -478,6 +478,11 @@ func (cache *txCache) Push(tx types.Tx) bool {
 	cache.mtx.Lock()
 	defer cache.mtx.Unlock()
 
+	// if cache size is 0, do nothing
+	if cache.size == 0 {
+		return true
+	}
+
 	if _, exists := cache.map_[string(tx)]; exists {
 		return false
 	}

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -45,6 +45,14 @@ func (memR *MempoolReactor) SetLogger(l log.Logger) {
 	memR.Mempool.SetLogger(l)
 }
 
+// OnStart implements p2p.BaseReactor.
+func (memR *MempoolReactor) OnStart() error {
+	if !memR.config.Broadcast {
+		memR.Logger.Info("Tx broadcasting is disabled")
+	}
+	return nil
+}
+
 // GetChannels implements Reactor.
 // It returns the list of channels for this reactor.
 func (memR *MempoolReactor) GetChannels() []*p2p.ChannelDescriptor {
@@ -103,7 +111,6 @@ type PeerState interface {
 // Send new mempool txs to peer.
 func (memR *MempoolReactor) broadcastTxRoutine(peer p2p.Peer) {
 	if !memR.config.Broadcast {
-		memR.Logger.Info("Tx broadcasting is disabled")
 		return
 	}
 

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	abci "github.com/tendermint/abci/types"
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tmlibs/clist"
 	"github.com/tendermint/tmlibs/log"
 

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -103,6 +103,7 @@ type PeerState interface {
 // Send new mempool txs to peer.
 func (memR *MempoolReactor) broadcastTxRoutine(peer p2p.Peer) {
 	if !memR.config.Broadcast {
+		memR.Logger.Info("Tx broadcasting is disabled")
 		return
 	}
 
@@ -129,7 +130,8 @@ func (memR *MempoolReactor) broadcastTxRoutine(peer p2p.Peer) {
 		height := memTx.Height()
 		if peerState_i := peer.Get(types.PeerStateKey); peerState_i != nil {
 			peerState := peerState_i.(PeerState)
-			if peerState.GetHeight() < height-1 { // Allow for a lag of 1 block
+			peerHeight := peerState.GetHeight()
+			if peerHeight < height-1 { // Allow for a lag of 1 block
 				time.Sleep(peerCatchupSleepIntervalMS * time.Millisecond)
 				continue
 			}

--- a/types/keys.go
+++ b/types/keys.go
@@ -2,6 +2,5 @@ package types
 
 // UNSTABLE
 var (
-	PeerStateKey     = "ConsensusReactor.peerState"
-	PeerMempoolChKey = "MempoolReactor.peerMempoolCh"
+	PeerStateKey = "ConsensusReactor.peerState"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -4,13 +4,13 @@ package version
 const (
 	Maj = "0"
 	Min = "20"
-	Fix = "0"
+	Fix = "1"
 )
 
 var (
 	// Version is the current version of Tendermint
 	// Must be a string because scripts like dist.sh read this file.
-	Version = "0.20.0"
+	Version = "0.20.1"
 
 	// GitCommit is the current HEAD set using ldflags.
 	GitCommit string


### PR DESCRIPTION
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG.md

consensus: fixes #1754

* updateToState exits early if the state isn't new, which happens after
* fast syncing. This results in not sending a NewRoundStep message. The mempool
* reactor depends on PeerState, which is updated by NewRoundStep
* messages. If the peer never sends a NewRoundStep, the mempool reactor
* will think they're behind, and never forward transactions. Note this
* only happens when `create_empty_blocks = false`, because otherwise
* peers will move through the consensus state and send a NewRoundStep
* for a new step soon anyways. Simple fix is just to send the
* NewRoundStep message during updateToState even if exit early