### PR TITLE
crypto/ed25519: Remove privkey.Generate method

### DIFF
--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -103,27 +103,6 @@ func (privKey PrivKeyEd25519) ToCurve25519() *[PubKeyEd25519Size]byte {
 	return keyCurve25519
 }
 
-// Generate deterministically derives a new priv-key bytes from key.
-// The privkey is generated as Sha256(amino_encode({privkey, index}))
-// Note that we append the public key to the private key, the same way
-// that golang/x/crypto/ed25519 does. See
-// https://github.com/tendermint/ed25519/blob/master/ed25519.go#L39 for
-// further details.
-func (privKey PrivKeyEd25519) Generate(index int) PrivKeyEd25519 {
-	bz := cdc.MustMarshalBinaryBare(struct {
-		PrivKey [64]byte
-		Index   int
-	}{privKey, index})
-	newBytes := crypto.Sha256(bz)
-	newKey := new([64]byte)
-	copy(newKey[:32], newBytes)
-	// ed25519.MakePublicKey(newKey) alters the last 32 bytes of newKey.
-	// It places the pubkey in the last 32 bytes of newKey, and returns the
-	// public key.
-	ed25519.MakePublicKey(newKey)
-	return PrivKeyEd25519(*newKey)
-}
-
 // GenPrivKey generates a new ed25519 private key.
 // It uses OS randomness in conjunction with the current global random seed
 // in tendermint/libs/common to generate the private key.

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -9,16 +9,6 @@ import (
 	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
-func TestGeneratePrivKey(t *testing.T) {
-	testPriv := ed25519.GenPrivKey()
-	testGenerate := testPriv.Generate(1)
-	signBytes := []byte("something to sign")
-	pub := testGenerate.PubKey()
-	sig, err := testGenerate.Sign(signBytes)
-	assert.NoError(t, err)
-	assert.True(t, pub.VerifyBytes(signBytes, sig))
-}
-
 func TestSignAndValidateEd25519(t *testing.T) {
 
 	privKey := ed25519.GenPrivKey()


### PR DESCRIPTION
The privkey.Generate method here was a custom-made method for deriving
a private key from another private key. This function is currently
not used anywhere in our codebase, and has not been reviewed enough
that it would be secure to use. This removes that method. We should
adopt the official ed25519 HD derivation once that has been standardized,
in order to fulfill this need.

closes #2000 

This was originally reviewed and accepted as #2016. Due to having multiple pr's piled up, and the order of merging being super confusing, ending up getting merged to a branch after it got merged to develop. This commit just cherry-picks that, and redirects the PR directly to develop. 

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [X] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [X] Wrote tests
* [X] Updated CHANGELOG.md
