### PR TITLE
p2p: log 'Send failed' on Debug

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,9 +26,12 @@ program](https://hackerone.com/tendermint).
 
 
 ### FEATURES:
-- [log] new `log_format` config option, which can be set to 'plain' for colored
+
+- [log] \#2843 New `log_format` config option, which can be set to 'plain' for colored
   text or 'json' for JSON output
 
 ### IMPROVEMENTS:
+
+- [p2p] \#2857 "Send failed" is logged at debug level instead of error.
 
 ### BUG FIXES:

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -269,7 +269,7 @@ func (c *MConnection) Send(chID byte, msgBytes []byte) bool {
 		default:
 		}
 	} else {
-		c.Logger.Error("Send failed", "channel", chID, "conn", c, "msgBytes", fmt.Sprintf("%X", msgBytes))
+		c.Logger.Debug("Send failed", "channel", chID, "conn", c, "msgBytes", fmt.Sprintf("%X", msgBytes))
 	}
 	return success
 }


### PR DESCRIPTION
Addresses https://github.com/tendermint/tendermint/issues/1817

It's the responsibility of callers to check if the send failed and act appropriately.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
