### PR TITLE
Reduce memory allocations within merkle.SimpleHashFromByteSlices

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -41,6 +41,7 @@ IMPROVEMENTS:
 - [config] \#2232 added ValidateBasic method, which performs basic checks
 - [tools] \#2238 Binary dependencies are now locked to a specific git commit
 - [crypto] \#2099 make crypto random use chacha, and have forward secrecy of generated randomness
+- [crypto] \#2604 Reduce memory allocations within merkle.SimpleHashFromByteSlices (previously) merkle.SimpleHashFromByters
 
 BUG FIXES:
 - [autofile] \#2428 Group.RotateFile need call Flush() before rename (@goolAdapter)

--- a/crypto/merkle/simple_tree.go
+++ b/crypto/merkle/simple_tree.go
@@ -45,15 +45,20 @@ func SimpleHashFromMap(m map[string][]byte) []byte {
 
 // Expects hashes!
 func simpleHashFromHashes(hashes [][]byte) []byte {
-	// Recursive impl.
-	switch len(hashes) {
+	return simpleHashFromHashesInPlace(hashes, 0, len(hashes))
+}
+
+func simpleHashFromHashesInPlace(hashes [][]byte, start, end int) []byte {
+	// In place recursive impl.
+	numHashes := end - start
+	switch numHashes {
 	case 0:
 		return nil
 	case 1:
-		return hashes[0]
+		return hashes[start]
 	default:
-		left := simpleHashFromHashes(hashes[:(len(hashes)+1)/2])
-		right := simpleHashFromHashes(hashes[(len(hashes)+1)/2:])
+		left := simpleHashFromHashesInPlace(hashes, start, start+(numHashes+1)/2)
+		right := simpleHashFromHashesInPlace(hashes, start+(numHashes+1)/2, end)
 		return SimpleHashFromTwoHashes(left, right)
 	}
 }

--- a/types/tx.go
+++ b/types/tx.go
@@ -31,18 +31,11 @@ type Txs []Tx
 
 // Hash returns the simple Merkle root hash of the transactions.
 func (txs Txs) Hash() []byte {
-	// Recursive impl.
-	// Copied from tendermint/crypto/merkle to avoid allocations
-	switch len(txs) {
-	case 0:
-		return nil
-	case 1:
-		return txs[0].Hash()
-	default:
-		left := Txs(txs[:(len(txs)+1)/2]).Hash()
-		right := Txs(txs[(len(txs)+1)/2:]).Hash()
-		return merkle.SimpleHashFromTwoHashes(left, right)
+	txBz := make([][]byte, len(txs))
+	for i := 0; i < len(txBz); i++ {
+		txBz[i] = txs[i]
 	}
+	return merkle.SimpleHashFromByteSlices(txBz)
 }
 
 // Index returns the index of this transaction in the list, or -1 if not found


### PR DESCRIPTION
Do we want a benchmark for this? Seems like a clear improvement so I opted to not make one. 

* [ ] Updated all relevant documentation in docs - n/a ?
* [x] Updated all code comments where relevant
* [ ] Wrote tests - current tests cover it
* [x] Updated CHANGELOG_PENDING.md
