### PR TITLE
mempool: Disable WAL by default

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,6 +5,7 @@ Special thanks to external contributors on this release:
 BREAKING CHANGES:
 
 * CLI/RPC/Config
+- [config] `mempool.wal` is disabled by default
 
 * Apps
 

--- a/config/config.go
+++ b/config/config.go
@@ -420,7 +420,7 @@ func DefaultMempoolConfig() *MempoolConfig {
 		Recheck:      true,
 		RecheckEmpty: true,
 		Broadcast:    true,
-		WalPath:      filepath.Join(defaultDataDir, "mempool.wal"),
+		WalPath:      "",
 		// Each signature verification takes .5ms, size reduced until we implement
 		// ABCI Recheck
 		Size:      5000,

--- a/docs/tendermint-core/running-in-production.md
+++ b/docs/tendermint-core/running-in-production.md
@@ -74,6 +74,10 @@ propose it. Clients must monitor their txs by subscribing over websockets,
 polling for them, or using `/broadcast_tx_commit`. In the worst case, txs can be
 resent from the mempool WAL manually.
 
+For the above reasons, the `mempool.wal` is disabled by default. To enable, set
+`mempool.wal_dir` to where you want the WAL to be located (e.g.
+`data/mempool.wal`).
+
 ## DOS Exposure and Mitigation
 
 Validators are supposed to setup [Sentry Node


### PR DESCRIPTION
This should reduce file IO and disk space. For those, who want better guarantees, a note in https://tendermint.com/docs/tendermint-core/running-in-production.html is left of how to enable mempool WAL. In the future, we may want to provide better support and tooling for the mempool WAL recover procedure.

Not sure the measurements below are correct, but that's better than having no pictures 😃 These were taken using `iostat -yd 5` while tendermint (kvstore) & tm-bench were running in parallel inside my virtual box.

![chart](https://user-images.githubusercontent.com/1282182/46069091-cab0cf00-c18b-11e8-92b9-bcc9f7d722b9.png)
![chart 1](https://user-images.githubusercontent.com/1282182/46069093-cc7a9280-c18b-11e8-901a-6f11cdec79e1.png)


<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] ~~Updated all relevant documentation in docs~~
* [x] Updated all code comments where relevant
* [ ] ~~Wrote tests~~
* [x] Updated CHANGELOG_PENDING.md
