### PR TITLE
add Google Analytics for documentation pages

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,6 +1,7 @@
 module.exports = {
-  title: "Tendermint Core",
-  description: "Documentation for Tendermint Core",
+  title: "Tendermint Documentation",
+  description: "Documentation for Tendermint Core.",
+  ga: "UA-51029217-1",
   dest: "./dist/docs",
   base: "/docs/",
   markdown: {


### PR DESCRIPTION
We need Google Analytics to start measuring how many developers are viewing our documentation. That way we can gauge how successful and useful various pages are. VuePress supports GA and all we have to provide is the tracking code.

This PR also renames the static docs site to "Tendermint Documentation", which is a better representation of the contents than only "Tendermint Core".