### PR TITLE
libs/cmn: Remove Tempfile, Tempdir, switch to ioutil variants

### DIFF
--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -378,8 +378,11 @@ func randConsensusNetWithPeers(nValidators, nPeers int, testName string, tickerF
 		if i < nValidators {
 			privVal = privVals[i]
 		} else {
-			_, tempFilePath := cmn.Tempfile("priv_validator_")
-			privVal = privval.GenFilePV(tempFilePath)
+			tempFile, err := ioutil.TempFile("", "priv_validator_")
+			if err != nil {
+				panic(err)
+			}
+			privVal = privval.GenFilePV(tempFile.Name())
 		}
 
 		app := appFunc()

--- a/libs/autofile/autofile_test.go
+++ b/libs/autofile/autofile_test.go
@@ -1,6 +1,7 @@
 package autofile
 
 import (
+	"io/ioutil"
 	"os"
 	"sync/atomic"
 	"syscall"
@@ -13,10 +14,14 @@ import (
 func TestSIGHUP(t *testing.T) {
 
 	// First, create an AutoFile writing to a tempfile dir
-	file, name := cmn.Tempfile("sighup_test")
-	if err := file.Close(); err != nil {
+	file, err := ioutil.TempFile("", "sighup_test")
+	if err != nil {
 		t.Fatalf("Error creating tempfile: %v", err)
 	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Error closing tempfile: %v", err)
+	}
+	name := file.Name()
 	// Here is the actual AutoFile
 	af, err := OpenAutoFile(name)
 	if err != nil {

--- a/libs/common/tempfile.go
+++ b/libs/common/tempfile.go
@@ -3,7 +3,6 @@ package common
 import (
 	fmt "fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -123,27 +122,4 @@ func WriteFileAtomic(filename string, data []byte, perm os.FileMode) (err error)
 	f.Close()
 
 	return os.Rename(f.Name(), filename)
-}
-
-//--------------------------------------------------------------------------------
-
-func Tempfile(prefix string) (*os.File, string) {
-	file, err := ioutil.TempFile("", prefix)
-	if err != nil {
-		PanicCrisis(err)
-	}
-	return file, file.Name()
-}
-
-func Tempdir(prefix string) (*os.File, string) {
-	tempDir := os.TempDir() + "/" + prefix + RandStr(12)
-	err := EnsureDir(tempDir, 0700)
-	if err != nil {
-		panic(Fmt("Error creating temp dir: %v", err))
-	}
-	dir, err := os.Open(tempDir)
-	if err != nil {
-		panic(Fmt("Error opening temp dir: %v", err))
-	}
-	return dir, tempDir
 }

--- a/libs/db/backend_test.go
+++ b/libs/db/backend_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,8 +18,8 @@ func cleanupDBDir(dir, name string) {
 
 func testBackendGetSetDelete(t *testing.T, backend DBBackendType) {
 	// Default
-	dir, dirname := cmn.Tempdir(fmt.Sprintf("test_backend_%s_", backend))
-	defer dir.Close()
+	dirname, err := ioutil.TempDir("", fmt.Sprintf("test_backend_%s_", backend))
+	require.Nil(t, err)
 	db := NewDB("testdb", backend, dirname)
 
 	// A nonexistent key should return nil, even if the key is empty

--- a/libs/db/common_test.go
+++ b/libs/db/common_test.go
@@ -2,12 +2,12 @@ package db
 
 import (
 	"fmt"
+	"io/ioutil"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
 //----------------------------------------
@@ -61,9 +61,9 @@ func checkValuePanics(t *testing.T, itr Iterator) {
 }
 
 func newTempDB(t *testing.T, backend DBBackendType) (db DB) {
-	dir, dirname := cmn.Tempdir("db_common_test")
+	dirname, err := ioutil.TempDir("", "db_common_test")
+	require.Nil(t, err)
 	db = NewDB("testdb", backend, dirname)
-	dir.Close()
 	return db
 }
 


### PR DESCRIPTION
Our Tempfile was just a wrapper on ioutil that panicked instead of error.

Our Tempdir was a less safe variant of ioutil's Tempdir.

They have both been removed in favor of ioutil. If my other write file atomic PR is merged first, please rebase this onto develop.

Ref https://github.com/tendermint/tendermint/pull/2113#discussion_r206333777
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [X] Updated all relevant documentation in docs - n/a
* [ ] Updated all code comments where relevant - comments seems sufficient to me
* [X] Wrote tests - n/a?
* [X] Updated CHANGELOG.md
