### PR TITLE
makefile: fix build-docker-localnode target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,9 +292,7 @@ build-linux:
 	GOOS=linux GOARCH=amd64 $(MAKE) build
 
 build-docker-localnode:
-	cd networks/local
-	make
-	cd -
+	@cd networks/local && make
 
 # Run a 4-node testnet locally
 localnet-start: localnet-stop


### PR DESCRIPTION
cd does not work because it's executed in a subprocess
so it has to be either chained by && or ;
See https://stackoverflow.com/q/1789594/820520
for more details.

Fixes #3058