### PR TITLE
Register Evidence Interface on types cdc

### DIFF
--- a/evidence/wire.go
+++ b/evidence/wire.go
@@ -12,14 +12,5 @@ func init() {
 	RegisterEvidenceMessages(cdc)
 	cryptoAmino.RegisterAmino(cdc)
 	types.RegisterEvidences(cdc)
-	RegisterMockEvidences(cdc) // For testing
-}
-
-//-------------------------------------------
-
-func RegisterMockEvidences(cdc *amino.Codec) {
-	cdc.RegisterConcrete(types.MockGoodEvidence{},
-		"tendermint/MockGoodEvidence", nil)
-	cdc.RegisterConcrete(types.MockBadEvidence{},
-		"tendermint/MockBadEvidence", nil)
+	types.RegisterMockEvidences(cdc) // For testing
 }

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	crypto "github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
@@ -99,6 +99,25 @@ func TestBlockMakePartSet(t *testing.T) {
 	partSet := MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil).MakePartSet(1024)
 	assert.NotNil(t, partSet)
 	assert.Equal(t, 1, partSet.Total())
+}
+
+func TestBlockMakePartSetWithEvidence(t *testing.T) {
+	assert.Nil(t, (*Block)(nil).MakePartSet(2))
+
+	txs := []Tx{Tx("foo"), Tx("bar")}
+	lastID := makeBlockIDRandom()
+	h := int64(3)
+
+	voteSet, valSet, vals := randVoteSet(h-1, 1, VoteTypePrecommit, 10, 1)
+	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals)
+	require.NoError(t, err)
+
+	ev := NewMockGoodEvidence(h, 0, valSet.Validators[0].Address)
+	evList := []Evidence{ev}
+
+	partSet := MakeBlock(h, txs, commit, evList).MakePartSet(1024)
+	assert.NotNil(t, partSet)
+	assert.Equal(t, 3, partSet.Total())
 }
 
 func TestBlockHashesTo(t *testing.T) {

--- a/types/wire.go
+++ b/types/wire.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"github.com/tendermint/go-amino"
-	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
+	"github.com/tendermint/tendermint/crypto/encoding/amino"
 )
 
 var cdc = amino.NewCodec()
@@ -10,4 +10,14 @@ var cdc = amino.NewCodec()
 func init() {
 	cryptoAmino.RegisterAmino(cdc)
 	RegisterEvidences(cdc)
+	RegisterMockEvidences(cdc)
+}
+
+//-------------------------------------------
+
+func RegisterMockEvidences(cdc *amino.Codec) {
+	cdc.RegisterConcrete(MockGoodEvidence{},
+		"tendermint/MockGoodEvidence", nil)
+	cdc.RegisterConcrete(MockBadEvidence{},
+		"tendermint/MockBadEvidence", nil)
 }

--- a/types/wire.go
+++ b/types/wire.go
@@ -9,4 +9,5 @@ var cdc = amino.NewCodec()
 
 func init() {
 	cryptoAmino.RegisterAmino(cdc)
+	RegisterEvidences(cdc)
 }


### PR DESCRIPTION
Blocks containing Evidence could not be marshaled since the Evidence interface was not registered on the amino codec of the types package.

I added the registration to the init() of the types wire.go.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGELOG.md
