### PR TITLE
do not pin deps to exact versions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -129,14 +129,6 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:b0c25f00bad20d783d259af2af8666969e2fc343fa0dc9efe52936bbd67fb758"
-  name = "github.com/rs/cors"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "9a47f48565a795472d43519dd49aac781f3034fb"
-  version = "v1.6.0"
-
-[[projects]]
   digest = "1:ea40c24cdbacd054a6ae9de03e62c5f252479b96c716375aace5c120d68647c8"
   name = "github.com/hashicorp/hcl"
   packages = [
@@ -226,14 +218,16 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:c1a04665f9613e082e1209cf288bf64f4068dcd6c87a64bf1c4ff006ad422ba0"
+  digest = "1:26663fafdea73a38075b07e8e9d82fc0056379d2be8bb4e13899e8fda7c7dd23"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
+    "prometheus/internal",
     "prometheus/promhttp",
   ]
   pruneopts = "UT"
-  revision = "ae27198cdd90bf12cd134ad79d1366a6cf49f632"
+  revision = "abad2d1bd44235a26707c172eab6bca5bf2dbad3"
+  version = "v0.9.1"
 
 [[projects]]
   branch = "master"
@@ -274,6 +268,14 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
+
+[[projects]]
+  digest = "1:b0c25f00bad20d783d259af2af8666969e2fc343fa0dc9efe52936bbd67fb758"
+  name = "github.com/rs/cors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9a47f48565a795472d43519dd49aac781f3034fb"
+  version = "v1.6.0"
 
 [[projects]]
   digest = "1:6a4a11ba764a56d2758899ec6f3848d24698d48442ebce85ee7a3f63284526cd"
@@ -524,6 +526,7 @@
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/rcrowley/go-metrics",
+    "github.com/rs/cors",
     "github.com/spf13/cobra",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,57 +20,60 @@
 #   unused-packages = true
 #
 ###########################################################
-# NOTE: All packages should be pinned to specific versions.
-# Packages without releases must pin to a commit.
 
-
+# Allow only patch releases for serialization libraries
 [[constraint]]
-  name = "github.com/go-kit/kit"
-  version = "=0.6.0"
+  name = "github.com/tendermint/go-amino"
+  version = "~0.14.1"
 
 [[constraint]]
   name = "github.com/gogo/protobuf"
-  version = "=1.1.1"
+  version = "~1.1.1"
 
 [[constraint]]
   name = "github.com/golang/protobuf"
-  version = "=1.1.0"
+  version = "~1.1.0"
+
+# Allow only minor releases for other libraries
+[[constraint]]
+  name = "github.com/go-kit/kit"
+  version = "^0.6.0"
 
 [[constraint]]
   name = "github.com/gorilla/websocket"
-  version = "=1.2.0"
+  version = "^1.2.0"
 
 [[constraint]]
   name = "github.com/rs/cors"
-  version = "1.6.0"
+  version = "^1.6.0"
 
 [[constraint]]
   name = "github.com/pkg/errors"
-  version = "=0.8.0"
+  version = "^0.8.0"
 
 [[constraint]]
   name = "github.com/spf13/cobra"
-  version = "=0.0.1"
+  version = "^0.0.1"
 
 [[constraint]]
   name = "github.com/spf13/viper"
-  version = "=1.0.0"
+  version = "^1.0.0"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "=1.2.1"
-
-[[constraint]]
-  name = "github.com/tendermint/go-amino"
-  version = "v0.14.1"
+  version = "^1.2.1"
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "=1.13.0"
+  version = "~1.13.0"
 
 [[constraint]]
   name = "github.com/fortytw2/leaktest"
-  version = "=1.2.0"
+  version = "^1.2.0"
+
+[[constraint]]
+  name = "github.com/prometheus/client_golang"
+  version = "^0.9.1"
 
 ###################################
 ## Some repos dont have releases.
@@ -93,11 +96,6 @@
 [[constraint]]
   name = "github.com/tendermint/btcd"
   revision = "e5840949ff4fff0c56f9b6a541e22b63581ea9df"
-
-# Haven't made a release since 2016.
-[[constraint]]
-  name = "github.com/prometheus/client_golang"
-  revision = "ae27198cdd90bf12cd134ad79d1366a6cf49f632"
 
 [[constraint]]
   name = "github.com/rcrowley/go-metrics"


### PR DESCRIPTION
(at least those with releases)

because
- they are locked in .lock file already
- individual dependencies can be updated with `dep ensure -update XXX`
- review process (and ^^^) should help us prevent accidental updates

Closes #2798

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
