### PR TITLE
makeNodeInfo returns error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.27.2
+
+*December 16th, 2018*
+
+### IMPROVEMENTS:
+
+- [node] [\#3025](https://github.com/tendermint/tendermint/issues/3025) Validate NodeInfo addresses on startup.
+
+### BUG FIXES:
+
+- [p2p] [\#3025](https://github.com/tendermint/tendermint/pull/3025) Revert to using defers in addrbook.  Fixes deadlocks in pex and consensus upon invalid ExternalAddr/ListenAddr configuration.
+
 ## v0.27.1
 
 *December 15th, 2018*

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,8 @@ Special thanks to external contributors on this release:
 
 ### IMPROVEMENTS:
 
+- [node] \#3025 Validate NodeInfo addresses on startup.
+
 ### BUG FIXES:
 
-- [\#3025](https://github.com/tendermint/tendermint/pull/3025) - Revert to using defers in addrbook.  Fixes deadlocks in pex and consensus upon invalid ExternalAddr/ListenAddr configuration.
+- [p2p] [\#3025](https://github.com/tendermint/tendermint/pull/3025) Revert to using defers in addrbook.  Fixes deadlocks in pex and consensus upon invalid ExternalAddr/ListenAddr configuration.

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,4 @@
-## v0.27.2
+## v0.27.3
 
 *TBD*
 
@@ -20,8 +20,5 @@ Special thanks to external contributors on this release:
 
 ### IMPROVEMENTS:
 
-- [node] \#3025 Validate NodeInfo addresses on startup.
-
 ### BUG FIXES:
 
-- [p2p] [\#3025](https://github.com/tendermint/tendermint/pull/3025) Revert to using defers in addrbook.  Fixes deadlocks in pex and consensus upon invalid ExternalAddr/ListenAddr configuration.

--- a/node/node.go
+++ b/node/node.go
@@ -348,20 +348,21 @@ func NewNode(config *cfg.Config,
 	indexerService := txindex.NewIndexerService(txIndexer, eventBus)
 	indexerService.SetLogger(logger.With("module", "txindex"))
 
-	var (
-		p2pLogger = logger.With("module", "p2p")
-		nodeInfo  = makeNodeInfo(
-			config,
-			nodeKey.ID(),
-			txIndexer,
-			genDoc.ChainID,
-			p2p.NewProtocolVersion(
-				version.P2PProtocol, // global
-				state.Version.Consensus.Block,
-				state.Version.Consensus.App,
-			),
-		)
+	p2pLogger := logger.With("module", "p2p")
+	nodeInfo, err := makeNodeInfo(
+		config,
+		nodeKey.ID(),
+		txIndexer,
+		genDoc.ChainID,
+		p2p.NewProtocolVersion(
+			version.P2PProtocol, // global
+			state.Version.Consensus.Block,
+			state.Version.Consensus.App,
+		),
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Setup Transport.
 	var (
@@ -782,7 +783,7 @@ func makeNodeInfo(
 	txIndexer txindex.TxIndexer,
 	chainID string,
 	protocolVersion p2p.ProtocolVersion,
-) p2p.NodeInfo {
+) (p2p.NodeInfo, error) {
 	txIndexerStatus := "on"
 	if _, ok := txIndexer.(*null.TxIndex); ok {
 		txIndexerStatus = "off"
@@ -818,11 +819,7 @@ func makeNodeInfo(
 	nodeInfo.ListenAddr = lAddr
 
 	err := nodeInfo.Validate()
-	if err != nil {
-		panic(err)
-	}
-
-	return nodeInfo
+	return nodeInfo, err
 }
 
 //------------------------------------------------------------------------------

--- a/version/version.go
+++ b/version/version.go
@@ -18,7 +18,7 @@ const (
 	// TMCoreSemVer is the current version of Tendermint Core.
 	// It's the Semantic Version of the software.
 	// Must be a string because scripts like dist.sh read this file.
-	TMCoreSemVer = "0.27.1"
+	TMCoreSemVer = "0.27.2"
 
 	// ABCISemVer is the semantic version of the ABCI library
 	ABCISemVer  = "0.15.0"


### PR DESCRIPTION
In https://github.com/tendermint/tendermint/pull/3025 makeNodeInfo calls nodeInfo.Validate and panics on error. Instead it should return the error up the stack.

This also prepares changelog/version for v0.27.2

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
