### PR TITLE
update secret connection to use a little endian encoded nonce

### DIFF
--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -334,11 +334,7 @@ func shareAuthSignature(sc *SecretConnection, pubKey crypto.PubKey, signature []
 
 // increment nonce big-endian by 1 with wraparound.
 func incrNonce(nonce *[aeadNonceSize]byte) {
-	for i := aeadNonceSize - 1; 0 <= i; i-- {
-		nonce[i]++
-		// if this byte wrapped around to zero, we need to increment the next byte
-		if nonce[i] != 0 {
-			return
-		}
-	}
+	counter := binary.LittleEndian.Uint64(nonce[4:])
+	counter++
+	binary.LittleEndian.PutUint64(nonce[4:], counter)
 }

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -332,7 +332,10 @@ func shareAuthSignature(sc *SecretConnection, pubKey crypto.PubKey, signature []
 
 //--------------------------------------------------------------------------------
 
-// increment nonce big-endian by 1 with wraparound.
+// Increment nonce little-endian by 1 with wraparound.
+// Due to chacha20poly1305 expecting a 12 byte nonce we do not use the first four
+// bytes and only increment a 64 bit unsigned int in the remaining 8 bytes
+// (little-endian in nonce[4:]).
 func incrNonce(nonce *[aeadNonceSize]byte) {
 	counter := binary.LittleEndian.Uint64(nonce[4:])
 	counter++

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -123,7 +123,7 @@ func (sc *SecretConnection) Write(data []byte) (n int, err error) {
 			data = nil
 		}
 		chunkLength := len(chunk)
-		binary.BigEndian.PutUint32(frame, uint32(chunkLength))
+		binary.LittleEndian.PutUint32(frame, uint32(chunkLength))
 		copy(frame[dataLenSize:], chunk)
 
 		aead, err := chacha20poly1305.New(sc.sendSecret[:])
@@ -172,7 +172,7 @@ func (sc *SecretConnection) Read(data []byte) (n int, err error) {
 	incrNonce(sc.recvNonce)
 	// end decryption
 
-	var chunkLength = binary.BigEndian.Uint32(frame) // read the first two bytes
+	var chunkLength = binary.LittleEndian.Uint32(frame) // read the first four bytes
 	if chunkLength > dataMaxSize {
 		return 0, errors.New("chunkLength is greater than dataMaxSize")
 	}

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -334,7 +334,7 @@ func shareAuthSignature(sc *SecretConnection, pubKey crypto.PubKey, signature []
 
 // Increment nonce little-endian by 1 with wraparound.
 // Due to chacha20poly1305 expecting a 12 byte nonce we do not use the first four
-// bytes and only increment a 64 bit unsigned int in the remaining 8 bytes
+// bytes. We only increment a 64 bit unsigned int in the remaining 8 bytes
 // (little-endian in nonce[4:]).
 func incrNonce(nonce *[aeadNonceSize]byte) {
 	counter := binary.LittleEndian.Uint64(nonce[4:])


### PR DESCRIPTION
Minor change that implements #2263.

Looks like circelci fails because this comes from a fork?
