### PR TITLE
p2p: re-check after sleeps

### DIFF
--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -34,6 +34,11 @@ type NetAddress struct {
 
 // IDAddressString returns id@hostPort.
 func IDAddressString(id ID, hostPort string) string {
+	// we respect the protocol definition in here.
+	if p := strings.Index(hostPort, "://"); p > -1 {
+		return fmt.Sprintf("%s://%s@%s", hostPort[:p], id, hostPort[p+3:])
+	}
+
 	return fmt.Sprintf("%s@%s", id, hostPort)
 }
 

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	amino "github.com/tendermint/go-amino"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/p2p"
@@ -394,6 +393,9 @@ func (r *PEXReactor) ensurePeers() {
 		}
 		if r.Switch.IsDialingOrExistingAddress(try) {
 			continue
+		}
+		if r.Switch.NodeInfo().ID == try.ID {
+			continue // we don't want to dial ourselves, usually.
 		}
 		// TODO: consider moving some checks from toDial into here
 		// so we don't even consider dialing peers that we want to wait

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -325,6 +325,11 @@ func (sw *Switch) reconnectToPeer(addr *NetAddress) {
 			return
 		}
 
+		if sw.IsDialingOrExistingAddress(addr) {
+			sw.Logger.Info("Peer connection has been established or dialed while we waiting next try", "addr", addr)
+			return
+		}
+
 		err := sw.DialPeerWithAddress(addr, true)
 		if err == nil {
 			return // success
@@ -412,12 +417,16 @@ func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent b
 			if addr.Same(ourAddr) {
 				sw.Logger.Debug("Ignore attempt to connect to ourselves", "addr", addr, "ourAddr", ourAddr)
 				return
-			} else if sw.IsDialingOrExistingAddress(addr) {
+			}
+
+			sw.randomSleep(0)
+
+			// check the destination address in established/dialed peers after sleep.
+			if sw.IsDialingOrExistingAddress(addr) {
 				sw.Logger.Debug("Ignore attempt to connect to an existing peer", "addr", addr)
 				return
 			}
 
-			sw.randomSleep(0)
 			err := sw.DialPeerWithAddress(addr, persistent)
 			if err != nil {
 				switch err.(type) {


### PR DESCRIPTION
Hi there, I saw there are many re-connection attempts and trying to connect itself while ensuring peers in pex reactor. I think that issues appear for me because I'm testing three node setup with persistent peers. So I guess this patch is the solution. It works for me.