### PR TITLE
Pass http.ServeTLS() errors back to the caller

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -33,3 +33,4 @@ IMPROVEMENTS:
 
 BUG FIXES:
 - [node] \#2294 Delay starting node until Genesis time
+- [rpc] \#2460 StartHTTPAndTLSServer() now passes StartTLS() errors back to the caller rather than hanging forever.

--- a/rpc/lib/server/http_server.go
+++ b/rpc/lib/server/http_server.go
@@ -56,14 +56,13 @@ func StartHTTPServer(
 		listener = netutil.LimitListener(listener, config.MaxOpenConnections)
 	}
 
-	err = http.Serve(
-		listener,
-		RecoverAndLogHandler(maxBytesHandler{h: handler, n: maxBodyBytes}, logger),
-	)
-	if err != nil {
+	go func() {
+		err := http.Serve(
+			listener,
+			RecoverAndLogHandler(maxBytesHandler{h: handler, n: maxBodyBytes}, logger),
+		)
 		logger.Info("RPC HTTP server stopped", "err", err)
-		return nil, err
-	}
+	}()
 	return listener, nil
 }
 

--- a/rpc/lib/server/http_server.go
+++ b/rpc/lib/server/http_server.go
@@ -56,13 +56,14 @@ func StartHTTPServer(
 		listener = netutil.LimitListener(listener, config.MaxOpenConnections)
 	}
 
-	go func() {
-		err := http.Serve(
-			listener,
-			RecoverAndLogHandler(maxBytesHandler{h: handler, n: maxBodyBytes}, logger),
-		)
+	err = http.Serve(
+		listener,
+		RecoverAndLogHandler(maxBytesHandler{h: handler, n: maxBodyBytes}, logger),
+	)
+	if err != nil {
 		logger.Info("RPC HTTP server stopped", "err", err)
-	}()
+		return nil, err
+	}
 	return listener, nil
 }
 

--- a/rpc/lib/server/http_server.go
+++ b/rpc/lib/server/http_server.go
@@ -102,15 +102,16 @@ func StartHTTPAndTLSServer(
 		listener = netutil.LimitListener(listener, config.MaxOpenConnections)
 	}
 
-	go func() {
-		err := http.ServeTLS(
-			listener,
-			RecoverAndLogHandler(maxBytesHandler{h: handler, n: maxBodyBytes}, logger),
-			certFile,
-			keyFile,
-		)
+	err = http.ServeTLS(
+		listener,
+		RecoverAndLogHandler(maxBytesHandler{h: handler, n: maxBodyBytes}, logger),
+		certFile,
+		keyFile,
+	)
+	if err != nil {
 		logger.Error("RPC HTTPS server stopped", "err", err)
-	}()
+		return nil, err
+	}
 	return listener, nil
 }
 

--- a/rpc/lib/server/http_server_test.go
+++ b/rpc/lib/server/http_server_test.go
@@ -5,10 +5,13 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/libs/log"
 )
@@ -59,4 +62,16 @@ func TestMaxOpenConnections(t *testing.T) {
 	if int(failed) >= attempts/2 {
 		t.Errorf("%d requests failed within %d attempts", failed, attempts)
 	}
+}
+
+func TestStartHTTPAndTLSServer(t *testing.T) {
+	// set up fixtures
+	listenerAddr := "tcp://0.0.0.0:0"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
+
+	// test failure
+	gotListener, err := StartHTTPAndTLSServer(listenerAddr, mux, "", "", log.TestingLogger(), Config{MaxOpenConnections: 1})
+	require.Nil(t, gotListener)
+	require.IsType(t, (*os.PathError)(nil), err)
 }


### PR DESCRIPTION
When http.ServeTLS() fails, StartHTTPAndTLSServer() logs the error then hangs for ever.
It should instead pass the error back to the caller.

Closes: #2460

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
