### PR TITLE
New NewGoLevelDBWithOpts() to pass opts down to goleveldb

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,6 +23,7 @@ BREAKING CHANGES:
 
 FEATURES:
 - [types] allow genesis file to have 0 validators ([#2015](https://github.com/tendermint/tendermint/issues/2015))
+- [libs] allow passing options through when creating instances of leveldb dbs ([#2292](https://github.com/tendermint/tendermint/issues/2292))
 
 IMPROVEMENTS:
 - [docs] Lint documentation with `write-good` and `stop-words`.

--- a/libs/db/go_level_db.go
+++ b/libs/db/go_level_db.go
@@ -28,8 +28,12 @@ type GoLevelDB struct {
 }
 
 func NewGoLevelDB(name string, dir string) (*GoLevelDB, error) {
+	return NewGoLevelDBWithOpts(name, dir, nil)
+}
+
+func NewGoLevelDBWithOpts(name string, dir string, o *opt.Options) (*GoLevelDB, error) {
 	dbPath := filepath.Join(dir, name+".db")
-	db, err := leveldb.OpenFile(dbPath, nil)
+	db, err := leveldb.OpenFile(dbPath, o)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/db/go_level_db_test.go
+++ b/libs/db/go_level_db_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
@@ -16,18 +16,18 @@ func TestNewGoLevelDB(t *testing.T) {
 	name := fmt.Sprintf("test_%x", cmn.RandStr(12))
 	// Test write locks
 	db, err := NewGoLevelDB(name, "")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	_, err = NewGoLevelDB(name, "")
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	db.Close() // Close the db to release the lock
 
 	// Open the db twice in a row to test read-only locks
 	ro1, err := NewGoLevelDBWithOpts(name, "", &opt.Options{ReadOnly: true})
-	defer func() { ro1.Close() }()
-	assert.Nil(t, err)
+	defer ro1.Close()
+	require.Nil(t, err)
 	ro2, err := NewGoLevelDBWithOpts(name, "", &opt.Options{ReadOnly: true})
-	defer func() { ro2.Close() }()
-	assert.Nil(t, err)
+	defer ro2.Close()
+	require.Nil(t, err)
 }
 
 func BenchmarkRandomReadsWrites(b *testing.B) {

--- a/libs/db/go_level_db_test.go
+++ b/libs/db/go_level_db_test.go
@@ -6,8 +6,29 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/syndtr/goleveldb/leveldb/opt"
+
+	"github.com/stretchr/testify/assert"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
+
+func TestNewGoLevelDB(t *testing.T) {
+	name := fmt.Sprintf("test_%x", cmn.RandStr(12))
+	// Test write locks
+	db, err := NewGoLevelDB(name, "")
+	assert.Nil(t, err)
+	_, err = NewGoLevelDB(name, "")
+	assert.NotNil(t, err)
+	db.Close() // Close the db to release the lock
+
+	// Open the db twice in a row to test read-only locks
+	ro1, err := NewGoLevelDBWithOpts(name, "", &opt.Options{ReadOnly: true})
+	defer func() { ro1.Close() }()
+	assert.Nil(t, err)
+	ro2, err := NewGoLevelDBWithOpts(name, "", &opt.Options{ReadOnly: true})
+	defer func() { ro2.Close() }()
+	assert.Nil(t, err)
+}
 
 func BenchmarkRandomReadsWrites(b *testing.B) {
 	b.StopTimer()


### PR DESCRIPTION
This is meant to allow Cosmos SDK to create and handle read-only leveldb instances.

Closes: #2292

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
