### PR TITLE
Bucky/docs cleanup

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -11,12 +11,12 @@ module.exports = {
     nav: [{ text: "Back to Tendermint", link: "https://tendermint.com" }],
     sidebar: [
       {
-        title: "Getting Started",
+        title: "Introduction",
         collapsable: false,
         children: [
           "/introduction/quick-start",
           "/introduction/install",
-          "/introduction/introduction"
+          "/introduction/what-is-tendermint"
         ]
       },
       {
@@ -48,7 +48,7 @@ module.exports = {
         title: "Networks",
         collapsable: false,
         children: [
-          "/networks/deploy-testnets",
+          "/networks/docker-compose",
           "/networks/terraform-and-ansible",
         ]
       },

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,43 +1,27 @@
 # Tendermint
 
-Welcome to the Tendermint Core documentation! Below you'll find an
-overview of the documentation.
+Welcome to the Tendermint Core documentation!
 
-Tendermint Core is Byzantine Fault Tolerant (BFT) middleware that takes a state
-transition machine - written in any programming language - and securely
-replicates it on many machines. In other words, a blockchain.
+Tendermint Core is a blockchain application platform; it provides the equivalent
+of a web-server, database, and supporting libraries for blockchain applications
+written in any programming language. Like a web-server serving web applications,
+Tendermint serves blockchain applications.
 
-Tendermint requires an application running over the Application Blockchain
-Interface (ABCI) - and comes packaged with an example application to do so.
+More formally, Tendermint Core performs Byzantine Fault Tolerant (BFT)
+State Machine Replication (SMR) for arbitrary deterministic, finite state machines.
+For more background, see [What is
+Tendermint?](introduction/what-is-tendermint.md).
 
-## Getting Started
+To get started quickly with an example application, see the [quick start guide](introduction/quick-start.md).
 
-Here you'll find quick start guides and links to more advanced "get up and running"
-documentation.
+To learn about application development on Tendermint, see the [Application Blockchain Interface](spec/abci).
 
-## Core
+For more details on using Tendermint, see the respective documentation for
+[Tendermint Core](tendermint-core), [some tools](tools), and [network deployments](networks).
 
-Details about the core functionality and configuration of Tendermint.
+## Contribute
 
-## Tools
-
-Benchmarking and monitoring tools.
-
-## Networks
-
-Setting up testnets manually or automated, local or in the cloud.
-
-## Apps
-
-Building appplications with the ABCI.
-
-## Specification
-
-Dive deep into the spec. There's one for each Tendermint and the ABCI
-
-## Edit the Documentation
-
-See [this file](./DOCS_README.md) for details of the build process and
+To contribute to the documentation, see [this file](./DOCS_README.md) for details of the build process and
 considerations when making changes.
 
 ## Version

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ To get started quickly with an example application, see the [quick start guide](
 To learn about application development on Tendermint, see the [Application Blockchain Interface](spec/abci).
 
 For more details on using Tendermint, see the respective documentation for
-[Tendermint Core](tendermint-core), [some tools](tools), and [network deployments](networks).
+[Tendermint Core](tendermint-core), [benchmarking and monitoring](tools), and [network deployments](networks).
 
 ## Contribute
 

--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -1,0 +1,15 @@
+# Introduction
+
+## Quick Start
+
+Get Tendermint up-and-running quickly with the [quick-start guide](quick-start.md)!
+
+## Install
+
+Detailed [installation instructions](install.md).
+
+## What is Tendermint?
+
+Dive into [what Tendermint is and why](what-is-tendermint.md)!
+
+

--- a/docs/introduction/introduction.md
+++ b/docs/introduction/introduction.md
@@ -1,6 +1,6 @@
 # What is Tendermint?
 
-Link deprecated. See [What is Tendermint?](what-is-tendermint.md).
+DEPRECATED! See [What is Tendermint?](what-is-tendermint.md).
 
 Tendermint is software for securely and consistently replicating an
 application on many machines. By securely, we mean that Tendermint works

--- a/docs/introduction/quick-start.md
+++ b/docs/introduction/quick-start.md
@@ -1,4 +1,4 @@
-# Tendermint
+# Tendermint Quick Start
 
 ## Overview
 
@@ -9,45 +9,21 @@ works and want to get started right away, continue.
 
 ### Quick Install
 
-On a fresh Ubuntu 16.04 machine can be done with [this script](https://git.io/fFfOR), like so:
+To quickly get Tendermint installed on a fresh
+Ubuntu 16.04 machine, use [this script](https://git.io/fFfOR).
+
+WARNING: do not run this on your local machine.
 
 ```
 curl -L https://git.io/fFfOR | bash
 source ~/.profile
 ```
 
-WARNING: do not run the above on your local machine.
-
 The script is also used to facilitate cluster deployment below.
 
 ### Manual Install
 
-Requires:
-
-- `go` minimum version 1.10
-- `$GOPATH` environment variable must be set
-- `$GOPATH/bin` must be on your `$PATH` (see [here](https://github.com/tendermint/tendermint/wiki/Setting-GOPATH))
-
-To install Tendermint, run:
-
-```
-go get github.com/tendermint/tendermint
-cd $GOPATH/src/github.com/tendermint/tendermint
-make get_tools && make get_vendor_deps
-make install
-```
-
-Note that `go get` may return an error but it can be ignored.
-
-Confirm installation:
-
-```
-$ tendermint version
-0.23.0
-```
-
-Note: see the [releases page](https://github.com/tendermint/tendermint/releases) and the latest version
-should match what you see above.
+For manual installation, see the [install instructions](install.md)
 
 ## Initialization
 

--- a/docs/introduction/quick-start.md
+++ b/docs/introduction/quick-start.md
@@ -1,4 +1,4 @@
-# Tendermint Quick Start
+# Quick Start
 
 ## Overview
 

--- a/docs/introduction/what-is-tendermint.md
+++ b/docs/introduction/what-is-tendermint.md
@@ -1,7 +1,5 @@
 # What is Tendermint?
 
-Link deprecated. See [What is Tendermint?](what-is-tendermint.md).
-
 Tendermint is software for securely and consistently replicating an
 application on many machines. By securely, we mean that Tendermint works
 even if up to 1/3 of machines fail in arbitrary ways. By consistently,

--- a/docs/networks/README.md
+++ b/docs/networks/README.md
@@ -1,0 +1,9 @@
+# Networks
+
+Use [Docker Compose](docker-compose.md) to spin up Tendermint testnets on your
+local machine.
+
+Use [Terraform and Ansible](terraform-and-ansible.md) to deploy Tendermint
+testnets to the cloud.
+
+See the `tendermint testnet --help` command for more help initializing testnets.

--- a/docs/networks/deploy-testnets.md
+++ b/docs/networks/deploy-testnets.md
@@ -1,8 +1,8 @@
 # Deploy a Testnet
 
-Now that we've seen how ABCI works, and even played with a few
-applications on a single validator node, it's time to deploy a test
-network to four validator nodes.
+DEPRECATED DOCS!
+
+See [Networks](../networks).
 
 ## Manual Deployments
 
@@ -21,17 +21,16 @@ Here are the steps to setting up a testnet manually:
 3.  Generate a private key and a node key for each validator using
     `tendermint init`
 4.  Compile a list of public keys for each validator into a
-    `genesis.json` file and replace the existing file with it.
-5.  Run
-    `tendermint node --proxy_app=kvstore --p2p.persistent_peers=< peer addresses >` on each node, where `< peer addresses >` is a comma separated
-    list of the ID@IP:PORT combination for each node. The default port for
-    Tendermint is `26656`. The ID of a node can be obtained by running
-    `tendermint show_node_id` command. Thus, if the IP addresses of your nodes
-    were `192.168.0.1, 192.168.0.2, 192.168.0.3, 192.168.0.4`, the command
-    would look like:
+    new `genesis.json` file and replace the existing file with it.
+5.  Get the node IDs of any peers you want other peers to connect to by
+    running `tendermint show_node_id` on the relevant machine
+6.  Set the `p2p.persistent_peers` in the config for all nodes to the comma
+    separated list of `ID@IP:PORT` for all nodes. Default port is 26656.
+
+Then start the node
 
 ```
-tendermint node --proxy_app=kvstore --p2p.persistent_peers=96663a3dd0d7b9d17d4c8211b191af259621c693@192.168.0.1:26656, 429fcf25974313b95673f58d77eacdd434402665@192.168.0.2:26656, 0491d373a8e0fcf1023aaf18c51d6a1d0d4f31bd@192.168.0.3:26656, f9baeaa15fedf5e1ef7448dd60f46c01f1a9e9c4@192.168.0.4:26656
+tendermint node --proxy_app=kvstore
 ```
 
 After a few seconds, all the nodes should connect to each other and

--- a/docs/networks/docker-compose.md
+++ b/docs/networks/docker-compose.md
@@ -1,8 +1,10 @@
-# Local Cluster with Docker Compose
+# Docker Compose
 
-DEPRECATED!
+With Docker Compose, we can spin up local testnets in a single command:
 
-See the [docs](https://tendermint.com/docs/networks/docker-compose.html).
+```
+make localnet-start
+```
 
 ## Requirements
 

--- a/docs/networks/terraform-and-ansible.md
+++ b/docs/networks/terraform-and-ansible.md
@@ -29,7 +29,7 @@ export SSH_KEY_FILE="$HOME/.ssh/id_rsa.pub"
 
 These will be used by both `terraform` and `ansible`.
 
-### Terraform
+## Terraform
 
 This step will create four Digital Ocean droplets. First, go to the
 correct directory:
@@ -49,7 +49,7 @@ and you will get a list of IP addresses that belong to your droplets.
 
 With the droplets created and running, let's setup Ansible.
 
-### Ansible
+## Ansible
 
 The playbooks in [the ansible
 directory](https://github.com/tendermint/tendermint/tree/master/networks/remote/ansible)
@@ -144,7 +144,7 @@ Peek at the logs with the status role:
 ansible-playbook -i inventory/digital_ocean.py -l sentrynet status.yml
 ```
 
-### Logging
+## Logging
 
 The crudest way is the status role described above. You can also ship
 logs to Logz.io, an Elastic stack (Elastic search, Logstash and Kibana)
@@ -160,7 +160,7 @@ go get github.com/mheese/journalbeat
 ansible-playbook -i inventory/digital_ocean.py -l sentrynet logzio.yml -e LOGZIO_TOKEN=ABCDEFGHIJKLMNOPQRSTUVWXYZ012345
 ```
 
-### Cleanup
+## Cleanup
 
 To remove your droplets, run:
 

--- a/docs/spec/abci/README.md
+++ b/docs/spec/abci/README.md
@@ -1,7 +1,7 @@
 # ABCI
 
 ABCI is the interface between Tendermint (a state-machine replication engine)
-and an application (the actual state machine). It consists of a set of
+and your application (the actual state machine). It consists of a set of
 *methods*, where each method has a corresponding `Request` and `Response`
 message type. Tendermint calls the ABCI methods on the ABCI application by sending the `Request*`
 messages and receiving the `Response*` messages in return.

--- a/docs/spec/abci/abci.md
+++ b/docs/spec/abci/abci.md
@@ -7,9 +7,9 @@ file](https://github.com/tendermint/tendermint/blob/develop/abci/types/types.pro
 
 ABCI methods are split across 3 separate ABCI *connections*:
 
-- `Consensus Connection: InitChain, BeginBlock, DeliverTx, EndBlock, Commit`
-- `Mempool Connection: CheckTx`
-- `Info Connection: Info, SetOption, Query`
+- `Consensus Connection`: `InitChain, BeginBlock, DeliverTx, EndBlock, Commit`
+- `Mempool Connection`: `CheckTx`
+- `Info Connection`: `Info, SetOption, Query`
 
 The `Consensus Connection` is driven by a consensus protocol and is responsible
 for block execution.

--- a/docs/tendermint-core/README.md
+++ b/docs/tendermint-core/README.md
@@ -1,0 +1,4 @@
+# Tendermint Core
+
+See the side-bar for details on the various features of Tendermint Core.
+

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,0 +1,4 @@
+# Tools
+
+Tendermint comes with some tools for [benchmarking](benchmarking.md)
+and [monitoring](monitoring.md).

--- a/docs/tools/benchmarking.md
+++ b/docs/tools/benchmarking.md
@@ -20,7 +20,7 @@ Blocks/sec     0.818     0.386      1        9
 
 ## Quick Start
 
-[Install Tendermint](../introduction/install)
+[Install Tendermint](../introduction/install.md)
 This currently is setup to work on tendermint's develop branch. Please ensure
 you are on that. (If not, update `tendermint` and `tmlibs` in gopkg.toml to use
 the master branch.)

--- a/docs/tools/monitoring.md
+++ b/docs/tools/monitoring.md
@@ -33,20 +33,20 @@ docker run -it --rm -p "26670:26670" --link=tm tendermint/monitor tm:26657
 
 ### Using Binaries
 
-[Install Tendermint](https://github.com/tendermint/tendermint#install)
+[Install Tendermint](../introduction/install.md).
 
-then run:
+Start a Tendermint node:
 
 ```
 tendermint init
 tendermint node --proxy_app=kvstore
 ```
 
+In another window, run the monitor:
+
 ```
 tm-monitor localhost:26657
 ```
-
-with the last command being in a seperate window.
 
 ## Usage
 

--- a/networks/remote/README.md
+++ b/networks/remote/README.md
@@ -1,3 +1,3 @@
 # Remote Cluster with Terraform and Ansible
 
-See the [docs](/docs/terraform-and-ansible.md)
+See the [docs](https://tendermint.com/docs/networks/terraform-and-ansible.html).


### PR DESCRIPTION
Closes #2376 and #2378.

Small makeover/improvements to `docs`:

- Fix some mismatches between files/headers/links. Fix some links
- Add and cleanup the READMEs 
  - TODO: can we get the sidebar headers to be links to these?
- DEPRECATE:
  - `docs/introduction/introduction.md` - moved to `introduction/what-is-tendermint.md`
  - `docs/networks/deploy-testnets.md` - it's mostly duplication of other information and doesn't read that well. Let's encourage people to look at `tendermint testnet --help` and understand the `Tendermint Core` section instead. Otherwise replaces with `docs/networks/docker-compose.md`.
  - `networks/local/README.md` - moved to `docs/networks/docker-compose.md`
