### PR TITLE
Updated Marshal and unmarshal methods to make compatible with protobuf

### DIFF
--- a/consensus/types/peer_round_state.go
+++ b/consensus/types/peer_round_state.go
@@ -56,19 +56,21 @@ func (prs PeerRoundState) StringIndented(indent string) string {
 		indent)
 }
 
-// Protobuf Compatiablity
-// Size returns size of the PeerRoundState in bytes.
+//-----------------------------------------------------------
+// These methods are for Protobuf Compatibility
+
+// Size returns the size of the amino encoding, in bytes.
 func (ps *PeerRoundState) Size() int {
 	bs, _ := ps.Marshal()
 	return len(bs)
 }
 
-//Marshal interface  serialize the PeerRoundState object and allocates the appropriate buffer.
+// Marshal returns the amino encoding.
 func (ps *PeerRoundState) Marshal() ([]byte, error) {
 	return cdc.MarshalBinaryBare(ps)
 }
 
-//MarshalTo method allows PeerRoundState object to use reusable buffer.
+// MarshalTo calls Marshal and copies to the given buffer.
 func (ps *PeerRoundState) MarshalTo(data []byte) (int, error) {
 	bs, err := ps.Marshal()
 	if err != nil {
@@ -77,7 +79,7 @@ func (ps *PeerRoundState) MarshalTo(data []byte) (int, error) {
 	return copy(data, bs), nil
 }
 
-//Unmarshal interface takes the serialized peerRoundState object and transforms into an executable form.
+// Unmarshal deserializes from amino encoded form.
 func (ps *PeerRoundState) Unmarshal(bs []byte) error {
 	return cdc.UnmarshalBinaryBare(bs, ps)
 }

--- a/consensus/types/peer_round_state.go
+++ b/consensus/types/peer_round_state.go
@@ -55,3 +55,29 @@ func (prs PeerRoundState) StringIndented(indent string) string {
 		indent, prs.CatchupCommit, prs.CatchupCommitRound,
 		indent)
 }
+
+// Protobuf Compatiablity
+// Size returns size of the PeerRoundState in bytes.
+func (ps *PeerRoundState) Size() int {
+	bs, _ := ps.Marshal()
+	return len(bs)
+}
+
+//Marshal interface  serialize the PeerRoundState object and allocates the appropriate buffer.
+func (ps *PeerRoundState) Marshal() ([]byte, error) {
+	return cdc.MarshalBinaryBare(ps)
+}
+
+//MarshalTo method allows PeerRoundState object to use reusable buffer.
+func (ps *PeerRoundState) MarshalTo(data []byte) (int, error) {
+	bs, err := ps.Marshal()
+	if err != nil {
+		return -1, err
+	}
+	return copy(data, bs), nil
+}
+
+//Unmarshal interface takes the serialized peerRoundState object and transforms into an executable form.
+func (ps *PeerRoundState) Unmarshal(bs []byte) error {
+	return cdc.UnmarshalBinaryBare(bs, ps)
+}

--- a/consensus/types/round_state.go
+++ b/consensus/types/round_state.go
@@ -202,19 +202,21 @@ func (rs *RoundState) StringShort() string {
 		rs.Height, rs.Round, rs.Step, rs.StartTime)
 }
 
-// Protobuf Compatiablity
-// Size returns size of the RoundStateSimple in bytes.
+//-----------------------------------------------------------
+// These methods are for Protobuf Compatibility
+
+// Size returns the size of the amino encoding, in bytes.
 func (rs *RoundStateSimple) Size() int {
 	bs, _ := rs.Marshal()
 	return len(bs)
 }
 
-//Marshal interface  serialize the RoundStateSimple object and allocates the appropriate buffer.
+// Marshal returns the amino encoding.
 func (rs *RoundStateSimple) Marshal() ([]byte, error) {
 	return cdc.MarshalBinaryBare(rs)
 }
 
