### PR TITLE
rpc: broadcastTxCommit: check if deliverTxResCh is still open, return an err otherwise

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -46,3 +46,4 @@ program](https://hackerone.com/tendermint).
     - keep accums averaged near 0
 - [types] \#2941 Preserve val.Accum during ValidatorSet.Update to avoid it being
   reset to 0 every time a validator is updated
+- [rpc] \#2408 `/broadcast_tx_commit`: Fix interface conversion: interface {} in nil, not EventDataTx error

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -198,7 +198,10 @@ func BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
 	// TODO: configurable?
 	var deliverTxTimeout = rpcserver.WriteTimeout / 2
 	select {
-	case deliverTxResMsg := <-deliverTxResCh: // The tx was included in a block.
+	case deliverTxResMsg, ok := <-deliverTxResCh: // The tx was included in a block.
+		if !ok {
+			return nil, errors.New("Error on broadcastTxCommit: expected DeliverTxResult, got nil. Did the Tendermint stop?")
+		}
 		deliverTxRes := deliverTxResMsg.(types.EventDataTx)
 		return &ctypes.ResultBroadcastTxCommit{
 			CheckTx:   *checkTxRes,


### PR DESCRIPTION
`deliverTxResCh`, like any other eventBus (pubsub) channel, is closed when eventBus is stopped. We must check if the channel is still open. The alternative approach is to not close any channels, which seems a bit odd.

Fixes #2408

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] ~~Updated all relevant documentation in docs~~
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
