### PR TITLE
crypto: Remove interface from crypto.Signature

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,7 @@ BREAKING CHANGES:
 - [p2p] Remove salsa and ripemd primitives, in favor of using chacha as a stream cipher, and hkdf
 - [abci] Changed time format from int64 to google.protobuf.Timestamp
 - [abci] Changed Validators to LastCommitInfo in RequestBeginBlock
+- [crypto] Switch crypto.Signature from interface to []byte for space efficiency
 
 FEATURES:
 - [tools] Added `make check_dep`

--- a/abci/example/example_test.go
+++ b/abci/example/example_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"google.golang.org/grpc"
 
 	"golang.org/x/net/context"
@@ -43,7 +45,7 @@ func testStream(t *testing.T, app types.Application) {
 	server := abciserver.NewSocketServer("unix://test.sock", app)
 	server.SetLogger(log.TestingLogger().With("module", "abci-server"))
 	if err := server.Start(); err != nil {
-		t.Fatalf("Error starting socket server: %v", err.Error())
+		require.NoError(t, err, "Error starting socket server")
 	}
 	defer server.Stop()
 

--- a/consensus/types/round_state_test.go
+++ b/consensus/types/round_state_test.go
@@ -23,7 +23,7 @@ func BenchmarkRoundStateDeepCopy(b *testing.B) {
 			Hash: cmn.RandBytes(20),
 		},
 	}
