### PR TITLE
[WIP]: few follow up changes to the proposer priorities

### DIFF
--- a/state/state_test.go
+++ b/state/state_test.go
@@ -283,6 +283,7 @@ func TestProposerFrequency(t *testing.T) {
 
 		// 3 vals
 		{[]int64{1, 1, 1}},
+		{[]int64{1, 1, 2}},
 		{[]int64{1, 2, 3}},
 		{[]int64{1, 2, 3}},
 		{[]int64{1, 1, 10}},
@@ -291,6 +292,7 @@ func TestProposerFrequency(t *testing.T) {
 		{[]int64{1, 1, 1000}},
 		{[]int64{1, 10, 1000}},
 		{[]int64{1, 100, 1000}},
+		{[]int64{114, 438, 79}},
 
 		// 4 vals
 		{[]int64{1, 1, 1, 1}},
@@ -302,6 +304,7 @@ func TestProposerFrequency(t *testing.T) {
 		{[]int64{1, 1, 10, 1000}},
 		{[]int64{1, 1, 100, 1000}},
 		{[]int64{1, 10, 100, 1000}},
+		{[]int64{47, 270, 701, 462}},
 	}
 
 	for caseNum, testCase := range testCases {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -331,7 +331,7 @@ func TestProposerFrequency(t *testing.T) {
 			vals[j] = val
 		}
 		valSet := types.NewValidatorSet(vals)
-		valSet.RescalePriorities(totalVotePower)
+		//valSet.rescalePriorities(totalVotePower)
 		testProposerFreq(t, i, valSet)
 	}
 }
@@ -348,7 +348,7 @@ func genValSetWithPowers(powers []int64) *types.ValidatorSet {
 		vals[i] = val
 	}
 	valSet := types.NewValidatorSet(vals)
-	valSet.RescalePriorities(totalVotePower)
+	//valSet.rescalePriorities(totalVotePower)
 	return valSet
 }
 
@@ -380,7 +380,7 @@ func testProposerFreq(t *testing.T, caseNum int, valSet *types.ValidatorSet) {
 		// https://github.com/cwgoes/tm-proposer-idris
 		// and inferred to generalize to N-1
 		bound := N - 1
-		require.True(t, abs <= bound, fmt.Sprintf("Case %d val %d (%d): got %d, expected %d", caseNum, i, N, gotFreq, expectFreq))
+		assert.True(t, abs <= bound, fmt.Sprintf("Case %d val %d (%d): got %d, expected %d", caseNum, i, N, gotFreq, expectFreq))
 	}
 }
 

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -80,13 +80,13 @@ func (vals *ValidatorSet) IncrementProposerPriority(times int) {
 	// Cap the difference between priorities to be proportional to totalPower by
 	// re-normalizing priorities, i.e., rescale all priorities by multiplying with:
 	// totalVotingPower/(maxPriority - minPriority)
-	threshold := vals.TotalVotingPower()
+	threshold := 2 * vals.TotalVotingPower()
 	vals.rescalePriorities(threshold)
-	vals.shiftByAvgProposerPriority()
 
 	var proposer *Validator
 	// call IncrementProposerPriority(1) times times:
 	for i := 0; i < times; i++ {
+		vals.shiftByAvgProposerPriority()
 		proposer = vals.incrementProposerPriority()
 	}
 
@@ -109,7 +109,9 @@ func (vals *ValidatorSet) rescalePriorities(threshold int64) {
 	// possible alternative: val.ProposerPriority = (val.ProposerPriority * threshold) / diff (more precise)
 	// concern: fairness on floor division, e.g. prio 21 / 2, prio 20 / 2 - probably minor
 	if diff > threshold {
+		fmt.Println("diff", diff, "threshold", threshold)
 		for _, val := range vals.Validators {
+			fmt.Println("old", val.ProposerPriority, "new", (val.ProposerPriority*threshold)/diff)
 			val.ProposerPriority = (val.ProposerPriority * threshold) / diff
 		}
 	}

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -105,11 +105,10 @@ func (vals *ValidatorSet) rescalePriorities(threshold int64) {
 	// Re-normalization is performed by dividing by an integer for simplicity.
 	// NOTE: This may make debugging priority issues easier as well.
 	diff := computeMaxMinPriorityDiff(vals)
-	ratio := diff / threshold
 	// problem: ceiling is not quite correct, e.g. 1.1 leads to division by 2
 	// possible alternative: val.ProposerPriority = (val.ProposerPriority * threshold) / diff (more precise)
 	// concern: fairness on floor division, e.g. prio 21 / 2, prio 20 / 2 - probably minor
-	if ratio > 1 {
+	if diff > threshold {
 		for _, val := range vals.Validators {
 			val.ProposerPriority = (val.ProposerPriority * threshold) / diff
 		}


### PR DESCRIPTION
- floor instead of ceil when rescaling prios
- move averaging to top
- make ValidatorSet.RescalePriorities unexported
- remove calls to RescalePriorities from bucky's tests
- re-rename diffMax to threshold
- fix some typos

WIP as `TestProposerPriorityDoesNotGetResetToZero` needs minor changes to be fixed and there is an outdated comment in the code

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
