### PR TITLE
return maxPerPage (not defaultPerPage) if per_page is greater than max

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,7 +7,7 @@ Special thanks to external contributors on this release:
 ### BREAKING CHANGES:
 
 * CLI/RPC/Config
-- [types] consistent field order of `CanonicalVote` and `CanonicalProposal` 
+- [types] consistent field order of `CanonicalVote` and `CanonicalProposal`
 
 * Apps
 
@@ -21,5 +21,6 @@ Special thanks to external contributors on this release:
 ### FEATURES:
 
 ### IMPROVEMENTS:
+- [rpc] \#3065 return maxPerPage (100), not defaultPerPage (30) if `per_page` is greater than the max 100.
 
 ### BUG FIXES:

--- a/rpc/core/pipe.go
+++ b/rpc/core/pipe.go
@@ -149,8 +149,10 @@ func validatePage(page, perPage, totalCount int) int {
 }
 
 func validatePerPage(perPage int) int {
-	if perPage < 1 || perPage > maxPerPage {
+	if perPage < 1 {
 		return defaultPerPage
+	} else if perPage > maxPerPage {
+		return maxPerPage
 	}
 	return perPage
 }

--- a/rpc/core/pipe_test.go
+++ b/rpc/core/pipe_test.go
@@ -47,7 +47,6 @@ func TestPaginationPage(t *testing.T) {
 }
 
 func TestPaginationPerPage(t *testing.T) {
-
 	cases := []struct {
 		totalCount int
 		perPage    int
@@ -59,7 +58,7 @@ func TestPaginationPerPage(t *testing.T) {
 		{5, defaultPerPage, defaultPerPage},
 		{5, maxPerPage - 1, maxPerPage - 1},
 		{5, maxPerPage, maxPerPage},
-		{5, maxPerPage + 1, defaultPerPage},
+		{5, maxPerPage + 1, maxPerPage},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
it's more user-friendly.

Refs #3065

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] ~~Updated all relevant documentation in docs~~
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
