### PR TITLE
libs/common/cmap: Remove defers

### DIFF
--- a/libs/common/cmap.go
+++ b/libs/common/cmap.go
@@ -16,58 +16,60 @@ func NewCMap() *CMap {
 
 func (cm *CMap) Set(key string, value interface{}) {
 	cm.l.Lock()
-	defer cm.l.Unlock()
 	cm.m[key] = value
+	cm.l.Unlock()
 }
 
 func (cm *CMap) Get(key string) interface{} {
 	cm.l.Lock()
-	defer cm.l.Unlock()
-	return cm.m[key]
+	val := cm.m[key]
+	cm.l.Unlock()
+	return val
 }
 
 func (cm *CMap) Has(key string) bool {
 	cm.l.Lock()
-	defer cm.l.Unlock()
 	_, ok := cm.m[key]
+	cm.l.Unlock()
 	return ok
 }
 
 func (cm *CMap) Delete(key string) {
 	cm.l.Lock()
-	defer cm.l.Unlock()
 	delete(cm.m, key)
+	cm.l.Unlock()
 }
 
 func (cm *CMap) Size() int {
 	cm.l.Lock()
-	defer cm.l.Unlock()
-	return len(cm.m)
+	size := len(cm.m)
+	cm.l.Unlock()
+	return size
 }
 
 func (cm *CMap) Clear() {
 	cm.l.Lock()
-	defer cm.l.Unlock()
 	cm.m = make(map[string]interface{})
+	cm.l.Unlock()
 }
 
 func (cm *CMap) Keys() []string {
 	cm.l.Lock()
-	defer cm.l.Unlock()
 
 	keys := []string{}
 	for k := range cm.m {
 		keys = append(keys, k)
 	}
+	cm.l.Unlock()
 	return keys
 }
 
 func (cm *CMap) Values() []interface{} {
 	cm.l.Lock()
-	defer cm.l.Unlock()
 	items := []interface{}{}
 	for _, v := range cm.m {
 		items = append(items, v)
 	}
+	cm.l.Unlock()
 	return items
 }

--- a/libs/common/cmap_test.go
+++ b/libs/common/cmap_test.go
@@ -51,3 +51,14 @@ func TestContains(t *testing.T) {
 	assert.False(t, cmap.Has("key2"))
 	assert.Nil(t, cmap.Get("key2"))
 }
+
+func BenchmarkCMapHas(b *testing.B) {
+	m := NewCMap()
+	for i := 0; i < 1000; i++ {
+		m.Set(string(i), i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Has(string(i))
+	}
+}


### PR DESCRIPTION
All functions in cmap have just one code path. Thus there is not a reason
to use defer statements. (Only having one code path makes what is going on quite clear)

Before:
```
BenchmarkCMapHas-8   	20000000	        73.9 ns/op	       0 B/op	       0 allocs/op
```
After:
```
BenchmarkCMapHas-8   	50000000	        36.9 ns/op	       0 B/op	       0 allocs/op
```
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->
* [X] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md - should the changelog be updated for this?
