### PR TITLE
Minor log changes

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -459,6 +459,7 @@ func NewNode(config *cfg.Config,
 				Seeds:    splitAndTrimEmpty(config.P2P.Seeds, ",", " "),
 				SeedMode: config.P2P.SeedMode,
 			})
+		pexReactor.SetLogger(logger.With("module", "pex"))
 		sw.AddReactor("PEX", pexReactor)
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -210,13 +210,18 @@ func NewNode(config *cfg.Config,
 	// what happened during block replay).
 	state = sm.LoadState(stateDB)
 
-	// Ensure the state's block version matches that of the software.
+	// Log the version info.
+	logger.Info("Version info",
+		"software", version.TMCoreSemVer,
+		"block", version.BlockProtocol,
+		"p2p", version.P2PProtocol,
+	)
+
+	// If the state and software differ in block version, at least log it.
 	if state.Version.Consensus.Block != version.BlockProtocol {
-		return nil, fmt.Errorf(
-			"Block version of the software does not match that of the state.\n"+
-				"Got version.BlockProtocol=%v, state.Version.Consensus.Block=%v",
-			version.BlockProtocol,
-			state.Version.Consensus.Block,
+		logger.Info("Software and state have different block protocols",
+			"software", version.BlockProtocol,
+			"state", state.Version.Consensus.Block,
 		)
 	}
 
@@ -454,7 +459,6 @@ func NewNode(config *cfg.Config,
 				Seeds:    splitAndTrimEmpty(config.P2P.Seeds, ",", " "),
 				SeedMode: config.P2P.SeedMode,
 			})
-		pexReactor.SetLogger(p2pLogger)
 		sw.AddReactor("PEX", pexReactor)
 	}
 


### PR DESCRIPTION
This allows the node to start even if the latest block protocol version for the node is ahead of that found in the state. This means the node has code for a newer block protocol version than the blockchain it's running on. Unless the logic for the new version is written carefully, this could lead the node to fall out of consensus. 

The only change from block protocol `7` to `8` was validation based on PubKeyTypes. So if the only type being used was ED25519, the change won't cause any problems.

To make the change from 7 to 8 fully backwards compatible, the code that validates against PubKeyTypes should only be run if the `state.Version.Consensus.Block==8` . This way the software would support both versions 7 and 8.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
