### PR TITLE
Make mempool fail txs with negative gas wanted

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -108,6 +108,10 @@ func PostCheckMaxGas(maxGas int64) PostCheckFunc {
 		if maxGas == -1 {
 			return nil
 		}
+		if res.GasWanted < 0 {
+			return fmt.Errorf("gas wanted %d is negative",
+				res.GasWanted)
+		}
 		if res.GasWanted > maxGas {
 			return fmt.Errorf("gas wanted %d is greater than max gas %d",
 				res.GasWanted, maxGas)


### PR DESCRIPTION
This is only one part of #2989.
We also need to fix the cosmos-sdk application, and add rules to consensus to ensure this. (eventually we ought to just to convert abci.GasWanted to uint64) I think those can be done in separate PR's though. 
(I'm not changing ABCI now, though it would be simpler and correct, because theres a push for non-breaking changes atm, and I don't want the PR to take 5 weeks to be merged)

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs - need better mempool docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests - Is it needed for this change? It would add many lines of code to do, since we'd have to setup a new application which has a bug for negative gas wanted. It seems clear that this does prevents the mempool from getting such txs.
* [x] Updated CHANGELOG_PENDING.md
