### PR TITLE
A link fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See the [install instructions](/docs/install.md)
 
 - [Single node](/docs/using-tendermint.md)
 - [Local cluster using docker-compose](/networks/local)
-- [Remote cluster using terraform and ansible](/docs/terraform-and-ansible.md)
+- [Remote cluster using terraform and ansible](/docs/networks/terraform-and-ansible.md)
 - [Join the public testnet](https://cosmos.network/testnet)
 
 ## Resources


### PR DESCRIPTION
To address the relocation of terraform-and-ansible.md under networks/, as per https://github.com/tendermint/tendermint/commit/e54c0f804faa3d4a6c0c1ada0288c07d2a49ce50 

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
