### PR TITLE
[Ecosystem] Add ParadigmCore to ecosystem.json

### DIFF
--- a/docs/app-dev/ecosystem.json
+++ b/docs/app-dev/ecosystem.json
@@ -64,6 +64,13 @@
       "description": "Public service reporting and tracking"
     },
     {
+      "name": "ParadigmCore",
+      "url": "https://github.com/ParadigmFoundation/ParadigmCore",
+      "language": "TypeScript",
+      "author": "Paradigm Labs",
+      "description": "Reference implementation of the Paradigm Protocol, and OrderStream network client."
+    },
+    {
       "name": "Passchain",
       "url": "https://github.com/trusch/passchain",
       "language": "Go",


### PR DESCRIPTION
Adding the OrderStream network client (alpha), [ParadigmCore](https://github.com/ParadigmFoundation/ParadigmCore), to the `ecosystem.json` file.
