### PR TITLE
Fix panic if validator set is empty(#2951)

### DIFF
--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -304,6 +304,13 @@ func (h *Handshaker) ReplayBlocks(
 			state.Validators = types.NewValidatorSet(vals)
 			state.NextValidators = types.NewValidatorSet(vals)
 		}
+		else {
+			// If validator set is not set in genesis and still empty after InitChain, exit.
+			if len(h.genDoc.Validators) == 0 {
+				return nil, fmt.Errorf("Validator set is still empty after InitChain")
+			}
+		}
+		
 		if res.ConsensusParams != nil {
 			state.ConsensusParams = types.PB2TM.ConsensusParams(res.ConsensusParams)
 		}

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -276,17 +276,11 @@ func (h *Handshaker) ReplayBlocks(
 
 	// If appBlockHeight == 0 it means that we are at genesis and hence should send InitChain.
 	if appBlockHeight == 0 {
-		// Empty validator set is allowed in the genesis, because it can be set by the app in InitChain
-		var validatorSet *types.ValidatorSet
-		if len(h.genDoc.Validators) > 0 {
-			validators := make([]*types.Validator, len(h.genDoc.Validators))
-			for i, val := range h.genDoc.Validators {
-				validators[i] = types.NewValidator(val.PubKey, val.Power)
-			}
-			validatorSet = types.NewValidatorSet(validators)
-		} else {
-			validatorSet = types.NewValidatorSet(nil)
+		validators := make([]*types.Validator, len(h.genDoc.Validators))
+		for i, val := range h.genDoc.Validators {
+			validators[i] = types.NewValidator(val.PubKey, val.Power)
 		}
+		validatorSet := types.NewValidatorSet(validators)
 		nextVals := types.TM2PB.ValidatorUpdates(validatorSet)
 		csParams := types.TM2PB.ConsensusParams(h.genDoc.ConsensusParams)
 		req := abci.RequestInitChain{


### PR DESCRIPTION
Fixes #2951

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
Integration test passed with log:
ERROR: Failed to create node: Error during handshake: Error on replay: Validator set is nil in genesis and still empty after InitChain
* [ ] Updated CHANGELOG_PENDING.md