### PR TITLE
p2p/pex: Connect to peers from a seed node immediately

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,7 +20,7 @@ IMPROVEMENTS:
     - only process one block at a time to avoid starving
 - [crypto] Switch hkdfchachapoly1305 to xchachapoly1305
 - [common] bit array functions which take in another parameter are now thread safe
-- [p2p] \#2093 begin connecting to peers as soon a seed node provides them to you
+- [p2p] begin connecting to peers as soon a seed node provides them to you ([#2093](https://github.com/tendermint/tendermint/issues/2093))
 
 BUG FIXES:
 - [privval] fix a deadline for accepting new connections in socket private

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,7 @@ IMPROVEMENTS:
     - only process one block at a time to avoid starving
 - [crypto] Switch hkdfchachapoly1305 to xchachapoly1305
 - [common] bit array functions which take in another parameter are now thread safe
+- [p2p] \#2093 begin connecting to peers as soon a seed node provides them to you
 
 BUG FIXES:
 - [privval] fix a deadline for accepting new connections in socket private

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -304,7 +304,7 @@ func (r *PEXReactor) ReceiveAddrs(addrs []*p2p.NetAddress, src Peer) error {
 
 		// If this address came from a seed node, try to connect to it without waiting.
 		for _, seedAddr := range r.seedAddrs {
-			if seedAddr == srcAddr {
+			if seedAddr.Equals(srcAddr) {
 				r.ensurePeers()
 			}
 		}

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -211,12 +211,12 @@ func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 	defer os.RemoveAll(dir) // nolint: errcheck
 
 	// 1. create seed
-	seed := createSeed(dir, 0, []*p2p.NetAddress{}, []*p2p.NetAddress{})
+	seed := testCreateSeed(dir, 0, []*p2p.NetAddress{}, []*p2p.NetAddress{})
 	require.Nil(t, seed.Start())
 	defer seed.Stop()
 
 	// 2. create usual peer with only seed configured.
-	peer := createPeerWithSeed(dir, 1, seed)
+	peer := testCreatePeerWithSeed(dir, 1, seed)
 	require.Nil(t, peer.Start())
 	defer peer.Stop()
 
@@ -259,12 +259,12 @@ func TestConnectionSpeedForPeerReceivedFromSeed(t *testing.T) {
 	defer peer.Stop()
 
 	// 2. Create seed which knows about the peer
-	seed := createSeed(dir, 2, []*p2p.NetAddress{peer.NodeInfo().NetAddress()}, []*p2p.NetAddress{peer.NodeInfo().NetAddress()})
+	seed := testCreateSeed(dir, 2, []*p2p.NetAddress{peer.NodeInfo().NetAddress()}, []*p2p.NetAddress{peer.NodeInfo().NetAddress()})
 	require.Nil(t, seed.Start())
 	defer seed.Stop()
 
 	// 3. create another peer with only seed configured.
-	secondPeer := createPeerWithSeed(dir, 3, seed)
+	secondPeer := testCreatePeerWithSeed(dir, 3, seed)
 	require.Nil(t, secondPeer.Start())
 	defer secondPeer.Stop()
 
@@ -437,7 +437,7 @@ func assertPeersWithTimeout(
 
 // Creates a seed which knows about the provided addresses / source address pairs.
 // Starting and stopping the seed is left to the caller
-func createSeed(dir string, id int, knownAddrs, srcAddrs []*p2p.NetAddress) *p2p.Switch {
+func testCreateSeed(dir string, id int, knownAddrs, srcAddrs []*p2p.NetAddress) *p2p.Switch {
 	seed := p2p.MakeSwitch(
 		cfg,
 		id,
@@ -468,7 +468,7 @@ func createSeed(dir string, id int, knownAddrs, srcAddrs []*p2p.NetAddress) *p2p
 
 // Creates a peer which knows about the provided seed.
 // Starting and stopping the peer is left to the caller
-func createPeerWithSeed(dir string, id int, seed *p2p.Switch) *p2p.Switch {
+func testCreatePeerWithSeed(dir string, id int, seed *p2p.Switch) *p2p.Switch {
 	peer := p2p.MakeSwitch(
 		cfg,
 		id,

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -211,31 +211,26 @@ func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 	defer os.RemoveAll(dir) // nolint: errcheck
 
 	// 1. create seed
-	seed := p2p.MakeSwitch(
-		cfg,
-		0,
-		"127.0.0.1",
-		"123.123.123",
-		func(i int, sw *p2p.Switch) *p2p.Switch {
-			book := NewAddrBook(filepath.Join(dir, "addrbook0.json"), false)
-			book.SetLogger(log.TestingLogger())
-			sw.SetAddrBook(book)
-
-			sw.SetLogger(log.TestingLogger())
-
-			r := NewPEXReactor(book, &PEXReactorConfig{})
-			r.SetLogger(log.TestingLogger())
-			sw.AddReactor("pex", r)
-			return sw
-		},
-	)
-	seed.AddListener(
-		p2p.NewDefaultListener("tcp://"+seed.NodeInfo().ListenAddr, "", false, log.TestingLogger()),
-	)
+	seed := createSeed(dir, 0, []*p2p.NetAddress{}, []*p2p.NetAddress{})
 	require.Nil(t, seed.Start())
 	defer seed.Stop()
 
 	// 2. create usual peer with only seed configured.
+	peer := createPeerWithSeed(dir, 1, seed)
+	require.Nil(t, peer.Start())
+	defer peer.Stop()
+
+	// 3. check that the peer connects to seed immediately
+	assertPeersWithTimeout(t, []*p2p.Switch{peer}, 10*time.Millisecond, 3*time.Second, 1)
+}
+
+func TestConnectionSpeedForPeerReceivedFromSeed(t *testing.T) {
+	// directory to store address books
+	dir, err := ioutil.TempDir("", "pex_reactor")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir) // nolint: errcheck
+
+	// 1. create peer
 	peer := p2p.MakeSwitch(
 		cfg,
 		1,
@@ -250,20 +245,34 @@ func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 
 			r := NewPEXReactor(
 				book,
-				&PEXReactorConfig{
-					Seeds: []string{seed.NodeInfo().NetAddress().String()},
-				},
+				&PEXReactorConfig{},
 			)
 			r.SetLogger(log.TestingLogger())
 			sw.AddReactor("pex", r)
 			return sw
 		},
 	)
+	peer.AddListener(
+		p2p.NewDefaultListener("tcp://"+peer.NodeInfo().ListenAddr, "", false, log.TestingLogger()),
+	)
 	require.Nil(t, peer.Start())
 	defer peer.Stop()
 
-	// 3. check that the peer connects to seed immediately
-	assertPeersWithTimeout(t, []*p2p.Switch{peer}, 10*time.Millisecond, 3*time.Second, 1)
+	// 2. Create seed which knows about the peer
+	seed := createSeed(dir, 2, []*p2p.NetAddress{peer.NodeInfo().NetAddress()}, []*p2p.NetAddress{peer.NodeInfo().NetAddress()})
+	require.Nil(t, seed.Start())
+	defer seed.Stop()
+
+	// 3. create another peer with only seed configured.
+	secondPeer := createPeerWithSeed(dir, 3, seed)
+	require.Nil(t, secondPeer.Start())
+	defer secondPeer.Stop()
+
+	// 4. check that the second peer connects to seed immediately
+	assertPeersWithTimeout(t, []*p2p.Switch{secondPeer}, 10*time.Millisecond, 3*time.Second, 1)
+
+	// 5. check that the second peer connects to the first peer immediately
+	assertPeersWithTimeout(t, []*p2p.Switch{secondPeer}, 10*time.Millisecond, 1*time.Second, 2)
 }
 
 func TestPEXReactorCrawlStatus(t *testing.T) {
@@ -401,6 +410,7 @@ func assertPeersWithTimeout(
 				outbound, inbound, _ := s.NumPeers()
 				if outbound+inbound < nPeers {
 					allGood = false
+					break
 				}
 			}
 			remaining -= checkPeriod
@@ -417,12 +427,75 @@ func assertPeersWithTimeout(
 				numPeersStr += fmt.Sprintf("%d => {outbound: %d, inbound: %d}, ", i, outbound, inbound)
 			}
 			t.Errorf(
-				"expected all switches to be connected to at least one peer (switches: %s)",
-				numPeersStr,
+				"expected all switches to be connected to at least %d peer(s) (switches: %s)",
+				nPeers, numPeersStr,
 			)
 			return
 		}
 	}
+}
+
+// Creates a seed which knows about the provided addresses / source address pairs.
+// Starting and stopping the seed is left to the caller
+func createSeed(dir string, id int, knownAddrs, srcAddrs []*p2p.NetAddress) *p2p.Switch {
+	seed := p2p.MakeSwitch(
+		cfg,
+		id,
+		"127.0.0.1",
+		"123.123.123",
+		func(i int, sw *p2p.Switch) *p2p.Switch {
+			book := NewAddrBook(filepath.Join(dir, "addrbookSeed.json"), false)
+			book.SetLogger(log.TestingLogger())
+			for j := 0; j < len(knownAddrs); j++ {
+				book.AddAddress(knownAddrs[j], srcAddrs[j])
+				book.MarkGood(knownAddrs[j])
+			}
+			sw.SetAddrBook(book)
+
+			sw.SetLogger(log.TestingLogger())
+
+			r := NewPEXReactor(book, &PEXReactorConfig{})
+			r.SetLogger(log.TestingLogger())
+			sw.AddReactor("pex", r)
+			return sw
+		},
+	)
+	seed.AddListener(
+		p2p.NewDefaultListener("tcp://"+seed.NodeInfo().ListenAddr, "", false, log.TestingLogger()),
+	)
+	return seed
+}
+
+// Creates a peer which knows about the provided seed.
+// Starting and stopping the peer is left to the caller
+func createPeerWithSeed(dir string, id int, seed *p2p.Switch) *p2p.Switch {
+	peer := p2p.MakeSwitch(
+		cfg,
+		id,
+		"127.0.0.1",
+		"123.123.123",
+		func(i int, sw *p2p.Switch) *p2p.Switch {
+			book := NewAddrBook(filepath.Join(dir, fmt.Sprintf("addrbook%d.json", id)), false)
+			book.SetLogger(log.TestingLogger())
+			sw.SetAddrBook(book)
+
+			sw.SetLogger(log.TestingLogger())
+
+			r := NewPEXReactor(
+				book,
+				&PEXReactorConfig{
+					Seeds: []string{seed.NodeInfo().NetAddress().String()},
+				},
+			)
+			r.SetLogger(log.TestingLogger())
+			sw.AddReactor("pex", r)
+			return sw
+		},
+	)
+	peer.AddListener(
+		p2p.NewDefaultListener("tcp://"+peer.NodeInfo().ListenAddr, "", false, log.TestingLogger()),
+	)
+	return peer
 }
 
 func createReactor(conf *PEXReactorConfig) (r *PEXReactor, book *addrBook) {


### PR DESCRIPTION
This is to reduce wait times when initially connecting. This still runs checks
such as whether you still want additional peers.

A test case has been created, which fails if this change is not included.

This is to reduce wait times when initially connecting. This still runs checks
such as whether you still want additional peers.

A test case has been created, which fails if this change is not included.

Closes #2093 
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - should I update the docs here?
* [X] Updated all code comments where relevant
* [X] Wrote tests
* [X] Updated CHANGELOG.md
