### PR TITLE
Fix crypto/merkle ProofOperators.Verify to check bounds on keypath pa…

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -25,3 +25,5 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+
+* [crypto/merkle] [\#2756](https://github.com/tendermint/tendermint/issues/2756) Fix crypto/merkle ProofOperators.Verify to check bounds on keypath parts.

--- a/crypto/merkle/proof.go
+++ b/crypto/merkle/proof.go
@@ -43,6 +43,9 @@ func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) (er
 	for i, op := range poz {
 		key := op.GetKey()
 		if len(key) != 0 {
+			if len(keys) == 0 {
+				return cmn.NewError("Key path has insufficient # of parts: expected no more keys but got %+v", string(key))
+			}
 			lastKey := keys[len(keys)-1]
 			if !bytes.Equal(lastKey, key) {
 				return cmn.NewError("Key mismatch on operation #%d: expected %+v but got %+v", i, string(lastKey), string(key))

--- a/crypto/merkle/proof_test.go
+++ b/crypto/merkle/proof_test.go
@@ -107,6 +107,10 @@ func TestProofOperators(t *testing.T) {
 	err = popz.Verify(bz("OUTPUT4"), "//KEY4/KEY2/KEY1", [][]byte{bz("INPUT1")})
 	assert.NotNil(t, err)
 
+	// BAD KEY 5
+	err = popz.Verify(bz("OUTPUT4"), "/KEY2/KEY1", [][]byte{bz("INPUT1")})
+	assert.NotNil(t, err)
+
 	// BAD OUTPUT 1
 	err = popz.Verify(bz("OUTPUT4_WRONG"), "/KEY4/KEY2/KEY1", [][]byte{bz("INPUT1")})
 	assert.NotNil(t, err)


### PR DESCRIPTION
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md

NOTE: Go 1.11 has issues where despite the lack of bounds checking prior to this PR, it doesn't panic at all due to a bug in 1.11.  https://go-review.googlesource.com/c/go/+/132495/ . Upgrade to 1.11.2.