### PR TITLE
crypto: Abstract pubkey / signature size when known to constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## TBD
 
-BREAKING CHANGES:
- - [crypto] Remove xchacha20poly1305 in favor of hkdfchachapoly1305
-
 IMPROVEMENTS:
  - [crypto] Make public key size into public constants
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## TBD
 
+BREAKING CHANGES:
+ - [crypto] Remove xchacha20poly1305 in favor of hkdfchachapoly1305
+
+IMPROVEMENTS:
+ - [crypto] Make public key size into public constants
+
 BUG FIXES:
 
 - [rpc] limited number of HTTP/WebSocket connections

--- a/crypto/pub_key.go
+++ b/crypto/pub_key.go
@@ -40,8 +40,10 @@ type PubKey interface {
 
 var _ PubKey = PubKeyEd25519{}
 
+const PubKeyEd25519Size = 32
+
 // Implements PubKeyInner
-type PubKeyEd25519 [32]byte
+type PubKeyEd25519 [PubKeyEd25519Size]byte
 
 // Address is the SHA256-20 of the raw pubkey bytes.
 func (pubKey PubKeyEd25519) Address() Address {
@@ -62,15 +64,15 @@ func (pubKey PubKeyEd25519) VerifyBytes(msg []byte, sig_ Signature) bool {
 	if !ok {
 		return false
 	}
-	pubKeyBytes := [32]byte(pubKey)
-	sigBytes := [64]byte(sig)
+	pubKeyBytes := [PubKeyEd25519Size]byte(pubKey)
+	sigBytes := [SignatureEd25519Size]byte(sig)
 	return ed25519.Verify(&pubKeyBytes, msg, &sigBytes)
 }
 
 // For use with golang/crypto/nacl/box
 // If error, returns nil.
-func (pubKey PubKeyEd25519) ToCurve25519() *[32]byte {
-	keyCurve25519, pubKeyBytes := new([32]byte), [32]byte(pubKey)
+func (pubKey PubKeyEd25519) ToCurve25519() *[PubKeyEd25519Size]byte {
+	keyCurve25519, pubKeyBytes := new([PubKeyEd25519Size]byte), [PubKeyEd25519Size]byte(pubKey)
 	ok := extra25519.PublicKeyToCurve25519(keyCurve25519, &pubKeyBytes)
 	if !ok {
 		return nil
@@ -94,10 +96,12 @@ func (pubKey PubKeyEd25519) Equals(other PubKey) bool {
 
 var _ PubKey = PubKeySecp256k1{}
 
+const PubKeySecp256k1Size = 33
+
 // Implements PubKey.
 // Compressed pubkey (just the x-cord),
 // prefixed with 0x02 or 0x03, depending on the y-cord.
-type PubKeySecp256k1 [33]byte
+type PubKeySecp256k1 [PubKeySecp256k1Size]byte
 
 // Implements Bitcoin style addresses: RIPEMD160(SHA256(pubkey))
 func (pubKey PubKeySecp256k1) Address() Address {

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -25,8 +25,10 @@ type Signature interface {
 
 var _ Signature = SignatureEd25519{}
 
+const SignatureEd25519Size = 64
+
 // Implements Signature
-type SignatureEd25519 [64]byte
+type SignatureEd25519 [SignatureEd25519Size]byte
 
 func (sig SignatureEd25519) Bytes() []byte {
 	bz, err := cdc.MarshalBinaryBare(sig)


### PR DESCRIPTION
* Created PubKeyEd25519Size as 32
* Created PubkeySecp256k1Size as 33
* Created SignatureEd25519Size as 64

Closes https://github.com/tendermint/go-crypto/issues/81

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - is there any I should be updating?
* [X] Updated all code comments where relevant - n/a, constant names are self-descriptive
* [X] Wrote tests - n/a
* [X] Updated CHANGELOG.md - Did I update the right changelog?

Note, I am not updating secret connection in this PR, in favor of https://github.com/tendermint/tendermint/pull/1563 being settled first.