### PR TITLE
mempool,pool: Fix potential memory leak

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,4 +24,5 @@ IMPROVEMENTS:
 
 BUG FIXES:
 - [mempool] No longer possible to fill up linked list without getting caching
-  benefits [#2180](https://github.com/tendermint/tendermint/issues/2180)
+benefits [#2180](https://github.com/tendermint/tendermint/issues/2180)
+- [evidence, mempool] Fix potential memory leaks from not detaching pointers from removed elements

--- a/evidence/pool.go
+++ b/evidence/pool.go
@@ -143,6 +143,7 @@ func (evpool *EvidencePool) removeEvidence(height, maxAge int64, blockEvidenceMa
 			// remove from clist
 			evpool.evidenceList.Remove(e)
 			e.DetachPrev()
+			e.DetachNext()
 		}
 	}
 }

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -209,6 +209,7 @@ func (mem *Mempool) Flush() {
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
 		mem.txs.Remove(e)
 		e.DetachPrev()
+		e.DetachNext()
 	}
 }
 
@@ -321,6 +322,7 @@ func (mem *Mempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 			// Tx became invalidated due to newly committed block.
 			mem.txs.Remove(mem.recheckCursor)
 			mem.recheckCursor.DetachPrev()
+			mem.recheckCursor.DetachNext()
 
 			// remove from cache (it might be good later)
 			mem.cache.Remove(req.GetCheckTx().Tx)
@@ -435,6 +437,7 @@ func (mem *Mempool) filterTxs(blockTxsMap map[string]struct{}) []types.Tx {
 			// remove from clist
 			mem.txs.Remove(e)
 			e.DetachPrev()
+			e.DetachNext()
 
 			// NOTE: we don't remove committed txs from the cache.
 			continue


### PR DESCRIPTION
We weren't calling detachNext() on elements removed from the clist.
This means it is possible that a pointer to the next node would linger
along, which could eventually cause memory leaks.

ref #2207 

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - n/a?
* [ ] Wrote tests - n/a?
* [X] Updated CHANGELOG_PENDING.md
