### PR TITLE
[p2p] Malformed external address causes SIGSEGV (if URL has empty host)

### DIFF
--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"errors"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
@@ -97,16 +98,19 @@ func NewNetAddressStringWithOptionalID(addr string) (*NetAddress, error) {
 	if err != nil {
 		return nil, ErrNetAddressInvalid{addrWithoutProtocol, err}
 	}
+	if len(host) == 0 {
+		return nil, ErrNetAddressInvalid{
+			addrWithoutProtocol,
+			errors.New("host is empty")}
+	}
 
 	ip := net.ParseIP(host)
 	if ip == nil {
-		if len(host) > 0 {
-			ips, err := net.LookupIP(host)
-			if err != nil {
-				return nil, ErrNetAddressLookup{host, err}
-			}
-			ip = ips[0]
+		ips, err := net.LookupIP(host)
+		if err != nil {
+			return nil, ErrNetAddressLookup{host, err}
 		}
+		ip = ips[0]
 	}
 
 	port, err := strconv.ParseUint(portStr, 10, 16)

--- a/p2p/netaddress_test.go
+++ b/p2p/netaddress_test.go
@@ -49,6 +49,7 @@ func TestNewNetAddressStringWithOptionalID(t *testing.T) {
 
 		{"tcp://@127.0.0.1:8080", "", false},
 		{"tcp://@", "", false},
+		{"tcp://:26656", "", false},
 		{"", "", false},
 		{"@", "", false},
 		{" @", "", false},


### PR DESCRIPTION
fix #2071

Signed-off-by: phymbert <pierrick.hymbert@gmail.com>
