### PR TITLE
Add private peer ID tracking to AddrBook

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -284,7 +284,6 @@ type P2PConfig struct {
 	Seeds string `mapstructure:"seeds"`
 
 	// Comma separated list of nodes to keep persistent connections to
-	// Do not add private peers to this list if you don't want them advertised
 	PersistentPeers string `mapstructure:"persistent_peers"`
 
 	// UPNP port forwarding

--- a/config/toml.go
+++ b/config/toml.go
@@ -152,7 +152,6 @@ external_address = "{{ .P2P.ExternalAddress }}"
 seeds = "{{ .P2P.Seeds }}"
 
 # Comma separated list of nodes to keep persistent connections to
-# Do not add private peers to this list if you don't want them advertised
 persistent_peers = "{{ .P2P.PersistentPeers }}"
 
 # UPNP port forwarding

--- a/docs/tendermint-core/configuration.md
+++ b/docs/tendermint-core/configuration.md
@@ -99,7 +99,6 @@ laddr = "tcp://0.0.0.0:26656"
 seeds = ""
 
 # Comma separated list of nodes to keep persistent connections to
-# Do not add private peers to this list if you don't want them advertised
 persistent_peers = ""
 
 # UPNP port forwarding

--- a/node/node.go
+++ b/node/node.go
@@ -449,6 +449,9 @@ func (n *Node) OnStart() error {
 	// Add ourselves to addrbook to prevent dialing ourselves
 	n.addrBook.AddOurAddress(nodeInfo.NetAddress())
 
+	// Add private IDs to addrbook to block those peers being added
+	n.addrBook.AddPrivateIDs(cmn.SplitAndTrim(n.config.P2P.PrivatePeerIDs, ",", " "))
+
 	// Start the RPC server before the P2P server
 	// so we can eg. receive txs for the first block
 	if n.config.RPC.ListenAddress != "" {

--- a/node/node.go
+++ b/node/node.go
@@ -322,9 +322,9 @@ func NewNode(config *cfg.Config,
 		// TODO persistent peers ? so we can have their DNS addrs saved
 		pexReactor := pex.NewPEXReactor(addrBook,
 			&pex.PEXReactorConfig{
-				Seeds:          cmn.SplitAndTrim(config.P2P.Seeds, ",", " "),
-				SeedMode:       config.P2P.SeedMode,
-				PrivatePeerIDs: cmn.SplitAndTrim(config.P2P.PrivatePeerIDs, ",", " ")})
+				Seeds:    cmn.SplitAndTrim(config.P2P.Seeds, ",", " "),
+				SeedMode: config.P2P.SeedMode,
+			})
 		pexReactor.SetLogger(p2pLogger)
 		sw.AddReactor("PEX", pexReactor)
 	}

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tendermint/tendermint/p2p"
+	"github.com/stretchr/testify/require"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/p2p"
 )
 
 func createTempFileName(prefix string) string {
@@ -353,4 +354,30 @@ func TestAddrBookHasAddress(t *testing.T) {
 	book.RemoveAddress(addr)
 
 	assert.False(t, book.HasAddress(addr))
+}
+
+func TestPrivatePeers(t *testing.T) {
+	fname := createTempFileName("addrbook_test")
+	defer deleteTempFile(fname)
+
+	book := NewAddrBook(fname, true)
+	book.SetLogger(log.TestingLogger())
+
+	addrs := make([]*p2p.NetAddress, 10)
+	for i := 0; i < 10; i++ {
+		addrs[i] = randIPv4Address(t)
+	}
+
+	private := make([]string, 10)
+	for i, addr := range addrs {
+		private[i] = string(addr.ID)
+	}
+	book.AddPrivateIDs(private)
+
+	for _, addr := range addrs {
+		err := book.AddAddress(addr, addr)
+		require.Error(t, err, "AddAddress should have failed with private peer %s", addr)
+		_, ok := err.(ErrAddrBookPrivate)
+		require.True(t, ok, "Wrong error type, wanted ErrAddrBookPrivate, got error: %s", err)
+	}
 }

--- a/p2p/pex/errors.go
+++ b/p2p/pex/errors.go
@@ -22,6 +22,14 @@ func (err ErrAddrBookSelf) Error() string {
 	return fmt.Sprintf("Cannot add ourselves with address %v", err.Addr)
 }
 
+type ErrAddrBookPrivate struct {
+	Addr *p2p.NetAddress
+}
+
+func (err ErrAddrBookPrivate) Error() string {
+	return fmt.Sprintf("Cannot add private peer with address %v", err.Addr)
+}
+
 type ErrAddrBookNilAddr struct {
 	Addr *p2p.NetAddress
 	Src  *p2p.NetAddress

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -179,12 +179,10 @@ func (r *PEXReactor) AddPeer(p Peer) {
 func (r *PEXReactor) logErrAddrBook(err error) {
 	if err != nil {
 		switch err.(type) {
-		case ErrAddrBookPrivate:
-			r.Logger.Error("Failed to add private peer to book", "err", err)
 		case ErrAddrBookNilAddr:
 			r.Logger.Error("Failed to add new address", "err", err)
 		default:
-			// non-routable, self, full book, etc.
+			// non-routable, self, full book, private, etc.
 			r.Logger.Debug("Failed to add new address", "err", err)
 		}
 	}

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -295,7 +295,8 @@ func TestPEXReactorCrawlStatus(t *testing.T) {
 func TestPEXReactorDoesNotAddPrivatePeersToAddrBook(t *testing.T) {
 	peer := p2p.CreateRandomPeer(false)
 
-	pexR, book := createReactor(&PEXReactorConfig{PrivatePeerIDs: []string{string(peer.NodeInfo().ID)}})
+	pexR, book := createReactor(&PEXReactorConfig{})
+	book.AddPrivateIDs([]string{string(peer.NodeInfo().ID)})
 	defer teardownReactor(book)
 
 	// we have to send a request to receive responses


### PR DESCRIPTION
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md

Fixes #1705 by tracking private peer IDs in the AddrBook, and blocking when AddAddress is called.