### PR TITLE
crypto/ed25519: Remove privkey.Generate method

### DIFF
--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -103,27 +103,6 @@ func (privKey PrivKeyEd25519) ToCurve25519() *[PubKeyEd25519Size]byte {
 	return keyCurve25519
 }
 
-// Generate deterministically derives a new priv-key bytes from key.
-// The privkey is generated as Sha256(amino_encode({privkey, index}))
-// Note that we append the public key to the private key, the same way
-// that golang/x/crypto/ed25519 does. See
-// https://github.com/tendermint/ed25519/blob/master/ed25519.go#L39 for
-// further details.
-func (privKey PrivKeyEd25519) Generate(index int) PrivKeyEd25519 {
-	bz := cdc.MustMarshalBinaryBare(struct {
-		PrivKey [64]byte
-		Index   int
-	}{privKey, index})
-	newBytes := crypto.Sha256(bz)
-	newKey := new([64]byte)
-	copy(newKey[:32], newBytes)
-	// ed25519.MakePublicKey(newKey) alters the last 32 bytes of newKey.
-	// It places the pubkey in the last 32 bytes of newKey, and returns the
-	// public key.
-	ed25519.MakePublicKey(newKey)
-	return PrivKeyEd25519(*newKey)
-}
-
 // GenPrivKeyEd25519 generates a new ed25519 private key.
 // It uses OS randomness in conjunction with the current global random seed
 // in tendermint/libs/common to generate the private key.

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -9,16 +9,6 @@ import (
 	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
-func TestGeneratePrivKey(t *testing.T) {
-	testPriv := ed25519.GenPrivKeyEd25519()
-	testGenerate := testPriv.Generate(1)
-	signBytes := []byte("something to sign")
-	pub := testGenerate.PubKey()
-	sig, err := testGenerate.Sign(signBytes)
-	assert.NoError(t, err)
-	assert.True(t, pub.VerifyBytes(signBytes, sig))
-}
-
 func TestSignAndValidateEd25519(t *testing.T) {
 
 	privKey := ed25519.GenPrivKeyEd25519()


### PR DESCRIPTION
The privkey.Generate method here was a custom-made method for deriving
a private key from another private key. This function is currently
not used anywhere in our codebase, and has not been reviewed enough
that it would be secure to use. This removes that method. We should
adopt the official ed25519 HD derivation once that has been standardized,
in order to fulfill this need.

closes #2000

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - n/a?
* [X] Updated all code comments where relevant - n/a
* [X] Wrote tests - n/a
* [ ] Updated CHANGELOG.md - not sure if I should. While this is an API change, it wasn't used anywhere.
