### PR TITLE
Minor fixes to non-hyperlinked links in docs

### DIFF
--- a/docs/tendermint-core/rpc.md
+++ b/docs/tendermint-core/rpc.md
@@ -2,6 +2,6 @@
 
 The RPC documentation is hosted here:
 
-- https://tendermint.com/rpc/
+- [https://tendermint.com/rpc/](https://tendermint.com/rpc/)
 
 To update the documentation, edit the relevant `godoc` comments in the [rpc/core directory](https://github.com/tendermint/tendermint/tree/develop/rpc/core).

--- a/docs/tools/benchmarking.md
+++ b/docs/tools/benchmarking.md
@@ -2,7 +2,7 @@
 
 Tendermint blockchain benchmarking tool:
 
-- https://github.com/tendermint/tools/tree/master/tm-bench
+- [https://github.com/tendermint/tendermint/tree/master/tools/tm-bench](https://github.com/tendermint/tendermint/tree/master/tools/tm-bench)
 
 For example, the following:
 

--- a/docs/tools/monitoring.md
+++ b/docs/tools/monitoring.md
@@ -3,7 +3,7 @@
 Tendermint blockchain monitoring tool; watches over one or more nodes,
 collecting and providing various statistics to the user:
 
-- https://github.com/tendermint/tendermint/tree/master/tools/tm-monitor
+- [https://github.com/tendermint/tendermint/tree/master/tools/tm-monitor](https://github.com/tendermint/tendermint/tree/master/tools/tm-monitor)
 
 ## Quick Start
 

--- a/tools/tm-bench/README.md
+++ b/tools/tm-bench/README.md
@@ -2,7 +2,7 @@
 
 Tendermint blockchain benchmarking tool:
 
-- https://github.com/tendermint/tools/tree/master/tm-bench
+- [https://github.com/tendermint/tendermint/tree/master/tools/tm-bench](https://github.com/tendermint/tendermint/tree/master/tools/tm-bench)
 
 For example, the following: `tm-bench -T 30 -r 10000 localhost:26657`
 

--- a/tools/tm-monitor/README.md
+++ b/tools/tm-monitor/README.md
@@ -3,7 +3,7 @@
 Tendermint blockchain monitoring tool; watches over one or more nodes,
 collecting and providing various statistics to the user:
 
-- https://github.com/tendermint/tools/tree/master/tm-monitor
+- [https://github.com/tendermint/tendermint/tree/master/tools/tm-monitor](https://github.com/tendermint/tendermint/tree/master/tools/tm-monitor)
 
 ## Quick Start
 


### PR DESCRIPTION
There are a few links in the docs that aren't hyperlinks, so I just fixed these quick.

Plus, the `tm-bench` utility's docs were still pointing to the deprecated tools repo.