### PR TITLE
Add metrics for tx in cache errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,4 +20,6 @@ Special thanks to external contributors on this release:
 
 ### IMPROVEMENTS:
 
+Added a Metric to track errors when a Tx is already in the Mempool cache.
+
 ### BUG FIXES:

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -317,6 +317,7 @@ func (mem *Mempool) CheckTx(tx types.Tx, cb func(*abci.Response)) (err error) {
 
 	// CACHE
 	if !mem.cache.Push(tx) {
+		mem.metrics.ErrTxInCache.Add(1)
 		return ErrTxInCache
 	}
 	// END CACHE

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -20,6 +20,8 @@ type Metrics struct {
 	FailedTxs metrics.Counter
 	// Number of times transactions are rechecked in the mempool.
 	RecheckTimes metrics.Counter
+	// Number of times transactions errored from are already in the cache.
+	ErrTxInCache metrics.Counter
 }
 
 // PrometheusMetrics returns Metrics build using Prometheus client library.
@@ -50,6 +52,12 @@ func PrometheusMetrics(namespace string) *Metrics {
 			Name:      "recheck_times",
 			Help:      "Number of times transactions are rechecked in the mempool.",
 		}, []string{}),
+		ErrTxInCache: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsytem,
+			Name:      "error_tx_in_cache",
+			Help:      "Number of times a tx was already in the cache for the mempool.",
+		}, []string{}),
 	}
 }
 
@@ -60,5 +68,6 @@ func NopMetrics() *Metrics {
 		TxSizeBytes:  discard.NewHistogram(),
 		FailedTxs:    discard.NewCounter(),
 		RecheckTimes: discard.NewCounter(),
+		ErrTxInCache: discard.NewCounter(),
 	}
 }


### PR DESCRIPTION
Under high load we see a lot of errors with "Tx already exists in cache", we are trying to track down is this is something wrong with the client or the server. This seems like a very useful metric to determine the health of a Tendermint node.

* [ [N/A] Updated all relevant documentation in docs
* [ X] Updated all code comments where relevant
* [N/A ] Wrote tests
* [X ] Updated CHANGELOG_PENDING.md