### PR TITLE
Expanding tests to cover Unix sockets version of client

### DIFF
--- a/privval/client_test.go
+++ b/privval/client_test.go
@@ -278,47 +278,51 @@ func TestRemoteSignerRetryTCPOnly(t *testing.T) {
 
 func TestRemoteSignVoteErrors(t *testing.T) {
 	for _, tc := range socketTestCases(t) {
-		var (
-			chainID = cmn.RandStr(12)
-			sc, rs  = testSetupSocketPair(t, chainID, types.NewErroringMockPV(), tc.addr, tc.dialer)
+		func() {
+			var (
+				chainID = cmn.RandStr(12)
+				sc, rs  = testSetupSocketPair(t, chainID, types.NewErroringMockPV(), tc.addr, tc.dialer)
 
-			ts    = time.Now()
-			vType = types.PrecommitType
-			vote  = &types.Vote{Timestamp: ts, Type: vType}
-		)
-		defer sc.Stop()
-		defer rs.Stop()
+				ts    = time.Now()
+				vType = types.PrecommitType
+				vote  = &types.Vote{Timestamp: ts, Type: vType}
+			)
+			defer sc.Stop()
+			defer rs.Stop()
 
-		err := sc.SignVote("", vote)
-		require.Equal(t, err.(*RemoteSignerError).Description, types.ErroringMockPVErr.Error())
+			err := sc.SignVote("", vote)
+			require.Equal(t, err.(*RemoteSignerError).Description, types.ErroringMockPVErr.Error())
 
-		err = rs.privVal.SignVote(chainID, vote)
-		require.Error(t, err)
-		err = sc.SignVote(chainID, vote)
-		require.Error(t, err)
+			err = rs.privVal.SignVote(chainID, vote)
+			require.Error(t, err)
+			err = sc.SignVote(chainID, vote)
+			require.Error(t, err)
+		}()
 	}
 }
 
 func TestRemoteSignProposalErrors(t *testing.T) {
 	for _, tc := range socketTestCases(t) {
-		var (
-			chainID = cmn.RandStr(12)
-			sc, rs  = testSetupSocketPair(t, chainID, types.NewErroringMockPV(), tc.addr, tc.dialer)
+		func() {
+			var (
+				chainID = cmn.RandStr(12)
+				sc, rs  = testSetupSocketPair(t, chainID, types.NewErroringMockPV(), tc.addr, tc.dialer)
 
-			ts       = time.Now()
-			proposal = &types.Proposal{Timestamp: ts}
-		)
-		defer sc.Stop()
-		defer rs.Stop()
+				ts       = time.Now()
+				proposal = &types.Proposal{Timestamp: ts}
+			)
+			defer sc.Stop()
+			defer rs.Stop()
 
-		err := sc.SignProposal("", proposal)
-		require.Equal(t, err.(*RemoteSignerError).Description, types.ErroringMockPVErr.Error())
+			err := sc.SignProposal("", proposal)
+			require.Equal(t, err.(*RemoteSignerError).Description, types.ErroringMockPVErr.Error())
 
-		err = rs.privVal.SignProposal(chainID, proposal)
-		require.Error(t, err)
+			err = rs.privVal.SignProposal(chainID, proposal)
+			require.Error(t, err)
 
-		err = sc.SignProposal(chainID, proposal)
-		require.Error(t, err)
+			err = sc.SignProposal(chainID, proposal)
+			require.Error(t, err)
+		}()
 	}
 }
 

--- a/privval/client_test.go
+++ b/privval/client_test.go
@@ -186,9 +186,9 @@ func TestSocketPVVoteKeepalive(t *testing.T) {
 	}
 }
 