-	sig := ed25519.SignatureEd25519{}
+	sig := make([]byte, ed25519.SignatureEd25519Size)
 	for i := 0; i < nval; i++ {
 		precommits[i] = &types.Vote{
 			ValidatorAddress: types.Address(cmn.RandBytes(20)),

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -24,9 +24,7 @@ crypto `.Bytes()` uses Amino:binary encoding, but Amino:JSON is also supported.
 Example Amino:JSON encodings:
 
 ed25519.PrivKeyEd25519     - {"type":"954568A3288910","value":"EVkqJO/jIXp3rkASXfh9YnyToYXRXhBr6g9cQVxPFnQBP/5povV4HTjvsy530kybxKHwEi85iU8YL0qQhSYVoQ=="}
-crypto.SignatureEd25519   - {"type":"6BF5903DA1DB28","value":"77sQNZOrf7ltExpf7AV1WaYPCHbyRLgjBsoWVzcduuLk+jIGmYk+s5R6Emm29p12HeiNAuhUJgdFGmwkpeGJCA=="}
 ed25519.PubKeyEd25519      - {"type":"AC26791624DE60","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="}
 crypto.PrivKeySecp256k1   - {"type":"019E82E1B0F798","value":"zx4Pnh67N+g2V+5vZbQzEyRerX9c4ccNZOVzM9RvJ0Y="}
-crypto.SignatureSecp256k1 - {"type":"6D1EA416E1FEE8","value":"MEUCIQCIg5TqS1l7I+MKTrSPIuUN2+4m5tA29dcauqn3NhEJ2wIgICaZ+lgRc5aOTVahU/XoLopXKn8BZcl0bnuYWLvohR8="}
 crypto.PubKeySecp256k1    - {"type":"F8CCEAEB5AE980","value":"A8lPKJXcNl5VHt1FK8a244K9EJuS4WX1hFBnwisi0IJx"}
 ```

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -6,7 +6,7 @@ import (
 
 type PrivKey interface {
 	Bytes() []byte
-	Sign(msg []byte) (Signature, error)
+	Sign(msg []byte) ([]byte, error)
 	PubKey() PubKey
 	Equals(PrivKey) bool
 }
@@ -19,14 +19,8 @@ type Address = cmn.HexBytes
 type PubKey interface {
 	Address() Address
 	Bytes() []byte
-	VerifyBytes(msg []byte, sig Signature) bool
+	VerifyBytes(msg []byte, sig []byte) bool
 	Equals(PubKey) bool
-}
-
-type Signature interface {
-	Bytes() []byte
-	IsZero() bool
-	Equals(Signature) bool
 }
 
 type Symmetric interface {

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -23,9 +23,7 @@ func TestSignAndValidateEd25519(t *testing.T) {
 
 	// Mutate the signature, just one bit.
 	// TODO: Replace this with a much better fuzzer, tendermint/ed25519/issues/10
-	sigEd := sig.(ed25519.SignatureEd25519)
-	sigEd[7] ^= byte(0x01)
-	sig = sigEd
+	sig[7] ^= byte(0x01)
 
 	assert.False(t, pubKey.VerifyBytes(msg, sig))
 }

--- a/crypto/encoding/amino/amino.go
+++ b/crypto/encoding/amino/amino.go
@@ -33,12 +33,6 @@ func RegisterAmino(cdc *amino.Codec) {
 		"tendermint/PrivKeyEd25519", nil)
 	cdc.RegisterConcrete(secp256k1.PrivKeySecp256k1{},
 		"tendermint/PrivKeySecp256k1", nil)
-
-	cdc.RegisterInterface((*crypto.Signature)(nil), nil)
-	cdc.RegisterConcrete(ed25519.SignatureEd25519{},
-		"tendermint/SignatureEd25519", nil)
-	cdc.RegisterConcrete(secp256k1.SignatureSecp256k1{},
-		"tendermint/SignatureSecp256k1", nil)
 }
 
 func PrivKeyFromBytes(privKeyBytes []byte) (privKey crypto.PrivKey, err error) {
@@ -47,11 +41,6 @@ func PrivKeyFromBytes(privKeyBytes []byte) (privKey crypto.PrivKey, err error) {
 }
 
 func PubKeyFromBytes(pubKeyBytes []byte) (pubKey crypto.PubKey, err error) {
-	err = cdc.UnmarshalBinaryBare(pubKeyBytes, &pubKey)
-	return
-}
-
-func SignatureFromBytes(pubKeyBytes []byte) (pubKey crypto.Signature, err error) {
 	err = cdc.UnmarshalBinaryBare(pubKeyBytes, &pubKey)
 	return
 }

--- a/crypto/encoding/amino/encode_test.go
+++ b/crypto/encoding/amino/encode_test.go
@@ -59,20 +59,18 @@ func ExamplePrintRegisteredTypes() {
 
 func TestKeyEncodings(t *testing.T) {
 	cases := []struct {
-		privKey                    crypto.PrivKey
-		privSize, pubSize, sigSize int // binary sizes
+		privKey           crypto.PrivKey
+		privSize, pubSize int // binary sizes
 	}{
 		{
 			privKey:  ed25519.GenPrivKey(),
 			privSize: 69,
 			pubSize:  37,
-			sigSize:  65,
 		},
 		{
 			privKey:  secp256k1.GenPrivKey(),
 			privSize: 37,
 			pubSize:  38,
-			sigSize:  71, // can also be 72
 		},
 	}
 

--- a/crypto/encoding/amino/encode_test.go
+++ b/crypto/encoding/amino/encode_test.go
@@ -15,12 +15,14 @@ type byter interface {
 	Bytes() []byte
 }
 
-func checkAminoBinary(t *testing.T, src byter, dst interface{}, size int) {
+func checkAminoBinary(t *testing.T, src, dst interface{}, size int) {
 	// Marshal to binary bytes.
 	bz, err := cdc.MarshalBinaryBare(src)
 	require.Nil(t, err, "%+v", err)
-	// Make sure this is compatible with current (Bytes()) encoding.
-	assert.Equal(t, src.Bytes(), bz, "Amino binary vs Bytes() mismatch")
+	if byterSrc, ok := src.(byter); ok {
+		// Make sure this is compatible with current (Bytes()) encoding.
+		assert.Equal(t, byterSrc.Bytes(), bz, "Amino binary vs Bytes() mismatch")
+	}
 	// Make sure we have the expected length.
 	if size != -1 {
 		assert.Equal(t, size, len(bz), "Amino binary size mismatch")
@@ -53,24 +55,24 @@ func ExamplePrintRegisteredTypes() {
 	//| PubKeySecp256k1 | tendermint/PubKeySecp256k1 | 0xEB5AE987 | 0x21 |  |
 	//| PrivKeyEd25519 | tendermint/PrivKeyEd25519 | 0xA3288910 | 0x40 |  |
 	//| PrivKeySecp256k1 | tendermint/PrivKeySecp256k1 | 0xE1B0F79B | 0x20 |  |
-	//| SignatureEd25519 | tendermint/SignatureEd25519 | 0x2031EA53 | 0x40 |  |
-	//| SignatureSecp256k1 | tendermint/SignatureSecp256k1 | 0x7FC4A495 | variable |  |
 }
 
 func TestKeyEncodings(t *testing.T) {
 	cases := []struct {
-		privKey           crypto.PrivKey
-		privSize, pubSize int // binary sizes
+		privKey                    crypto.PrivKey
+		privSize, pubSize, sigSize int // binary sizes
 	}{
 		{
 			privKey:  ed25519.GenPrivKey(),
 			privSize: 69,
 			pubSize:  37,
+			sigSize:  65,
 		},
 		{
 			privKey:  secp256k1.GenPrivKey(),
 			privSize: 37,
 			pubSize:  38,
+			sigSize:  71, // can also be 72
 		},
 	}
 
@@ -84,13 +86,11 @@ func TestKeyEncodings(t *testing.T) {
 		assert.EqualValues(t, tc.privKey, priv3, "tc #%d", tcIndex)
 
 		// Check (de/en)codings of Signatures.
-		var sig1, sig2, sig3 crypto.Signature
+		var sig1, sig2 []byte
 		sig1, err := tc.privKey.Sign([]byte("something"))
 		assert.NoError(t, err, "tc #%d", tcIndex)
 		checkAminoBinary(t, sig1, &sig2, -1) // Signature size changes for Secp anyways.
 		assert.EqualValues(t, sig1, sig2, "tc #%d", tcIndex)
-		checkAminoJSON(t, sig1, &sig3, false) // TODO also check Prefix bytes.
-		assert.EqualValues(t, sig1, sig3, "tc #%d", tcIndex)
 
 		// Check (de/en)codings of PubKeys.
 		pubKey := tc.privKey.PubKey()
@@ -105,7 +105,7 @@ func TestKeyEncodings(t *testing.T) {
 func TestNilEncodings(t *testing.T) {
 
 	// Check nil Signature.
-	var a, b crypto.Signature
+	var a, b []byte
 	checkAminoJSON(t, &a, &b, true)
 	assert.EqualValues(t, a, b)
 

--- a/crypto/secp256k1/secpk256k1_test.go
+++ b/crypto/secp256k1/secpk256k1_test.go
@@ -59,9 +59,7 @@ func TestSignAndValidateSecp256k1(t *testing.T) {
 	assert.True(t, pubKey.VerifyBytes(msg, sig))
 
 	// Mutate the signature, just one bit.
-	sigEd := sig.(secp256k1.SignatureSecp256k1)
-	sigEd[3] ^= byte(0x01)
-	sig = sigEd
+	sig[3] ^= byte(0x01)
 
 	assert.False(t, pubKey.VerifyBytes(msg, sig))
 }

--- a/node/id.go
+++ b/node/id.go
@@ -26,7 +26,7 @@ type NodeGreeting struct {
 
 type SignedNodeGreeting struct {
 	NodeGreeting
-	Signature crypto.Signature
+	Signature []byte
 }
 
 func (pnid *PrivNodeID) SignGreeting() *SignedNodeGreeting {

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -285,7 +285,7 @@ func sort32(foo, bar *[32]byte) (lo, hi *[32]byte) {
 	return
 }
 
-func signChallenge(challenge *[32]byte, locPrivKey crypto.PrivKey) (signature crypto.Signature) {
+func signChallenge(challenge *[32]byte, locPrivKey crypto.PrivKey) (signature []byte) {
 	signature, err := locPrivKey.Sign(challenge[:])
 	// TODO(ismail): let signChallenge return an error instead
 	if err != nil {
@@ -296,10 +296,10 @@ func signChallenge(challenge *[32]byte, locPrivKey crypto.PrivKey) (signature cr
 
 type authSigMessage struct {
 	Key crypto.PubKey
-	Sig crypto.Signature
+	Sig []byte
 }
 
-func shareAuthSignature(sc *SecretConnection, pubKey crypto.PubKey, signature crypto.Signature) (recvMsg authSigMessage, err error) {
+func shareAuthSignature(sc *SecretConnection, pubKey crypto.PubKey, signature []byte) (recvMsg authSigMessage, err error) {
 
 	// Send our info and receive theirs in tandem.
 	var trs, _ = cmn.Parallel(

--- a/privval/priv_validator.go
+++ b/privval/priv_validator.go
@@ -38,14 +38,14 @@ func voteToStep(vote *types.Vote) int8 {
 // to prevent double signing.
 // NOTE: the directory containing the pv.filePath must already exist.
 type FilePV struct {
-	Address       types.Address    `json:"address"`
-	PubKey        crypto.PubKey    `json:"pub_key"`
-	LastHeight    int64            `json:"last_height"`
-	LastRound     int              `json:"last_round"`
-	LastStep      int8             `json:"last_step"`
-	LastSignature crypto.Signature `json:"last_signature,omitempty"` // so we dont lose signatures XXX Why would we lose signatures?
-	LastSignBytes cmn.HexBytes     `json:"last_signbytes,omitempty"` // so we dont lose signatures XXX Why would we lose signatures?
-	PrivKey       crypto.PrivKey   `json:"priv_key"`
+	Address       types.Address  `json:"address"`
+	PubKey        crypto.PubKey  `json:"pub_key"`
+	LastHeight    int64          `json:"last_height"`
+	LastRound     int            `json:"last_round"`
+	LastStep      int8           `json:"last_step"`
+	LastSignature []byte         `json:"last_signature,omitempty"` // so we dont lose signatures XXX Why would we lose signatures?
+	LastSignBytes cmn.HexBytes   `json:"last_signbytes,omitempty"` // so we dont lose signatures XXX Why would we lose signatures?
+	PrivKey       crypto.PrivKey `json:"priv_key"`
 
 	// For persistence.
 	// Overloaded for testing.
@@ -138,7 +138,7 @@ func (pv *FilePV) save() {
 // Reset resets all fields in the FilePV.
 // NOTE: Unsafe!
 func (pv *FilePV) Reset() {
-	var sig crypto.Signature
+	var sig []byte
 	pv.LastHeight = 0
 	pv.LastRound = 0
 	pv.LastStep = 0
@@ -277,7 +277,7 @@ func (pv *FilePV) signProposal(chainID string, proposal *types.Proposal) error {
 
 // Persist height/round/step and signature
 func (pv *FilePV) saveSigned(height int64, round int, step int8,
-	signBytes []byte, sig crypto.Signature) {
+	signBytes []byte, sig []byte) {
 
 	pv.LastHeight = height
 	pv.LastRound = round

--- a/privval/priv_validator_test.go
+++ b/privval/priv_validator_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/types"
 )
@@ -194,7 +193,7 @@ func TestDifferByTimestamp(t *testing.T) {
 
 		// manipulate the timestamp. should get changed back
 		proposal.Timestamp = proposal.Timestamp.Add(time.Millisecond)
-		var emptySig crypto.Signature
+		var emptySig []byte
 		proposal.Signature = emptySig
 		err = privVal.SignProposal("mychainid", proposal)
 		assert.NoError(t, err, "expected no error on signing same proposal")
@@ -218,7 +217,7 @@ func TestDifferByTimestamp(t *testing.T) {
 
 		// manipulate the timestamp. should get changed back
 		vote.Timestamp = vote.Timestamp.Add(time.Millisecond)
-		var emptySig crypto.Signature
+		var emptySig []byte
 		vote.Signature = emptySig
 		err = privVal.SignVote("mychainid", vote)
 		assert.NoError(t, err, "expected no error on signing same vote")

--- a/types/heartbeat.go
+++ b/types/heartbeat.go
@@ -3,7 +3,6 @@ package types
 import (
 	"fmt"
 
-	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
@@ -13,12 +12,12 @@ import (
 // json field tags because we always want the JSON
 // representation to be in its canonical form.
 type Heartbeat struct {
-	ValidatorAddress Address          `json:"validator_address"`
-	ValidatorIndex   int              `json:"validator_index"`
-	Height           int64            `json:"height"`
-	Round            int              `json:"round"`
-	Sequence         int              `json:"sequence"`
-	Signature        crypto.Signature `json:"signature"`
+	ValidatorAddress Address `json:"validator_address"`
+	ValidatorIndex   int     `json:"validator_index"`
+	Height           int64   `json:"height"`
+	Round            int     `json:"round"`
+	Sequence         int     `json:"sequence"`
+	Signature        []byte  `json:"signature"`
 }
 
 // SignBytes returns the Heartbeat bytes for signing.
@@ -48,5 +47,6 @@ func (heartbeat *Heartbeat) String() string {
 
 	return fmt.Sprintf("Heartbeat{%v:%X %v/%02d (%v) %v}",
 		heartbeat.ValidatorIndex, cmn.Fingerprint(heartbeat.ValidatorAddress),
-		heartbeat.Height, heartbeat.Round, heartbeat.Sequence, heartbeat.Signature)
+		heartbeat.Height, heartbeat.Round, heartbeat.Sequence,
+		fmt.Sprintf("/%X.../", cmn.Fingerprint(heartbeat.Signature[:])))
 }

--- a/types/heartbeat_test.go
+++ b/types/heartbeat_test.go
@@ -24,13 +24,13 @@ func TestHeartbeatString(t *testing.T) {
 	require.Contains(t, nilHb.String(), "nil", "expecting a string and no panic")
 
 	hb := &Heartbeat{ValidatorIndex: 1, Height: 11, Round: 2}
-	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) <nil>}")
+	require.Equal(t, "Heartbeat{1:000000000000 11/02 (0) /000000000000.../}", hb.String())
 
 	var key ed25519.PrivKeyEd25519
 	sig, err := key.Sign([]byte("Tendermint"))
 	require.NoError(t, err)
 	hb.Signature = sig
-	require.Equal(t, hb.String(), "Heartbeat{1:000000000000 11/02 (0) /FF41E371B9BF.../}")
+	require.Equal(t, "Heartbeat{1:000000000000 11/02 (0) /FF41E371B9BF.../}", hb.String())
 }
 
 func TestHeartbeatWriteSignBytes(t *testing.T) {

--- a/types/proposal.go
+++ b/types/proposal.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-
-	"github.com/tendermint/tendermint/crypto"
 )
 
 var (
@@ -19,13 +17,13 @@ var (
 // to be considered valid. It may depend on votes from a previous round,
 // a so-called Proof-of-Lock (POL) round, as noted in the POLRound and POLBlockID.
 type Proposal struct {
-	Height           int64            `json:"height"`
-	Round            int              `json:"round"`
-	Timestamp        time.Time        `json:"timestamp"`
-	BlockPartsHeader PartSetHeader    `json:"block_parts_header"`
-	POLRound         int              `json:"pol_round"`    // -1 if null.
-	POLBlockID       BlockID          `json:"pol_block_id"` // zero if null.
-	Signature        crypto.Signature `json:"signature"`
+	Height           int64         `json:"height"`
+	Round            int           `json:"round"`
+	Timestamp        time.Time     `json:"timestamp"`
+	BlockPartsHeader PartSetHeader `json:"block_parts_header"`
+	POLRound         int           `json:"pol_round"`    // -1 if null.
+	POLBlockID       BlockID       `json:"pol_block_id"` // zero if null.
+	Signature        []byte        `json:"signature"`
 }
 
 // NewProposal returns a new Proposal.

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -39,7 +39,7 @@ func TestProposalSignable(t *testing.T) {
 
 func TestProposalString(t *testing.T) {
 	str := testProposal.String()
-	expected := `Proposal{12345/23456 111:626C6F636B70 (-1,:0:000000000000) <nil> @ 2018-02-11T07:09:22.765Z}`
+	expected := `Proposal{12345/23456 111:626C6F636B70 (-1,:0:000000000000) [] @ 2018-02-11T07:09:22.765Z}`
 	if str != expected {
 		t.Errorf("Got unexpected string for Proposal. Expected:\n%v\nGot:\n%v", expected, str)
 	}

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -111,7 +111,7 @@ type pubKeyEddie struct{}
 
 func (pubKeyEddie) Address() Address                                  { return []byte{} }
 func (pubKeyEddie) Bytes() []byte                                     { return []byte{} }
-func (pubKeyEddie) VerifyBytes(msg []byte, sig crypto.Signature) bool { return false }
+func (pubKeyEddie) VerifyBytes(msg []byte, sig []byte) bool { return false }
 func (pubKeyEddie) Equals(crypto.PubKey) bool                         { return false }
 
 func TestABCIValidatorFromPubKeyAndPower(t *testing.T) {

--- a/types/vote.go
+++ b/types/vote.go
@@ -68,7 +68,7 @@ type Vote struct {
 	Timestamp        time.Time        `json:"timestamp"`
 	Type             byte             `json:"type"`
 	BlockID          BlockID          `json:"block_id"` // zero if vote is nil.
-	Signature        crypto.Signature `json:"signature"`
+	Signature        []byte `json:"signature"`
 }
 
 func (vote *Vote) SignBytes(chainID string) []byte {

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -179,7 +179,7 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 
 	// If we already know of this vote, return false.
 	if existing, ok := voteSet.getVote(valIndex, blockKey); ok {
-		if existing.Signature.Equals(vote.Signature) {
+		if bytes.Equal(existing.Signature, vote.Signature) {
 			return false, nil // duplicate
 		}
 		return false, errors.Wrapf(ErrVoteNonDeterministicSignature, "Existing vote: %v; New vote: %v", existing, vote)


### PR DESCRIPTION
Signatures are now []byte, which saves on the number of bytes after
amino encoding. This is 4 - 5 less bytes in all signatures :)

Ref #2121. All that remains for that ADR's implementation is forking btced. (Which will definitely be done in a separate PR)

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - any spec / docs I should update? I searched for `crypto.Signature` and replaced all instances of it.
* [X] Updated all code comments where relevant
* [X] Wrote tests
* [X] Updated CHANGELOG.md
