### PR TITLE
[R4R] libs/log: add year to log format

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -83,6 +83,7 @@ IMPROVEMENTS:
 - [crypto/ed25519] [\#2558](https://github.com/tendermint/tendermint/issues/2558) Switch to use latest `golang.org/x/crypto` through our fork at
   github.com/tendermint/crypto
 - [tools] [\#2238](https://github.com/tendermint/tendermint/issues/2238) Binary dependencies are now locked to a specific git commit
+- [libs/log] [\#2706](https://github.com/tendermint/tendermint/issues/2706) Add year to log format
 
 BUG FIXES:
 - [autofile] [\#2428](https://github.com/tendermint/tendermint/issues/2428) Group.RotateFile need call Flush() before rename (@goolAdapter)

--- a/docs/architecture/adr-001-logging.md
+++ b/docs/architecture/adr-001-logging.md
@@ -52,13 +52,13 @@ On top of this interface, we will need to implement a stdout logger, which will 
 Many people say that they like the current output, so let's stick with it.
 
 ```
-NOTE[04-25|14:45:08] ABCI Replay Blocks                       module=consensus appHeight=0 storeHeight=0 stateHeight=0
+NOTE[2017-04-25|14:45:08] ABCI Replay Blocks                       module=consensus appHeight=0 storeHeight=0 stateHeight=0
 ```
 
 Couple of minor changes:
 
 ```
-I[04-25|14:45:08.322] ABCI Replay Blocks            module=consensus appHeight=0 storeHeight=0 stateHeight=0
+I[2017-04-25|14:45:08.322] ABCI Replay Blocks            module=consensus appHeight=0 storeHeight=0 stateHeight=0
 ```
 
 Notice the level is encoded using only one char plus milliseconds.
@@ -155,14 +155,14 @@ Important keyvals should go first. Example:
 
 ```
 correct
-I[04-25|14:45:08.322] ABCI Replay Blocks                       module=consensus instance=1 appHeight=0 storeHeight=0 stateHeight=0
+I[2017-04-25|14:45:08.322] ABCI Replay Blocks                       module=consensus instance=1 appHeight=0 storeHeight=0 stateHeight=0
 ```
 
 not
 
 ```
 wrong
-I[04-25|14:45:08.322] ABCI Replay Blocks                       module=consensus appHeight=0 storeHeight=0 stateHeight=0 instance=1
+I[2017-04-25|14:45:08.322] ABCI Replay Blocks                       module=consensus appHeight=0 storeHeight=0 stateHeight=0 instance=1
 ```
 
 for that in most cases you'll need to add `instance` field to a logger upon creating, not when u log a particular message:

--- a/libs/log/tmfmt_logger.go
+++ b/libs/log/tmfmt_logger.go
@@ -84,13 +84,13 @@ func (l tmfmtLogger) Log(keyvals ...interface{}) error {
 	// Form a custom Tendermint line
 	//
 	// Example:
-	//     D[05-02|11:06:44.322] Stopping AddrBook (ignoring: already stopped)
+	//     D[2016-05-02|11:06:44.322]   Stopping AddrBook (ignoring: already stopped)
 	//
 	// Description:
 	//     D										- first character of the level, uppercase (ASCII only)
-	//     [05-02|11:06:44.322] - our time format (see https://golang.org/src/time/format.go)
+	//     [2016-05-02|11:06:44.322]    - our time format (see https://golang.org/src/time/format.go)
 	//     Stopping ...					- message
-	enc.buf.WriteString(fmt.Sprintf("%c[%s] %-44s ", lvl[0]-32, time.Now().Format("01-02|15:04:05.000"), msg))
+	enc.buf.WriteString(fmt.Sprintf("%c[%s] %-44s ", lvl[0]-32, time.Now().Format("2016-01-02|15:04:05.000"), msg))
 
 	if module != unknown {
 		enc.buf.WriteString("module=" + module + " ")


### PR DESCRIPTION
According to https://github.com/tendermint/tendermint/issues/2706, I encountered a problem about log format collecting logs to ELK stack for lacking year in timestamp.

Our log format before is:
```
NOTE[04-25|14:45:08] ABCI Replay Blocks                       module=consensus appHeight=0 storeHeight=0 stateHeight=0
```
I want to change it to 
```
NOTE[2017-04-25|14:45:08] ABCI Replay Blocks                       module=consensus appHeight=0 storeHeight=0 stateHeight=0
```

It will help a lot to analyze logs for us.