### PR TITLE
#2051 Make kv index for tx.height

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -29,3 +29,4 @@ IMPROVEMENTS:
 BUG FIXES:
 - [mempool] No longer possible to fill up linked list without getting caching
   benefits [#2180](https://github.com/tendermint/tendermint/issues/2180)
+- [state] kv store index tx.height to support search


### PR DESCRIPTION
Partially fixed https://github.com/tendermint/tendermint/issues/2051 to make rest api request like http://127.0.0.1:8080/txs?tag=tx.height=1330 work

This is tested against our ABCI application which relies on cosmos default Send msg tx.
To make sure this change works, I:
0. change config.toml file: `index_all_tags=true` and `timeout_commit=30000` (so that 2 transactions issued manually can be included in same block
1. started local test net in 4 docker container
2. restored two accounts for different home (so that I can run 2 gaiacli to make transaction at the same time)
3. transfer coins "at the same time"
4. start a node rest api-server and check **http://127.0.0.1:8080/txs?tag=tx.height=1330**

I can get json response like:

```
[  
   {  
      hash:"798E4CE82A5CFEB65E9DECD3F4D00F9753509FE7",
      height:"1330",
      tx:{  
         type:"auth/StdTx",
         value:{  
            msg:[  
               {  
                  type:"cosmos-sdk/Send",
                  value:{  
                     inputs:[  
                        {  
                           address:"cosmosaccaddr19zqnmalreaugjf8mxm5z0x99ew49anghxpv3x4",
                           coins:[  
                              {  
                                 denom:"BBB",
                                 amount:"10000000000"
                              }
                           ]
                        }
                     ],
                     outputs:[  
                        {  
                           address:"cosmosaccaddr1gtj97w4sxz0eademencfdj8nesmy4c306a3g50",
                           coins:[  
                              {  
                                 denom:"BBB",
                                 amount:"10000000000"
                              }
                           ]
                        }
                     ]
                  }
               }
            ],
            fee:{  
               amount:[  
                  {  
                     denom:"",
                     amount:"0"
                  }
               ],
               gas:"200000"
            },
            signatures:[  
               {  
                  pub_key:{  
                     type:"tendermint/PubKeySecp256k1",
                     value:"AgOIKfLYQ0qmtER5Dy58oH4VcAEJodb4xMG29QuHr/2P"
                  },
                  signature:{  
                     type:"tendermint/SignatureSecp256k1",
                     value:"MEUCIQCJSAW5yPYpiHLeSm4DwnQUrwXz05sYB1cD10kS4o3qSAIgQu/a7+WS3fh6KCQ8MMML+Q4sYVDH4aa3nPzvrPLbGyg="
                  },
                  account_number:"2",
                  sequence:"0"
               }
            ],
            memo:""
         }
      },
      result:{  
         log:"Msg 0: ",
         gasUsed:"4924",
         tags:[  
            {  
               key:"c2VuZGVy",
               value:"Y29zbW9zYWNjYWRkcjE5enFubWFscmVhdWdqZjhteG01ejB4OTlldzQ5YW5naHhwdjN4NA=="
            },
            {  
               key:"cmVjaXBpZW50",
               value:"Y29zbW9zYWNjYWRkcjFndGo5N3c0c3h6MGVhZGVtZW5jZmRqOG5lc215NGMzMDZhM2c1MA=="
            }
         ],
         fee:{  

         }
      }
   },
   {  
      hash:"81D9D88B85B86C52BEEAE56CF77791AEE81A08FE",
      height:"1330",
      tx:{  
         type:"auth/StdTx",
         value:{  
            msg:[  
               {  
                  type:"cosmos-sdk/Send",
                  value:{  
                     inputs:[  
                        {  
                           address:"cosmosaccaddr1gtj97w4sxz0eademencfdj8nesmy4c306a3g50",
                           coins:[  
                              {  
                                 denom:"BBB",
                                 amount:"100000000000"
                              }
                           ]
                        }
                     ],
                     outputs:[  
                        {  
                           address:"cosmosaccaddr19zqnmalreaugjf8mxm5z0x99ew49anghxpv3x4",
                           coins:[  
                              {  
                                 denom:"BBB",
                                 amount:"100000000000"
                              }
                           ]
                        }
                     ]
                  }
               }
            ],
            fee:{  
               amount:[  
                  {  
                     denom:"",
                     amount:"0"
                  }
               ],
               gas:"200000"
            },
            signatures:[  
               {  
                  pub_key:{  
                     type:"tendermint/PubKeySecp256k1",
                     value:"Aso+s1hyS8mhjVxH0TsVtEKe7jyq5XHY6e4UhnYXqWbI"
                  },
                  signature:{  
                     type:"tendermint/SignatureSecp256k1",
                     value:"MEQCIFRRELdb6gMV6ICRUXIF4BVCiKXiSEnZ2oGaQKkGeKZpAiA76pVmlFSlGco6O6cbMIcylq3KijF7dxY0e74HcikZvg=="
                  },
                  account_number:"0",
                  sequence:"2"
               }
            ],
            memo:""
         }
      },
      result:{  
         log:"Msg 0: ",
         gasUsed:"5029",
         tags:[  
            {  
               key:"c2VuZGVy",
               value:"Y29zbW9zYWNjYWRkcjFndGo5N3c0c3h6MGVhZGVtZW5jZmRqOG5lc215NGMzMDZhM2c1MA=="
            },
            {  
               key:"cmVjaXBpZW50",
               value:"Y29zbW9zYWNjYWRkcjE5enFubWFscmVhdWdqZjhteG01ejB4OTlldzQ5YW5naHhwdjN4NA=="
            }
         ],
         fee:{  

         }
      }
   }
]
```

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
