### PR TITLE
fix build script

### DIFF
--- a/DOCKER/build.sh
+++ b/DOCKER/build.sh
@@ -3,7 +3,7 @@ set -e
 
 # Get the tag from the version, or try to figure it out.
 if [ -z "$TAG" ]; then
-	TAG=$(awk -F\" '/Version =/ { print $2; exit }' < ../version/version.go)
+	TAG=$(awk -F\" '/TMCoreSemVer =/ { print $2; exit }' < ../version/version.go)
 fi
 if [ -z "$TAG" ]; then
 		echo "Please specify a tag."


### PR DESCRIPTION
Search for the right variable when introspecting Go code. `Version` was
renamed to `TMCoreSemVer`.

This is regression introduced in
b95ac688af14d130e6ad0b580ed9a8181f6c487c
