### PR TITLE
abciClient.BeginBlockSync should not hang on crashed server 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 *TBD*
 
+BUG FIXES:
+- [abci] Fix #1891, pending requests cannot hang when abci server dies. Previously a crash in BeginBlock could leave tendermint in broken state.
+
 ## 0.22.0
 
 *July 2nd, 2018*

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -357,6 +357,13 @@ func (cli *socketClient) queueRequest(req *types.Request) *ReqRes {
 }
 
 func (cli *socketClient) flushQueue() {
+	// mark all in-flight messages as resolved (they will get cli.Error())
+	for req := cli.reqSent.Front(); req != nil; req = req.Next() {
+		reqres := req.Value.(*ReqRes)
+		reqres.Done()
+	}
+
+	// mark all queued messages as resolved
 LOOP:
 	for {
 		select {

--- a/abci/client/socket_client_test.go
+++ b/abci/client/socket_client_test.go
@@ -5,7 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/abci/client"
+	"github.com/tendermint/tendermint/abci/server"
+	"github.com/tendermint/tendermint/abci/types"
 )
 
 func TestSocketClientStopForErrorDeadlock(t *testing.T) {
@@ -25,4 +29,35 @@ func TestSocketClientStopForErrorDeadlock(t *testing.T) {
 	case <-time.After(time.Second * 4):
 		t.Fatalf("Test took too long, potential deadlock still exists")
 	}
+}
+
+func TestProperSyncCalls(t *testing.T) {
+	port := ":29385"
+	app := new(types.BaseApplication)
+
+	s, err := server.NewServer(port, "socket", app)
+	require.NoError(t, err)
+	err = s.Start()
+	require.NoError(t, err)
+	defer s.Stop()
+
+	c := abcicli.NewSocketClient(port, true)
+	err = c.Start()
+	require.NoError(t, err)
+	defer c.Stop()
+
+	resp := make(chan error, 1)
+	go func() {
+		_, err := c.BeginBlockSync(types.RequestBeginBlock{})
+		resp <- err
+	}()
+
+	select {
+	case <-time.After(time.Second):
+		require.Fail(t, "No response arrived")
+	case err, ok := <-resp:
+		require.True(t, ok, "Must not close channel")
+		assert.NoError(t, err, "This should return success")
+	}
+
 }


### PR DESCRIPTION
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG.md

Addressing issue #1890

Reproduced the errant behavior, and pushing to demo that.
Working on a solution.