### PR TITLE
wire2amino wasn't actually loading the private/public key bytes

### DIFF
--- a/scripts/wire2amino.go
+++ b/scripts/wire2amino.go
@@ -49,8 +49,8 @@ type PrivVal struct {
 }
 
 type Data struct {
-	Type string       `json:"type"`
-	Data cmn.HexBytes `json:"data"`
+	Type string `json:"type"`
+	Data []byte `json:"value"`
 }
 
 func convertNodeKey(cdc *amino.Codec, jsonBytes []byte) ([]byte, error) {

--- a/scripts/wire2amino.go
+++ b/scripts/wire2amino.go
@@ -178,5 +178,4 @@ func main() {
 		panic(err)
 	}
 	fmt.Println(string(bz))
-
 }


### PR DESCRIPTION
The key bytes are stored in the `value` field when serialized to JSON, not the `data` field this tool was attempting to load them from. And the key bytes in the JSON files are base64 encoded, not hex-encoded.