### PR TITLE
Switch usage of math/rand to cmn's rand

### DIFF
--- a/blockchain/pool_test.go
+++ b/blockchain/pool_test.go
@@ -1,7 +1,6 @@
 package blockchain
 
 import (
-	"math/rand"
 	"testing"
 	"time"
 
@@ -25,7 +24,7 @@ func makePeers(numPeers int, minHeight, maxHeight int64) map[p2p.ID]testPeer {
 	peers := make(map[p2p.ID]testPeer, numPeers)
 	for i := 0; i < numPeers; i++ {
 		peerID := p2p.ID(cmn.RandStr(12))
-		height := minHeight + rand.Int63n(maxHeight-minHeight)
+		height := minHeight + cmn.RandInt63n(maxHeight-minHeight)
 		peers[peerID] = testPeer{peerID, height}
 	}
 	return peers

--- a/libs/clist/clist_test.go
+++ b/libs/clist/clist_test.go
@@ -2,11 +2,12 @@ package clist
 
 import (
 	"fmt"
-	"math/rand"
 	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
 func TestSmall(t *testing.T) {
@@ -131,7 +132,7 @@ func _TestGCRandom(t *testing.T) {
 		els = append(els, el)
 	}
 
-	for _, i := range rand.Perm(numElements) {
+	for _, i := range cmn.RandPerm(numElements) {
 		el := els[i]
 		l.Remove(el)
 		_ = el.Next()
@@ -189,7 +190,7 @@ func TestScanRightDeleteRandom(t *testing.T) {
 	// Remove an element, push back an element.
 	for i := 0; i < numTimes; i++ {
 		// Pick an element to remove
-		rmElIdx := rand.Intn(len(els))
+		rmElIdx := cmn.RandIntn(len(els))
 		rmEl := els[rmElIdx]
 
 		// Remove it
@@ -243,7 +244,7 @@ func TestWaitChan(t *testing.T) {
 		for i := 1; i < 100; i++ {
 			l.PushBack(i)
 			pushed++
-			time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+			time.Sleep(time.Duration(cmn.RandIntn(100)) * time.Millisecond)
 		}
 		close(done)
 	}()

--- a/libs/common/os_test.go
+++ b/libs/common/os_test.go
@@ -3,17 +3,14 @@ package common
 import (
 	"bytes"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestWriteFileAtomic(t *testing.T) {
 	var (
-		seed             = rand.New(rand.NewSource(time.Now().UnixNano()))
-		data             = []byte(RandStr(seed.Intn(2048)))
-		old              = RandBytes(seed.Intn(2048))
+		data             = []byte(RandStr(RandIntn(2048)))
+		old              = RandBytes(RandIntn(2048))
 		perm os.FileMode = 0600
 	)
 

--- a/libs/common/repeat_timer_test.go
+++ b/libs/common/repeat_timer_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -131,7 +130,7 @@ func TestRepeatTimerReset(t *testing.T) {
 
 	// just random calls
 	for i := 0; i < 100; i++ {
-		time.Sleep(time.Duration(rand.Intn(40)) * time.Millisecond)
+		time.Sleep(time.Duration(RandIntn(40)) * time.Millisecond)
 		timer.Reset()
 	}
 }

--- a/libs/events/events_test.go
+++ b/libs/events/events_test.go
@@ -2,11 +2,11 @@ package events
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
 // TestAddListenerForEventFireOnce sets up an EventSwitch, subscribes a single
@@ -306,8 +306,8 @@ func TestRemoveListenersAsync(t *testing.T) {
 	// collect received events for event2
 	go sumReceivedNumbers(numbers2, doneSum2)
 	addListenersStress := func() {
-		s1 := rand.NewSource(time.Now().UnixNano())
-		r1 := rand.New(s1)
+		r1 := cmn.NewRand()
+		r1.Seed(time.Now().UnixNano())
 		for k := uint16(0); k < 400; k++ {
 			listenerNumber := r1.Intn(100) + 3
 			eventNumber := r1.Intn(3) + 1
@@ -317,8 +317,8 @@ func TestRemoveListenersAsync(t *testing.T) {
 		}
 	}
 	removeListenersStress := func() {
-		s2 := rand.NewSource(time.Now().UnixNano())
-		r2 := rand.New(s2)
+		r2 := cmn.NewRand()
+		r2.Seed(time.Now().UnixNano())
 		for k := uint16(0); k < 80; k++ {
 			listenerNumber := r2.Intn(100) + 3
 			go evsw.RemoveListener(fmt.Sprintf("listener%v", listenerNumber))

--- a/lite/performance_test.go
+++ b/lite/performance_test.go
@@ -2,13 +2,12 @@ package lite
 
 import (
 	"fmt"
-	"math/rand"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
+	cmn "github.com/tendermint/tendermint/libs/common"
 	liteErr "github.com/tendermint/tendermint/lite/errors"
 )
 
@@ -280,7 +279,11 @@ func BenchmarkMemStoreProviderGetByHeightBinarySearch1000(b *testing.B) {
 	benchmarkMemStoreProvidergetByHeight(b, fcs1000, h1000, binarySearch)
 }
 
-var rng = rand.New(rand.NewSource(10))
+var rng = cmn.NewRand()
+
+func init() {
+	rng.Seed(10)
+}
 
 func benchmarkMemStoreProvidergetByHeight(b *testing.B, fcs []FullCommit, fHeights []int64, algo algo) {
 	lazyGenerateFullCommits(b)

--- a/p2p/peer_set_test.go
+++ b/p2p/peer_set_test.go
@@ -1,7 +1,6 @@
 package p2p
 
 import (
-	"math/rand"
 	"net"
 	"sync"
 	"testing"
@@ -22,7 +21,7 @@ func randPeer(ip net.IP) *peer {
 	p := &peer{
 		nodeInfo: NodeInfo{
 			ID:         nodeKey.ID(),
-			ListenAddr: cmn.Fmt("%v.%v.%v.%v:26656", rand.Int()%256, rand.Int()%256, rand.Int()%256, rand.Int()%256),
+			ListenAddr: cmn.Fmt("%v.%v.%v.%v:26656", cmn.RandInt()%256, cmn.RandInt()%256, cmn.RandInt()%256, cmn.RandInt()%256),
 		},
 	}
 

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -4,14 +4,13 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tendermint/tendermint/p2p"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/p2p"
 )
 
 func createTempFileName(prefix string) string {
@@ -202,12 +201,12 @@ func randNetAddressPairs(t *testing.T, n int) []netAddressPair {
 func randIPv4Address(t *testing.T) *p2p.NetAddress {
 	for {
 		ip := fmt.Sprintf("%v.%v.%v.%v",
-			rand.Intn(254)+1,
-			rand.Intn(255),
-			rand.Intn(255),
-			rand.Intn(255),
+			cmn.RandIntn(254)+1,
+			cmn.RandIntn(255),
+			cmn.RandIntn(255),
+			cmn.RandIntn(255),
 		)
-		port := rand.Intn(65535-1) + 1
+		port := cmn.RandIntn(65535-1) + 1
 		id := p2p.ID(hex.EncodeToString(cmn.RandBytes(p2p.IDByteLength)))
 		idAddr := p2p.IDAddressString(id, fmt.Sprintf("%v:%v", ip, port))
 		addr, err := p2p.NewNetAddressString(idAddr)

--- a/rpc/lib/rpc_test.go
+++ b/rpc/lib/rpc_test.go
@@ -6,7 +6,6 @@ import (
 	crand "crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -206,7 +205,7 @@ func testWithHTTPClient(t *testing.T, cl client.HTTPClient) {
 	require.Nil(t, err)
 	assert.Equal(t, got3, val3)
 
-	val4 := rand.Intn(10000)
+	val4 := cmn.RandIntn(10000)
 	got4, err := echoIntViaHTTP(cl, val4)
 	require.Nil(t, err)
 	assert.Equal(t, got4, val4)
@@ -370,7 +369,7 @@ func TestWSClientPingPong(t *testing.T) {
 }
 
 func randBytes(t *testing.T) []byte {
-	n := rand.Intn(10) + 2
+	n := cmn.RandIntn(10) + 2
 	buf := make([]byte, n)
 	_, err := crand.Read(buf)
 	require.Nil(t, err)

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -3,7 +3,6 @@ package types
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -150,7 +149,7 @@ func BenchmarkEventBus(b *testing.B) {
 
 func benchmarkEventBus(numClients int, randQueries bool, randEvents bool, b *testing.B) {
 	// for random* functions
-	rand.Seed(time.Now().Unix())
+	cmn.Seed(time.Now().Unix())
 
 	eventBus := NewEventBusWithBufferCapacity(0) // set buffer capacity to 0 so we are not testing cache
 	eventBus.Start()
@@ -199,7 +198,7 @@ var events = []string{
 	EventVote}
 
 func randEvent() string {
-	return events[rand.Intn(len(events))]
+	return events[cmn.RandIntn(len(events))]
 }
 
 var queries = []tmpubsub.Query{
@@ -217,5 +216,5 @@ var queries = []tmpubsub.Query{
 	EventQueryVote}
 
 func randQuery() tmpubsub.Query {
-	return queries[rand.Intn(len(queries))]
+	return queries[cmn.RandIntn(len(queries))]
 }


### PR DESCRIPTION
This commit switches all usage of math/rand to cmn's rand. The only
exceptions are within the random file itself, the tools package, and the
crypto package. In tools/tm-bench you don't want it to lock between the go-routines.
The crypto package doesn't use it so the crypto package has no other
dependencies within tendermint/tendermint for easier portability.

Crypto/rand usage is unadjusted.

Closes #1343

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - n/a?
* [ ] Updated all code comments where relevant - n/a?
* [ ] Wrote tests - n/a?
* [ ] Updated CHANGELOG.md  - not a user-facing change
