### PR TITLE
limit number of open connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## TBD
 
-FEATURES:
-- [node] added metrics (served under /metrics using a Prometheus client; disabled by default)
+BUG FIXES:
+
+- [rpc] limited number of HTTP/WebSocket connections
+  (`rpc.max_open_connections`) and gRPC connections
+  (`rpc.grpc_max_open_connections`). Check out [Running In
+  Production](https://tendermint.readthedocs.io/en/master/running-in-production.html)
+  guide if you want to increase them.
 
 ## 0.21.0
 
@@ -19,6 +24,13 @@ IMPROVEMENT
 
 - [pubsub] Set default capacity to 0
 - [docs] Various improvements
+
+FEATURES
+
+- [main] added metrics (served under `/metrics` using a Prometheus client;
+  disabled by default). See the new `instrumentation` section in the config and
+  [metrics](https://tendermint.readthedocs.io/projects/tools/en/v0.21.0/metrics.html)
+  guide.
 
 BUG FIXES
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -362,6 +362,7 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
+    "netutil",
     "trace"
   ]
   revision = "db08ff08e8622530d9ed3a0e8ac279f6d4c02196"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -97,3 +97,7 @@
 [[constraint]]
   name = "github.com/prometheus/client_golang"
   version = "0.8.0"
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/net"

--- a/config/config.go
+++ b/config/config.go
@@ -251,10 +251,9 @@ func DefaultRPCConfig() *RPCConfig {
 		GRPCMaxOpenConnections: 900, // no ipv4
 
 		Unsafe: false,
-		// should be < ({ulimit -Sn} - {MaxNumPeers} - {N of wal, db and other open files}) / 2
-		// divided by 2 because 1 fd for ipv4, 1 fd - ipv6
-		// 1024 - 50 - 50 = 924 / 2 = ~450
-		MaxOpenConnections: 450,
+		// should be < {ulimit -Sn} - {MaxNumPeers} - {N of wal, db and other open files}
+		// 1024 - 50 - 50 = 924 = ~900
+		MaxOpenConnections: 900,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -119,8 +119,22 @@ laddr = "{{ .RPC.ListenAddress }}"
 # NOTE: This server only supports /broadcast_tx_commit
 grpc_laddr = "{{ .RPC.GRPCListenAddress }}"
 
+# Maximum number of simultaneous connections.
+# Does not include RPC (HTTP&WebSocket) connections. See max_open_connections
+# If you want to accept more significant number than the default, make sure
+# you increase your OS limits.
+# 0 - unlimited.
+grpc_max_open_connections = {{ .RPC.GRPCMaxOpenConnections }}
+
 # Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
 unsafe = {{ .RPC.Unsafe }}
+
+# Maximum number of simultaneous connections (including WebSocket).
+# Does not include gRPC connections. See grpc_max_open_connections
+# If you want to accept more significant number than the default, make sure
+# you increase your OS limits.
+# 0 - unlimited.
+max_open_connections = {{ .RPC.MaxOpenConnections }}
 
 ##### peer to peer configuration options #####
 [p2p]

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -8,28 +8,30 @@ This functionality is disabled by default.
 To enable the Prometheus metrics, set `instrumentation.prometheus=true` if your
 config file. Metrics will be served under `/metrics` on 26660 port by default.
 Listen address can be changed in the config file (see
-`prometheus_listen_addr`).
+`instrumentation.prometheus_listen_addr`).
 
 ## List of available metrics
 
 The following metrics are available:
 
+```
 | Name                                    | Type      | Since     | Description                                                                   |
 | --------------------------------------- | -------   | --------- | ----------------------------------------------------------------------------- |
-| consensus_height                        | Gauge     | 0.20.1    | Height of the chain                                                           |
-| consensus_validators                    | Gauge     | 0.20.1    | Number of validators                                                          |
-| consensus_validators_power              | Gauge     | 0.20.1    | Total voting power of all validators                                          |
-| consensus_missing_validators            | Gauge     | 0.20.1    | Number of validators who did not sign                                         |
-| consensus_missing_validators_power      | Gauge     | 0.20.1    | Total voting power of the missing validators                                  |
-| consensus_byzantine_validators          | Gauge     | 0.20.1    | Number of validators who tried to double sign                                 |
-| consensus_byzantine_validators_power    | Gauge     | 0.20.1    | Total voting power of the byzantine validators                                |
-| consensus_block_interval_seconds        | Histogram | 0.20.1    | Time between this and last block (Block.Header.Time) in seconds               |
-| consensus_rounds                        | Gauge     | 0.20.1    | Number of rounds                                                              |
-| consensus_num_txs                       | Gauge     | 0.20.1    | Number of transactions                                                        |
-| mempool_size                            | Gauge     | 0.20.1    | Number of uncommitted transactions                                            |
-| consensus_total_txs                     | Gauge     | 0.20.1    | Total number of transactions committed                                        |
-| consensus_block_size_bytes              | Gauge     | 0.20.1    | Block size in bytes                                                           |
-| p2p_peers                               | Gauge     | 0.20.1    | Number of peers node's connected to                                           |
+| consensus_height                        | Gauge     | 0.21.0    | Height of the chain                                                           |
+| consensus_validators                    | Gauge     | 0.21.0    | Number of validators                                                          |
+| consensus_validators_power              | Gauge     | 0.21.0    | Total voting power of all validators                                          |
+| consensus_missing_validators            | Gauge     | 0.21.0    | Number of validators who did not sign                                         |
+| consensus_missing_validators_power      | Gauge     | 0.21.0    | Total voting power of the missing validators                                  |
+| consensus_byzantine_validators          | Gauge     | 0.21.0    | Number of validators who tried to double sign                                 |
+| consensus_byzantine_validators_power    | Gauge     | 0.21.0    | Total voting power of the byzantine validators                                |
+| consensus_block_interval_seconds        | Histogram | 0.21.0    | Time between this and last block (Block.Header.Time) in seconds               |
+| consensus_rounds                        | Gauge     | 0.21.0    | Number of rounds                                                              |
+| consensus_num_txs                       | Gauge     | 0.21.0    | Number of transactions                                                        |
+| mempool_size                            | Gauge     | 0.21.0    | Number of uncommitted transactions                                            |
+| consensus_total_txs                     | Gauge     | 0.21.0    | Total number of transactions committed                                        |
+| consensus_block_size_bytes              | Gauge     | 0.21.0    | Block size in bytes                                                           |
+| p2p_peers                               | Gauge     | 0.21.0    | Number of peers node's connected to                                           |
+```
 
 ## Useful queries
 

--- a/docs/specification/configuration.md
+++ b/docs/specification/configuration.md
@@ -73,8 +73,22 @@ laddr = "tcp://0.0.0.0:26657"
 # NOTE: This server only supports /broadcast_tx_commit
 grpc_laddr = ""
 
+# Maximum number of simultaneous connections.
+# Does not include RPC (HTTP&WebSocket) connections. See max_open_connections
+# If you want to accept more significant number than the default, make sure
+# you increase your OS limits.
+# 0 - unlimited.
+grpc_max_open_connections = 900
+
 # Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
 unsafe = false
+
+# Maximum number of simultaneous connections (including WebSocket).
+# Does not include gRPC connections. See grpc_max_open_connections
+# If you want to accept more significant number than the default, make sure
+# you increase your OS limits.
+# 0 - unlimited.
+max_open_connections = 450
 
 ##### peer to peer configuration options #####
 [p2p]

--- a/lite/proxy/proxy.go
+++ b/lite/proxy/proxy.go
@@ -3,7 +3,7 @@ package proxy
 import (
 	"net/http"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tmlibs/log"
 
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
@@ -38,7 +38,8 @@ func StartProxy(c rpcclient.Client, listenAddr string, logger log.Logger) error 
 	core.SetLogger(logger)
 	mux.HandleFunc(wsEndpoint, wm.WebsocketHandler)
 
-	_, err = rpc.StartHTTPServer(listenAddr, mux, logger)
+	// TODO: limit max number of open connections rpc.Config{MaxOpenConnections: X}
+	_, err = rpc.StartHTTPServer(listenAddr, mux, logger, rpc.Config{})
 
 	return err
 }

--- a/rpc/grpc/client_server.go
+++ b/rpc/grpc/client_server.go
@@ -6,13 +6,21 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/netutil"
 	"google.golang.org/grpc"
 
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
-// Start the grpcServer in a go routine
-func StartGRPCServer(protoAddr string) (net.Listener, error) {
+// Config is an gRPC server configuration.
+type Config struct {
+	MaxOpenConnections int
+}
+
+// StartGRPCServer starts a new gRPC BroadcastAPIServer, listening on
+// protoAddr, in a goroutine. Returns a listener and an error, if it fails to
+// parse an address.
+func StartGRPCServer(protoAddr string, config Config) (net.Listener, error) {
 	parts := strings.SplitN(protoAddr, "://", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("Invalid listen address for grpc server (did you forget a tcp:// prefix?) : %s", protoAddr)
@@ -22,6 +30,9 @@ func StartGRPCServer(protoAddr string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
+	if config.MaxOpenConnections > 0 {
+		ln = netutil.LimitListener(ln, config.MaxOpenConnections)
+	}
 
 	grpcServer := grpc.NewServer()
 	RegisterBroadcastAPIServer(grpcServer, &broadcastAPI{})
@@ -30,7 +41,8 @@ func StartGRPCServer(protoAddr string) (net.Listener, error) {
 	return ln, nil
 }
 
-// Start the client by dialing the server
+// StartGRPCClient dials the gRPC server using protoAddr and returns a new
+// BroadcastAPIClient.
 func StartGRPCClient(protoAddr string) BroadcastAPIClient {
 	conn, err := grpc.Dial(protoAddr, grpc.WithInsecure(), grpc.WithDialer(dialerFunc))
 	if err != nil {

--- a/rpc/lib/rpc_test.go
+++ b/rpc/lib/rpc_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 
@@ -123,7 +123,7 @@ func setup() {
 	wm.SetLogger(tcpLogger)
 	mux.HandleFunc(websocketEndpoint, wm.WebsocketHandler)
 	go func() {
-		_, err := server.StartHTTPServer(tcpAddr, mux, tcpLogger)
+		_, err := server.StartHTTPServer(tcpAddr, mux, tcpLogger, server.Config{})
 		if err != nil {
 			panic(err)
 		}
@@ -136,7 +136,7 @@ func setup() {
 	wm.SetLogger(unixLogger)
 	mux2.HandleFunc(websocketEndpoint, wm.WebsocketHandler)
 	go func() {
-		_, err := server.StartHTTPServer(unixAddr, mux2, unixLogger)
+		_, err := server.StartHTTPServer(unixAddr, mux2, unixLogger, server.Config{})
 		if err != nil {
 			panic(err)
 		}
@@ -274,18 +274,18 @@ func TestServersAndClientsBasic(t *testing.T) {
 	serverAddrs := [...]string{tcpAddr, unixAddr}
 	for _, addr := range serverAddrs {
 		cl1 := client.NewURIClient(addr)
-		fmt.Printf("=== testing server on %s using %v client", addr, cl1)
+		fmt.Printf("=== testing server on %s using URI client", addr)
 		testWithHTTPClient(t, cl1)
 
 		cl2 := client.NewJSONRPCClient(addr)
-		fmt.Printf("=== testing server on %s using %v client", addr, cl2)
+		fmt.Printf("=== testing server on %s using JSONRPC client", addr)
 		testWithHTTPClient(t, cl2)
 
 		cl3 := client.NewWSClient(addr, websocketEndpoint)
 		cl3.SetLogger(log.TestingLogger())
 		err := cl3.Start()
 		require.Nil(t, err)
-		fmt.Printf("=== testing server on %s using %v client", addr, cl3)
+		fmt.Printf("=== testing server on %s using WS client", addr)
 		testWithWSClient(t, cl3)
 		cl3.Stop()
 	}

--- a/rpc/lib/server/http_server.go
+++ b/rpc/lib/server/http_server.go
@@ -25,11 +25,19 @@ type Config struct {
 
 // StartHTTPServer starts an HTTP server on listenAddr with the given handler.
 // It wraps handler with RecoverAndLogHandler.
-func StartHTTPServer(listenAddr string, handler http.Handler, logger log.Logger, config Config) (listener net.Listener, err error) {
+func StartHTTPServer(
+	listenAddr string,
+	handler http.Handler,
+	logger log.Logger,
+	config Config,
+) (listener net.Listener, err error) {
 	var proto, addr string
 	parts := strings.SplitN(listenAddr, "://", 2)
 	if len(parts) != 2 {
-		return nil, errors.Errorf("Invalid listening address %s (use fully formed addresses, including the tcp:// or unix:// prefix)", listenAddr)
+		return nil, errors.Errorf(
+			"Invalid listening address %s (use fully formed addresses, including the tcp:// or unix:// prefix)",
+			listenAddr,
+		)
 	}
 	proto, addr = parts[0], parts[1]
 
@@ -55,15 +63,31 @@ func StartHTTPServer(listenAddr string, handler http.Handler, logger log.Logger,
 // StartHTTPAndTLSServer starts an HTTPS server on listenAddr with the given
 // handler.
 // It wraps handler with RecoverAndLogHandler.
-func StartHTTPAndTLSServer(listenAddr string, handler http.Handler, certFile, keyFile string, logger log.Logger, config Config) (listener net.Listener, err error) {
+func StartHTTPAndTLSServer(
+	listenAddr string,
+	handler http.Handler,
+	certFile, keyFile string,
+	logger log.Logger,
+	config Config,
+) (listener net.Listener, err error) {
 	var proto, addr string
 	parts := strings.SplitN(listenAddr, "://", 2)
 	if len(parts) != 2 {
-		return nil, errors.Errorf("Invalid listening address %s (use fully formed addresses, including the tcp:// or unix:// prefix)", listenAddr)
+		return nil, errors.Errorf(
+			"Invalid listening address %s (use fully formed addresses, including the tcp:// or unix:// prefix)",
+			listenAddr,
+		)
 	}
 	proto, addr = parts[0], parts[1]
 
-	logger.Info(fmt.Sprintf("Starting RPC HTTPS server on %s (cert: %q, key: %q)", listenAddr, certFile, keyFile))
+	logger.Info(
+		fmt.Sprintf(
+			"Starting RPC HTTPS server on %s (cert: %q, key: %q)",
+			listenAddr,
+			certFile,
+			keyFile,
+		),
+	)
 	listener, err = net.Listen(proto, addr)
 	if err != nil {
 		return nil, errors.Errorf("Failed to listen on %v: %v", listenAddr, err)
@@ -84,7 +108,11 @@ func StartHTTPAndTLSServer(listenAddr string, handler http.Handler, certFile, ke
 	return listener, nil
 }
 
-func WriteRPCResponseHTTPError(w http.ResponseWriter, httpCode int, res types.RPCResponse) {
+func WriteRPCResponseHTTPError(
+	w http.ResponseWriter,
+	httpCode int,
+	res types.RPCResponse,
+) {
 	jsonBytes, err := json.MarshalIndent(res, "", "  ")
 	if err != nil {
 		panic(err)
@@ -134,7 +162,10 @@ func RecoverAndLogHandler(handler http.Handler, logger log.Logger) http.Handler 
 					WriteRPCResponseHTTP(rww, res)
 				} else {
 					// For the rest,
-					logger.Error("Panic in RPC HTTP handler", "err", e, "stack", string(debug.Stack()))
+					logger.Error(
+						"Panic in RPC HTTP handler", "err", e, "stack",
+						string(debug.Stack()),
+					)
 					rww.WriteHeader(http.StatusInternalServerError)
 					WriteRPCResponseHTTP(rww, types.RPCInternalError("", e.(error)))
 				}

--- a/rpc/lib/server/http_server_test.go
+++ b/rpc/lib/server/http_server_test.go
@@ -1,0 +1,62 @@
+package rpcserver
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tendermint/tmlibs/log"
+)
+
+func TestMaxOpenConnections(t *testing.T) {
+	const max = 5 // max simultaneous connections
+
+	// Start the server.
+	var open int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if n := atomic.AddInt32(&open, 1); n > int32(max) {
+			t.Errorf("%d open connections, want <= %d", n, max)
+		}
+		defer atomic.AddInt32(&open, -1)
+		time.Sleep(10 * time.Millisecond)
+		fmt.Fprint(w, "some body")
+	})
+	l, err := StartHTTPServer("tcp://127.0.0.1:0", mux, log.TestingLogger(), Config{MaxOpenConnections: max})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	// Make N GET calls to the server.
+	attempts := max * 2
+	var wg sync.WaitGroup
+	var failed int32
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := http.Client{Timeout: 3 * time.Second}
+			r, err := c.Get("http://" + l.Addr().String())
+			if err != nil {
+				t.Log(err)
+				atomic.AddInt32(&failed, 1)
+				return
+			}
+			defer r.Body.Close()
+			io.Copy(ioutil.Discard, r.Body)
+		}()
+	}
+	wg.Wait()
+
+	// We expect some Gets to fail as the server's accept queue is filled,
+	// but most should succeed.
+	if int(failed) >= attempts/2 {
+		t.Errorf("%d requests failed within %d attempts", failed, attempts)
+	}
+}

--- a/rpc/lib/test/main.go
+++ b/rpc/lib/test/main.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	rpcserver "github.com/tendermint/tendermint/rpc/lib/server"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
@@ -28,7 +28,7 @@ func main() {
 	cdc := amino.NewCodec()
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	rpcserver.RegisterRPCFuncs(mux, routes, cdc, logger)
-	_, err := rpcserver.StartHTTPServer("0.0.0.0:8008", mux, logger)
+	_, err := rpcserver.StartHTTPServer("0.0.0.0:8008", mux, logger, rpcserver.Config{})
 	if err != nil {
 		cmn.Exit(err.Error())
 	}


### PR DESCRIPTION
Refs #1740

also, expose limit option for number concurrent streams for gRPC
(unlimited by default)

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG.md
* [ ] ~~add metrics: `rpc.ws_connections`~~ **will be done in a separate PR**
* [x] test creating many gRPC connections