### PR TITLE
Add client.Start() to RPC WS docs

### DIFF
--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -54,11 +54,12 @@ import (
 // import "github.com/tendermint/tendermint/types"
 //
 // client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
+// err := client.Start()
 // ctx, cancel := context.WithTimeout(context.Background(), timeout)
 // defer cancel()
 // query := query.MustParse("tm.event = 'Tx' AND tx.height = 3")
 // txs := make(chan interface{})
-// err := client.Subscribe(ctx, "test-client", query, txs)
+// err = client.Subscribe(ctx, "test-client", query, txs)
 //
 // go func() {
 //   for e := range txs {
@@ -116,7 +117,8 @@ func Subscribe(wsCtx rpctypes.WSRPCContext, query string) (*ctypes.ResultSubscri
 //
 // ```go
 // client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Unsubscribe("test-client", query)
+// err := client.Start()
+// err = client.Unsubscribe("test-client", query)
 // ```
 //
 // > The above command returns JSON structured like this:
@@ -155,7 +157,8 @@ func Unsubscribe(wsCtx rpctypes.WSRPCContext, query string) (*ctypes.ResultUnsub
 //
 // ```go
 // client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.UnsubscribeAll("test-client")
+// err := client.Start()
+// err = client.UnsubscribeAll("test-client")
 // ```
 //
 // > The above command returns JSON structured like this:


### PR DESCRIPTION
If we trying to use examples from [WS RPC docs](https://tendermint.com/rpc/#subscribe), we getting such panic: 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x1643589]

goroutine 1 [running]:
github.com/daniildulin/rpc-test/vendor/github.com/tendermint/tendermint/rpc/lib/client.(*WSClient).Call(0x0, 0x1a1e480, 0xc000012f00, 0x183227a, 0x9, 0xc000817c30, 0x20, 0x18)
```

This happens because we need to start client service before using WS methods like `Subscribe`/`Unsubscribe`.