### PR TITLE
C level db statt

### DIFF
--- a/libs/autofile/autofile.go
+++ b/libs/autofile/autofile.go
@@ -67,11 +67,13 @@ func (af *AutoFile) Close() error {
 }
 
 func (af *AutoFile) processTicks() {
-	select {
-	case <-af.ticker.C:
-		af.closeFile()
-	case <-af.tickerStopped:
-		return
+	for {
+		select {
+		case <-af.ticker.C:
+			af.closeFile()
+		case <-af.tickerStopped:
+			return
+		}
 	}
 }
 

--- a/libs/autofile/autofile_test.go
+++ b/libs/autofile/autofile_test.go
@@ -74,3 +74,35 @@ func TestSIGHUP(t *testing.T) {
 		t.Errorf("Unexpected body %s", body)
 	}
 }
+
+func TestAutoFile_Close(t *testing.T) {
+	// First, create an AutoFile writing to a tempfile dir
+	file, err := ioutil.TempFile("", "autoclose_test")
+	if err != nil {
+		t.Fatalf("Error creating tempfile: %v", err)
+	}
+
+	name := file.Name()
+	af, err := OpenAutoFile(name)
+	if err != nil {
+		t.Fatalf("Error creating autofile: %v", err)
+	}
+
+	time.Sleep(2 * autoFileOpenDuration)
+	// After 2 * autoFileOpenDuration , as.file should be nil.
+	if af.file != nil {
+		t.Fatalf("Error writing to autofile: %v", err)
+	}
+
+	// reopen the file and write to the file
+	_, err = af.Write([]byte("auto-closed\n"))
+	if err != nil {
+		t.Fatalf("Error writing to autofile: %v", err)
+	}
+
+	// After 2 * autoFileOpenDuration , as.file should be nil.
+	time.Sleep(2 * autoFileOpenDuration)
+	if af.file != nil {
+		t.Fatalf("Error writing to autofile: %v", err)
+	}
+}

--- a/libs/autofile/group.go
+++ b/libs/autofile/group.go
@@ -199,13 +199,16 @@ func (g *Group) Flush() error {
 }
 
 func (g *Group) processTicks() {
-	select {
-	case <-g.ticker.C:
-		g.checkHeadSizeLimit()
-		g.checkTotalSizeLimit()
-	case <-g.Quit():
-		return
+	for {
+		select {
+		case <-g.ticker.C:
+			g.checkHeadSizeLimit()
+			g.checkTotalSizeLimit()
+		case <-g.Quit():
+			return
+		}
 	}
+
 }
 
 // NOTE: this function is called manually in tests.

--- a/libs/db/c_level_db.go
+++ b/libs/db/c_level_db.go
@@ -128,8 +128,12 @@ func (db *CLevelDB) Print() {
 
 // Implements DB.
 func (db *CLevelDB) Stats() map[string]string {
-	// TODO: Find the available properties for the C LevelDB implementation
-	keys := []string{}
+	keys := []string{
+		"leveldb.num-files-at-level<N>",
+		"leveldb.stats",
+		"leveldb.sstables",
+		"leveldb.approximate-memory-usage",
+	}
 
 	stats := make(map[string]string)
 	for _, key := range keys {


### PR DESCRIPTION
In the `c_level_db.go`,the keys of Stats is Null.
```
// Implements DB.
func (db *CLevelDB) Stats() map[string]string {
	// TODO: Find the available properties for the C LevelDB implementation
	keys := []string{}
```

I searched the [golang/leveldb/db.h](https://github.com/google/leveldb/blob/09217fd0677a4fd9713c7a4d774c494a7d3c1f15/include/leveldb/db.h)
and in the line of `115` to `124`,it showed:
```
 // Valid property names include:
  //
  //  "leveldb.num-files-at-level<N>" - return the number of files at level <N>,
  //     where <N> is an ASCII representation of a level number (e.g. "0").
  //  "leveldb.stats" - returns a multi-line string that describes statistics
  //     about the internal operation of the DB.
  //  "leveldb.sstables" - returns a multi-line string that describes all
  //     of the sstables that make up the db contents.
  //  "leveldb.approximate-memory-usage" - returns the approximate number of
  //     bytes of memory in use by the DB.
```