### PR TITLE
test proposer frequencies

### DIFF
--- a/state/state_test.go
+++ b/state/state_test.go
@@ -271,13 +271,13 @@ func TestProposerFrequency(t *testing.T) {
 	testCases := []struct {
 		powers []int64
 	}{
-		//{[]int64{1, 1}},
-		//{[]int64{1, 2}},
-		//{[]int64{1, 100}},
-		//{[]int64{5, 5}},
-		//{[]int64{5, 100}},
-		//{[]int64{50, 50}},
-		//{[]int64{50, 100}},
+		{[]int64{1, 1}},
+		{[]int64{1, 2}},
+		{[]int64{1, 100}},
+		{[]int64{5, 5}},
+		{[]int64{5, 100}},
+		{[]int64{50, 50}},
+		{[]int64{50, 100}},
 		{[]int64{1, 1000}},
 		/*{[]int64{1, 1, 1}},
 		{[]int64{1, 2, 3}},
@@ -287,11 +287,11 @@ func TestProposerFrequency(t *testing.T) {
 		{[]int64{1, 10, 100}},
 		{[]int64{1, 1, 1000}},
 		{[]int64{1, 10, 1000}},
-		{[]int64{1, 100, 1000}},*/
+			{[]int64{1, 100, 1000}},*/
 	}
 
 	for caseNum, testCase := range testCases {
-		for i := 0; i < 20; i++ {
+		for i := 0; i < 100; i++ {
 			valSet := genValSetWithPowers(testCase.powers)
 			testProposerFreq(t, caseNum, valSet)
 		}
@@ -338,7 +338,7 @@ func testProposerFreq(t *testing.T, caseNum int, valSet *types.ValidatorSet) {
 	fmt.Println("TOTAL POWER", totalPower)
 
 	// run the proposer selection and track frequencies
-	runMult := 1
+	runMult := 2
 	runs := int(totalPower) * runMult
 	freqs := make([]int, N)
 	fmt.Println("VALSET", valSet)
@@ -355,7 +355,7 @@ func testProposerFreq(t *testing.T, caseNum int, valSet *types.ValidatorSet) {
 		expectFreq := int(val.VotingPower) * runMult
 		gotFreq := freq
 		abs := int(math.Abs(float64(expectFreq - gotFreq)))
-		assert.True(t, abs <= 1, fmt.Sprintf("Case %d val %d: got %d, expected %d", caseNum, i, gotFreq, expectFreq))
+		require.True(t, abs <= 1, fmt.Sprintf("Case %d val %d: got %d, expected %d", caseNum, i, gotFreq, expectFreq))
 	}
 }
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -271,14 +271,14 @@ func TestProposerFrequency(t *testing.T) {
 	testCases := []struct {
 		powers []int64
 	}{
-		{[]int64{1, 1}},
-		{[]int64{1, 2}},
+		//{[]int64{1, 1}},
+		//{[]int64{1, 2}},
 		//{[]int64{1, 100}},
-		{[]int64{5, 5}},
+		//{[]int64{5, 5}},
 		//{[]int64{5, 100}},
 		//{[]int64{50, 50}},
 		//{[]int64{50, 100}},
-		//{[]int64{1, 1000}},
+		{[]int64{1, 1000}},
 		/*{[]int64{1, 1, 1}},
 		{[]int64{1, 2, 3}},
 		{[]int64{1, 2, 3}},
@@ -291,8 +291,10 @@ func TestProposerFrequency(t *testing.T) {
 	}
 
 	for caseNum, testCase := range testCases {
-		valSet := genValSetWithPowers(testCase.powers)
-		testProposerFreq(t, caseNum, valSet)
+		for i := 0; i < 20; i++ {
+			valSet := genValSetWithPowers(testCase.powers)
+			testProposerFreq(t, caseNum, valSet)
+		}
 	}
 
 	// some random test cases with up to 1000 validators
@@ -336,9 +338,10 @@ func testProposerFreq(t *testing.T, caseNum int, valSet *types.ValidatorSet) {
 	fmt.Println("TOTAL POWER", totalPower)
 
 	// run the proposer selection and track frequencies
-	runMult := 2
+	runMult := 1
 	runs := int(totalPower) * runMult
 	freqs := make([]int, N)
+	fmt.Println("VALSET", valSet)
 	for i := 0; i < runs; i++ {
 		prop := valSet.GetProposer()
 		idx, _ := valSet.GetByAddress(prop.Address)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -371,7 +371,7 @@ func testProposerFreq(t *testing.T, caseNum int, valSet *types.ValidatorSet) {
 		// max bound on expected vs seen freq was proven
 		// to be 1 for the 2 validator case in
 		// https://github.com/cwgoes/tm-proposer-idris
-		// and infered to generalize to N-1
+		// and inferred to generalize to N-1
 		bound := N - 1
 		require.True(t, abs <= bound, fmt.Sprintf("Case %d val %d (%d): got %d, expected %d", caseNum, i, N, gotFreq, expectFreq))
 	}

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -52,7 +52,6 @@ func NewValidatorSet(valz []*Validator) *ValidatorSet {
 		Validators: validators,
 	}
 	if len(valz) > 0 {
-		fmt.Println("NEW VAL SET")
 		vals.IncrementProposerPriority(1)
 	}
 
@@ -75,7 +74,6 @@ func (vals *ValidatorSet) CopyIncrementProposerPriority(times int) *ValidatorSet
 // proposer. Panics if validator set is empty.
 // `times` must be positive.
 func (vals *ValidatorSet) IncrementProposerPriority(times int) {
-	fmt.Println("INCREMENT")
 	if times <= 0 {
 		panic("Cannot call IncrementProposerPriority with non-positive times")
 	}
@@ -88,17 +86,13 @@ func (vals *ValidatorSet) IncrementProposerPriority(times int) {
 	// the 2nd check (threshold > 0) is merely a sanity check which could be
 	// removed if all tests would init. voting power appropriately;
 	// i.e. threshold should always be > 0
-	fmt.Println("... DIFF", diff, threshold)
 
 	for diff > threshold && threshold > 0 {
 		// div = Ceil((maxPriority - minPriority) / 2*totalVotingPower)
 		// threshold > 0 and diff > threshold guarantees (diff / threshold > 0):
 		div := int64(math.Ceil(float64(diff) / float64(threshold)))
-		//_ = div
-		fmt.Println("... DIV", div)
 		vals.dividePrioritiesBy(div)
 		diff = computeMaxMinPriorityDiff(vals)
-		fmt.Println("... NEW DIFF", diff)
 	}
 
 	var proposer *Validator
@@ -108,8 +102,6 @@ func (vals *ValidatorSet) IncrementProposerPriority(times int) {
 	}
 	vals.shiftByAvgProposerPriority()
 
-	newDiff := computeMaxMinPriorityDiff(vals)
-	fmt.Println("... END DIFF", newDiff)
 	vals.Proposer = proposer
 }
 
@@ -117,24 +109,20 @@ func (vals *ValidatorSet) incrementProposerPriority() *Validator {
 	for _, val := range vals.Validators {
 		// Check for overflow for sum.
 		newPrio := safeAddClip(val.ProposerPriority, val.VotingPower)
-		fmt.Println("...... PRIO", val.ProposerPriority, newPrio)
 		val.ProposerPriority = newPrio
 	}
 	// Decrement the validator with most ProposerPriority:
 	mostest := vals.getValWitMostPriority()
 	// mind underflow
 	mostest.ProposerPriority = safeSubClip(mostest.ProposerPriority, vals.TotalVotingPower())
-	fmt.Println("...... PROPOSRE PRIO", mostest.ProposerPriority)
 
 	return mostest
 }
 
 // the caller should make sure divisor != 0
 func (vals *ValidatorSet) dividePrioritiesBy(divisor int64) {
-	fmt.Println(" ... DIV!")
 	for _, val := range vals.Validators {
 		newPrio := int64(math.Ceil(float64(val.ProposerPriority) / float64(divisor)))
-		fmt.Println(" ...... PRIO", val.ProposerPriority, newPrio)
 		val.ProposerPriority = newPrio
 	}
 }
@@ -181,7 +169,6 @@ func (vals *ValidatorSet) getValWitMostPriority() *Validator {
 
 func (vals *ValidatorSet) shiftByAvgProposerPriority() {
 	avgProposerPriority := vals.computeAvgProposerPriority()
-	fmt.Println("... AVG", avgProposerPriority)
 	for _, val := range vals.Validators {
 		val.ProposerPriority = safeSubClip(val.ProposerPriority, avgProposerPriority)
 	}

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -74,6 +74,7 @@ func (vals *ValidatorSet) CopyIncrementProposerPriority(times int) *ValidatorSet
 // proposer. Panics if validator set is empty.
 // `times` must be positive.
 func (vals *ValidatorSet) IncrementProposerPriority(times int) {
+	fmt.Println("INCREMENT")
 	if times <= 0 {
 		panic("Cannot call IncrementProposerPriority with non-positive times")
 	}
@@ -86,12 +87,14 @@ func (vals *ValidatorSet) IncrementProposerPriority(times int) {
 	// the 2nd check (threshold > 0) is merely a sanity check which could be
 	// removed if all tests would init. voting power appropriately;
 	// i.e. threshold should always be > 0
+	fmt.Println("... DIFF", diff, threshold)
+
 	if diff > threshold && threshold > 0 {
 		// div = Ceil((maxPriority - minPriority) / 2*totalVotingPower)
 		// threshold > 0 and diff > threshold guarantees (diff / threshold > 0):
 		div := int64(math.Ceil(float64(diff) / float64(threshold)))
 		//_ = div
-		fmt.Println("DIV", div)
+		fmt.Println("... DIV", div)
 		vals.dividePrioritiesBy(div)
 	}
 
@@ -154,7 +157,7 @@ func computeMaxMinPriorityDiff(vals *ValidatorSet) int64 {
 		}
 	}
 	diff := max - min
-	return diff
+	return int64(math.Abs(float64(diff)))
 }
 
 func (vals *ValidatorSet) getValWitMostPriority() *Validator {
@@ -167,7 +170,7 @@ func (vals *ValidatorSet) getValWitMostPriority() *Validator {
 
 func (vals *ValidatorSet) shiftByAvgProposerPriority() {
 	avgProposerPriority := vals.computeAvgProposerPriority()
-	fmt.Println("AVG", avgProposerPriority)
+	fmt.Println("... AVG", avgProposerPriority)
 	for _, val := range vals.Validators {
 		val.ProposerPriority = safeSubClip(val.ProposerPriority, avgProposerPriority)
 	}

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -90,6 +90,8 @@ func (vals *ValidatorSet) IncrementProposerPriority(times int) {
 		// div = Ceil((maxPriority - minPriority) / 2*totalVotingPower)
 		// threshold > 0 and diff > threshold guarantees (diff / threshold > 0):
 		div := int64(math.Ceil(float64(diff) / float64(threshold)))
+		//_ = div
+		fmt.Println("DIV", div)
 		vals.dividePrioritiesBy(div)
 	}
 
@@ -165,6 +167,7 @@ func (vals *ValidatorSet) getValWitMostPriority() *Validator {
 
 func (vals *ValidatorSet) shiftByAvgProposerPriority() {
 	avgProposerPriority := vals.computeAvgProposerPriority()
+	fmt.Println("AVG", avgProposerPriority)
 	for _, val := range vals.Validators {
 		val.ProposerPriority = safeSubClip(val.ProposerPriority, avgProposerPriority)
 	}


### PR DESCRIPTION
Add test to check that proposers are selected at the frequency we expect.

The following fixes needed to be made:
- take absolute value of the priorities diff
- normalize repeatedly until the diff is less than the threshold