### PR TITLE
Ensure multisig keys have 20-byte address

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -32,3 +32,4 @@ Special thanks to external contributors on this release:
 
 ### BUG FIXES:
 - [types] \#2926 do not panic if retrieving the private validator's public key fails
+- [crypto/multisig] \#3102 fix multisig keys address length

--- a/crypto/multisig/threshold_pubkey.go
+++ b/crypto/multisig/threshold_pubkey.go
@@ -31,7 +31,7 @@ func NewPubKeyMultisigThreshold(k int, pubkeys []crypto.PubKey) crypto.PubKey {
 // The multisig uses a bitarray, so multiple signatures for the same key is not
 // a concern.
 func (pk PubKeyMultisigThreshold) VerifyBytes(msg []byte, marshalledSig []byte) bool {
-	var sig *Multisignature
+	var sig Multisignature
 	err := cdc.UnmarshalBinaryBare(marshalledSig, &sig)
 	if err != nil {
 		return false
@@ -68,14 +68,14 @@ func (pk PubKeyMultisigThreshold) Bytes() []byte {
 }
 
 // Address returns tmhash(PubKeyMultisigThreshold.Bytes())
-func (pk *PubKeyMultisigThreshold) Address() crypto.Address {
+func (pk PubKeyMultisigThreshold) Address() crypto.Address {
 	return crypto.AddressHash(pk.Bytes())
 }
 
 // Equals returns true iff pk and other both have the same number of keys, and
 // all constituent keys are the same, and in the same order.
 func (pk PubKeyMultisigThreshold) Equals(other crypto.PubKey) bool {
-	otherKey, sameType := other.(*PubKeyMultisigThreshold)
+	otherKey, sameType := other.(PubKeyMultisigThreshold)
 	if !sameType {
 		return false
 	}

--- a/crypto/multisig/threshold_pubkey.go
+++ b/crypto/multisig/threshold_pubkey.go
@@ -2,7 +2,6 @@ package multisig
 
 import (
 	"github.com/tendermint/tendermint/crypto"
-	"github.com/tendermint/tendermint/crypto/tmhash"
 )
 
 // PubKeyMultisigThreshold implements a K of N threshold multisig.
@@ -70,7 +69,7 @@ func (pk *PubKeyMultisigThreshold) Bytes() []byte {
 
 // Address returns tmhash(PubKeyMultisigThreshold.Bytes())
 func (pk *PubKeyMultisigThreshold) Address() crypto.Address {
-	return crypto.Address(tmhash.Sum(pk.Bytes()))
+	return crypto.AddressHash(pk.Bytes())
 }
 
 // Equals returns true iff pk and other both have the same number of keys, and

--- a/crypto/multisig/threshold_pubkey_test.go
+++ b/crypto/multisig/threshold_pubkey_test.go
@@ -95,6 +95,13 @@ func TestMultiSigPubKeyEquality(t *testing.T) {
 	require.False(t, multisigKey.Equals(multisigKey2))
 }
 
+func TestAddress(t *testing.T) {
+	msg := []byte{1, 2, 3, 4}
+	pubkeys, _ := generatePubKeysAndSignatures(5, msg)
+	multisigKey := NewPubKeyMultisigThreshold(2, pubkeys)
+	require.Len(t, multisigKey.Address().Bytes(), 20)
+}
+
 func generatePubKeysAndSignatures(n int, msg []byte) (pubkeys []crypto.PubKey, signatures [][]byte) {
 	pubkeys = make([]crypto.PubKey, n)
 	signatures = make([][]byte, n)

--- a/crypto/multisig/threshold_pubkey_test.go
+++ b/crypto/multisig/threshold_pubkey_test.go
@@ -82,7 +82,7 @@ func TestMultiSigPubKeyEquality(t *testing.T) {
 	msg := []byte{1, 2, 3, 4}
 	pubkeys, _ := generatePubKeysAndSignatures(5, msg)
 	multisigKey := NewPubKeyMultisigThreshold(2, pubkeys)
-	var unmarshalledMultisig *PubKeyMultisigThreshold
+	var unmarshalledMultisig PubKeyMultisigThreshold
 	cdc.MustUnmarshalBinaryBare(multisigKey.Bytes(), &unmarshalledMultisig)
 	require.True(t, multisigKey.Equals(unmarshalledMultisig))
 


### PR DESCRIPTION
Use crypto.AddressHash() to avoid returning 32-byte long address.

Closes: #3102

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
