### PR TITLE
fix `RecoverAndLogHandler` not to call multiple writeheader

### DIFF
--- a/rpc/lib/server/http_server.go
+++ b/rpc/lib/server/http_server.go
@@ -173,8 +173,7 @@ func RecoverAndLogHandler(handler http.Handler, logger log.Logger) http.Handler 
 						"Panic in RPC HTTP handler", "err", e, "stack",
 						string(debug.Stack()),
 					)
-					rww.WriteHeader(http.StatusInternalServerError)
-					WriteRPCResponseHTTP(rww, types.RPCInternalError("", e.(error)))
+					WriteRPCResponseHTTPError(rww, http.StatusInternalServerError, types.RPCInternalError("", e.(error)))
 				}
 			}
 


### PR DESCRIPTION
This PR is for suppressing warning log.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md