### PR TITLE
Close and retry a RemoteSigner on err

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -25,4 +25,6 @@ program](https://hackerone.com/tendermint).
 
 ### IMPROVEMENTS:
 
+Retry RemoteSigner connections on Error
+
 ### BUG FIXES:

--- a/privval/tcp.go
+++ b/privval/tcp.go
@@ -123,6 +123,9 @@ func (sc *TCPVal) OnStart() error {
 						"Ping",
 						"err", err,
 					)
+					sc.conn.Close()
+					sc.RemoteSignerClient = NewRemoteSignerClient(sc.conn)
+
 				}
 			case <-sc.cancelPing:
 				sc.pingTicker.Stop()


### PR DESCRIPTION
This allows recovery if the RemoteSigner service is restarted etc without restarting the process.