### PR TITLE
fix #1544

### DIFF
--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -15,12 +15,12 @@ import (
 
 	cfg "github.com/tendermint/tendermint/config"
 	nm "github.com/tendermint/tendermint/node"
+	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/proxy"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	core_grpc "github.com/tendermint/tendermint/rpc/grpc"
 	rpcclient "github.com/tendermint/tendermint/rpc/lib/client"
-	"github.com/tendermint/tendermint/p2p"
 )
 
 var globalConfig *cfg.Config
@@ -122,10 +122,10 @@ func NewTendermint(app abci.Application) *nm.Node {
 	pv := privval.LoadOrGenFilePV(pvFile)
 	papp := proxy.NewLocalClientCreator(app)
 	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
-	if err != nil{
+	if err != nil {
 		panic(err)
 	}
-	node, err := nm.NewNode(config, pv, nodeKey ,papp,
+	node, err := nm.NewNode(config, pv, nodeKey, papp,
 		nm.DefaultGenesisDocProviderFunc(config),
 		nm.DefaultDBProvider,
 		nm.DefaultMetricsProvider(config.Instrumentation),

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -20,6 +20,7 @@ import (
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	core_grpc "github.com/tendermint/tendermint/rpc/grpc"
 	rpcclient "github.com/tendermint/tendermint/rpc/lib/client"
+	"github.com/tendermint/tendermint/p2p"
 )
 
 var globalConfig *cfg.Config
@@ -120,7 +121,11 @@ func NewTendermint(app abci.Application) *nm.Node {
 	pvFile := config.PrivValidatorFile()
 	pv := privval.LoadOrGenFilePV(pvFile)
 	papp := proxy.NewLocalClientCreator(app)
-	node, err := nm.NewNode(config, pv, papp,
+	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
+	if err != nil{
+		panic(err)
+	}
+	node, err := nm.NewNode(config, pv, nodeKey ,papp,
 		nm.DefaultGenesisDocProviderFunc(config),
 		nm.DefaultDBProvider,
 		nm.DefaultMetricsProvider(config.Instrumentation),


### PR DESCRIPTION
fix #1544 
```
	// Generate node PrivKey
	// TODO: pass in like privValidator
	nodeKey, err := p2p.LoadOrGenNodeKey(n.config.NodeKeyFile())
	if err != nil {
		return err
	}
```
