### PR TITLE
blockchain: Register evidence amino message

### DIFF
--- a/blockchain/wire.go
+++ b/blockchain/wire.go
@@ -2,6 +2,8 @@ package blockchain
 
 import (
 	"github.com/tendermint/go-amino"
+
+	"github.com/tendermint/tendermint/evidence"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -10,4 +12,5 @@ var cdc = amino.NewCodec()
 func init() {
 	RegisterBlockchainMessages(cdc)
 	types.RegisterBlockAmino(cdc)
+	evidence.RegisterEvidenceMessages(cdc)
 }


### PR DESCRIPTION
In order for deserialisation of the blockchain the evidence amino
messages need to be registered otherwise we going to crash.

Fixes #2423