-// This test is not relevant to Unix domain sockets, since the OS knows
-// instantaneously the state of both sides of the connection.
-func TestSocketPVDeadline(t *testing.T) {
+// TestSocketPVDeadlineTCPOnly is not relevant to Unix domain sockets, since the
+// OS knows instantaneously the state of both sides of the connection.
+func TestSocketPVDeadlineTCPOnly(t *testing.T) {
 	var (
 		addr            = testFreeTCPAddr(t)
 		listenc         = make(chan struct{})

--- a/privval/client_test.go
+++ b/privval/client_test.go
@@ -222,60 +222,6 @@ func TestSocketPVDeadlineTCPOnly(t *testing.T) {
 	<-listenc
 }
 
-// TestRemoteSignerRetryTCPOnly will test connection retry attempts over TCP. We
-// don't need this for Unix sockets because the OS instantly knows the state of
-// both ends of the socket connection. This basically causes the
-// RemoteSigner.dialer() call inside RemoteSigner.connect() to return
-// successfully immediately, putting an instant stop to any retry attempts.
-func TestRemoteSignerRetryTCPOnly(t *testing.T) {
-	var (
-		attemptc = make(chan int)
-		retries  = 2
-	)
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	go func(ln net.Listener, attemptc chan<- int) {
-		attempts := 0
-
-		for {
-			conn, err := ln.Accept()
-			require.NoError(t, err)
-
-			err = conn.Close()
-			require.NoError(t, err)
-
-			attempts++
-
-			if attempts == retries {
-				attemptc <- attempts
-				break
-			}
-		}
-	}(ln, attemptc)
-
-	rs := NewRemoteSigner(
-		log.TestingLogger(),
-		cmn.RandStr(12),
-		types.NewMockPV(),
-		DialTCPFn(ln.Addr().String(), testConnDeadline, ed25519.GenPrivKey()),
-	)
-	defer rs.Stop()
-
-	RemoteSignerConnDeadline(time.Millisecond)(rs)
-	RemoteSignerConnRetries(retries)(rs)
-
-	assert.Equal(t, rs.Start(), ErrDialRetryMax)
-
-	select {
-	case attempts := <-attemptc:
-		assert.Equal(t, retries, attempts)
-	case <-time.After(100 * time.Millisecond):
-		t.Error("expected remote to observe connection attempts")
-	}
-}
-
 func TestRemoteSignVoteErrors(t *testing.T) {
 	for _, tc := range socketTestCases(t) {
 		func() {

--- a/privval/remote_signer_test.go
+++ b/privval/remote_signer_test.go
@@ -1,0 +1,68 @@
+package privval
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/crypto/ed25519"
+	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/types"
+)
+
+// TestRemoteSignerRetryTCPOnly will test connection retry attempts over TCP. We
+// don't need this for Unix sockets because the OS instantly knows the state of
+// both ends of the socket connection. This basically causes the
+// RemoteSigner.dialer() call inside RemoteSigner.connect() to return
+// successfully immediately, putting an instant stop to any retry attempts.
+func TestRemoteSignerRetryTCPOnly(t *testing.T) {
+	var (
+		attemptc = make(chan int)
+		retries  = 2
+	)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func(ln net.Listener, attemptc chan<- int) {
+		attempts := 0
+
+		for {
+			conn, err := ln.Accept()
+			require.NoError(t, err)
+
+			err = conn.Close()
+			require.NoError(t, err)
+
+			attempts++
+
+			if attempts == retries {
+				attemptc <- attempts
+				break
+			}
+		}
+	}(ln, attemptc)
+
+	rs := NewRemoteSigner(
+		log.TestingLogger(),
+		cmn.RandStr(12),
+		types.NewMockPV(),
+		DialTCPFn(ln.Addr().String(), testConnDeadline, ed25519.GenPrivKey()),
+	)
+	defer rs.Stop()
+
+	RemoteSignerConnDeadline(time.Millisecond)(rs)
+	RemoteSignerConnRetries(retries)(rs)
+
+	assert.Equal(t, rs.Start(), ErrDialRetryMax)
+
+	select {
+	case attempts := <-attemptc:
+		assert.Equal(t, retries, attempts)
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected remote to observe connection attempts")
+	}
+}

--- a/privval/server.go
+++ b/privval/server.go
@@ -109,6 +109,7 @@ func (rs *RemoteSigner) OnStart() error {
 
 // OnStop implements cmn.Service.
 func (rs *RemoteSigner) OnStop() {
+	rs.Logger.Info("RemoteSigner stopping")
 	if rs.conn == nil {
 		return
 	}

--- a/privval/server.go
+++ b/privval/server.go
@@ -109,7 +109,6 @@ func (rs *RemoteSigner) OnStart() error {
 
 // OnStop implements cmn.Service.
 func (rs *RemoteSigner) OnStop() {
-	rs.Logger.Info("RemoteSigner stopping")
 	if rs.conn == nil {
 		return
 	}

--- a/privval/socket.go
+++ b/privval/socket.go
@@ -157,7 +157,7 @@ type timeoutConn struct {
 	connDeadline time.Duration
 }
 
-// newTimeoutConn returns an instance of newTCPTimeoutConn.
+// newTimeoutConn returns an instance of timeoutConn.
 func newTimeoutConn(
 	conn net.Conn,
 	connDeadline time.Duration) *timeoutConn {

--- a/privval/socket_test.go
+++ b/privval/socket_test.go
@@ -29,7 +29,7 @@ type listenerTestCase struct {
 // testUnixAddr will attempt to obtain a platform-independent temporary file
 // name for a Unix socket
 func testUnixAddr() (string, error) {
-	f, err := ioutil.TempFile("", "tendermint-privval-test")
+	f, err := ioutil.TempFile("", "tendermint-privval-test-*")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR attempts to complete #3115, where these commits add code (where relevant) to test the client over Unix domain sockets. Two tests in particular (now named `TestSocketPVDeadlineTCPOnly` and `TestRemoteSignerRetryTCPOnly`) are only relevant to the TCP version of the client (the OS knows both sides of a Unix domain socket instantaneously, and so these tests are not relevant to such connections).

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
