### PR TITLE
make `/status` RPC endpoint resistant to consensus halt

### DIFF
--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"time"
 
+	cmn "github.com/tendermint/tendermint/libs/common"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
-	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
 // Get Tendermint status including node info, pubkey, latest block
@@ -105,7 +105,11 @@ func Status() (*ctypes.ResultStatus, error) {
 }
 
 func validatorAtHeight(h int64) *types.Validator {
-	lastBlockHeight, vals := consensusState.GetValidators()
+	lastBlockHeight, vals := getValidatorsWithTimeout(1 * time.Second)
+
+	if lastBlockHeight == -1 {
+		return nil
+	}
 
 	privValAddress := pubKey.Address()
 
@@ -130,4 +134,26 @@ func validatorAtHeight(h int64) *types.Validator {
 	}
 
 	return nil
+}
+
+// NOTE: Consensus might halt, but we still need to process RPC requests (at
+// least for endpoints whole output does not depend on consensus state).
+func getValidatorsWithTimeout(t time.Duration) (int64, []*types.Validator) {
+	resultCh := make(chan struct {
+		lastBlockHeight int64
+		vals            []*types.Validator
+	})
+	go func() {
+		h, v := consensusState.GetValidators()
+		resultCh <- struct {
+			lastBlockHeight int64
+			vals            []*types.Validator
+		}{h, v}
+	}()
+	select {
+	case res := <-resultCh:
+		return res.lastBlockHeight, res.vals
+	case <-time.After(t):
+		return -1, []*types.Validator{}
+	}
 }

--- a/rpc/core/status_test.go
+++ b/rpc/core/status_test.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tendermint/tendermint/types"
+)
+
+func TestGetValidatorsWithTimeout(t *testing.T) {
+	height, vs := getValidatorsWithTimeout(
+		testValidatorReceiver{},
+		time.Millisecond,
+	)
+
+	if height != -1 {
+		t.Errorf("expected negative height")
+	}
+
+	if len(vs) != 0 {
+		t.Errorf("expected no validators")
+	}
+}
+
+type testValidatorReceiver struct{}
+
+func (tr testValidatorReceiver) GetValidators() (int64, []*types.Validator) {
+	vs := []*types.Validator{}
+
+	for i := 0; i < 3; i++ {
+		v, _ := types.RandValidator(true, 10)
+
+		vs = append(vs, v)
+	}
+
+	time.Sleep(time.Millisecond)
+
+	return 10, vs
+}


### PR DESCRIPTION
Refs #1772 

validator power is `0` when consensus halts

don't think we should do the same for /dump_consensus_state or /consensus_state endpoints cause their entire output depends on consensus state, which we can't get due to mutex.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
