### PR TITLE
Fix typo

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -129,8 +129,8 @@ The result should look like:
 
 Note the `value` in the result (`YWJjZA==`); this is the base64-encoding
 of the ASCII of `abcd`. You can verify this in a python 2 shell by
-running `"61626364".decode('base64')` or in python 3 shell by running
-`import codecs; codecs.decode("61626364", 'base64').decode('ascii')`.
+running `"YWJjZA==".decode('base64')` or in python 3 shell by running
+`import codecs; codecs.decode("YWJjZA==", 'base64').decode('ascii')`.
 Stay tuned for a future release that [makes this output more
 human-readable](https://github.com/tendermint/abci/issues/32).
 


### PR DESCRIPTION
The base64 encoding for 'abcd' is incorrect for the python decoding examples.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
