### PR TITLE
Set protocol versions in NodeInfo from state

### DIFF
--- a/benchmarks/codec_test.go
+++ b/benchmarks/codec_test.go
@@ -14,7 +14,7 @@ import (
 
 func testNodeInfo(id p2p.ID) p2p.DefaultNodeInfo {
 	return p2p.DefaultNodeInfo{
-		ProtocolVersion: p2p.InitProtocolVersion,
+		ProtocolVersion: p2p.ProtocolVersion{1, 2, 3},
 		ID_:             id,
 		Moniker:         "SOMENAME",
 		Network:         "SOMENAME",

--- a/node/node.go
+++ b/node/node.go
@@ -367,7 +367,11 @@ func NewNode(config *cfg.Config,
 			nodeKey.ID(),
 			txIndexer,
 			genDoc.ChainID,
-			p2p.ProtocolVersionWithApp(state.Version.Consensus.App),
+			p2p.NewProtocolVersion(
+				version.P2PProtocol, // global
+				state.Version.Consensus.Block,
+				state.Version.Consensus.App,
+			),
 		)
 	)
 

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -49,16 +49,20 @@ type ProtocolVersion struct {
 	App   version.Protocol `json:"app"`
 }
 
-// InitProtocolVersion populates the Block and P2P versions, but not the App.
-var InitProtocolVersion = ProtocolVersionWithApp(0)
+// defaultProtocolVersion populates the Block and P2P versions using
+// the global values, but not the App.
+var defaultProtocolVersion = NewProtocolVersion(
+	version.P2PProtocol,
+	version.BlockProtocol,
+	0,
+)
 
-// ProtocolVersionWithApp returns a fully populated ProtocolVersion
-// using the provided App version and the Block and P2P versions defined in the `version` package.
-func ProtocolVersionWithApp(appVersion version.Protocol) ProtocolVersion {
+// NewProtocolVersion returns a fully populated ProtocolVersion.
+func NewProtocolVersion(p2p, block, app version.Protocol) ProtocolVersion {
 	return ProtocolVersion{
-		P2P:   version.P2PProtocol,
-		Block: version.BlockProtocol,
-		App:   appVersion,
+		P2P:   p2p,
+		Block: block,
+		App:   app,
 	}
 }
 

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -207,7 +207,7 @@ func (rp *remotePeer) accept(l net.Listener) {
 
 func (rp *remotePeer) nodeInfo(l net.Listener) NodeInfo {
 	return DefaultNodeInfo{
-		ProtocolVersion: InitProtocolVersion,
+		ProtocolVersion: defaultProtocolVersion,
 		ID_:             rp.Addr().ID,
 		ListenAddr:      l.Addr().String(),
 		Network:         "testing",

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -249,7 +249,7 @@ func testNodeInfo(id ID, name string) NodeInfo {
 
 func testNodeInfoWithNetwork(id ID, name, network string) NodeInfo {
 	return DefaultNodeInfo{
-		ProtocolVersion: InitProtocolVersion,
+		ProtocolVersion: defaultProtocolVersion,
 		ID_:             id,
 		ListenAddr:      fmt.Sprintf("127.0.0.1:%d", cmn.RandIntn(64512)+1023),
 		Network:         network,

--- a/state/state.go
+++ b/state/state.go
@@ -222,7 +222,6 @@ func MakeGenesisState(genDoc *types.GenesisDoc) (State, error) {
 		return State{}, fmt.Errorf("Error in genesis file: %v", err)
 	}
 
-	// Make validators slice
 	var validatorSet, nextValidatorSet *types.ValidatorSet
 	if genDoc.Validators == nil {
 		validatorSet = types.NewValidatorSet(nil)
@@ -230,15 +229,7 @@ func MakeGenesisState(genDoc *types.GenesisDoc) (State, error) {
 	} else {
 		validators := make([]*types.Validator, len(genDoc.Validators))
 		for i, val := range genDoc.Validators {
-			pubKey := val.PubKey
-			address := pubKey.Address()
-
-			// Make validator
-			validators[i] = &types.Validator{
-				Address:     address,
-				PubKey:      pubKey,
-				VotingPower: val.Power,
-			}
+			validators[i] = types.NewValidator(val.PubKey, val.Power)
 		}
 		validatorSet = types.NewValidatorSet(validators)
 		nextValidatorSet = types.NewValidatorSet(validators).CopyIncrementAccum(1)

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -30,17 +30,9 @@ func TestABCIValidators(t *testing.T) {
 	pkEd := ed25519.GenPrivKey().PubKey()
 
 	// correct validator
-	tmValExpected := &Validator{
-		Address:     pkEd.Address(),
-		PubKey:      pkEd,
-		VotingPower: 10,
-	}
+	tmValExpected := NewValidator(pkEd, 10)
 
-	tmVal := &Validator{
-		Address:     pkEd.Address(),
-		PubKey:      pkEd,
-		VotingPower: 10,
-	}
+	tmVal := NewValidator(pkEd, 10)
 
 	abciVal := TM2PB.ValidatorUpdate(tmVal)
 	tmVals, err := PB2TM.ValidatorUpdates([]abci.ValidatorUpdate{abciVal})
@@ -127,11 +119,7 @@ func TestABCIValidatorFromPubKeyAndPower(t *testing.T) {
 func TestABCIValidatorWithoutPubKey(t *testing.T) {
 	pkEd := ed25519.GenPrivKey().PubKey()
 
-	abciVal := TM2PB.Validator(&Validator{
-		Address:     pkEd.Address(),
-		PubKey:      pkEd,
-		VotingPower: 10,
-	})
+	abciVal := TM2PB.Validator(NewValidator(pkEd, 10))
 
 	// pubkey must be nil
 	tmValExpected := abci.Validator{


### PR DESCRIPTION
Set the protocol versions in the NodeInfo from the state, not from the globals.

Also avoid use of some Validator literals


* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
