### PR TITLE
config: 10x default send/recv rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## PENDING
+
+IMPROVEMENTS:
+- [config] Increase default send/recv rates to to 5 mB/s 
+
 ## 0.22.4
 
 *July 14th, 2018*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## PENDING
 
 IMPROVEMENTS:
-- [config] Increase default send/recv rates to to 5 mB/s 
+- [config] Increase default send/recv rates to 5 mB/s
 
 ## 0.22.4
 

--- a/config/config.go
+++ b/config/config.go
@@ -349,9 +349,9 @@ func DefaultP2PConfig() *P2PConfig {
 		AddrBookStrict:          true,
 		MaxNumPeers:             50,
 		FlushThrottleTimeout:    100,
-		MaxPacketMsgPayloadSize: 1024,   // 1 kB
-		SendRate:                512000, // 500 kB/s
-		RecvRate:                512000, // 500 kB/s
+		MaxPacketMsgPayloadSize: 1024,    // 1 kB
+		SendRate:                5120000, // 5 mB/s
+		RecvRate:                5120000, // 5 mB/s
 		PexReactor:              true,
 		SeedMode:                false,
 		AllowDuplicateIP:        true, // so non-breaking yet

--- a/docs/tendermint-core/configuration.md
+++ b/docs/tendermint-core/configuration.md
@@ -121,10 +121,10 @@ max_num_peers = 50
 max_packet_msg_payload_size = 1024
 
 # Rate at which packets can be sent, in bytes/second
-send_rate = 512000
+send_rate = 5120000
 
 # Rate at which packets can be received, in bytes/second
-recv_rate = 512000
+recv_rate = 5120000
 
 # Set true to enable the peer-exchange reactor
 pex = true


### PR DESCRIPTION
This increases the default send/recv rate from 512 kB/s to 5.12 mB/s

Closes #1752

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - I think I updated all of the relevant parts of the docs
* [X] Updated all code comments where relevant
* [ ] Wrote tests - n/a
* [X] Updated CHANGELOG.md
