### PR TITLE
crypto/merkle: Remove byter in favor of plain byte slices

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,6 +23,7 @@ BREAKING CHANGES:
   * [rpc/client] \#2298 `ABCIQueryOptions.Trusted` -> `ABCIQueryOptions.Prove`
   * [types] \#2298 Remove `Index` and `Total` fields from `TxProof`.
   * [crypto/merkle & lite] \#2298 Various changes to accomodate General Merkle trees
+  * [crypto/merkle] \#2595 Remove all Hasher objects in favor of byte slices
 
 * Blockchain Protocol
   * [types] \#2459 `Vote`/`Proposal`/`Heartbeat` use amino encoding instead of JSON in `SignBytes`.

--- a/crypto/merkle/simple_map.go
+++ b/crypto/merkle/simple_map.go
@@ -23,7 +23,8 @@ func newSimpleMap() *simpleMap {
 	}
 }
 
-// Set hashes the key and value and appends it to the kv pairs.
+// Set creates a kv pair of the key and the hash of the value,
+// and then appends it to simpleMap's kv pairs.
 func (sm *simpleMap) Set(key string, value []byte) {
 	sm.sorted = false
 
@@ -69,6 +70,8 @@ func (sm *simpleMap) KVPairs() cmn.KVPairs {
 // then hashed.
 type KVPair cmn.KVPair
 
+// Bytes returns key || value, with both the
+// key and value length prefixed.
 func (kv KVPair) Bytes() []byte {
 	var b bytes.Buffer
 	err := amino.EncodeByteSlice(&b, kv.Key)

--- a/crypto/merkle/simple_map.go
+++ b/crypto/merkle/simple_map.go
@@ -1,6 +1,9 @@
 package merkle
 
 import (
+	"bytes"
+
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
@@ -21,13 +24,13 @@ func newSimpleMap() *simpleMap {
 }
 
 // Set hashes the key and value and appends it to the kv pairs.
-func (sm *simpleMap) Set(key string, value Hasher) {
+func (sm *simpleMap) Set(key string, value []byte) {
 	sm.sorted = false
 
 	// The value is hashed, so you can
 	// check for equality with a cached value (say)
 	// and make a determination to fetch or not.
-	vhash := value.Hash()
+	vhash := tmhash.Sum(value)
 
 	sm.kvs = append(sm.kvs, cmn.KVPair{
 		Key:   []byte(key),
@@ -66,23 +69,23 @@ func (sm *simpleMap) KVPairs() cmn.KVPairs {
 // then hashed.
 type KVPair cmn.KVPair
 
-func (kv KVPair) Hash() []byte {
-	hasher := tmhash.New()
-	err := encodeByteSlice(hasher, kv.Key)
+func (kv KVPair) Bytes() []byte {
+	var b bytes.Buffer
+	err := amino.EncodeByteSlice(&b, kv.Key)
 	if err != nil {
 		panic(err)
 	}
-	err = encodeByteSlice(hasher, kv.Value)
+	err = amino.EncodeByteSlice(&b, kv.Value)
 	if err != nil {
 		panic(err)
 	}
-	return hasher.Sum(nil)
+	return b.Bytes()
 }
 
 func hashKVPairs(kvs cmn.KVPairs) []byte {
-	kvsH := make([]Hasher, len(kvs))
+	kvsH := make([][]byte, len(kvs))
 	for i, kvp := range kvs {
-		kvsH[i] = KVPair(kvp)
+		kvsH[i] = KVPair(kvp).Bytes()
 	}
-	return SimpleHashFromHashers(kvsH)
+	return SimpleHashFromByteSlices(kvsH)
 }

--- a/crypto/merkle/simple_map_test.go
+++ b/crypto/merkle/simple_map_test.go
@@ -5,50 +5,29 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tendermint/tendermint/crypto/tmhash"
 )
 
-type strHasher string
-
-func (str strHasher) Hash() []byte {
-	return tmhash.Sum([]byte(str))
-}
-
 func TestSimpleMap(t *testing.T) {
-	{
-		db := newSimpleMap()
-		db.Set("key1", strHasher("value1"))
-		assert.Equal(t, "fa9bc106ffd932d919bee935ceb6cf2b3dd72d8f", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+	tests := []struct {
+		keys   []string
+		values []string // each string gets converted to []byte in test
+		want   string
+	}{
+		{[]string{"key1"}, []string{"value1"}, "fa9bc106ffd932d919bee935ceb6cf2b3dd72d8f"},
+		{[]string{"key1"}, []string{"value2"}, "e00e7dcfe54e9fafef5111e813a587f01ba9c3e8"},
+		// swap order with 2 keys
+		{[]string{"key1", "key2"}, []string{"value1", "value2"}, "eff12d1c703a1022ab509287c0f196130123d786"},
+		{[]string{"key2", "key1"}, []string{"value2", "value1"}, "eff12d1c703a1022ab509287c0f196130123d786"},
+		// swap order with 3 keys
+		{[]string{"key1", "key2", "key3"}, []string{"value1", "value2", "value3"}, "b2c62a277c08dbd2ad73ca53cd1d6bfdf5830d26"},
+		{[]string{"key1", "key3", "key2"}, []string{"value1", "value3", "value2"}, "b2c62a277c08dbd2ad73ca53cd1d6bfdf5830d26"},
 	}
-	{
+	for i, tc := range tests {
 		db := newSimpleMap()
-		db.Set("key1", strHasher("value2"))
-		assert.Equal(t, "e00e7dcfe54e9fafef5111e813a587f01ba9c3e8", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
-	}
-	{
-		db := newSimpleMap()
-		db.Set("key1", strHasher("value1"))
-		db.Set("key2", strHasher("value2"))
-		assert.Equal(t, "eff12d1c703a1022ab509287c0f196130123d786", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
-	}
-	{
-		db := newSimpleMap()
-		db.Set("key2", strHasher("value2")) // NOTE: out of order
-		db.Set("key1", strHasher("value1"))
-		assert.Equal(t, "eff12d1c703a1022ab509287c0f196130123d786", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
-	}
-	{
-		db := newSimpleMap()
-		db.Set("key1", strHasher("value1"))
-		db.Set("key2", strHasher("value2"))
-		db.Set("key3", strHasher("value3"))
-		assert.Equal(t, "b2c62a277c08dbd2ad73ca53cd1d6bfdf5830d26", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
-	}
-	{
-		db := newSimpleMap()
-		db.Set("key2", strHasher("value2")) // NOTE: out of order
-		db.Set("key1", strHasher("value1"))
-		db.Set("key3", strHasher("value3"))
-		assert.Equal(t, "b2c62a277c08dbd2ad73ca53cd1d6bfdf5830d26", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		for i := 0; i < len(tc.keys); i++ {
+			db.Set(tc.keys[i], []byte(tc.values[i]))
+		}
+		got := db.Hash()
+		assert.Equal(t, tc.want, fmt.Sprintf("%x", got), "Hash didn't match on tc %d", i)
 	}
 }

--- a/crypto/merkle/simple_tree.go
+++ b/crypto/merkle/simple_tree.go
@@ -18,11 +18,12 @@ func SimpleHashFromTwoHashes(left, right []byte) []byte {
 	return hasher.Sum(nil)
 }
 
-// SimpleHashFromHashers computes a Merkle tree from items that can be hashed.
-func SimpleHashFromHashers(items []Hasher) []byte {
+// SimpleHashFromByteSlices computes a Merkle tree where the leaves are the byte slice,
+// in the provided order.
+func SimpleHashFromByteSlices(items [][]byte) []byte {
 	hashes := make([][]byte, len(items))
 	for i, item := range items {
-		hash := item.Hash()
+		hash := tmhash.Sum(item)
 		hashes[i] = hash
 	}
 	return simpleHashFromHashes(hashes)
@@ -32,7 +33,7 @@ func SimpleHashFromHashers(items []Hasher) []byte {
 // Like calling SimpleHashFromHashers with
 // `item = []byte(Hash(key) | Hash(value))`,
 // sorted by `item`.
-func SimpleHashFromMap(m map[string]Hasher) []byte {
+func SimpleHashFromMap(m map[string][]byte) []byte {
 	sm := newSimpleMap()
 	for k, v := range m {
 		sm.Set(k, v)

--- a/crypto/merkle/simple_tree_test.go
+++ b/crypto/merkle/simple_tree_test.go
@@ -21,20 +21,20 @@ func TestSimpleProof(t *testing.T) {
 
 	total := 100
 
-	items := make([]Hasher, total)
+	items := make([][]byte, total)
 	for i := 0; i < total; i++ {
 		items[i] = testItem(cmn.RandBytes(tmhash.Size))
 	}
 
-	rootHash := SimpleHashFromHashers(items)
+	rootHash := SimpleHashFromByteSlices(items)
 
-	rootHash2, proofs := SimpleProofsFromHashers(items)
+	rootHash2, proofs := SimpleProofsFromByteSlices(items)
 
 	require.Equal(t, rootHash, rootHash2, "Unmatched root hashes: %X vs %X", rootHash, rootHash2)
 
 	// For each item, check the trail.
 	for i, item := range items {
-		itemHash := item.Hash()
+		itemHash := tmhash.Sum(item)
 		proof := proofs[i]
 
 		// Check total/index

--- a/crypto/merkle/types.go
+++ b/crypto/merkle/types.go
@@ -25,11 +25,6 @@ type Tree interface {
 	IterateRange(start []byte, end []byte, ascending bool, fx func(key []byte, value []byte) (stop bool)) (stopped bool)
 }
 
-// Hasher represents a hashable piece of data which can be hashed in the Tree.
-type Hasher interface {
-	Hash() []byte
-}
-
 //-----------------------------------------------------------------------
 
 // Uvarint length prefixed byteslice

--- a/types/encoding_helper.go
+++ b/types/encoding_helper.go
@@ -1,0 +1,14 @@
+package types
+
+import (
+	cmn "github.com/tendermint/tendermint/libs/common"
+)
+
+// cdcEncode returns nil if the input is nil, otherwise returns
+// cdc.MustMarshalBinaryBare(item)
+func cdcEncode(item interface{}) []byte {
+	if item != nil && !cmn.IsTypedNil(item) && !cmn.IsEmpty(item) {
+		return cdc.MustMarshalBinaryBare(item)
+	}
+	return nil
+}

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/tendermint/tendermint/crypto/tmhash"
+
 	amino "github.com/tendermint/go-amino"
 
 	"github.com/tendermint/tendermint/crypto"
@@ -104,7 +106,7 @@ func (dve *DuplicateVoteEvidence) Address() []byte {
 
 // Hash returns the hash of the evidence.
 func (dve *DuplicateVoteEvidence) Hash() []byte {
-	return aminoHasher(dve).Hash()
+	return tmhash.Sum(cdcEncode(dve))
 }
 
 // Verify returns an error if the two votes aren't conflicting.
@@ -157,8 +159,8 @@ func (dve *DuplicateVoteEvidence) Equal(ev Evidence) bool {
 	}
 
 	// just check their hashes
-	dveHash := aminoHasher(dve).Hash()
-	evHash := aminoHasher(ev).Hash()
+	dveHash := tmhash.Sum(cdcEncode(dve))
+	evHash := tmhash.Sum(cdcEncode(ev))
 	return bytes.Equal(dveHash, evHash)
 }
 

--- a/types/params.go
+++ b/types/params.go
@@ -82,10 +82,10 @@ func (params *ConsensusParams) Validate() error {
 
 // Hash returns a merkle hash of the parameters to store in the block header
 func (params *ConsensusParams) Hash() []byte {
-	return merkle.SimpleHashFromMap(map[string]merkle.Hasher{
-		"block_size_max_bytes":    aminoHasher(params.BlockSize.MaxBytes),
-		"block_size_max_gas":      aminoHasher(params.BlockSize.MaxGas),
-		"evidence_params_max_age": aminoHasher(params.EvidenceParams.MaxAge),
+	return merkle.SimpleHashFromMap(map[string][]byte{
+		"block_size_max_bytes":    cdcEncode(params.BlockSize.MaxBytes),
+		"block_size_max_gas":      cdcEncode(params.BlockSize.MaxGas),
+		"evidence_params_max_age": cdcEncode(params.EvidenceParams.MaxAge),
 	})
 }
 

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -88,7 +88,7 @@ func NewPartSetFromData(data []byte, partSize int) *PartSet {
 	// divide data into 4kb parts.
 	total := (len(data) + partSize - 1) / partSize
 	parts := make([]*Part, total)
-	parts_ := make([]merkle.Hasher, total)
+	partsBytes := make([][]byte, total)
 	partsBitArray := cmn.NewBitArray(total)
 	for i := 0; i < total; i++ {
 		part := &Part{
@@ -96,11 +96,11 @@ func NewPartSetFromData(data []byte, partSize int) *PartSet {
 			Bytes: data[i*partSize : cmn.MinInt(len(data), (i+1)*partSize)],
 		}
 		parts[i] = part
-		parts_[i] = part
+		partsBytes[i] = part.Bytes
 		partsBitArray.SetIndex(i, true)
 	}
 	// Compute merkle proofs
-	root, proofs := merkle.SimpleProofsFromHashers(parts_)
+	root, proofs := merkle.SimpleProofsFromByteSlices(partsBytes)
 	for i := 0; i < total; i++ {
 		parts[i].Proof = *proofs[i]
 	}

--- a/types/results.go
+++ b/types/results.go
@@ -3,6 +3,7 @@ package types
 import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
+	"github.com/tendermint/tendermint/crypto/tmhash"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
@@ -17,8 +18,12 @@ type ABCIResult struct {
 
 // Hash returns the canonical hash of the ABCIResult
 func (a ABCIResult) Hash() []byte {
-	bz := aminoHash(a)
+	bz := tmhash.Sum(cdcEncode(a))
 	return bz
+}
+
+func (a ABCIResult) Bytes() []byte {
+	return cdcEncode(a)
 }
 
 // ABCIResults wraps the deliver tx results to return a proof
@@ -54,20 +59,20 @@ func (a ABCIResults) Bytes() []byte {
 func (a ABCIResults) Hash() []byte {
 	// NOTE: we copy the impl of the merkle tree for txs -
 	// we should be consistent and either do it for both or not.
-	return merkle.SimpleHashFromHashers(a.toHashers())
+	return merkle.SimpleHashFromByteSlices(a.toByteSlices())
 }
 
 // ProveResult returns a merkle proof of one result from the set
 func (a ABCIResults) ProveResult(i int) merkle.SimpleProof {
-	_, proofs := merkle.SimpleProofsFromHashers(a.toHashers())
+	_, proofs := merkle.SimpleProofsFromByteSlices(a.toByteSlices())
 	return *proofs[i]
 }
 
-func (a ABCIResults) toHashers() []merkle.Hasher {
+func (a ABCIResults) toByteSlices() [][]byte {
 	l := len(a)
-	hashers := make([]merkle.Hasher, l)
+	bzs := make([][]byte, l)
 	for i := 0; i < l; i++ {
-		hashers[i] = a[i]
+		bzs[i] = a[i].Bytes()
 	}
-	return hashers
+	return bzs
 }

--- a/types/tx.go
+++ b/types/tx.go
@@ -70,11 +70,11 @@ func (txs Txs) IndexByHash(hash []byte) int {
 // TODO: optimize this!
 func (txs Txs) Proof(i int) TxProof {
 	l := len(txs)
-	hashers := make([]merkle.Hasher, l)
+	bzs := make([][]byte, l)
 	for i := 0; i < l; i++ {
-		hashers[i] = txs[i]
+		bzs[i] = txs[i]
 	}
-	root, proofs := merkle.SimpleProofsFromHashers(hashers)
+	root, proofs := merkle.SimpleProofsFromByteSlices(bzs)
 
 	return TxProof{
 		RootHash: root,

--- a/types/validator.go
+++ b/types/validator.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/tendermint/tendermint/crypto/tmhash"
+
 	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
@@ -71,13 +73,21 @@ func (v *Validator) String() string {
 // Hash computes the unique ID of a validator with a given voting power.
 // It excludes the Accum value, which changes with every round.
 func (v *Validator) Hash() []byte {
-	return aminoHash(struct {
+	return tmhash.Sum(v.Bytes())
+}
+
+// Bytes computes the unique ID of a validator with a given voting power.
+// These are the bytes that gets hashed in consensus. It excludes pubkey
+// as its redundant with the address. This also excludes accum which changes
+// every round.
+func (v *Validator) Bytes() []byte {
+	return cdcEncode((struct {
 		Address     Address
 		VotingPower int64
 	}{
 		v.Address,
 		v.VotingPower,
-	})
+	}))
 }
 
 //----------------------------------------

--- a/types/validator.go
+++ b/types/validator.go
@@ -76,7 +76,7 @@ func (v *Validator) Hash() []byte {
 	return tmhash.Sum(v.Bytes())
 }
 
-// Bytes computes the unique ID of a validator with a given voting power.
+// Bytes computes the unique encoding of a validator with a given voting power.
 // These are the bytes that gets hashed in consensus. It excludes pubkey
 // as its redundant with the address. This also excludes accum which changes
 // every round.

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -176,11 +176,11 @@ func (vals *ValidatorSet) Hash() []byte {
 	if len(vals.Validators) == 0 {
 		return nil
 	}
-	hashers := make([]merkle.Hasher, len(vals.Validators))
+	bzs := make([][]byte, len(vals.Validators))
 	for i, val := range vals.Validators {
-		hashers[i] = val
+		bzs[i] = val.Bytes()
 	}
-	return merkle.SimpleHashFromHashers(hashers)
+	return merkle.SimpleHashFromByteSlices(bzs)
 }
 
 // Add adds val to the validator set and returns true. It returns false if val


### PR DESCRIPTION
This PR is fully backwards compatible in terms of function output!
(The Go API differs though) The only test case changes was to refactor
it to be table driven.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests - existing tests required no change
* [x] Updated CHANGELOG_PENDING.md
