### PR TITLE
crypto: revert to mainline Go crypto lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.27.3
+
+*December 16th, 2018*
+
+### BREAKING CHANGES:
+
+* Go API
+
+- [dep] [\#3027](https://github.com/tendermint/tendermint/issues/3027) Revert to mainline Go crypto library, eliminating the modified
+  `bcrypt.GenerateFromPassword`
+
 ## v0.27.2
 
 *December 16th, 2018*
@@ -84,17 +95,17 @@ message.
 ### IMPROVEMENTS:
 
 - [state] [\#2929](https://github.com/tendermint/tendermint/issues/2929) Minor refactor of updateState logic (@danil-lashin)
-- [node] \#2959 Allow node to start even if software's BlockProtocol is
+- [node] [\#2959](https://github.com/tendermint/tendermint/issues/2959) Allow node to start even if software's BlockProtocol is
   different from state's BlockProtocol
-- [pex] \#2959 Pex reactor logger uses `module=pex`
+- [pex] [\#2959](https://github.com/tendermint/tendermint/issues/2959) Pex reactor logger uses `module=pex`
 
 ### BUG FIXES:
 
-- [p2p] \#2968 Panic on transport error rather than continuing to run but not
+- [p2p] [\#2968](https://github.com/tendermint/tendermint/issues/2968) Panic on transport error rather than continuing to run but not
   accept new connections
-- [p2p] \#2969 Fix mismatch in peer count between `/net_info` and the prometheus
+- [p2p] [\#2969](https://github.com/tendermint/tendermint/issues/2969) Fix mismatch in peer count between `/net_info` and the prometheus
   metrics
-- [rpc] \#2408 `/broadcast_tx_commit`: Fix "interface conversion: interface {} in nil, not EventDataTx" panic (could happen if somebody sent a tx using `/broadcast_tx_commit` while Tendermint was being stopped)
+- [rpc] [\#2408](https://github.com/tendermint/tendermint/issues/2408) `/broadcast_tx_commit`: Fix "interface conversion: interface {} in nil, not EventDataTx" panic (could happen if somebody sent a tx using `/broadcast_tx_commit` while Tendermint was being stopped)
 - [state] [\#2785](https://github.com/tendermint/tendermint/issues/2785) Fix accum for new validators to be `-1.125*totalVotingPower`
   instead of 0, forcing them to wait before becoming the proposer. Also:
     - do not batch clip

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,4 @@
-## v0.27.3
+## v0.27.4
 
 *TBD*
 
@@ -11,9 +11,6 @@ Special thanks to external contributors on this release:
 * Apps
 
 * Go API
-
-- [dep] \#3027 Revert to mainline Go crypto library, eliminating the modified
-  `bcrypt.GenerateFromPassword`
 
 * Blockchain Protocol
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,9 @@ Special thanks to external contributors on this release:
 
 * Go API
 
+- [dep] \#3027 Revert to mainline Go crypto library, eliminating the modified
+  `bcrypt.GenerateFromPassword`
+
 * Blockchain Protocol
 
 * P2P Protocol
@@ -22,4 +25,4 @@ Special thanks to external contributors on this release:
 
 ### BUG FIXES:
 
-- [\#3025](https://github.com/tendermint/tendermint/pull/3025) - Revert to using defers in addrbook.  Fixes deadlocks in pex and consensus upon invalid ExternalAddr/ListenAddr configuration.
+- [p2p] [\#3025](https://github.com/tendermint/tendermint/pull/3025) Revert to using defers in addrbook.  Fixes deadlocks in pex and consensus upon invalid ExternalAddr/ListenAddr configuration.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -376,7 +376,7 @@
   version = "v0.14.1"
 
 [[projects]]
-  digest = "1:72b71e3a29775e5752ed7a8012052a3dee165e27ec18cedddae5288058f09acf"
+  digest = "1:00d2b3e64cdc3fa69aa250dfbe4cc38c4837d4f37e62279be2ae52107ffbbb44"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -397,8 +397,7 @@
     "salsa20/salsa",
   ]
   pruneopts = "UT"
-  revision = "3764759f34a542a3aef74d6b02e35be7ab893bba"
-  source = "github.com/tendermint/crypto"
+  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
 
 [[projects]]
   digest = "1:d36f55a999540d29b6ea3c2ea29d71c76b1d9853fdcd3e5c5cb4836f2ba118f1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -81,8 +81,7 @@
 
 [[constraint]]
   name = "golang.org/x/crypto"
-  source = "github.com/tendermint/crypto"
-  revision = "3764759f34a542a3aef74d6b02e35be7ab893bba"
+  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
 
 [[override]]
   name = "github.com/jmhodges/levigo"

--- a/crypto/armor/armor.go
+++ b/crypto/armor/armor.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"golang.org/x/crypto/openpgp/armor" // forked to github.com/tendermint/crypto
+	"golang.org/x/crypto/openpgp/armor"
 )
 
 func EncodeArmor(blockType string, headers map[string]string, data []byte) string {

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	amino "github.com/tendermint/go-amino"
-	"golang.org/x/crypto/ed25519" // forked to github.com/tendermint/crypto
+	"golang.org/x/crypto/ed25519"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/tmhash"

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -3,7 +3,7 @@ package crypto
 import (
 	"crypto/sha256"
 
-	"golang.org/x/crypto/ripemd160" // forked to github.com/tendermint/crypto
+	"golang.org/x/crypto/ripemd160"
 )
 
 func Sha256(bytes []byte) []byte {

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -9,7 +9,7 @@ import (
 
 	secp256k1 "github.com/tendermint/btcd/btcec"
 	amino "github.com/tendermint/go-amino"
-	"golang.org/x/crypto/ripemd160" // forked to github.com/tendermint/crypto
+	"golang.org/x/crypto/ripemd160"
 
 	"github.com/tendermint/tendermint/crypto"
 )

--- a/crypto/xchacha20poly1305/xchachapoly.go
+++ b/crypto/xchacha20poly1305/xchachapoly.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"golang.org/x/crypto/chacha20poly1305" // forked to github.com/tendermint/crypto
+	"golang.org/x/crypto/chacha20poly1305"
 )
 
 // Implements crypto.AEAD

--- a/crypto/xsalsa20symmetric/symmetric.go
+++ b/crypto/xsalsa20symmetric/symmetric.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"golang.org/x/crypto/nacl/secretbox" // forked to github.com/tendermint/crypto
+	"golang.org/x/crypto/nacl/secretbox"
 
 	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"

--- a/crypto/xsalsa20symmetric/symmetric_test.go
+++ b/crypto/xsalsa20symmetric/symmetric_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/crypto/bcrypt" // forked to github.com/tendermint/crypto
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/tendermint/tendermint/crypto"
 )
@@ -30,9 +30,7 @@ func TestSimpleWithKDF(t *testing.T) {
 
 	plaintext := []byte("sometext")
 	secretPass := []byte("somesecret")
-	salt := []byte("somesaltsomesalt") // len 16
-	// NOTE: we use a fork of x/crypto so we can inject our own randomness for salt
-	secret, err := bcrypt.GenerateFromPassword(salt, secretPass, 12)
+	secret, err := bcrypt.GenerateFromPassword(secretPass, 12)
 	if err != nil {
 		t.Error(err)
 	}

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"time"
 
-	// forked to github.com/tendermint/crypto
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/nacl/box"

--- a/version/version.go
+++ b/version/version.go
@@ -18,7 +18,7 @@ const (
 	// TMCoreSemVer is the current version of Tendermint Core.
 	// It's the Semantic Version of the software.
 	// Must be a string because scripts like dist.sh read this file.
-	TMCoreSemVer = "0.27.2"
+	TMCoreSemVer = "0.27.3"
 
 	// ABCISemVer is the semantic version of the ABCI library
 	ABCISemVer  = "0.15.0"


### PR DESCRIPTION
We used to use a fork for a modified bcrypt so we could pass our own
randomness but this was largely unecessary, unused, and a burden.
So now we just use the mainline Go crypto lib.

cc https://github.com/tendermint/crypto/commit/3764759f34a542a3aef74d6b02e35be7ab893bba#commitcomment-31685132

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
