### PR TITLE
config: reduce default mempool size

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -32,6 +32,7 @@ IMPROVEMENTS:
 - [mempool] Now stores txs by hash inside of the cache, to mitigate memory leakage
 - [config] Replace db_path with db_dir from automatically generated configuration files.
   Issue reported to Cosmos SDK ([#1712](https://github.com/cosmos/cosmos-sdk/issues/1712))
+- [config] Reduce default mempool size from 100k to 5k, until ABCI rechecking is implemented.
 
 BUG FIXES:
 - [mempool] No longer possible to fill up linked list without getting caching

--- a/config/config.go
+++ b/config/config.go
@@ -421,8 +421,10 @@ func DefaultMempoolConfig() *MempoolConfig {
 		RecheckEmpty: true,
 		Broadcast:    true,
 		WalPath:      filepath.Join(defaultDataDir, "mempool.wal"),
-		Size:         100000,
-		CacheSize:    100000,
+		// Each signature verification takes .5ms, size reduced until we implement
+		// ABCI Recheck
+		Size:      5000,
+		CacheSize: 10000,
 	}
 }
 

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -99,7 +99,7 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 	height, round := cs.Height, cs.Round
 	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
 
-	NTxs := 10000
+	NTxs := 3000
 	go deliverTxsRange(cs, 0, NTxs)
 
 	startTestRound(cs, height, round)


### PR DESCRIPTION
This reduces the mempool size from 100k to 5k. Note that each secp256k1 sig
takes .5ms to compute. Therefore an adversary could previously delay every
node on the network's computation time upon receiving a block by 50 seconds.

This now reduces that ability to being able to only delay each node by 2.5
seconds. This change should be reverted once ABCI recheck is implemented.

ref #2127 

I think this should be included next release, to improve network resiliency. 

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->
* [X] Updated CHANGELOG_PENDING.md
