### PR TITLE
abci/types:Make response can be read by humans

### DIFF
--- a/abci/types/types.pb.go
+++ b/abci/types/types.pb.go
@@ -54,6 +54,7 @@ import common "github.com/tendermint/tendermint/libs/common"
 
 import context "golang.org/x/net/context"
 import grpc "google.golang.org/grpc"
+import "strconv"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/abci/types/types.pb.go
+++ b/abci/types/types.pb.go
@@ -1374,6 +1374,21 @@ func (m *ResponseBeginBlock) GetTags() []common.KVPair {
 	return nil
 }
 
+//make response can be read by humans
+func (m *ResponseBeginBlock) GetReadableString() string{
+
+	readableStr := "\n"
+
+	readableStr +="{\n"
+
+	for _,x :=range m.Tags{
+		readableStr += "    "+string(x.Key)+":"+string(x.Value)+"\n"
+	}
+	readableStr +="}"
+
+	return  readableStr
+}
+
 type ResponseCheckTx struct {
 	Code      uint32          `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	Data      []byte          `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
@@ -1444,6 +1459,28 @@ func (m *ResponseCheckTx) GetFee() common.KI64Pair {
 		return m.Fee
 	}
 	return common.KI64Pair{}
+}
+
+//make response can be read by humans
+func (m *ResponseCheckTx) GetReadableString() string{
+
+	readableStr := "\n"
+	readableStr += "Code: " + strconv.Itoa(int(m.Code)) + "\n"
+	readableStr += "Data: " + string(m.Data) + "\n"
+	readableStr += "Log: "   + m.Log + "\n"
+	readableStr += "Info: "  + m.Info + "\n"
+	readableStr += "GasWanted: " + strconv.Itoa(int(m.GasWanted)) +"\n"
+	readableStr += "GasUsed: " + strconv.Itoa(int(m.GasUsed))+"\n"
+	readableStr += "Fee: {"+ string(m.Fee.Key) + ":"+strconv.Itoa(int(m.Fee.Value))+"}\n"
+
+	readableStr +="{\n"
+
+	for _,x :=range m.Tags{
+		readableStr += "    "+string(x.Key)+":"+string(x.Value)+"\n"
+	}
+	readableStr +="}"
+
+	return  readableStr
 }
 
 type ResponseDeliverTx struct {
@@ -1518,11 +1555,36 @@ func (m *ResponseDeliverTx) GetFee() common.KI64Pair {
 	return common.KI64Pair{}
 }
 
+//make response can be read by humans
+func (m *ResponseDeliverTx) GetReadableString() string{
+
+	readableStr := "\n"
+	readableStr += "Code: " + strconv.Itoa(int(m.Code)) + "\n"
+	readableStr += "Data: " + string(m.Data) + "\n"
+	readableStr += "Log: "   + m.Log + "\n"
+	readableStr += "Info: "  + m.Info + "\n"
+	readableStr += "GasWanted: " + strconv.Itoa(int(m.GasWanted)) +"\n"
+	readableStr += "GasUsed: " + strconv.Itoa(int(m.GasUsed))+"\n"
+	readableStr += "Fee: {"+ string(m.Fee.Key) + ":"+strconv.Itoa(int(m.Fee.Value))+"}\n"
+
+	readableStr +="{\n"
+
+	for _,x :=range m.Tags{
+		readableStr += "    "+string(x.Key)+":"+string(x.Value)+"\n"
+	}
+	readableStr +="}"
+
+	return  readableStr
+}
+
+
 type ResponseEndBlock struct {
 	ValidatorUpdates      []Validator      `protobuf:"bytes,1,rep,name=validator_updates,json=validatorUpdates" json:"validator_updates"`
 	ConsensusParamUpdates *ConsensusParams `protobuf:"bytes,2,opt,name=consensus_param_updates,json=consensusParamUpdates" json:"consensus_param_updates,omitempty"`
 	Tags                  []common.KVPair  `protobuf:"bytes,3,rep,name=tags" json:"tags,omitempty"`
 }
+
+
 
 func (m *ResponseEndBlock) Reset()                    { *m = ResponseEndBlock{} }
 func (m *ResponseEndBlock) String() string            { return proto.CompactTextString(m) }


### PR DESCRIPTION
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

For solving the Human Unreadable Bug in CosmosSDK [issue#1604](https://github.com/cosmos/cosmos-sdk/issues/1604),  I think this bug should be fixed in Tendermint. 
So I  add a function to the `Response`  and make `Response`  readable.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
