### PR TITLE
privval: set deadline in readMsg

### DIFF
--- a/privval/socket.go
+++ b/privval/socket.go
@@ -585,7 +585,7 @@ func readMsg(r io.Reader) (msg SocketPVMsg, err error) {
 	// set deadline before trying to read
 	conn := r.(net.Conn)
 	if err := conn.SetDeadline(time.Now().Add(time.Second * defaultConnDeadlineSeconds)); err != nil {
-		err = cmn.ErrorWrap(err, "setting connection timeout failedin readMsg")
+		err = cmn.ErrorWrap(err, "setting connection timeout failed in readMsg")
 		return msg, err
 	}
 


### PR DESCRIPTION
This is a quick-fix for https://github.com/tendermint/tendermint/issues/2027.

The problem is that we set the deadline once, but need to reset each time we want to read, else the first deadline will expire at some random later read.

Also note this is using the default. It seems the ability to use the options has been eliminated? We probably want to bring that back, and actually use an internal, configured value for the read deadline rather than the default.