### PR TITLE
Use os/user to retrieve home directory instead of $HOME

### DIFF
--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"os"
+	"os/user"
 	"path/filepath"
 
 	"github.com/tendermint/tendermint/libs/cli"
@@ -41,7 +41,13 @@ func main() {
 	// Create & start node
 	rootCmd.AddCommand(cmd.NewRunNodeCmd(nodeFunc))
 
-	cmd := cli.PrepareBaseCmd(rootCmd, "TM", os.ExpandEnv(filepath.Join("$HOME", cfg.DefaultTendermintDir)))
+	// Retrieve user's home directory
+	usr, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+
+	cmd := cli.PrepareBaseCmd(rootCmd, "TM", filepath.Join(usr.HomeDir, cfg.DefaultTendermintDir))
 	if err := cmd.Execute(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This change fixes an issue where, on Windows, the .tendermint directory is put in C:\ instead of the user's home directory due to the HOME environment variable not being set on Windows.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
