### PR TITLE
Do not force block creation when app hash changes

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,7 @@ Special thanks to external contributors on this release:
 * Blockchain Protocol
 
 * P2P Protocol
+- [consensus] Do not force block creation when app hash changes.
 
 ### FEATURES:
 

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -37,7 +37,6 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 	ensureNoNewEventOnChannel(newBlockCh)
 	deliverTxsRange(cs, 0, 1)
 	ensureNewEventOnChannel(newBlockCh) // commit txs
-	ensureNewEventOnChannel(newBlockCh) // commit updated app hash
 	ensureNoNewEventOnChannel(newBlockCh)
 }
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -802,14 +802,8 @@ func (cs *ConsensusState) enterNewRound(height int64, round int) {
 }
 
 // needProofBlock returns true on the first height (so the genesis app hash is signed right away)
-// and where the last block (height-1) caused the app hash to change
 func (cs *ConsensusState) needProofBlock(height int64) bool {
-	if height == 1 {
-		return true
-	}
-
-	lastBlockMeta := cs.blockStore.LoadBlockMeta(height - 1)
-	return !bytes.Equal(cs.state.AppHash, lastBlockMeta.Header.AppHash)
+	return height == 1
 }
 
 // Enter (CreateEmptyBlocks): from enterNewRound(height,round)

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -231,11 +231,10 @@ Some fields from the config file can be overwritten with flags.
 While the default behaviour of `tendermint` is still to create blocks
 approximately once per second, it is possible to disable empty blocks or
 set a block creation interval. In the former case, blocks will be
-created when there are new transactions or when the AppHash changes.
+created when there are new transactions.
 
 To configure Tendermint to not produce empty blocks unless there are
-transactions or the app hash changes, run Tendermint with this
-additional flag:
+transactions, run Tendermint with this additional flag:
 
 ```
 tendermint node --consensus.create_empty_blocks=false


### PR DESCRIPTION
For rationale of why this may be a reasonable default, see the following comments in #1909:

* https://github.com/tendermint/tendermint/issues/1909#issuecomment-433934284
* https://github.com/tendermint/tendermint/issues/1909#issuecomment-437585377