### PR TITLE
compatible old version

### DIFF
--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -82,8 +82,8 @@ func (info NodeInfo) Validate() error {
 // CONTRACT: two nodes are compatible if the major version matches and network match
 // and they have at least one channel in common.
 func (info NodeInfo) CompatibleWith(other NodeInfo) error {
-	iMajor, _, _, iErr := splitVersion(info.Version)
-	oMajor, _, _, oErr := splitVersion(other.Version)
+	_, _, _, iErr := splitVersion(info.Version)
+	_, _, _, oErr := splitVersion(other.Version)
 
 	// if our own version number is not formatted right, we messed up
 	if iErr != nil {
@@ -93,11 +93,6 @@ func (info NodeInfo) CompatibleWith(other NodeInfo) error {
 	// version number must be formatted correctly ("x.x.x")
 	if oErr != nil {
 		return oErr
-	}
-
-	// major version must match
-	if iMajor != oMajor {
-		return fmt.Errorf("Peer is on a different major version. Got %v, expected %v", oMajor, iMajor)
 	}
 
 	// nodes must be on the same network


### PR DESCRIPTION
Now update version must change code： https://github.com/tendermint/tendermint/commit/2fa99628351bd6d4ba14226bb7336135d655ff40.


There is a problem, if  already run old version(major  version different) nodes，and many user use them everyday. I can't upgrade one node which use new version code. 

In my opinion , new version should compatible old version. At least it should not be due to the issue of version number, such as Ethereum 、 Bitcoin
