### PR TITLE
Remove counter from every mempoolTx

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,5 +27,6 @@ program](https://hackerone.com/tendermint).
 
 - [config] \#2877 add blocktime_iota to the config.toml (@ackratos)
 - [mempool] \#2855 add txs from Update to cache
+- [mempool] \#2835 Remove local int64 counter from being stored in every tx
 
 ### BUG FIXES:


### PR DESCRIPTION
Within every tx in the mempool, we store a 64 bit counter,
as an index for when it was inserted into the mempool.
This counter doesn't really serve any purpose.
It was likely added for debugging at one point,
Removing the counter reclaims memory,
which enables greater mempool sizes / mitigates resources at the same size.

Closes #2835

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs - not mentioned in docs
* [x] Wrote tests - current tests all pass
* [x] Updated CHANGELOG_PENDING.md
