### PR TITLE
tools/tmbench fix end time calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ BUG FIXES
     - NOTE: this is only for URI requests. JSONRPC requests and all responses
       will use quoted integers (the proto3 JSON standard).
 - [consensus] Fix halt on shutdown
-- [tm_bench] Fix method of computing start time
+- [tm_bench] Fix method of computing start time, and end time
 
 ## 0.22.1
 


### PR DESCRIPTION
Previously we were using the time at which all connections closed in statistics, not
the time after {duration} seconds.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [X] Updated all relevant documentation in docs - this is making the relevant code match the documentation
* [ ] Updated all code comments where relevant
* [ ] Wrote tests - plan to write tm-bench tests in a seperate PR soon
* [X] Updated CHANGELOG.md
