### PR TITLE
common/rand: Remove exponential distribution functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 BREAKING CHANGES:
 - [genesis] removed deprecated `app_options` field.
 - [types] Genesis.AppStateJSON -> Genesis.AppState
+- [libs/common] remove exponentially distributed random numbers
 
 FEATURES:
 - [tools] Merged in from github.com/tendermint/tools

--- a/libs/common/random.go
+++ b/libs/common/random.go
@@ -109,18 +109,6 @@ func RandInt63n(n int64) int64 {
 	return grand.Int63n(n)
 }
 
-func RandUint16Exp() uint16 {
-	return grand.Uint16Exp()
-}
-
-func RandUint32Exp() uint32 {
-	return grand.Uint32Exp()
-}
-
-func RandUint64Exp() uint64 {
-	return grand.Uint64Exp()
-}
-
 func RandFloat32() float32 {
 	return grand.Float32()
 }
@@ -247,39 +235,6 @@ func (r *Rand) Int63n(n int64) int64 {
 	return i63n
 }
 
-// Distributed pseudo-exponentially to test for various cases
-func (r *Rand) Uint16Exp() uint16 {
-	bits := r.Uint32() % 16
-	if bits == 0 {
-		return 0
-	}
-	n := uint16(1 << (bits - 1))
-	n += uint16(r.Int31()) & ((1 << (bits - 1)) - 1)
-	return n
-}
-
-// Distributed pseudo-exponentially to test for various cases
-func (r *Rand) Uint32Exp() uint32 {
-	bits := r.Uint32() % 32
-	if bits == 0 {
-		return 0
-	}
-	n := uint32(1 << (bits - 1))
-	n += uint32(r.Int31()) & ((1 << (bits - 1)) - 1)
-	return n
-}
-
-// Distributed pseudo-exponentially to test for various cases
-func (r *Rand) Uint64Exp() uint64 {
-	bits := r.Uint32() % 64
-	if bits == 0 {
-		return 0
-	}
-	n := uint64(1 << (bits - 1))
-	n += uint64(r.Int63()) & ((1 << (bits - 1)) - 1)
-	return n
-}
-
 func (r *Rand) Float32() float32 {
 	r.Lock()
 	f32 := r.rand.Float32()
@@ -295,7 +250,7 @@ func (r *Rand) Float64() float64 {
 }
 
 func (r *Rand) Time() time.Time {
-	return time.Unix(int64(r.Uint64Exp()), 0)
+	return time.Unix(int64(r.Uint64()), 0)
 }
 
 // Bytes returns n random bytes generated from the internal

--- a/libs/common/random_test.go
+++ b/libs/common/random_test.go
@@ -73,9 +73,6 @@ func testThemAll() string {
 	fmt.Fprintf(out, "randInt64: %d\n", RandInt64())
 	fmt.Fprintf(out, "randUint32: %d\n", RandUint32())
 	fmt.Fprintf(out, "randUint64: %d\n", RandUint64())
-	fmt.Fprintf(out, "randUint16Exp: %d\n", RandUint16Exp())
-	fmt.Fprintf(out, "randUint32Exp: %d\n", RandUint32Exp())
-	fmt.Fprintf(out, "randUint64Exp: %d\n", RandUint64Exp())
 	return out.String()
 }
 


### PR DESCRIPTION
We were computing these functions incorrectly. I'm not sure what distribution
these numbers are, but it isn't the normal definition of exponential distribution. (We're making
the probability of getting a number of a particular bitlength equal, but the number in 
that bitlength thats gets chosen is uniformly chosen)

We weren't using these functions anywhere in our codebase, and they
had a nomenclature error. (There aren't exponentially distributed
integers, instead they would be geometrically distributed) While they were
implicitly part of RandTime, and rand.Time, neither of those functions were
used anywhere.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - don't think these were in the docs?
* [ ] ~Updated all code comments where relevant~
* [ ] ~Wrote tests~
* [X] Updated CHANGELOG.md
