### PR TITLE
libs/autofile/group_test: Remove unnecessary logging

### DIFF
--- a/libs/autofile/group_test.go
+++ b/libs/autofile/group_test.go
@@ -147,14 +147,13 @@ func TestSearch(t *testing.T) {
 
 	// Now search for each number
 	for i := 0; i < 100; i++ {
-		t.Log("Testing for i", i)
 		gr, match, err := g.Search("INFO", makeSearchFunc(i))
-		require.NoError(t, err, "Failed to search for line")
-		assert.True(t, match, "Expected Search to return exact match")
+		require.NoError(t, err, "Failed to search for line, tc #%d", i)
+		assert.True(t, match, "Expected Search to return exact match, tc #%d", i)
 		line, err := gr.ReadLine()
-		require.NoError(t, err, "Failed to read line after search")
+		require.NoError(t, err, "Failed to read line after search, tc #%d", i)
 		if !strings.HasPrefix(line, fmt.Sprintf("INFO %v ", i)) {
-			t.Fatal("Failed to get correct line")
+			t.Fatalf("Failed to get correct line, tc #%d", i)
 		}
 		// Make sure we can continue to read from there.
 		cur := i + 1
@@ -165,16 +164,16 @@ func TestSearch(t *testing.T) {
 					// OK!
 					break
 				} else {
-					t.Fatal("Got EOF after the wrong INFO #")
+					t.Fatalf("Got EOF after the wrong INFO #, tc #%d", i)
 				}
 			} else if err != nil {
-				t.Fatal("Error reading line", err)
+				t.Fatalf("Error reading line, tc #%d, err:\n%s", i, err)
 			}
 			if !strings.HasPrefix(line, "INFO ") {
 				continue
 			}
 			if !strings.HasPrefix(line, fmt.Sprintf("INFO %v ", cur)) {
-				t.Fatalf("Unexpected INFO #. Expected %v got:\n%v", cur, line)
+				t.Fatalf("Unexpected INFO #. Expected %v got:\n%v, tc #%d", cur, line, i)
 			}
 			cur++
 		}


### PR DESCRIPTION
Previously we logged `Testing for i <i>` for all i in [0,100).
This was unnecessary. This changes it to just log the value for i on
error messages, to reduce the unnecessary verbosity in the circle log files for testing.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - n/a?
* [ ] Updated all code comments where relevant - I think its sufficiently clear?
* [X] Wrote tests
* [ ] Updated CHANGELOG.md - does this warrant a changelog update?
