### PR TITLE
Fix 32-bit builds

### DIFF
--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -19,7 +19,7 @@ import (
 // x + (x >> 3) = x + x/8 = x * (1 + 0.125).
 // MaxTotalVotingPower is the largest int64 `x` with the property that `x + (x >> 3)` is
 // still in the bounds of int64.
-const MaxTotalVotingPower = 8198552921648689607
+const MaxTotalVotingPower = int64(8198552921648689607)
 
 // ValidatorSet represent a set of *Validator at a given height.
 // The validators can be fetched by address or index.


### PR DESCRIPTION
explicitly type `MaxTotalVotingPower` to `int64`
fixes #2952 

Tested build in 32 bit ubuntu docker image. Some tests still use ints interchangeably with int64 (e.g. `types/block_test.go:259:39: constant 9223372036854775807 overflows int`) but the build will succeed...

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
