### PR TITLE
Dev/dialseeds bugfix

### DIFF
--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -504,12 +504,7 @@ func (r *PEXReactor) checkSeeds() (numOnline int, netAddrs []*p2p.NetAddress, er
 
 // randomly dial seeds until we connect to one or exhaust them
 func (r *PEXReactor) dialSeeds() {
-	lSeeds := len(r.config.Seeds)
-	if lSeeds == 0 {
-		return
-	}
-
-	perm := cmn.RandPerm(lSeeds)
+	perm := cmn.RandPerm(len(r.seedAddrs))
 	// perm := r.Switch.rng.Perm(lSeeds)
 	for _, i := range perm {
 		// dial a random seed


### PR DESCRIPTION
Closes #2150.

This was caused by me forgetting that the number of addresses `p2p.NewNetAddressStrings` returns isn't the same as the size of the input.

This also means that if there was a DNS resolution error, we don't retry that seed node each time. We perhaps need to change that functionality.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs - n/a bug fix
* [x] Updated all code comments where relevant - seems sufficiently clear
* [x] Wrote tests - bug seems sufficiently clear, and it was caught in other tests.
* [x] Updated CHANGELOG.md - n/a, bug never existed on a release
