### PR TITLE
proxy: remove Handshaker from proxy pkg

### DIFF
--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -298,11 +298,16 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 
 	// Create proxyAppConn connection (consensus, mempool, query)
 	clientCreator := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
-	proxyApp := proxy.NewAppConns(clientCreator,
-		NewHandshaker(stateDB, state, blockStore, gdoc))
+	proxyApp := proxy.NewAppConns(clientCreator)
 	err = proxyApp.Start()
 	if err != nil {
 		cmn.Exit(fmt.Sprintf("Error starting proxy app conns: %v", err))
+	}
+
+	handshaker := NewHandshaker(stateDB, state, blockStore, gdoc)
+	err = handshaker.Handshake(proxyApp)
+	if err != nil {
+		cmn.Exit(fmt.Sprintf("Error on handshake: %v", err))
 	}
 
 	eventBus := types.NewEventBus()

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -52,17 +52,12 @@ func WALWithNBlocks(numBlocks int) (data []byte, err error) {
 		return nil, errors.Wrap(err, "failed to make genesis state")
 	}
 	blockStore := bc.NewBlockStore(blockStoreDB)
-	handshaker := NewHandshaker(stateDB, state, blockStore, genDoc)
 	proxyApp := proxy.NewAppConns(proxy.NewLocalClientCreator(app))
 	proxyApp.SetLogger(logger.With("module", "proxy"))
 	if err := proxyApp.Start(); err != nil {
 		return nil, errors.Wrap(err, "failed to start proxy app connections")
 	}
 	defer proxyApp.Stop()
-
-	if err = handshaker.Handshake(proxyApp); err != nil {
-		return nil, errors.Wrap(err, "failed handshake")
-	}
 
 	eventBus := types.NewEventBus()
 	eventBus.SetLogger(logger.With("module", "events"))

--- a/node/node.go
+++ b/node/node.go
@@ -190,16 +190,20 @@ func NewNode(config *cfg.Config,
 		return nil, err
 	}
 
-	// Create the proxyApp, which manages connections (consensus, mempool, query)
-	// and sync tendermint and the app by performing a handshake
-	// and replaying any necessary blocks
-	consensusLogger := logger.With("module", "consensus")
-	handshaker := cs.NewHandshaker(stateDB, state, blockStore, genDoc)
-	handshaker.SetLogger(consensusLogger)
-	proxyApp := proxy.NewAppConns(clientCreator, handshaker)
+	// Create the proxyApp and establish connections to the ABCI app (consensus, mempool, query).
+	proxyApp := proxy.NewAppConns(clientCreator)
 	proxyApp.SetLogger(logger.With("module", "proxy"))
 	if err := proxyApp.Start(); err != nil {
 		return nil, fmt.Errorf("Error starting proxy app connections: %v", err)
+	}
+
+	// Create the handshaker, which calls RequestInfo and replays any blocks
+	// as necessary to sync tendermint with the app.
+	consensusLogger := logger.With("module", "consensus")
+	handshaker := cs.NewHandshaker(stateDB, state, blockStore, genDoc)
+	handshaker.SetLogger(consensusLogger)
+	if err := handshaker.Handshake(proxyApp); err != nil {
+		return nil, fmt.Errorf("Error during handshake: %v", err)
 	}
 
 	// reload the state (it may have been updated by the handshake)

--- a/proxy/multi_app_conn.go
+++ b/proxy/multi_app_conn.go
@@ -17,25 +17,18 @@ type AppConns interface {
 	Query() AppConnQuery
 }
 
-func NewAppConns(clientCreator ClientCreator, handshaker Handshaker) AppConns {
-	return NewMultiAppConn(clientCreator, handshaker)
+func NewAppConns(clientCreator ClientCreator) AppConns {
+	return NewMultiAppConn(clientCreator)
 }
 
 //-----------------------------
 // multiAppConn implements AppConns
 
-type Handshaker interface {
-	Handshake(AppConns) error
-}
-
 // a multiAppConn is made of a few appConns (mempool, consensus, query)
-// and manages their underlying abci clients, including the handshake
-// which ensures the app and tendermint are synced.
+// and manages their underlying abci clients
 // TODO: on app restart, clients must reboot together
 type multiAppConn struct {
 	cmn.BaseService
-
-	handshaker Handshaker
 
 	mempoolConn   *appConnMempool
 	consensusConn *appConnConsensus
@@ -45,9 +38,8 @@ type multiAppConn struct {
 }
 
 // Make all necessary abci connections to the application
-func NewMultiAppConn(clientCreator ClientCreator, handshaker Handshaker) *multiAppConn {
+func NewMultiAppConn(clientCreator ClientCreator) *multiAppConn {
 	multiAppConn := &multiAppConn{
-		handshaker:    handshaker,
 		clientCreator: clientCreator,
 	}
 	multiAppConn.BaseService = *cmn.NewBaseService(nil, "multiAppConn", multiAppConn)
@@ -102,11 +94,6 @@ func (app *multiAppConn) OnStart() error {
 		return errors.Wrap(err, "Error starting ABCI client (consensus connection)")
 	}
 	app.consensusConn = NewAppConnConsensus(concli)
-
-	// ensure app is synced to the latest state
-	if app.handshaker != nil {
-		return app.handshaker.Handshake(app)
-	}
 
 	return nil
 }

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -29,7 +29,7 @@ var (
 
 func TestApplyBlock(t *testing.T) {
 	cc := proxy.NewLocalClientCreator(kvstore.NewKVStoreApplication())
-	proxyApp := proxy.NewAppConns(cc, nil)
+	proxyApp := proxy.NewAppConns(cc)
 	err := proxyApp.Start()
 	require.Nil(t, err)
 	defer proxyApp.Stop()
@@ -52,7 +52,7 @@ func TestApplyBlock(t *testing.T) {
 func TestBeginBlockValidators(t *testing.T) {
 	app := &testApp{}
 	cc := proxy.NewLocalClientCreator(app)
-	proxyApp := proxy.NewAppConns(cc, nil)
+	proxyApp := proxy.NewAppConns(cc)
 	err := proxyApp.Start()
 	require.Nil(t, err)
 	defer proxyApp.Stop()
@@ -105,7 +105,7 @@ func TestBeginBlockValidators(t *testing.T) {
 func TestBeginBlockByzantineValidators(t *testing.T) {
 	app := &testApp{}
 	cc := proxy.NewLocalClientCreator(app)
-	proxyApp := proxy.NewAppConns(cc, nil)
+	proxyApp := proxy.NewAppConns(cc)
 	err := proxyApp.Start()
 	require.Nil(t, err)
 	defer proxyApp.Stop()
@@ -239,7 +239,7 @@ func TestUpdateValidators(t *testing.T) {
 func TestEndBlockValidatorUpdates(t *testing.T) {
 	app := &testApp{}
 	cc := proxy.NewLocalClientCreator(app)
-	proxyApp := proxy.NewAppConns(cc, nil)
+	proxyApp := proxy.NewAppConns(cc)
 	err := proxyApp.Start()
 	require.Nil(t, err)
 	defer proxyApp.Stop()


### PR DESCRIPTION
Handshaker was removed from proxy package so it can be called
independently of starting the abci app connections and can return a
result to the caller.

Ref https://github.com/tendermint/tendermint/issues/2436

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
