### PR TITLE
libs/autofile: bring back loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.23.1
+
+*August 22nd, 2018*
+
+BUG FIXES:
+- [libs/autofile] \#2261 Fix log rotation so it actually happens.
+    - Fixes issues with consensus WAL growing unbounded ala \#2259
+
 ## 0.23.0
 
 *August 5th, 2018*

--- a/libs/autofile/autofile.go
+++ b/libs/autofile/autofile.go
@@ -67,11 +67,13 @@ func (af *AutoFile) Close() error {
 }
 
 func (af *AutoFile) processTicks() {
-	select {
-	case <-af.ticker.C:
-		af.closeFile()
-	case <-af.tickerStopped:
-		return
+	for {
+		select {
+		case <-af.ticker.C:
+			af.closeFile()
+		case <-af.tickerStopped:
+			return
+		}
 	}
 }
 

--- a/libs/autofile/group.go
+++ b/libs/autofile/group.go
@@ -199,12 +199,14 @@ func (g *Group) Flush() error {
 }
 
 func (g *Group) processTicks() {
-	select {
-	case <-g.ticker.C:
-		g.checkHeadSizeLimit()
-		g.checkTotalSizeLimit()
-	case <-g.Quit():
-		return
+	for {
+		select {
+		case <-g.ticker.C:
+			g.checkHeadSizeLimit()
+			g.checkTotalSizeLimit()
+		case <-g.Quit():
+			return
+		}
 	}
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -4,13 +4,13 @@ package version
 const (
 	Maj = "0"
 	Min = "23"
-	Fix = "0"
+	Fix = "1"
 )
 
 var (
 	// Version is the current version of Tendermint
 	// Must be a string because scripts like dist.sh read this file.
-	Version = "0.23.0"
+	Version = "0.23.1"
 
 	// GitCommit is the current HEAD set using ldflags.
 	GitCommit string


### PR DESCRIPTION
Trying to understand why https://github.com/tendermint/tendermint/issues/2259 is happening.

Looks like could be due to the changes in https://github.com/tendermint/tendermint/pull/2135, where we may have accidentally removed these loops.


* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
