### PR TITLE
[R4R] Add adr-034: PrivValidator file structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ increasing attention to backwards compatibility. Thanks for bearing with us!
 - [abci] [\#2557](https://github.com/tendermint/tendermint/issues/2557) Add `Codespace` field to `Response{CheckTx, DeliverTx, Query}`
 - [abci] [\#2662](https://github.com/tendermint/tendermint/issues/2662) Add `BlockVersion` and `P2PVersion` to `RequestInfo`
 - [crypto/merkle] [\#2298](https://github.com/tendermint/tendermint/issues/2298) General Merkle Proof scheme for chaining various types of Merkle trees together
+- [docs/architecture] [\#1181](https://github.com/tendermint/tendermint/issues/1181) S
+plit immutable and mutable parts of priv_validator.json
 
 ### IMPROVEMENTS:
 - Additional Metrics

--- a/docs/architecture/adr-034-priv-validator-file-structure.md
+++ b/docs/architecture/adr-034-priv-validator-file-structure.md
@@ -19,8 +19,8 @@ References:
 
 We can split mutable and immutable parts with two structs:
 ```go
-// PVKey stores the immutable part of PrivValidator
-type PVKey struct {
+// FilePVKey stores the immutable part of PrivValidator
+type FilePVKey struct {
 	Address types.Address  `json:"address"`
 	PubKey  crypto.PubKey  `json:"pub_key"`
 	PrivKey crypto.PrivKey `json:"priv_key"`
@@ -29,8 +29,8 @@ type PVKey struct {
 	mtx      sync.Mutex
 }
 
-// PVState stores the mutable part of PrivValidator
-type PVState struct {
+// FilePVState stores the mutable part of PrivValidator
+type FilePVState struct {
 	LastHeight    int64        `json:"last_height"`
 	LastRound     int          `json:"last_round"`
 	LastStep      int8         `json:"last_step"`
@@ -42,7 +42,7 @@ type PVState struct {
 }
 ```
 
-Then we can combine `PVKey` with `PVState` and will get the original `FilePV`.
+Then we can combine `FilePVKey` with `FilePVState` and will get the original `FilePV`.
 
 ```go
 type FilePV struct {

--- a/docs/architecture/adr-034-priv-validator-file-structure.md
+++ b/docs/architecture/adr-034-priv-validator-file-structure.md
@@ -26,30 +26,32 @@ type FilePVKey struct {
 	PrivKey crypto.PrivKey `json:"priv_key"`
 
 	filePath string
-	mtx      sync.Mutex
 }
 
 // FilePVState stores the mutable part of PrivValidator
-type FilePVState struct {
-	LastHeight    int64        `json:"last_height"`
-	LastRound     int          `json:"last_round"`
-	LastStep      int8         `json:"last_step"`
-	LastSignature []byte       `json:"last_signature,omitempty"`
-	LastSignBytes cmn.HexBytes `json:"last_signbytes,omitempty"`
+type FilePVLastSignState struct {
+	Height    int64        `json:"height"`
+	Round     int          `json:"round"`
+	Step      int8         `json:"step"`
+	Signature []byte       `json:"signature,omitempty"`
+	SignBytes cmn.HexBytes `json:"signbytes,omitempty"`
 
 	filePath string
 	mtx      sync.Mutex
 }
 ```
 
-Then we can combine `FilePVKey` with `FilePVState` and will get the original `FilePV`.
+Then we can combine `FilePVKey` with `FilePVLastSignState` and will get the original `FilePV`.
 
 ```go
 type FilePV struct {
-	Key   PVKey
-	State PVState
+	Key           FilePVKey
+	LastSignState FilePVLastSignState
 }
 ```
+
+As discussed, `FilePV` should be located in `config`, and `FilePVLastSignState` should be stored in `data`. The 
+store path of each file should be specified in `config.yml`.
 
 What we need to do next is changing the methods of `FilePV`.
 


### PR DESCRIPTION
# ADR 034: PrivValidator file structure

## Changelog

03-11-2018: Initial Draft

## Context

For now, the PrivValidator file `priv_validator.json` contains mutable and immutable parts. 
Even in an insecure mode which does not encrypt private key on disk, it is reasonable to separate 
the mutable part and immutable part.

References:
[#1181](https://github.com/tendermint/tendermint/issues/1181)
[#2657](https://github.com/tendermint/tendermint/issues/2657)
[#2313](https://github.com/tendermint/tendermint/issues/2313)

## Proposed Solution

We can split mutable and immutable parts with two structs:
```go
// PVKey stores the immutable part of PrivValidator
type PVKey struct {
	Address types.Address  `json:"address"`
	PubKey  crypto.PubKey  `json:"pub_key"`
	PrivKey crypto.PrivKey `json:"priv_key"`

	filePath string
	mtx      sync.Mutex
}

// PVState stores the mutable part of PrivValidator
type PVState struct {
	LastHeight    int64        `json:"last_height"`
	LastRound     int          `json:"last_round"`
	LastStep      int8         `json:"last_step"`
	LastSignature []byte       `json:"last_signature,omitempty"`
	LastSignBytes cmn.HexBytes `json:"last_signbytes,omitempty"`

	filePath string
	mtx      sync.Mutex
}
```

Then we can combine `PVKey` with `PVState` and will get the original `FilePV`.

```go
type FilePV struct {
	Key   PVKey
	State PVState
}
```

What we need to do next is changing the methods of `FilePV`.

## Status

Draft.

## Consequences

### Positive

- separate the mutable and immutable of PrivValidator

### Negative

- need to add more config for file path

### Neutral
