### PR TITLE
p2p/trust: Fix nil pointer error on TrustMetric Copy()

### DIFF
--- a/p2p/trust/metric.go
+++ b/p2p/trust/metric.go
@@ -256,11 +256,12 @@ func (tm *TrustMetric) SetTicker(ticker MetricTicker) {
 
 // Copy returns a new trust metric with members containing the same values
 func (tm *TrustMetric) Copy() *TrustMetric {
-	tm.mtx.Lock()
-	defer tm.mtx.Unlock()
 	if tm == nil {
 		return nil
 	}
+
+	tm.mtx.Lock()
+	defer tm.mtx.Unlock()
 
 	return &TrustMetric{
 		proportionalWeight: tm.proportionalWeight,

--- a/p2p/trust/metric_test.go
+++ b/p2p/trust/metric_test.go
@@ -56,6 +56,14 @@ func TestTrustMetricConfig(t *testing.T) {
 	tm.Wait()
 }
 
+func TestTrustMetricCopyNilPointer(t *testing.T) {
+	var tm *TrustMetric
+
+	ctm := tm.Copy()
+
+	assert.Nil(t, ctm)
+}
+
 // XXX: This test fails non-deterministically
 func _TestTrustMetricStopPause(t *testing.T) {
 	// The TestTicker will provide manual control over


### PR DESCRIPTION
Fix the following issue: https://github.com/tendermint/tendermint/issues/1765