### PR TITLE
rpc: log error when we timeout getting validators from consensus

### DIFF
--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -166,6 +166,9 @@ func getValidatorsWithTimeout(
 	case res := <-resultCh:
 		return res.lastBlockHeight, res.vals
 	case <-time.After(t):
+		if logger != nil {
+			logger.Error("Timed out querying validators from consensus", "timeout", t)
+		}
 		return -1, []*types.Validator{}
 	}
 }


### PR DESCRIPTION
Haven't been able to replicate https://github.com/tendermint/tendermint/issues/1772 and don't want to lose sight of what might be going on there so at least adding this log line