### PR TITLE
Bucky/abci docs

### DIFF
--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -35,6 +35,8 @@ of the sidebar.
 **NOTE:** Strongly consider the existing links - both within this directory
 and to the website docs - when moving or deleting files.
 
+Links to directories *MUST* end in a `/`.
+
 Relative links should be used nearly everywhere, having discovered and weighed the following:
 
 ### Relative

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,10 +14,10 @@ Tendermint?](introduction/what-is-tendermint.md).
 
 To get started quickly with an example application, see the [quick start guide](introduction/quick-start.md).
 
-To learn about application development on Tendermint, see the [Application Blockchain Interface](spec/abci).
+To learn about application development on Tendermint, see the [Application Blockchain Interface](spec/abci/).
 
 For more details on using Tendermint, see the respective documentation for
-[Tendermint Core](tendermint-core), [benchmarking and monitoring](tools), and [network deployments](networks).
+[Tendermint Core](tendermint-core/), [benchmarking and monitoring](tools/), and [network deployments](networks/).
 
 ## Contribute
 


### PR DESCRIPTION
Document the General Merkle Proofs in ABCI spec as follow up from https://github.com/tendermint/tendermint/issues/2509

Also add some missing/extra ConsensusParams docs