### PR TITLE
Adding configurability via config file to address book

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -311,6 +311,9 @@ type P2PConfig struct {
 	// FUzz connection
 	TestFuzz       bool            `mapstructure:"test_fuzz"`
 	TestFuzzConfig *FuzzConnConfig `mapstructure:"test_fuzz_config"`
+
+	// Addresses under which the address manager will claim to need more addresses
+	NeedAddressThreshold int `mapstructure:"need_address_threshold"`
 }
 
 // DefaultP2PConfig returns a default configuration for the peer-to-peer layer
@@ -332,6 +335,7 @@ func DefaultP2PConfig() *P2PConfig {
 		TestDialFail:            false,
 		TestFuzz:                false,
 		TestFuzzConfig:          DefaultFuzzConnConfig(),
+		NeedAddressThreshold:    1000,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -168,6 +168,9 @@ seed_mode = {{ .P2P.SeedMode }}
 # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
 private_peer_ids = "{{ .P2P.PrivatePeerIDs }}"
 
+# Addresses under which the address manager will claim to need more addresses
+need_address_threshold = "{{ .P2P.NeedAddressThreshold }}"
+
 ##### mempool configuration options #####
 [mempool]
 

--- a/node/node.go
+++ b/node/node.go
@@ -271,7 +271,7 @@ func NewNode(config *cfg.Config,
 	//
 	// If PEX is on, it should handle dialing the seeds. Otherwise the switch does it.
 	// Note we currently use the addrBook regardless at least for AddOurAddress
-	addrBook := pex.NewAddrBook(config.P2P.AddrBookFile(), config.P2P.AddrBookStrict)
+	addrBook := pex.NewAddrBook(config.P2P)
 	addrBook.SetLogger(p2pLogger.With("book", config.P2P.AddrBookFile()))
 	if config.P2P.PexReactor {
 		// TODO persistent peers ? so we can have their DNS addrs saved

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -11,8 +11,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tendermint/tendermint/p2p"
 	cmn "github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tmlibs/log"
 )
+
+func createNewAddrbook(filePath string, routabilityStrict bool) *addrBook {
+	cfg := config.DefaultP2PConfig()
+	cfg.AddrBook = filePath
+	cfg.AddrBookStrict = routabilityStrict
+	return NewAddrBook(cfg)
+}
 
 func createTempFileName(prefix string) string {
 	f, err := ioutil.TempFile("", prefix)
@@ -39,7 +47,7 @@ func TestAddrBookPickAddress(t *testing.T) {
 	defer deleteTempFile(fname)
 
 	// 0 addresses
-	book := NewAddrBook(fname, true)
+	book := createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 	assert.Zero(t, book.Size())
 
@@ -75,11 +83,11 @@ func TestAddrBookSaveLoad(t *testing.T) {
 	defer deleteTempFile(fname)
 
 	// 0 addresses
-	book := NewAddrBook(fname, true)
+	book := createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 	book.saveToFile(fname)
 
-	book = NewAddrBook(fname, true)
+	book = createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 	book.loadFromFile(fname)
 
@@ -95,7 +103,7 @@ func TestAddrBookSaveLoad(t *testing.T) {
 	assert.Equal(t, 100, book.Size())
 	book.saveToFile(fname)
 
-	book = NewAddrBook(fname, true)
+	book = createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 	book.loadFromFile(fname)
 
@@ -108,7 +116,7 @@ func TestAddrBookLookup(t *testing.T) {
 
 	randAddrs := randNetAddressPairs(t, 100)
 
-	book := NewAddrBook(fname, true)
+	book := createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 	for _, addrSrc := range randAddrs {
 		addr := addrSrc.addr
@@ -130,7 +138,7 @@ func TestAddrBookPromoteToOld(t *testing.T) {
 
 	randAddrs := randNetAddressPairs(t, 100)
 
-	book := NewAddrBook(fname, true)
+	book := createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 	for _, addrSrc := range randAddrs {
 		book.AddAddress(addrSrc.addr, addrSrc.src)
@@ -171,7 +179,7 @@ func TestAddrBookHandlesDuplicates(t *testing.T) {
 	fname := createTempFileName("addrbook_test")
 	defer deleteTempFile(fname)
 
-	book := NewAddrBook(fname, true)
+	book := createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 
 	randAddrs := randNetAddressPairs(t, 100)
@@ -222,7 +230,7 @@ func TestAddrBookRemoveAddress(t *testing.T) {
 	fname := createTempFileName("addrbook_test")
 	defer deleteTempFile(fname)
 
-	book := NewAddrBook(fname, true)
+	book := createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 
 	addr := randIPv4Address(t)
@@ -241,7 +249,7 @@ func TestAddrBookGetSelection(t *testing.T) {
 	fname := createTempFileName("addrbook_test")
 	defer deleteTempFile(fname)
 
-	book := NewAddrBook(fname, true)
+	book := createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 
 	// 1) empty book
@@ -281,7 +289,7 @@ func TestAddrBookGetSelectionWithBias(t *testing.T) {
 	fname := createTempFileName("addrbook_test")
 	defer deleteTempFile(fname)
 
-	book := NewAddrBook(fname, true)
+	book := createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 
 	// 1) empty book
@@ -343,7 +351,7 @@ func TestAddrBookHasAddress(t *testing.T) {
 	fname := createTempFileName("addrbook_test")
 	defer deleteTempFile(fname)
 
-	book := NewAddrBook(fname, true)
+	book := createNewAddrbook(fname, true)
 	book.SetLogger(log.TestingLogger())
 	addr := randIPv4Address(t)
 	book.AddAddress(addr, addr)

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -84,7 +84,9 @@ func TestPEXReactorRunning(t *testing.T) {
 	// create switches
 	for i := 0; i < N; i++ {
 		switches[i] = p2p.MakeSwitch(cfg, i, "testing", "123.123.123", func(i int, sw *p2p.Switch) *p2p.Switch {
-			books[i] = NewAddrBook(filepath.Join(dir, fmt.Sprintf("addrbook%d.json", i)), false)
+			books[i] = NewAddrBook(&config.P2PConfig{
+				AddrBook: 					filepath.Join(dir, fmt.Sprintf("addrbook%d.json", i)),
+				AddrBookStrict: 	false})
 			books[i].SetLogger(logger.With("pex", i))
 			sw.SetAddrBook(books[i])
 
@@ -216,7 +218,9 @@ func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 		"127.0.0.1",
 		"123.123.123",
 		func(i int, sw *p2p.Switch) *p2p.Switch {
-			book := NewAddrBook(filepath.Join(dir, "addrbook0.json"), false)
+			book := NewAddrBook(&config.P2PConfig{
+				AddrBook: 					filepath.Join(dir, "addrbook0.json"),
+				AddrBookStrict: 	false})
 			book.SetLogger(log.TestingLogger())
 			sw.SetAddrBook(book)
 
@@ -246,7 +250,9 @@ func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 		"127.0.0.1",
 		"123.123.123",
 		func(i int, sw *p2p.Switch) *p2p.Switch {
-			book := NewAddrBook(filepath.Join(dir, "addrbook1.json"), false)
+			book := NewAddrBook(&config.P2PConfig{
+				AddrBook: 					filepath.Join(dir, "addrbook1.json"),
+				AddrBookStrict: 	false})
 			book.SetLogger(log.TestingLogger())
 			sw.SetAddrBook(book)
 
@@ -433,7 +439,9 @@ func createReactor(conf *PEXReactorConfig) (r *PEXReactor, book *addrBook) {
 	if err != nil {
 		panic(err)
 	}
-	book = NewAddrBook(filepath.Join(dir, "addrbook.json"), true)
+	book = NewAddrBook(&config.P2PConfig{
+		AddrBook: 					filepath.Join(dir, "addrbook.json"),
+		AddrBookStrict: 	true})
 	book.SetLogger(log.TestingLogger())
 
 	r = NewPEXReactor(book, conf)


### PR DESCRIPTION
This diff adds the ability to configure elements in the address book via the config file.  For now, only adding the "Need address threshold" to the config file, but this would allow any configuration items to be added.  Also reduces number of elements we need to pass to NewAddrBook