-//MarshalTo method allows RoundStateSimple object to use reusable buffer.
+// MarshalTo calls Marshal and copies to the given buffer.
 func (rs *RoundStateSimple) MarshalTo(data []byte) (int, error) {
 	bs, err := rs.Marshal()
 	if err != nil {
@@ -223,7 +225,7 @@ func (rs *RoundStateSimple) MarshalTo(data []byte) (int, error) {
 	return copy(data, bs), nil
 }
 
-//Unmarshal interface takes the serialized RoundStateSimple object and transforms into an executable form.
+// Unmarshal deserializes from amino encoded form.
 func (rs *RoundStateSimple) Unmarshal(bs []byte) error {
 	return cdc.UnmarshalBinaryBare(bs, rs)
 }

--- a/consensus/types/round_state.go
+++ b/consensus/types/round_state.go
@@ -201,3 +201,29 @@ func (rs *RoundState) StringShort() string {
 	return fmt.Sprintf(`RoundState{H:%v R:%v S:%v ST:%v}`,
 		rs.Height, rs.Round, rs.Step, rs.StartTime)
 }
+
+// Protobuf Compatiablity
+// Size returns size of the RoundStateSimple in bytes.
+func (rs *RoundStateSimple) Size() int {
+	bs, _ := rs.Marshal()
+	return len(bs)
+}
+
+//Marshal interface  serialize the RoundStateSimple object and allocates the appropriate buffer.
+func (rs *RoundStateSimple) Marshal() ([]byte, error) {
+	return cdc.MarshalBinaryBare(rs)
+}
+
+//MarshalTo method allows RoundStateSimple object to use reusable buffer.
+func (rs *RoundStateSimple) MarshalTo(data []byte) (int, error) {
+	bs, err := rs.Marshal()
+	if err != nil {
+		return -1, err
+	}
+	return copy(data, bs), nil
+}
+
+//Unmarshal interface takes the serialized RoundStateSimple object and transforms into an executable form.
+func (rs *RoundStateSimple) Unmarshal(bs []byte) error {
+	return cdc.UnmarshalBinaryBare(bs, rs)
+}

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -231,18 +231,21 @@ func (info DefaultNodeInfo) NetAddress() *NetAddress {
 	return netAddr
 }
 
-// Protobuf Compatiablity
-//Unmarshal interface takes the serialized DefaultNodeInfo object and transforms into an executable form.
-func (info *DefaultNodeInfo) Unmarshal(bs []byte) error {
-	return cdc.UnmarshalBinaryBare(bs, info)
+//-----------------------------------------------------------
+// These methods are for Protobuf Compatibility
+
+// Size returns the size of the amino encoding, in bytes.
+func (info *DefaultNodeInfo) Size() int {
+	bs, _ := info.Marshal()
+	return len(bs)
 }
 
-//Marshal interface  serialize the DefaultNodeInfo object and allocates the appropriate buffer.
+// Marshal returns the amino encoding.
 func (info *DefaultNodeInfo) Marshal() ([]byte, error) {
 	return cdc.MarshalBinaryBare(info)
 }
 
-//MarshalTo method allows DefaultNodeInfo object to use reusable buffer.
+// MarshalTo calls Marshal and copies to the given buffer.
 func (info *DefaultNodeInfo) MarshalTo(data []byte) (int, error) {
 	bs, err := info.Marshal()
 	if err != nil {
@@ -251,9 +254,7 @@ func (info *DefaultNodeInfo) MarshalTo(data []byte) (int, error) {
 	return copy(data, bs), nil
 }
 
-// Size returns size of the DefaultNodeInfo in bytes.
-func (info *DefaultNodeInfo) Size() int {
-	bs, _ := info.Marshal()
-	return len(bs)
+// Unmarshal deserializes from amino encoded form.
+func (info *DefaultNodeInfo) Unmarshal(bs []byte) error {
+	return cdc.UnmarshalBinaryBare(bs, info)
 }
-

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -230,3 +230,30 @@ func (info DefaultNodeInfo) NetAddress() *NetAddress {
 	}
 	return netAddr
 }
+
+// Protobuf Compatiablity
+//Unmarshal interface takes the serialized DefaultNodeInfo object and transforms into an executable form.
+func (info *DefaultNodeInfo) Unmarshal(bs []byte) error {
+	return cdc.UnmarshalBinaryBare(bs, info)
+}
+
+//Marshal interface  serialize the DefaultNodeInfo object and allocates the appropriate buffer.
+func (info *DefaultNodeInfo) Marshal() ([]byte, error) {
+	return cdc.MarshalBinaryBare(info)
+}
+
+//MarshalTo method allows DefaultNodeInfo object to use reusable buffer.
+func (info *DefaultNodeInfo) MarshalTo(data []byte) (int, error) {
+	bs, err := info.Marshal()
+	if err != nil {
+		return -1, err
+	}
+	return copy(data, bs), nil
+}
+
+// Size returns size of the DefaultNodeInfo in bytes.
+func (info *DefaultNodeInfo) Size() int {
+	bs, _ := info.Marshal()
+	return len(bs)
+}
+

--- a/types/block.go
+++ b/types/block.go
@@ -275,13 +275,15 @@ func (b *Block) StringShort() string {
 	return fmt.Sprintf("Block#%v", b.Hash())
 }
 
-// Protobuf Compatiablity
-//Marshal interface  serialize the block object and allocates the appropriate buffer.
+//-----------------------------------------------------------
+// These methods are for Protobuf Compatibility
+
+// Marshal returns the amino encoding.
 func (b *Block) Marshal() ([]byte, error) {
 	return cdc.MarshalBinaryBare(b)
 }
 
-//MarshalTo method allows block object to use reusable buffer.
+// MarshalTo calls Marshal and copies to the given buffer.
 func (b *Block) MarshalTo(data []byte) (int, error) {
 	bs, err := b.Marshal()
 	if err != nil {
@@ -290,7 +292,7 @@ func (b *Block) MarshalTo(data []byte) (int, error) {
 	return copy(data, bs), nil
 }
 
-//Unmarshal interface takes the serialized block object and transforms into an executable form.
+// Unmarshal deserializes from amino encoded form.
 func (b *Block) Unmarshal(bs []byte) error {
 	return cdc.UnmarshalBinaryBare(bs, b)
 }

--- a/types/block.go
+++ b/types/block.go
@@ -275,6 +275,26 @@ func (b *Block) StringShort() string {
 	return fmt.Sprintf("Block#%v", b.Hash())
 }
 
+// Protobuf Compatiablity
+//Marshal interface  serialize the block object and allocates the appropriate buffer.
+func (b *Block) Marshal() ([]byte, error) {
+	return cdc.MarshalBinaryBare(b)
+}
+
+//MarshalTo method allows block object to use reusable buffer.
+func (b *Block) MarshalTo(data []byte) (int, error) {
+	bs, err := b.Marshal()
+	if err != nil {
+		return -1, err
+	}
+	return copy(data, bs), nil
+}
+
+//Unmarshal interface takes the serialized block object and transforms into an executable form.
+func (b *Block) Unmarshal(bs []byte) error {
+	return cdc.UnmarshalBinaryBare(bs, b)
+}
+
 //-----------------------------------------------------------------------------
 
 // MaxDataBytes returns the maximum size of block's data.

--- a/types/block_meta.go
+++ b/types/block_meta.go
@@ -14,18 +14,21 @@ func NewBlockMeta(block *Block, blockParts *PartSet) *BlockMeta {
 	}
 }
 
-// Protobuf Compatiablity
-//Unmarshal interface takes the serialized block-meta object and transforms into an executable form.
-func (bm *BlockMeta) Unmarshal(bs []byte) error {
-	return cdc.UnmarshalBinaryBare(bs, bm)
+//-----------------------------------------------------------
+// These methods are for Protobuf Compatibility
+
+// Size returns the size of the amino encoding, in bytes.
+func (bm *BlockMeta) Size() int {
+	bs, _ := bm.Marshal()
+	return len(bs)
 }
 
-//Marshal interface  serialize the block-meta object and allocates the appropriate buffer.
+// Marshal returns the amino encoding.
 func (bm *BlockMeta) Marshal() ([]byte, error) {
 	return cdc.MarshalBinaryBare(bm)
 }
 
-//MarshalTo method allows BlockMeta object to use reusable buffer.
+// MarshalTo calls Marshal and copies to the given buffer.
 func (bm *BlockMeta) MarshalTo(data []byte) (int, error) {
 	bs, err := bm.Marshal()
 	if err != nil {
@@ -34,8 +37,7 @@ func (bm *BlockMeta) MarshalTo(data []byte) (int, error) {
 	return copy(data, bs), nil
 }
 
-// Size returns size of the block in bytes.
-func (bm *BlockMeta) Size() int {
-	bs, _ := bm.Marshal()
-	return len(bs)
+// Unmarshal deserializes from amino encoded form.
+func (bm *BlockMeta) Unmarshal(bs []byte) error {
+	return cdc.UnmarshalBinaryBare(bs, bm)
 }

--- a/types/block_meta.go
+++ b/types/block_meta.go
@@ -13,3 +13,29 @@ func NewBlockMeta(block *Block, blockParts *PartSet) *BlockMeta {
 		Header:  block.Header,
 	}
 }
+
+// Protobuf Compatiablity
+//Unmarshal interface takes the serialized block-meta object and transforms into an executable form.
+func (bm *BlockMeta) Unmarshal(bs []byte) error {
+	return cdc.UnmarshalBinaryBare(bs, bm)
+}
+
+//Marshal interface  serialize the block-meta object and allocates the appropriate buffer.
+func (bm *BlockMeta) Marshal() ([]byte, error) {
+	return cdc.MarshalBinaryBare(bm)
+}
+
+//MarshalTo method allows BlockMeta object to use reusable buffer.
+func (bm *BlockMeta) MarshalTo(data []byte) (int, error) {
+	bs, err := bm.Marshal()
+	if err != nil {
+		return -1, err
+	}
+	return copy(data, bs), nil
+}
+
+// Size returns size of the block in bytes.
+func (bm *BlockMeta) Size() int {
+	bs, _ := bm.Marshal()
+	return len(bs)
+}


### PR DESCRIPTION
Reffer to #2705 
 * updated the comment for marshal and unmarshal methods which was created to make protobuf 
    compatible.
 * Added the marshal,unmarshal,size and MarshalTo methods  for nodeinfo.go

