### PR TITLE
Detecting deadlocks online

### DIFF
--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -1,10 +1,9 @@
 package abcicli
 
 import (
-	"sync"
-
 	types "github.com/tendermint/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/libs/sync"
 )
 
 var _ Client = (*localClient)(nil)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -3,16 +3,17 @@ package consensus
 import (
 	"fmt"
 	"reflect"
-	"sync"
+
 	"time"
 
 	"github.com/pkg/errors"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cstypes "github.com/tendermint/tendermint/consensus/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	tmevents "github.com/tendermint/tendermint/libs/events"
 	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/libs/sync"
 	"github.com/tendermint/tendermint/p2p"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
@@ -438,9 +439,9 @@ func (conR *ConsensusReactor) broadcastHasVoteMessage(vote *types.Vote) {
 
 func makeRoundStepMessage(rs *cstypes.RoundState) (nrsMsg *NewRoundStepMessage) {
 	nrsMsg = &NewRoundStepMessage{
-		Height: rs.Height,
-		Round:  rs.Round,
-		Step:   rs.Step,
+		Height:                rs.Height,
+		Round:                 rs.Round,
+		Step:                  rs.Step,
 		SecondsSinceStartTime: int(time.Since(rs.StartTime).Seconds()),
 		LastCommitRound:       rs.LastCommit.Round(),
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"runtime/debug"
-	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -13,6 +12,7 @@ import (
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/fail"
 	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/libs/sync"
 	tmtime "github.com/tendermint/tendermint/types/time"
 
 	cfg "github.com/tendermint/tendermint/config"

--- a/libs/sync/sync.go
+++ b/libs/sync/sync.go
@@ -1,0 +1,33 @@
+package sync
+
+/*
+// For detecting deadlock situations
+
+import deadlock "github.com/sasha-s/go-deadlock"
+import "sync"
+
+type Mutex struct {
+	deadlock.Mutex
+}
+
+type RWMutex struct {
+	deadlock.RWMutex
+}
+
+type WaitGroup struct {
+	sync.WaitGroup
+}
+*/
+
+import "sync"
+
+type Mutex struct {
+	sync.Mutex
+}
+
+type RWMutex struct {
+	sync.RWMutex
+}
+type WaitGroup struct {
+	sync.WaitGroup
+}

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -1,14 +1,13 @@
 package proxy
 
 import (
-	"sync"
-
 	"github.com/pkg/errors"
 
 	abcicli "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/counter"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	"github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/sync"
 )
 
 // NewABCIClient returns newly connected client


### PR DESCRIPTION
In this PR I am using [go-deadlock](https://github.com/sasha-s/go-deadlock/) for detecting deadlock situations online. The `syns` package has no ability to detect the deadlock situations.
We were struggling a lot on an strange deadlock when updating the validator-set. Helping this package I could find the source of the issue:
```
POTENTIAL DEADLOCK: Recursive locking:
current goroutine 1947 lock 0xc0004d1910
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:196 consensus.(*ConsensusState).GetState { cs.mtx.RLock() } <<<<<
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/rpc/core/consensus.go:53 core.Validators { height := consensusState.GetState().LastBlockHeight + 1 }
~/go/src/github.com/gallactic/gallactic/core/validator/validator_set.go:25 validator._validatorListProxy.validators { result, err := tmRPC.Validators(&height) }
<autogenerated>:1 validator.(*_validatorListProxy).validators ???
~/go/src/github.com/gallactic/gallactic/core/validator/validator_set.go:108 validator.(*ValidatorSet).AdjustPower { result, err := set.proxy.validators(height) }
~/go/src/github.com/gallactic/gallactic/core/consensus/tendermint/abci/app.go:189 abci.(*App).EndBlock { set.AdjustPower(reqEndBlock.GetHeight()) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/abci/client/local_client.go:238 client.(*localClient).EndBlockSync { res := app.Application.EndBlock(req) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/proxy/app_conn.go:77 proxy.(*appConnConsensus).EndBlockSync { return app.appConn.EndBlockSync(req) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/state/execution.go:265 state.execBlockOnProxyApp { abciResponses.EndBlock, err = proxyAppConn.EndBlockSync(abci.RequestEndBlock{Height: block.Height}) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/state/execution.go:96 state.(*BlockExecutor).ApplyBlock { abciResponses, err := execBlockOnProxyApp(blockExec.logger, blockExec.proxyApp, block, state.LastValidators, blockExec.db) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1292 consensus.(*ConsensusState).finalizeCommit { stateCopy, err = cs.blockExec.ApplyBlock(stateCopy, types.BlockID{block.Hash(), blockParts.Header()}, block) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1223 consensus.(*ConsensusState).tryFinalizeCommit { cs.finalizeCommit(height) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1169 consensus.(*ConsensusState).enterCommit.func1 { cs.tryFinalizeCommit(height) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1200 consensus.(*ConsensusState).enterCommit { } }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1625 consensus.(*ConsensusState).addVote { cs.enterCommit(height, vote.Round) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1471 consensus.(*ConsensusState).tryAddVote { added, err := cs.addVote(vote, peerID) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:651 consensus.(*ConsensusState).handleMsg { added, err := cs.tryAddVote(msg.Vote, peerID) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:608 consensus.(*ConsensusState).receiveRoutine { cs.handleMsg(mi) }

Previous place where the lock was grabbed (same goroutine)
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:627 consensus.(*ConsensusState).handleMsg { cs.mtx.Lock() } <<<<<
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:608 consensus.(*ConsensusState).receiveRoutine { cs.handleMsg(mi) }

Other goroutines holding locks:
goroutine 1947 lock 0xc000bb9348
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/abci/client/local_client.go:235 client.(*localClient).EndBlockSync { app.mtx.Lock() } <<<<<
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/proxy/app_conn.go:77 proxy.(*appConnConsensus).EndBlockSync { return app.appConn.EndBlockSync(req) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/state/execution.go:265 state.execBlockOnProxyApp { abciResponses.EndBlock, err = proxyAppConn.EndBlockSync(abci.RequestEndBlock{Height: block.Height}) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/state/execution.go:96 state.(*BlockExecutor).ApplyBlock { abciResponses, err := execBlockOnProxyApp(blockExec.logger, blockExec.proxyApp, block, state.LastValidators, blockExec.db) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1292 consensus.(*ConsensusState).finalizeCommit { stateCopy, err = cs.blockExec.ApplyBlock(stateCopy, types.BlockID{block.Hash(), blockParts.Header()}, block) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1223 consensus.(*ConsensusState).tryFinalizeCommit { cs.finalizeCommit(height) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1169 consensus.(*ConsensusState).enterCommit.func1 { cs.tryFinalizeCommit(height) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1200 consensus.(*ConsensusState).enterCommit { } }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1625 consensus.(*ConsensusState).addVote { cs.enterCommit(height, vote.Round) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:1471 consensus.(*ConsensusState).tryAddVote { added, err := cs.addVote(vote, peerID) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:651 consensus.(*ConsensusState).handleMsg { added, err := cs.tryAddVote(msg.Vote, peerID) }
~/go/src/github.com/gallactic/gallactic/vendor/github.com/tendermint/tendermint/consensus/state.go:608 consensus.(*ConsensusState).receiveRoutine { cs.handleMsg(mi) }


```