### PR TITLE
Minor goimports update

### DIFF
--- a/benchmarks/codec_test.go
+++ b/benchmarks/codec_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 
 	proto "github.com/tendermint/tendermint/benchmarks/proto"
 	"github.com/tendermint/tendermint/crypto/ed25519"

--- a/blockchain/wire.go
+++ b/blockchain/wire.go
@@ -1,7 +1,7 @@
 package blockchain
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/types"
 )
 

--- a/cmd/tendermint/commands/wire.go
+++ b/cmd/tendermint/commands/wire.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 )
 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cstypes "github.com/tendermint/tendermint/consensus/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	tmevents "github.com/tendermint/tendermint/libs/events"
@@ -438,9 +438,9 @@ func (conR *ConsensusReactor) broadcastHasVoteMessage(vote *types.Vote) {
 
 func makeRoundStepMessage(rs *cstypes.RoundState) (nrsMsg *NewRoundStepMessage) {
 	nrsMsg = &NewRoundStepMessage{
-		Height: rs.Height,
-		Round:  rs.Round,
-		Step:   rs.Step,
+		Height:                rs.Height,
+		Round:                 rs.Round,
+		Step:                  rs.Step,
 		SecondsSinceStartTime: int(time.Since(rs.StartTime).Seconds()),
 		LastCommitRound:       rs.LastCommit.Round(),
 	}

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tendermint/tendermint/abci/client"
+	abcicli "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	abci "github.com/tendermint/tendermint/abci/types"
 	bc "github.com/tendermint/tendermint/blockchain"

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -6,6 +6,7 @@ import (
 	"hash/crc32"
 	"io"
 	"reflect"
+
 	//"strconv"
 	//"strings"
 	"time"

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -94,7 +94,7 @@ type ConsensusState struct {
 	// internal state
 	mtx sync.RWMutex
 	cstypes.RoundState
-	state                     sm.State // State until height-1.
+	state sm.State // State until height-1.
 
 	// state changes may be triggered by: msgs from peers,
 	// msgs from ourself, or by timeouts

--- a/consensus/types/round_state_test.go
+++ b/consensus/types/round_state_test.go
@@ -3,7 +3,7 @@ package types
 import (
 	"testing"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/types"

--- a/consensus/wal_test.go
+++ b/consensus/wal_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
 	// "sync"
 	"testing"
 	"time"

--- a/consensus/wire.go
+++ b/consensus/wire.go
@@ -1,7 +1,7 @@
 package consensus
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/types"
 )
 

--- a/crypto/merkle/proof_test.go
+++ b/crypto/merkle/proof_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
 

--- a/crypto/merkle/wire.go
+++ b/crypto/merkle/wire.go
@@ -1,7 +1,7 @@
 package merkle
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 )
 
 var cdc *amino.Codec

--- a/evidence/wire.go
+++ b/evidence/wire.go
@@ -1,7 +1,7 @@
 package evidence
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 	"github.com/tendermint/tendermint/types"
 )

--- a/mempool/wire.go
+++ b/mempool/wire.go
@@ -1,7 +1,7 @@
 package mempool
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 )
 
 var cdc = amino.NewCodec()

--- a/node/node.go
+++ b/node/node.go
@@ -34,7 +34,7 @@ import (
 	rpccore "github.com/tendermint/tendermint/rpc/core"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	grpccore "github.com/tendermint/tendermint/rpc/grpc"
-	"github.com/tendermint/tendermint/rpc/lib/server"
+	rpcserver "github.com/tendermint/tendermint/rpc/lib/server"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/state/txindex"
 	"github.com/tendermint/tendermint/state/txindex/kv"

--- a/p2p/conn/wire.go
+++ b/p2p/conn/wire.go
@@ -1,7 +1,7 @@
 package conn
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 )
 

--- a/p2p/pex/wire.go
+++ b/p2p/pex/wire.go
@@ -1,7 +1,7 @@
 package pex
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 )
 
 var cdc *amino.Codec = amino.NewCodec()

--- a/p2p/wire.go
+++ b/p2p/wire.go
@@ -1,7 +1,7 @@
 package p2p
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 )
 

--- a/privval/remote_signer.go
+++ b/privval/remote_signer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/types"

--- a/privval/wire.go
+++ b/privval/wire.go
@@ -1,7 +1,7 @@
 package privval
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 )
 

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -12,7 +12,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/tendermint/tendermint/rpc/client"
-	"github.com/tendermint/tendermint/rpc/test"
+	rpctest "github.com/tendermint/tendermint/rpc/test"
 	"github.com/tendermint/tendermint/types"
 )
 

