### PR TITLE
types: NewValidatorSet doesn't panic on empty valz list

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -30,3 +30,5 @@ program](https://hackerone.com/tendermint).
 - [consensus] [\#2871](https://github.com/tendermint/tendermint/issues/2871) Remove *ProposalHeartbeat* infrastructure as it serves no real purpose
 
 ### BUG FIXES:
+- [types] \#2938 Fix regression in v0.26.4 where we panic on empty
+  genDoc.Validators

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -29,10 +29,10 @@ type ValidatorSet struct {
 	totalVotingPower int64
 }
 
+// NewValidatorSet initializes a ValidatorSet by copying over the
+// values from `valz`, a list of Validators. If valz is nil or empty,
+// the new ValidatorSet will have an empty list of Validators.
 func NewValidatorSet(valz []*Validator) *ValidatorSet {
-	if valz != nil && len(valz) == 0 {
-		panic("validator set initialization slice cannot be an empty slice (but it can be nil)")
-	}
 	validators := make([]*Validator, len(valz))
 	for i, val := range valz {
 		validators[i] = val.Copy()

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -17,9 +17,12 @@ import (
 )
 
 func TestValidatorSetBasic(t *testing.T) {
-	assert.Panics(t, func() { NewValidatorSet([]*Validator{}) })
+	// empty or nil validator lists are allowed,
+	// but attempting to IncrementAccum on them will panic.
+	vset := NewValidatorSet([]*Validator{})
+	assert.Panics(t, func() { vset.IncrementAccum(1) })
 
-	vset := NewValidatorSet(nil)
+	vset = NewValidatorSet(nil)
 	assert.Panics(t, func() { vset.IncrementAccum(1) })
 
 	assert.EqualValues(t, vset, vset.Copy())


### PR DESCRIPTION
Fixes regression in v0.26.4 https://github.com/tendermint/tendermint/issues/2937

We should backport this to v0.26.5 as well.

We should also write a test for the case where the genesis has no validators (allowed, since they can be set by InitChain), since this is what the SDK and more advanced apps will do ...

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
