### PR TITLE
fix:  add /kvPairKey: to key for proof verification

### DIFF
--- a/lite/proxy/query.go
+++ b/lite/proxy/query.go
@@ -77,7 +77,8 @@ func GetWithProofOptions(prt *merkle.ProofRuntime, path string, key []byte, opts
 	if resp.Value != nil {
 		// Value exists
 		// XXX How do we encode the key into a string...
-		err = prt.VerifyValue(resp.Proof, signedHeader.AppHash, string(resp.Key), resp.Value)
+		keyString := "/kvPairKey:" + string(resp.Key)
+		err = prt.VerifyValue(resp.Proof, signedHeader.AppHash, keyString, resp.Value)
 		if err != nil {
 			return nil, cmn.ErrorWrap(err, "Couldn't verify value proof")
 		}


### PR DESCRIPTION
prepending /kvPairKey: is likely a temporary fix. Ideally we would prepend just the `/` to allow for future implementations that don't have the kvPairKey prefix.  Currently the prefix is attached on the server side, I think prepending it on the client side would be ideal (if we need a prefix)