--- a/rpc/core/types/wire.go
+++ b/rpc/core/types/wire.go
@@ -1,7 +1,7 @@
 package core_types
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/types"
 )
 

--- a/rpc/grpc/grpc_test.go
+++ b/rpc/grpc/grpc_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/abci/example/kvstore"
-	"github.com/tendermint/tendermint/rpc/grpc"
-	"github.com/tendermint/tendermint/rpc/test"
+	core_grpc "github.com/tendermint/tendermint/rpc/grpc"
+	rpctest "github.com/tendermint/tendermint/rpc/test"
 )
 
 func TestMain(m *testing.M) {

--- a/rpc/lib/client/args_test.go
+++ b/rpc/lib/client/args_test.go
@@ -5,8 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 )
 
 type Tx []byte

--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 
 	types "github.com/tendermint/tendermint/rpc/lib/types"
 )

--- a/rpc/lib/client/ws_client.go
+++ b/rpc/lib/client/ws_client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	metrics "github.com/rcrowley/go-metrics"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	types "github.com/tendermint/tendermint/rpc/lib/types"
 )

--- a/rpc/lib/types/types_test.go
+++ b/rpc/lib/types/types_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 )
 
 type SampleResult struct {

--- a/scripts/json2wal/main.go
+++ b/scripts/json2wal/main.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cs "github.com/tendermint/tendermint/consensus"
 	"github.com/tendermint/tendermint/types"
 )

--- a/scripts/wal2json/main.go
+++ b/scripts/wal2json/main.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cs "github.com/tendermint/tendermint/consensus"
 	"github.com/tendermint/tendermint/types"
 )

--- a/state/txindex/kv/wire.go
+++ b/state/txindex/kv/wire.go
@@ -1,7 +1,7 @@
 package kv
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 )
 
 var cdc = amino.NewCodec()

--- a/state/wire.go
+++ b/state/wire.go
@@ -1,7 +1,7 @@
 package state
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 )
 

--- a/tools/tm-monitor/mock/eventmeter.go
+++ b/tools/tm-monitor/mock/eventmeter.go
@@ -4,7 +4,7 @@ import (
 	stdlog "log"
 	"reflect"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/libs/log"
 	em "github.com/tendermint/tendermint/tools/tm-monitor/eventmeter"
 )

--- a/tools/tm-monitor/monitor/monitor.go
+++ b/tools/tm-monitor/monitor/monitor.go
@@ -46,7 +46,7 @@ func NewMonitor(options ...func(*Monitor)) *Monitor {
 		nodeQuit:                      make(map[string]chan struct{}),
 		recalculateNetworkUptimeEvery: 10 * time.Second,
 		numValidatorsUpdateInterval:   5 * time.Second,
-		logger: log.NewNopLogger(),
+		logger:                        log.NewNopLogger(),
 	}
 
 	for _, option := range options {

--- a/tools/tm-monitor/monitor/monitor_test.go
+++ b/tools/tm-monitor/monitor/monitor_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	mock "github.com/tendermint/tendermint/tools/tm-monitor/mock"

--- a/tools/tm-monitor/monitor/node.go
+++ b/tools/tm-monitor/monitor/node.go
@@ -55,13 +55,13 @@ func NewNode(rpcAddr string, options ...func(*Node)) *Node {
 
 func NewNodeWithEventMeterAndRpcClient(rpcAddr string, em eventMeter, rpcClient rpc_client.HTTPClient, options ...func(*Node)) *Node {
 	n := &Node{
-		rpcAddr:   rpcAddr,
-		em:        em,
-		rpcClient: rpcClient,
-		Name:      rpcAddr,
-		quit:      make(chan struct{}),
+		rpcAddr:                  rpcAddr,
+		em:                       em,
+		rpcClient:                rpcClient,
+		Name:                     rpcAddr,
+		quit:                     make(chan struct{}),
 		checkIsValidatorInterval: 5 * time.Second,
-		logger: log.NewNopLogger(),
+		logger:                   log.NewNopLogger(),
 	}
 
 	for _, option := range options {

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -7,8 +7,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tendermint/go-amino"
-
+	amino "github.com/tendermint/go-amino"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"

--- a/types/tx.go
+++ b/types/tx.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/merkle"

--- a/types/wire.go
+++ b/types/wire.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	amino "github.com/tendermint/go-amino"
-	"github.com/tendermint/tendermint/crypto/encoding/amino"
+	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 )
 
 var cdc = amino.NewCodec()


### PR DESCRIPTION
As per conversation here: https://github.com/tendermint/tendermint/pull/3218#discussion_r251364041

This is the result of running the following code on the repo:

```bash
find . -name '*.go' | grep -v 'vendor/' | xargs -n 1 goimports -w
```

Also includes minor formatting fixes to code.