### PR TITLE
tools/tm-bench: Remove testing flags from help

### DIFF
--- a/tools/tm-bench/main.go
+++ b/tools/tm-bench/main.go
@@ -29,15 +29,16 @@ func main() {
 	var verbose bool
 	var outputFormat, broadcastTxMethod string
 
-	flag.IntVar(&connections, "c", 1, "Connections to keep open per endpoint")
-	flag.IntVar(&duration, "T", 10, "Exit after the specified amount of time in seconds")
-	flag.IntVar(&txsRate, "r", 1000, "Txs per second to send in a connection")
-	flag.IntVar(&txSize, "s", 250, "The size of a transaction in bytes.")
-	flag.StringVar(&outputFormat, "output-format", "plain", "Output format: plain or json")
-	flag.StringVar(&broadcastTxMethod, "broadcast-tx-method", "async", "Broadcast method: async (no guarantees; fastest), sync (ensures tx is checked) or commit (ensures tx is checked and committed; slowest)")
-	flag.BoolVar(&verbose, "v", false, "Verbose output")
+	flagSet := flag.NewFlagSet("tm-bench", flag.ExitOnError)
+	flagSet.IntVar(&connections, "c", 1, "Connections to keep open per endpoint")
+	flagSet.IntVar(&duration, "T", 10, "Exit after the specified amount of time in seconds")
+	flagSet.IntVar(&txsRate, "r", 1000, "Txs per second to send in a connection")
+	flagSet.IntVar(&txSize, "s", 250, "The size of a transaction in bytes.")
+	flagSet.StringVar(&outputFormat, "output-format", "plain", "Output format: plain or json")
+	flagSet.StringVar(&broadcastTxMethod, "broadcast-tx-method", "async", "Broadcast method: async (no guarantees; fastest), sync (ensures tx is checked) or commit (ensures tx is checked and committed; slowest)")
+	flagSet.BoolVar(&verbose, "v", false, "Verbose output")
 
-	flag.Usage = func() {
+	flagSet.Usage = func() {
 		fmt.Println(`Tendermint blockchain benchmarking tool.
 
 Usage:
@@ -46,13 +47,13 @@ Usage:
 Examples:
 	tm-bench localhost:26657`)
 		fmt.Println("Flags:")
-		flag.PrintDefaults()
+		flagSet.PrintDefaults()
 	}
 
-	flag.Parse()
+	flagSet.Parse(os.Args[1:])
 
-	if flag.NArg() == 0 {
-		flag.Usage()
+	if flagSet.NArg() == 0 {
+		flagSet.Usage()
 		os.Exit(1)
 	}
 
@@ -72,7 +73,7 @@ Examples:
 		}
 		logger = log.NewTMLoggerWithColorFn(log.NewSyncWriter(os.Stdout), colorFn)
 
-		fmt.Printf("Running %ds test @ %s\n", duration, flag.Arg(0))
+		fmt.Printf("Running %ds test @ %s\n", duration, flagSet.Arg(0))
 	}
 
 	if broadcastTxMethod != "async" &&
@@ -86,7 +87,7 @@ Examples:
 	}
 
 	var (
-		endpoints     = strings.Split(flag.Arg(0), ",")
+		endpoints     = strings.Split(flagSet.Arg(0), ",")
 		client        = tmrpc.NewHTTP(endpoints[0], "/websocket")
 		initialHeight = latestBlockHeight(client)
 	)


### PR DESCRIPTION
This achieved by creating a new flagset. 

This should check-off `Remove testing flags from usage docs` in #1940

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [X] ~Updated all relevant documentation in docs~ this makes the repo match the docs
* [ ] Updated all code comments where relevant - not sure any needed
* [x] Wrote tests - N/A
* [ ] Updated CHANGELOG.md - not updated since this is a bug that was introduced in develop
