### PR TITLE
Is there a bug in bit_array's sub function?

### DIFF
--- a/libs/common/bit_array.go
+++ b/libs/common/bit_array.go
@@ -196,12 +196,6 @@ func (bA *BitArray) Sub(o *BitArray) *BitArray {
 			for idx := i * 64; idx < o.Bits; idx++ {
 				c.setIndex(idx, c.getIndex(idx) && !o.getIndex(idx))
 			}
-			for idx := o.Bits; idx < (i+1)*64; idx++ {
-				c.setIndex(idx, false)
-			}
-		}
-		for i := len(o.Elems); i < len(c.Elems); i++ {
-			c.Elems[i] = 0
 		}
 		return c
 	}

--- a/libs/common/bit_array.go
+++ b/libs/common/bit_array.go
@@ -188,7 +188,7 @@ func (bA *BitArray) Sub(o *BitArray) *BitArray {
 	}()
 	if bA.Bits > o.Bits {
 		c := bA.copy()
-		for i := 0; i < len(o.Elems)-1; i++ {
+		for i := len(o.Elems)-1; i < len(c.Elems)-1; i++ {
 			c.Elems[i] &= ^c.Elems[i]
 		}
 		i := len(o.Elems) - 1

--- a/libs/common/bit_array.go
+++ b/libs/common/bit_array.go
@@ -188,7 +188,7 @@ func (bA *BitArray) Sub(o *BitArray) *BitArray {
 	}()
 	if bA.Bits > o.Bits {
 		c := bA.copy()
-		for i := len(o.Elems)-1; i < len(c.Elems)-1; i++ {
+		for i := len(o.Elems); i < len(c.Elems)-1; i++ {
 			c.Elems[i] &= ^c.Elems[i]
 		}
 		i := len(o.Elems) - 1

--- a/libs/common/bit_array.go
+++ b/libs/common/bit_array.go
@@ -188,14 +188,20 @@ func (bA *BitArray) Sub(o *BitArray) *BitArray {
 	}()
 	if bA.Bits > o.Bits {
 		c := bA.copy()
-		for i := len(o.Elems); i < len(c.Elems)-1; i++ {
-			c.Elems[i] &= ^c.Elems[i]
+		for i := 0; i < len(o.Elems)-1; i++ {
+			c.Elems[i] &= ^o.Elems[i]
 		}
 		i := len(o.Elems) - 1
 		if i >= 0 {
 			for idx := i * 64; idx < o.Bits; idx++ {
 				c.setIndex(idx, c.getIndex(idx) && !o.getIndex(idx))
 			}
+			for idx := o.Bits; idx < (i+1)*64; idx++ {
+				c.setIndex(idx, false)
+			}
+		}
+		for i := len(o.Elems); i < len(c.Elems); i++ {
+			c.Elems[i] = 0
 		}
 		return c
 	}

--- a/libs/common/bit_array_test.go
+++ b/libs/common/bit_array_test.go
@@ -131,6 +131,34 @@ func TestSub2(t *testing.T) {
 	}
 }
 
+func TestSub3(t *testing.T) {
+
+	bA1, _ := randBitArray(231)
+	bA2, _ := randBitArray(81)
+	bA3 := bA1.Sub(bA2)
+
+	bNil := (*BitArray)(nil)
+	require.Equal(t, bNil.Sub(bA1), (*BitArray)(nil))
+	require.Equal(t, bA1.Sub(nil), (*BitArray)(nil))
+	require.Equal(t, bNil.Sub(nil), (*BitArray)(nil))
+
+	if bA3.Bits != bA1.Bits {
+		t.Error("Expected bA1 bits")
+	}
+	if len(bA3.Elems) != len(bA1.Elems) {
+		t.Error("Expected bA1 elems length")
+	}
+	for i := 0; i < bA3.Bits; i++ {
+		expected := bA1.GetIndex(i)
+		if i < bA2.Bits && bA2.GetIndex(i) || i>=bA2.Bits{
+			expected = false
+		}
+		if bA3.GetIndex(i) != expected {
+			t.Error("Wrong bit from bA3")
+		}
+	}
+}
+
 func TestPickRandom(t *testing.T) {
 	for idx := 0; idx < 123; idx++ {
 		bA1 := NewBitArray(123)

--- a/libs/common/bit_array_test.go
+++ b/libs/common/bit_array_test.go
@@ -150,7 +150,7 @@ func TestSub3(t *testing.T) {
 	}
 	for i := 0; i < bA3.Bits; i++ {
 		expected := bA1.GetIndex(i)
-		if i < bA2.Bits && bA2.GetIndex(i) || i>=bA2.Bits{
+		if i < bA2.Bits && bA2.GetIndex(i){
 			expected = false
 		}
 		if bA3.GetIndex(i) != expected {


### PR DESCRIPTION
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
This is original code:
if bA.Bits > o.Bits {
		c := bA.copy()
		for i := 0; i < len(o.Elems)-1; i++ {
			c.Elems[i] &= ^c.Elems[i]
		}
		i := len(o.Elems) - 1
		if i >= 0 {
			for idx := i * 64; idx < o.Bits; idx++ {
				c.setIndex(idx, c.getIndex(idx) && !o.getIndex(idx))
			}
		}
		return c
	}

this part,
c := bA.copy()
		for i := 0; i < len(o.Elems)-1; i++ {
			c.Elems[i] &= ^c.Elems[i]
		}
I don't understand, is it wrong?