### PR TITLE
ci: Reduce log output in test_cover

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
             for pkg in $(go list github.com/tendermint/tendermint/... | circleci tests split --split-by=timings); do
               id=$(basename "$pkg")
 
-              GOCACHE=off go test -v -timeout 5m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
+              GOCACHE=off go test -timeout 5m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
             done
       - persist_to_workspace:
           root: /tmp/workspace


### PR DESCRIPTION
This commit makes it such that circle CI only shows the module whose
tests it is currently running in the log, unless a test fails. For each
failing test, it will display the name of all failing tests, along with
their log output. This is done to make
our log output far more scrollable. We lose no information in debugging.

An example with `go test`:
I added t.Log("test name") and t.Fail() to the bottom of two tests, and then ran go test, the following log output appeared:
```
 go test
--- FAIL: TestErrorPanic (0.00s)
	errors_test.go:30: TESTERRORPANIC
--- FAIL: TestErrorNewErrorWithTrace (0.00s)
	errors_test.go:97: TestErrorNewErrorWithTrace
```
(This test code is not in the commit, its just meant to show how it works)
Take a look at the CI logs!

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - n/a
* [ ] Updated all code comments where relevant - n/a
* [ ] Wrote tests - n/a
* [ ] Updated CHANGELOG.md - not user facing, only affects CI + reviewing PR's
