### PR TITLE
Add some ProposerPriority tests 

### DIFF
--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -279,6 +279,7 @@ func (vals *ValidatorSet) Update(val *Validator) (updated bool) {
 	if sameVal == nil {
 		return false
 	}
+	val.ProposerPriority = sameVal.ProposerPriority
 	vals.Validators[index] = val.Copy()
 	// Invalidate cache
 	vals.Proposer = nil

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -62,8 +62,12 @@ func TestValidatorSetBasic(t *testing.T) {
 
 	// update
 	assert.False(t, vset.Update(randValidator_()))
-	val.VotingPower = 100
+	_, val = vset.GetByAddress(val.Address)
+	val.VotingPower += 100
+	proposerPriority := val.ProposerPriority
 	assert.True(t, vset.Update(val))
+	_, val = vset.GetByAddress(val.Address)
+	assert.Equal(t, proposerPriority, val.ProposerPriority)
 
 	// remove
 	val2, removed := vset.Remove(randValidator_().Address)

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -390,97 +390,100 @@ func TestAveragingInIncrementProposerPriority(t *testing.T) {
 func TestAveragingInIncrementProposerPriorityWithVotingPower(t *testing.T) {
 	// Other than TestAveragingInIncrementProposerPriority this is a more complete test showing
 	// how each ProposerPriority changes in relation to the validator's voting power respectively.
+	vals := ValidatorSet{Validators: []*Validator{
+		{Address: []byte{0}, ProposerPriority: 0, VotingPower: 10},
+		{Address: []byte{1}, ProposerPriority: 0, VotingPower: 1},
+		{Address: []byte{2}, ProposerPriority: 0, VotingPower: 1}}}
 	tcs := []struct {
-		vals                  []*Validator
+		vals                  *ValidatorSet
 		wantProposerPrioritys []int64
 		times                 int
+		wantProposer          *Validator
 	}{
+
 		0: {
-			[]*Validator{
-				{Address: []byte("a"), ProposerPriority: 0, VotingPower: 10},
-				{Address: []byte("b"), ProposerPriority: 0, VotingPower: 1},
-				{Address: []byte("c"), ProposerPriority: 0, VotingPower: 1}},
+			vals.Copy(),
 			[]int64{
 				// Acumm+VotingPower-Avg:
 				0 + 10 - 12 - 4, // mostest will be subtracted by total voting power (12)
 				0 + 1 - 4,
 				0 + 1 - 4},
-			1},
+			1,
+			vals.Validators[0]},
 		1: {
-			[]*Validator{
-				{Address: []byte("a"), ProposerPriority: 0, VotingPower: 10},
-				{Address: []byte("b"), ProposerPriority: 0, VotingPower: 1},
-				{Address: []byte("c"), ProposerPriority: 0, VotingPower: 1}},
+			vals.Copy(),
 			[]int64{
 				(0 + 10 - 12 - 4) + 10 - 12 + 4, // this will be mostest on 2nd iter, too
 				(0 + 1 - 4) + 1 + 4,
 				(0 + 1 - 4) + 1 + 4},
-			2}, // increment twice -> expect average to be subtracted twice
+			2,
+			vals.Validators[0]}, // increment twice -> expect average to be subtracted twice
 		2: {
-			[]*Validator{
-				{Address: []byte("a"), ProposerPriority: 0, VotingPower: 10},
-				{Address: []byte("b"), ProposerPriority: 0, VotingPower: 1},
-				{Address: []byte("c"), ProposerPriority: 0, VotingPower: 1}},
+			vals.Copy(),
 			[]int64{
 				((0 + 10 - 12 - 4) + 10 - 12) + 10 - 12 + 4, // still mostest
 				((0 + 1 - 4) + 1) + 1 + 4,
 				((0 + 1 - 4) + 1) + 1 + 4},
-			3},
+			3,
+			vals.Validators[0]},
 		3: {
-			[]*Validator{
-				{Address: []byte("a"), ProposerPriority: 0, VotingPower: 10},
-				{Address: []byte("b"), ProposerPriority: 0, VotingPower: 1},
-				{Address: []byte("c"), ProposerPriority: 0, VotingPower: 1}},
+			vals.Copy(),
 			[]int64{
 				0 + 4*(10-12) + 4 - 4, // still mostest
 				0 + 4*1 + 4 - 4,
 				0 + 4*1 + 4 - 4},
-			4},
+			4,
+			vals.Validators[0]},
 		4: {
-			[]*Validator{
-				{Address: []byte("a"), ProposerPriority: 0, VotingPower: 10},
-				{Address: []byte("b"), ProposerPriority: 0, VotingPower: 1},
-				{Address: []byte("c"), ProposerPriority: 0, VotingPower: 1}},
+			vals.Copy(),
 			[]int64{
 				0 + 4*(10-12) + 10 + 4 - 4, // 4 iters was mostest
 				0 + 5*1 - 12 + 4 - 4,       // now this val is mostest for the 1st time (hence -12==totalVotingPower)
 				0 + 5*1 + 4 - 4},
-			5},
+			5,
+			vals.Validators[1]},
 		5: {
-			[]*Validator{
-				{Address: []byte("a"), ProposerPriority: 0, VotingPower: 10},
-				{Address: []byte("b"), ProposerPriority: 0, VotingPower: 1},
-				{Address: []byte("c"), ProposerPriority: 0, VotingPower: 1}},
+			vals.Copy(),
 			[]int64{
 				0 + 6*10 - 5*12 + 4 - 4, // mostest again
 				0 + 6*1 - 12 + 4 - 4,    // mostest once up to here
 				0 + 6*1 + 4 - 4},
-			6},
+			6,
+			vals.Validators[0]},
 		6: {
-			[]*Validator{
-				{Address: []byte("a"), ProposerPriority: 0, VotingPower: 10},
-				{Address: []byte("b"), ProposerPriority: 0, VotingPower: 1},
-				{Address: []byte("c"), ProposerPriority: 0, VotingPower: 1}},
+			vals.Copy(),
 			[]int64{
 				0 + 7*10 - 6*12 + 4 - 4, // in 7 iters this val is mostest 6 times
 				0 + 7*1 - 12 + 4 - 4,    // in 7 iters this val is mostest 1 time
 				0 + 7*1 + 4 - 4},
-			7},
+			7,
+			vals.Validators[0]},
 		7: {
-			[]*Validator{
-				{Address: []byte("a"), ProposerPriority: 0, VotingPower: 10},
-				{Address: []byte("b"), ProposerPriority: 0, VotingPower: 1},
-				{Address: []byte("c"), ProposerPriority: 0, VotingPower: 1}},
+			vals.Copy(),
 			[]int64{
-				0 + 10*10 - 8*12 + 4 - 4,
-				0 + 10*1 - 12 + 4 - 4,   // after 6 iters this val is "mostest" once and not in between
-				0 + 10*1 + -12 + 4 - 4}, // after 10 iters this val is "mostest" once
-			10},
+				0 + 8*10 - 7*12 + 4 - 4, // mostest
+				0 + 8*1 - 12 + 4 - 4,
+				0 + 8*1 + 4 - 4},
+			8,
+			vals.Validators[0]},
 		8: {
-			[]*Validator{
-				{Address: []byte("a"), ProposerPriority: 0, VotingPower: 10},
-				{Address: []byte("b"), ProposerPriority: 0, VotingPower: 1},
-				{Address: []byte("c"), ProposerPriority: 0, VotingPower: 1}},
+			vals.Copy(),
+			[]int64{
+				0 + 9*10 - 7*12 + 4 - 4,
+				0 + 9*1 - 12 + 4 - 4,
+				0 + 9*1 - 12 + 4 - 4}, // mostest
+			9,
+			vals.Validators[2]},
+		9: {
+			vals.Copy(),
+			[]int64{
+				0 + 10*10 - 8*12 + 4 - 4, // after 10 iters this is mostest again
+				0 + 10*1 - 12 + 4 - 4,    // after 6 iters this val is "mostest" once and not in between
+				0 + 10*1 - 12 + 4 - 4},   // in between 10 iters this val is "mostest" once
+			10,
+			vals.Validators[0]},
+		10: {
+			vals.Copy(),
 			[]int64{
 				// shift twice inside incrementProposerPriority (shift every 10th iter);
 				// don't shift at the end of IncremenctProposerPriority
@@ -491,12 +494,17 @@ func TestAveragingInIncrementProposerPriorityWithVotingPower(t *testing.T) {
 				0 + 11*10 - 8*12 - 4 - 12 - 0,
 				0 + 11*1 - 12 - 4 - 0,  // after 6 iters this val is "mostest" once and not in between
 				0 + 11*1 - 12 - 4 - 0}, // after 10 iters this val is "mostest" once
-			11},
+			11,
+			vals.Validators[0]},
 	}
 	for i, tc := range tcs {
-		vals := ValidatorSet{Validators: tc.vals}
-		vals.IncrementProposerPriority(tc.times)
-		for valIdx, val := range tc.vals {
+		tc.vals.IncrementProposerPriority(tc.times)
+
+		assert.Equal(t, tc.wantProposer.Address, tc.vals.GetProposer().Address,
+			"test case: %v",
+			i)
+
+		for valIdx, val := range tc.vals.Validators {
 			assert.Equal(t,
 				tc.wantProposerPrioritys[valIdx],
 				val.ProposerPriority,

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -335,7 +335,155 @@ func TestAvgProposerPriority(t *testing.T) {
 		got := tc.vs.computeAvgProposerPriority()
 		assert.Equal(t, tc.want, got, "test case: %v", i)
 	}
+}
 
+func TestAveragingInIncrementAccum(t *testing.T) {
+	tcs := []struct {
+		vs    ValidatorSet
+		times int
+		avg   int64
+	}{
+		0: {ValidatorSet{
+			Validators: []*Validator{
+				{Address: []byte("a"), Accum: 1},
+				{Address: []byte("b"), Accum: 2},
+				{Address: []byte("c"), Accum: 3}}},
+			1, 2},
+		1: {ValidatorSet{
+			Validators: []*Validator{
+				{Address: []byte("a"), Accum: 10},
+				{Address: []byte("b"), Accum: -10},
+				{Address: []byte("c"), Accum: 1}}},
+			// this should average twice but the average should be 0 after the first iteration
+			// (voting power is 0 -> no changes)
+			11, 1 / 3},
+		2: {ValidatorSet{
+			Validators: []*Validator{
+				{Address: []byte("a"), Accum: 100},
+				{Address: []byte("b"), Accum: -10},
+				{Address: []byte("c"), Accum: 1}}},
+			1, 91 / 3},
+	}
+	for i, tc := range tcs {
+		// work on copy to have the old Accums:
+		newVset := tc.vs.CopyIncrementAccum(tc.times)
+		for _, val := range tc.vs.Validators {
+			_, updatedVal := newVset.GetByAddress(val.Address)
+			assert.Equal(t, updatedVal.Accum, val.Accum-tc.avg, "test case: %v", i)
+		}
+	}
+}
+
+func TestAveragingInIncrementAccumWithVotingPower(t *testing.T) {
+	tcs := []struct {
+		vals       []*Validator
+		wantAccums []int64
+		times      int
+	}{
+		0: {
+			[]*Validator{
+				{Address: []byte("a"), Accum: 0, VotingPower: 10},
+				{Address: []byte("b"), Accum: 0, VotingPower: 1},
+				{Address: []byte("c"), Accum: 0, VotingPower: 1}},
+			[]int64{
+				// Acumm+VotingPower-Avg:
+				0 + 10 - 12 - 4, // mostest will be subtracted by total voting power (12)
+				0 + 1 - 4,
+				0 + 1 - 4},
+			1},
+		1: {
+			[]*Validator{
+				{Address: []byte("a"), Accum: 0, VotingPower: 10},
+				{Address: []byte("b"), Accum: 0, VotingPower: 1},
+				{Address: []byte("c"), Accum: 0, VotingPower: 1}},
+			[]int64{
+				(0 + 10 - 12 - 4) + 10 - 12 + 4, // this will be mostest on 2nd iter, too
+				(0 + 1 - 4) + 1 + 4,
+				(0 + 1 - 4) + 1 + 4},
+			2}, // increment twice -> expect average to be subtracted twice
+		2: {
+			[]*Validator{
+				{Address: []byte("a"), Accum: 0, VotingPower: 10},
+				{Address: []byte("b"), Accum: 0, VotingPower: 1},
+				{Address: []byte("c"), Accum: 0, VotingPower: 1}},
+			[]int64{
+				((0 + 10 - 12 - 4) + 10 - 12) + 10 - 12 + 4, // still mostest
+				((0 + 1 - 4) + 1) + 1 + 4,
+				((0 + 1 - 4) + 1) + 1 + 4},
+			3},
+		3: {
+			[]*Validator{
+				{Address: []byte("a"), Accum: 0, VotingPower: 10},
+				{Address: []byte("b"), Accum: 0, VotingPower: 1},
+				{Address: []byte("c"), Accum: 0, VotingPower: 1}},
+			[]int64{
+				0 + 4*(10-12) + 4 - 4, // still mostest
+				0 + 4*1 + 4 - 4,
+				0 + 4*1 + 4 - 4},
+			4},
+		4: {
+			[]*Validator{
+				{Address: []byte("a"), Accum: 0, VotingPower: 10},
+				{Address: []byte("b"), Accum: 0, VotingPower: 1},
+				{Address: []byte("c"), Accum: 0, VotingPower: 1}},
+			[]int64{
+				0 + 4*(10-12) + 10 + 4 - 4, // 4 iters was mostest
+				0 + 5*1 - 12 + 4 - 4,       // now this val is mostest for the 1st time (hence -12==totalVotingPower)
+				0 + 5*1 + 4 - 4},
+			5},
+		5: {
+			[]*Validator{
+				{Address: []byte("a"), Accum: 0, VotingPower: 10},
+				{Address: []byte("b"), Accum: 0, VotingPower: 1},
+				{Address: []byte("c"), Accum: 0, VotingPower: 1}},
+			[]int64{
+				0 + 6*10 - 5*12 + 4 - 4, // mostest again
+				0 + 6*1 - 12 + 4 - 4,    // mostest once up to here
+				0 + 6*1 + 4 - 4},
+			6},
+		6: {
+			[]*Validator{
+				{Address: []byte("a"), Accum: 0, VotingPower: 10},
+				{Address: []byte("b"), Accum: 0, VotingPower: 1},
+				{Address: []byte("c"), Accum: 0, VotingPower: 1}},
+			[]int64{
+				0 + 7*10 - 6*12 + 4 - 4, // in 7 iters this val is mostest 6 times
+				0 + 7*1 - 12 + 4 - 4,    // in 7 iters this val is mostest 1 time
+				0 + 7*1 + 4 - 4},
+			7},
+		7: {
+			[]*Validator{
+				{Address: []byte("a"), Accum: 0, VotingPower: 10},
+				{Address: []byte("b"), Accum: 0, VotingPower: 1},
+				{Address: []byte("c"), Accum: 0, VotingPower: 1}},
+			[]int64{
+				0 + 10*10 - 8*12 + 4 - 4,
+				0 + 10*1 - 12 + 4 - 4,   // after 6 iters this val is "mostest" once and not in between
+				0 + 10*1 + -12 + 4 - 4}, // after 10 iters this val is "mostest" once
+			10},
+		8: {
+			[]*Validator{
+				{Address: []byte("a"), Accum: 0, VotingPower: 10},
+				{Address: []byte("b"), Accum: 0, VotingPower: 1},
+				{Address: []byte("c"), Accum: 0, VotingPower: 1}},
+			[]int64{
+				// shift twice inside incrementAccum (shift every 10th iter);
+				// don't shift at the end of IncremenctAccum
+				// last avg should be zero because
+				// Accum of validator 0: (0 + 11*10 - 8*12 - 4) == 10
+				// Accum of validator 1 and 2: (0 + 11*1 - 12 - 4) == -5
+				0 + 11*10 - 8*12 - 4 - 12 - 0,
+				0 + 11*1 - 12 - 4 - 0,  // after 6 iters this val is "mostest" once and not in between
+				0 + 11*1 - 12 - 4 - 0}, // after 10 iters this val is "mostest" once
+			11},
+	}
+	for i, tc := range tcs {
+		vals := ValidatorSet{Validators: tc.vals}
+		vals.IncrementAccum(tc.times)
+		for valIdx, val := range tc.vals {
+			assert.Equal(t, tc.wantAccums[valIdx], val.Accum, "test case: %v, validator: %v", i, valIdx)
+		}
+	}
 }
 
 func TestSafeAdd(t *testing.T) {

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -65,6 +65,7 @@ func TestValidatorSetBasic(t *testing.T) {
 	_, val = vset.GetByAddress(val.Address)
 	val.VotingPower += 100
 	proposerPriority := val.ProposerPriority
+	val.ProposerPriority = 0
 	assert.True(t, vset.Update(val))
 	_, val = vset.GetByAddress(val.Address)
 	assert.Equal(t, proposerPriority, val.ProposerPriority)
@@ -279,6 +280,10 @@ func randPubKey() crypto.PubKey {
 
 func randValidator_() *Validator {
 	val := NewValidator(randPubKey(), cmn.RandInt64())
+	// TODO: this modulo should limit the ProposerPriority to stay in the
+	// bounds of MaxTotalVotingPower. If used in ValidatorSets this
+	// would not be enough as the already existing voting power is not
+	// considered making tests fail (panic) non-deterministically.
 	val.ProposerPriority = cmn.RandInt64() % MaxTotalVotingPower
 	return val
 }

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -280,9 +280,9 @@ func randPubKey() crypto.PubKey {
 }
 
 func randValidator_(totalVotingPower int64) *Validator {
-	val := NewValidator(randPubKey(), cmn.RandInt64())
-	// this modulo limits the ProposerPriority to stay in the
+	// this modulo limits the ProposerPriority/VotingPower to stay in the
 	// bounds of MaxTotalVotingPower minus the already existing voting power:
+	val := NewValidator(randPubKey(), cmn.RandInt64()%(MaxTotalVotingPower-totalVotingPower))
 	val.ProposerPriority = cmn.RandInt64() % (MaxTotalVotingPower - totalVotingPower)
 	return val
 }

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -62,7 +62,7 @@ func TestValidatorSetBasic(t *testing.T) {
 	assert.NotPanics(t, func() { vset.IncrementProposerPriority(1) })
 
 	// update
-	assert.False(t, vset.Update(randValidator_()))
+	assert.False(t, vset.Update(randValidator_(vset.TotalVotingPower())))
 	_, val = vset.GetByAddress(val.Address)
 	val.VotingPower += 100
 	proposerPriority := val.ProposerPriority


### PR DESCRIPTION
This PR adds two basic tests for `IncrementProposerPriority` (formerly IncrementAccum). It would have caught what Jae described in #2809:
> IncrementAccum() was written to efficiently calculate the accum as if IncrementAccum(1) was called times times, but clipping as implemented breaks this invariant.

Additionally, it fixes a `randValidator_()` and `randValidatorSet()` which are used in tests and would cause non-deteministic panics.

Part of #2942. Tests which test the whole turnaround in `state` in a follow-up PR.
 
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
