### PR TITLE
mempool: Keep cache hashmap and linked list in sync

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,3 +15,5 @@ FEATURES:
 IMPROVEMENTS:
 
 BUG FIXES:
+- [mempool] No longer possible to fill up linked list without getting caching 
+benefits [#2180](https://github.com/tendermint/tendermint/issues/2180)

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -523,8 +523,6 @@ func (cache *mapTxCache) Push(tx types.Tx) bool {
 	if cache.list.Len() >= cache.size {
 		popped := cache.list.Front()
 		poppedTx := popped.Value.(types.Tx)
-		// NOTE: the tx may have already been removed from the map
-		// but deleting a non-existent element is fine
 		delete(cache.map_, string(poppedTx))
 		cache.list.Remove(popped)
 		popped.DetachPrev()
@@ -539,8 +537,6 @@ func (cache *mapTxCache) Push(tx types.Tx) bool {
 func (cache *mapTxCache) Remove(tx types.Tx) {
 	cache.mtx.Lock()
 	stx := string(tx)
-	// TODO: Can we get value and index at the same time?
-	// If not, consider making a hashmap with prehashed inputs.
 	popped := cache.map_[stx]
 	delete(cache.map_, stx)
 	cache.list.Remove(popped)

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -224,6 +224,28 @@ func TestSerialReap(t *testing.T) {
 	reapCheck(600)
 }
 
+func TestCacheRemove(t *testing.T) {
+	cache := newMapTxCache(100)
+	numTxs := 10
+	txs := make([][]byte, numTxs)
+	for i := 0; i < numTxs; i++ {
+		// probability of collision is 2**-256
+		txBytes := make([]byte, 32)
+		rand.Read(txBytes)
+		txs[i] = txBytes
+		cache.Push(txBytes)
+		// make sure its added to both the linked list and the map
+		require.Equal(t, i+1, len(cache.map_))
+		require.Equal(t, i+1, cache.list.Len())
+	}
+	for i := 0; i < numTxs; i++ {
+		cache.Remove(txs[i])
+		// make sure its removed from both the map and the linked list
+		require.Equal(t, numTxs-(i+1), len(cache.map_))
+		require.Equal(t, numTxs-(i+1), cache.list.Len())
+	}
+}
+
 func TestMempoolCloseWAL(t *testing.T) {
 	// 1. Create the temporary directory for mempool and WAL testing.
 	rootDir, err := ioutil.TempDir("", "mempool-test")

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -295,6 +295,35 @@ func TestMempoolCloseWAL(t *testing.T) {
 	require.Equal(t, 1, len(m3), "expecting the wal match in")
 }
 
+func BenchmarkCacheInsertTime(b *testing.B) {
+	cache := newMapTxCache(b.N)
+	txs := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		txs[i] = make([]byte, 8)
+		binary.BigEndian.PutUint64(txs[i], uint64(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Push(txs[i])
+	}
+}
+
+// This benchmark is probably skewed, since we actually will be removing
+// txs in parallel, which may cause some overhead due to mutex locking.
+func BenchmarkCacheRemoveTime(b *testing.B) {
+	cache := newMapTxCache(b.N)
+	txs := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		txs[i] = make([]byte, 8)
+		binary.BigEndian.PutUint64(txs[i], uint64(i))
+		cache.Push(txs[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Remove(txs[i])
+	}
+}
+
 func checksumIt(data []byte) string {
 	h := md5.New()
 	h.Write(data)


### PR DESCRIPTION
This removes bugs with the linked list being full, but hashmap empty.

Ref #2180 

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
