### PR TITLE
HotFix for 0.22.7, bump to 0.22.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.22.8
+
+*July 26th, 2018*
+
+BUG FIXES
+
+- [consensus, blockchain] Fix 0.22.7 below.
+
 ## 0.22.7
 
 *July 26th, 2018*

--- a/blockchain/wire.go
+++ b/blockchain/wire.go
@@ -2,7 +2,6 @@ package blockchain
 
 import (
 	"github.com/tendermint/go-amino"
-	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -10,6 +9,5 @@ var cdc = amino.NewCodec()
 
 func init() {
 	RegisterBlockchainMessages(cdc)
-	cryptoAmino.RegisterAmino(cdc)
-	types.RegisterEvidences(cdc)
+	types.RegisterBlockAmino(cdc)
 }

--- a/consensus/types/wire.go
+++ b/consensus/types/wire.go
@@ -2,13 +2,11 @@ package types
 
 import (
 	"github.com/tendermint/go-amino"
-	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 	"github.com/tendermint/tendermint/types"
 )
 
 var cdc = amino.NewCodec()
 
 func init() {
-	cryptoAmino.RegisterAmino(cdc)
-	types.RegisterEvidences(cdc)
+	types.RegisterBlockAmino(cdc)
 }

--- a/consensus/wire.go
+++ b/consensus/wire.go
@@ -2,7 +2,7 @@ package consensus
 
 import (
 	"github.com/tendermint/go-amino"
-	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
+	"github.com/tendermint/tendermint/types"
 )
 
 var cdc = amino.NewCodec()
@@ -10,5 +10,5 @@ var cdc = amino.NewCodec()
 func init() {
 	RegisterConsensusMessages(cdc)
 	RegisterWALMessages(cdc)
-	cryptoAmino.RegisterAmino(cdc)
+	types.RegisterBlockAmino(cdc)
 }

--- a/lite/files/wire.go
+++ b/lite/files/wire.go
@@ -2,11 +2,11 @@ package files
 
 import (
 	"github.com/tendermint/go-amino"
-	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
+	"github.com/tendermint/tendermint/types"
 )
 
 var cdc = amino.NewCodec()
 
 func init() {
-	cryptoAmino.RegisterAmino(cdc)
+	types.RegisterBlockAmino(cdc)
 }

--- a/rpc/core/types/wire.go
+++ b/rpc/core/types/wire.go
@@ -2,12 +2,10 @@ package core_types
 
 import (
 	"github.com/tendermint/go-amino"
-	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 	"github.com/tendermint/tendermint/types"
 )
 
 func RegisterAmino(cdc *amino.Codec) {
 	types.RegisterEventDatas(cdc)
-	types.RegisterEvidences(cdc)
-	cryptoAmino.RegisterAmino(cdc)
+	types.RegisterBlockAmino(cdc)
 }

--- a/types/wire.go
+++ b/types/wire.go
@@ -8,6 +8,10 @@ import (
 var cdc = amino.NewCodec()
 
 func init() {
+	RegisterBlockAmino(cdc)
+}
+
+func RegisterBlockAmino(cdc *amino.Codec) {
 	cryptoAmino.RegisterAmino(cdc)
 	RegisterEvidences(cdc)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -4,13 +4,13 @@ package version
 const (
 	Maj = "0"
 	Min = "22"
-	Fix = "7"
+	Fix = "8"
 )
 
 var (
 	// Version is the current version of Tendermint
 	// Must be a string because scripts like dist.sh read this file.
-	Version = "0.22.7"
+	Version = "0.22.8"
 
 	// GitCommit is the current HEAD set using ldflags.
 	GitCommit string


### PR DESCRIPTION
Register codecs more properly, refactor/dry code to prevent issues in the future.