### PR TITLE
rpc: include peer's remote IP in `/net_info`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,6 +23,7 @@ Special thanks to external contributors on this release:
 ### FEATURES:
 
 ### IMPROVEMENTS:
+- [rpc] \#3047 Include peer's remote IP in `/net_info`
 
 ### BUG FIXES:
 

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -53,6 +53,7 @@ func NetInfo() (*ctypes.ResultNetInfo, error) {
 			NodeInfo:         nodeInfo,
 			IsOutbound:       peer.IsOutbound(),
 			ConnectionStatus: peer.Status(),
+			RemoteIP:         peer.RemoteIP(),
 		})
 	}
 	// TODO: Should we include PersistentPeers and Seeds in here?

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -2,6 +2,7 @@ package core_types
 
 import (
 	"encoding/json"
+	"net"
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -110,6 +111,7 @@ type Peer struct {
 	NodeInfo         p2p.DefaultNodeInfo  `json:"node_info"`
 	IsOutbound       bool                 `json:"is_outbound"`
 	ConnectionStatus p2p.ConnectionStatus `json:"connection_status"`
+	RemoteIP         net.IP               `json:"remote_ip"`
 }
 
 // Validators for a height


### PR DESCRIPTION
Refs #3047

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
