### PR TITLE
Modify the txs number in ReapMaxTxs

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -517,8 +517,9 @@ func (mem *Mempool) ReapMaxTxs(max int) types.Txs {
 		time.Sleep(time.Millisecond * 10)
 	}
 
-	txs := make([]types.Tx, 0, cmn.MinInt(mem.txs.Len(), max))
-	for e := mem.txs.Front(); e != nil && len(txs) <= max; e = e.Next() {
+	numTxsToReap := cmn.MinInt(mem.txs.Len(), max)
+	txs := make([]types.Tx, 0, numTxsToReap)
+	for e := mem.txs.Front(); len(txs) < numTxsToReap; e = e.Next() {
 		memTx := e.Value.(*mempoolTx)
 		txs = append(txs, memTx.tx)
 	}


### PR DESCRIPTION
if mem.txs.Len() is less than max, we should collect the mem.txs.Len()
txs in ReapMaxTxs, So it's better to use minimum among  mem.txs.Len() and
max when we colletc txs

Signed-off-by: Zeyu Zhu <zhuzeyu0409@gmail.com>

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
