### PR TITLE
libs: Make bitarray functions lock parameters that aren't the caller

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,7 @@ IMPROVEMENTS:
     - tweak params
     - only process one block at a time to avoid starving
 - [crypto] Switch hkdfchachapoly1305 to xchachapoly1305
+- [common] bit array functions which take in another parameter are now thread safe
 
 BUG FIXES:
 - [privval] fix a deadline for accepting new connections in socket private


### PR DESCRIPTION
This now makes bit array functions which take in a second bit array, thread
safe. Previously there was a warning on bitarray.Update to be lock the
second parameter externally if thread safety wasrequired.
This was not done within the codebase, so it was fine to change here.

Closes #2080

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [X] Updated all relevant documentation in docs - is there any? Updated the relevant godocs
* [X] Updated all code comments where relevant
* [X] Wrote tests - n/a
* [X] Updated CHANGELOG.md
