### PR TITLE
Introduce CommitSig alias for Vote in Commit

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,6 +11,7 @@ Special thanks to external contributors on this release:
 * Apps
 
 * Go API
+  - [types] \#3245 Commit uses `type CommitSig Vote` instead of `Vote` directly.
 
 * Blockchain Protocol
 

--- a/blockchain/reactor_test.go
+++ b/blockchain/reactor_test.go
@@ -100,8 +100,8 @@ func newBlockchainReactor(logger log.Logger, genDoc *types.GenesisDoc, privVals 
 			lastBlockMeta := blockStore.LoadBlockMeta(blockHeight - 1)
 			lastBlock := blockStore.LoadBlock(blockHeight - 1)
 
-			vote := makeVote(&lastBlock.Header, lastBlockMeta.BlockID, state.Validators, privVals[0])
-			lastCommit = &types.Commit{Precommits: []*types.Vote{vote}, BlockID: lastBlockMeta.BlockID}
+			vote := makeVote(&lastBlock.Header, lastBlockMeta.BlockID, state.Validators, privVals[0]).CommitSig()
+			lastCommit = &types.Commit{Precommits: []*types.CommitSig{vote}, BlockID: lastBlockMeta.BlockID}
 		}
 
 		thisBlock := makeBlock(blockHeight, state, lastCommit)

--- a/blockchain/store_test.go
+++ b/blockchain/store_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,15 @@ import (
 	"github.com/tendermint/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
 )
+
+// make a Commit with a single vote containing just the height and a timestamp
+func makeTestCommit(height int64, timestamp time.Time) *types.Commit {
+	return &types.Commit{
+		Precommits: []*types.CommitSig{
+			{Height: height, Timestamp: timestamp},
+		},
+	}
+}
 
 func makeStateAndBlockStore(logger log.Logger) (sm.State, *BlockStore) {
 	config := cfg.ResetTestRoot("blockchain_reactor_test")
@@ -86,8 +96,7 @@ var (
 	partSet     = block.MakePartSet(2)
 	part1       = partSet.GetPart(0)
 	part2       = partSet.GetPart(1)
-	seenCommit1 = &types.Commit{Precommits: []*types.Vote{{Height: 10,
-		Timestamp: tmtime.Now()}}}
+	seenCommit1 = makeTestCommit(10, tmtime.Now())
 )
 
 // TODO: This test should be simplified ...
@@ -107,8 +116,7 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 	// save a block
 	block := makeBlock(bs.Height()+1, state, new(types.Commit))
 	validPartSet := block.MakePartSet(2)
-	seenCommit := &types.Commit{Precommits: []*types.Vote{{Height: 10,
-		Timestamp: tmtime.Now()}}}
+	seenCommit := makeTestCommit(10, tmtime.Now())
 	bs.SaveBlock(block, partSet, seenCommit)
 	require.Equal(t, bs.Height(), block.Header.Height, "expecting the new height to be changed")
 
@@ -127,8 +135,7 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 
 	// End of setup, test data
 
-	commitAtH10 := &types.Commit{Precommits: []*types.Vote{{Height: 10,
-		Timestamp: tmtime.Now()}}}
+	commitAtH10 := makeTestCommit(10, tmtime.Now())
 	tuples := []struct {
 		block      *types.Block
 		parts      *types.PartSet
@@ -351,9 +358,7 @@ func TestBlockFetchAtHeight(t *testing.T) {
 	block := makeBlock(bs.Height()+1, state, new(types.Commit))
 
 	partSet := block.MakePartSet(2)
-	seenCommit := &types.Commit{Precommits: []*types.Vote{{Height: 10,
-		Timestamp: tmtime.Now()}}}
-
+	seenCommit := makeTestCommit(10, tmtime.Now())
 	bs.SaveBlock(block, partSet, seenCommit)
 	require.Equal(t, bs.Height(), block.Header.Height, "expecting the new height to be changed")
 

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -539,7 +539,7 @@ func makeBlockchainFromWAL(wal WAL) ([]*types.Block, []*types.Commit, error) {
 			if p.Type == types.PrecommitType {
 				thisBlockCommit = &types.Commit{
 					BlockID:    p.BlockID,
-					Precommits: []*types.Vote{p},
+					Precommits: []*types.CommitSig{p.CommitSig()},
 				}
 			}
 		}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -472,7 +472,7 @@ func (cs *ConsensusState) reconstructLastCommit(state sm.State) {
 		if precommit == nil {
 			continue
 		}
-		added, err := lastPrecommits.AddVote(precommit)
+		added, err := lastPrecommits.AddVote(seenCommit.ToVote(precommit))
 		if !added || err != nil {
 			cmn.PanicCrisis(fmt.Sprintf("Failed to reconstruct LastCommit: %v", err))
 		}
@@ -1330,7 +1330,7 @@ func (cs *ConsensusState) recordMetrics(height int64, block *types.Block) {
 	missingValidators := 0
 	missingValidatorsPower := int64(0)
 	for i, val := range cs.Validators.Validators {
-		var vote *types.Vote
+		var vote *types.CommitSig
 		if i < len(block.LastCommit.Precommits) {
 			vote = block.LastCommit.Precommits[i]
 		}

--- a/consensus/types/round_state_test.go
+++ b/consensus/types/round_state_test.go
@@ -16,7 +16,7 @@ func BenchmarkRoundStateDeepCopy(b *testing.B) {
 	// Random validators
 	nval, ntxs := 100, 100
 	vset, _ := types.RandValidatorSet(nval, 1)
-	precommits := make([]*types.Vote, nval)
+	precommits := make([]*types.CommitSig, nval)
 	blockID := types.BlockID{
 		Hash: cmn.RandBytes(20),
 		PartsHeader: types.PartSetHeader{
@@ -25,12 +25,12 @@ func BenchmarkRoundStateDeepCopy(b *testing.B) {
 	}
 	sig := make([]byte, ed25519.SignatureSize)
 	for i := 0; i < nval; i++ {
-		precommits[i] = &types.Vote{
+		precommits[i] = (&types.Vote{
 			ValidatorAddress: types.Address(cmn.RandBytes(20)),
 			Timestamp:        tmtime.Now(),
 			BlockID:          blockID,
 			Signature:        sig,
-		}
+		}).CommitSig()
 	}
 	txs := make([]types.Tx, ntxs)
 	for i := 0; i < ntxs; i++ {

--- a/lite/helpers.go
+++ b/lite/helpers.go
@@ -70,7 +70,7 @@ func (pkz privKeys) ToValidators(init, inc int64) *types.ValidatorSet {
 
 // signHeader properly signs the header with all keys from first to last exclusive.
 func (pkz privKeys) signHeader(header *types.Header, first, last int) *types.Commit {
-	votes := make([]*types.CommitSig, len(pkz))
+	commitSigs := make([]*types.CommitSig, len(pkz))
 
 	// We need this list to keep the ordering.
 	vset := pkz.ToValidators(1, 0)
@@ -78,12 +78,12 @@ func (pkz privKeys) signHeader(header *types.Header, first, last int) *types.Com
 	// Fill in the votes we want.
 	for i := first; i < last && i < len(pkz); i++ {
 		vote := makeVote(header, vset, pkz[i])
-		votes[vote.ValidatorIndex] = vote.CommitSig()
+		commitSigs[vote.ValidatorIndex] = vote.CommitSig()
 	}
 
 	res := &types.Commit{
 		BlockID:    types.BlockID{Hash: header.Hash()},
-		Precommits: votes,
+		Precommits: commitSigs,
 	}
 	return res
 }

--- a/lite/helpers.go
+++ b/lite/helpers.go
@@ -70,7 +70,7 @@ func (pkz privKeys) ToValidators(init, inc int64) *types.ValidatorSet {
 
 // signHeader properly signs the header with all keys from first to last exclusive.
 func (pkz privKeys) signHeader(header *types.Header, first, last int) *types.Commit {
-	votes := make([]*types.Vote, len(pkz))
+	votes := make([]*types.CommitSig, len(pkz))
 
 	// We need this list to keep the ordering.
 	vset := pkz.ToValidators(1, 0)
@@ -78,7 +78,7 @@ func (pkz privKeys) signHeader(header *types.Header, first, last int) *types.Com
 	// Fill in the votes we want.
 	for i := first; i < last && i < len(pkz); i++ {
 		vote := makeVote(header, vset, pkz[i])
-		votes[vote.ValidatorIndex] = vote
+		votes[vote.ValidatorIndex] = vote.CommitSig()
 	}
 
 	res := &types.Commit{

--- a/state/execution.go
+++ b/state/execution.go
@@ -315,7 +315,7 @@ func getBeginBlockValidatorInfo(block *types.Block, lastValSet *types.ValidatorS
 	// Collect the vote info (list of validators and whether or not they signed).
 	voteInfos := make([]abci.VoteInfo, len(lastValSet.Validators))
 	for i, val := range lastValSet.Validators {
-		var vote *types.Vote
+		var vote *types.CommitSig
 		if i < len(block.LastCommit.Precommits) {
 			vote = block.LastCommit.Precommits[i]
 		}

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -65,16 +65,16 @@ func TestBeginBlockValidators(t *testing.T) {
 	prevBlockID := types.BlockID{prevHash, prevParts}
 
 	now := tmtime.Now()
-	vote0 := (&types.Vote{ValidatorIndex: 0, Timestamp: now, Type: types.PrecommitType}).CommitSig()
-	vote1 := (&types.Vote{ValidatorIndex: 1, Timestamp: now}).CommitSig()
+	commitSig0 := (&types.Vote{ValidatorIndex: 0, Timestamp: now, Type: types.PrecommitType}).CommitSig()
+	commitSig1 := (&types.Vote{ValidatorIndex: 1, Timestamp: now}).CommitSig()
 
 	testCases := []struct {
 		desc                     string
 		lastCommitPrecommits     []*types.CommitSig
 		expectedAbsentValidators []int
 	}{
-		{"none absent", []*types.CommitSig{vote0, vote1}, []int{}},
-		{"one absent", []*types.CommitSig{vote0, nil}, []int{1}},
+		{"none absent", []*types.CommitSig{commitSig0, commitSig1}, []int{}},
+		{"one absent", []*types.CommitSig{commitSig0, nil}, []int{1}},
 		{"multiple absent", []*types.CommitSig{nil, nil}, []int{0, 1}},
 	}
 
@@ -136,10 +136,10 @@ func TestBeginBlockByzantineValidators(t *testing.T) {
 			types.TM2PB.Evidence(ev2, valSet, now)}},
 	}
 
-	vote0 := (&types.Vote{ValidatorIndex: 0, Timestamp: now, Type: types.PrecommitType}).CommitSig()
-	vote1 := (&types.Vote{ValidatorIndex: 1, Timestamp: now}).CommitSig()
-	votes := []*types.CommitSig{vote0, vote1}
-	lastCommit := &types.Commit{BlockID: prevBlockID, Precommits: votes}
+	commitSig0 := (&types.Vote{ValidatorIndex: 0, Timestamp: now, Type: types.PrecommitType}).CommitSig()
+	commitSig1 := (&types.Vote{ValidatorIndex: 1, Timestamp: now}).CommitSig()
+	commitSigs := []*types.CommitSig{commitSig0, commitSig1}
+	lastCommit := &types.Commit{BlockID: prevBlockID, Precommits: commitSigs}
 	for _, tc := range testCases {
 
 		block, _ := state.MakeBlock(10, makeTxs(2), lastCommit, nil, state.Validators.GetProposer().Address)

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -65,17 +65,17 @@ func TestBeginBlockValidators(t *testing.T) {
 	prevBlockID := types.BlockID{prevHash, prevParts}
 
 	now := tmtime.Now()
-	vote0 := &types.Vote{ValidatorIndex: 0, Timestamp: now, Type: types.PrecommitType}
-	vote1 := &types.Vote{ValidatorIndex: 1, Timestamp: now}
+	vote0 := (&types.Vote{ValidatorIndex: 0, Timestamp: now, Type: types.PrecommitType}).CommitSig()
+	vote1 := (&types.Vote{ValidatorIndex: 1, Timestamp: now}).CommitSig()
 
 	testCases := []struct {
 		desc                     string
-		lastCommitPrecommits     []*types.Vote
+		lastCommitPrecommits     []*types.CommitSig
 		expectedAbsentValidators []int
 	}{
-		{"none absent", []*types.Vote{vote0, vote1}, []int{}},
-		{"one absent", []*types.Vote{vote0, nil}, []int{1}},
-		{"multiple absent", []*types.Vote{nil, nil}, []int{0, 1}},
+		{"none absent", []*types.CommitSig{vote0, vote1}, []int{}},
+		{"one absent", []*types.CommitSig{vote0, nil}, []int{1}},
+		{"multiple absent", []*types.CommitSig{nil, nil}, []int{0, 1}},
 	}
 
 	for _, tc := range testCases {
@@ -136,9 +136,9 @@ func TestBeginBlockByzantineValidators(t *testing.T) {
 			types.TM2PB.Evidence(ev2, valSet, now)}},
 	}
 
-	vote0 := &types.Vote{ValidatorIndex: 0, Timestamp: now, Type: types.PrecommitType}
-	vote1 := &types.Vote{ValidatorIndex: 1, Timestamp: now}
-	votes := []*types.Vote{vote0, vote1}
+	vote0 := (&types.Vote{ValidatorIndex: 0, Timestamp: now, Type: types.PrecommitType}).CommitSig()
+	vote1 := (&types.Vote{ValidatorIndex: 1, Timestamp: now}).CommitSig()
+	votes := []*types.CommitSig{vote0, vote1}
 	lastCommit := &types.Commit{BlockID: prevBlockID, Precommits: votes}
 	for _, tc := range testCases {
 

--- a/types/block.go
+++ b/types/block.go
@@ -481,6 +481,7 @@ func (h *Header) StringIndented(indent string) string {
 // For now, it is identical to a vote,
 // but in the future it will contain fewer fields
 // to eliminate the redundancy in commits.
+// See https://github.com/tendermint/tendermint/issues/1648.
 type CommitSig Vote
 
 // String returns the underlying Vote.String()
@@ -489,8 +490,8 @@ func (cs *CommitSig) String() string {
 }
 
 // toVote converts the CommitSig to a vote.
-// Once CommitSig has fewer fields than vote, it will
-// need to be replaced.
+// Once CommitSig has fewer fields than vote,
+// converting to a Vote will require more information.
 func (cs *CommitSig) toVote() *Vote {
 	if cs == nil {
 		return nil
@@ -517,7 +518,7 @@ type Commit struct {
 
 // VoteSignBytes constructs the SignBytes for the given CommitSig.
 // The only unique part of the SignBytes is the Timestamp - all other fields
-// are otherwise the same for all validators.
+// signed over are otherwise the same for all validators.
 func (commit *Commit) VoteSignBytes(chainID string, cs *CommitSig) []byte {
 	return cs.toVote().SignBytes(chainID)
 }

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -198,7 +198,6 @@ func TestCommit(t *testing.T) {
 	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals)
 	require.NoError(t, err)
 
-	assert.NotNil(t, commit.FirstPrecommit())
 	assert.Equal(t, h-1, commit.Height())
 	assert.Equal(t, 1, commit.Round())
 	assert.Equal(t, PrecommitType, SignedMsgType(commit.Type()))

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -391,7 +391,7 @@ func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID, height i
 		}
 		_, val := vals.GetByIndex(idx)
 		// Validate signature.
-		precommitSignBytes := precommit.SignBytes(chainID)
+		precommitSignBytes := commit.ToVote(precommit).SignBytes(chainID)
 		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {
 			return fmt.Errorf("Invalid commit -- invalid signature: %v", precommit)
 		}
@@ -475,7 +475,7 @@ func (vals *ValidatorSet) VerifyFutureCommit(newSet *ValidatorSet, chainID strin
 		seen[idx] = true
 
 		// Validate signature.
-		precommitSignBytes := precommit.SignBytes(chainID)
+		precommitSignBytes := commit.ToVote(precommit).SignBytes(chainID)
 		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {
 			return cmn.NewError("Invalid commit -- invalid signature: %v", precommit)
 		}

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -391,7 +391,7 @@ func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID, height i
 		}
 		_, val := vals.GetByIndex(idx)
 		// Validate signature.
-		precommitSignBytes := commit.ToVote(precommit).SignBytes(chainID)
+		precommitSignBytes := commit.VoteSignBytes(chainID, precommit)
 		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {
 			return fmt.Errorf("Invalid commit -- invalid signature: %v", precommit)
 		}
@@ -475,7 +475,7 @@ func (vals *ValidatorSet) VerifyFutureCommit(newSet *ValidatorSet, chainID strin
 		seen[idx] = true
 
 		// Validate signature.
-		precommitSignBytes := commit.ToVote(precommit).SignBytes(chainID)
+		precommitSignBytes := commit.VoteSignBytes(chainID, precommit)
 		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {
 			return cmn.NewError("Invalid commit -- invalid signature: %v", precommit)
 		}

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -368,6 +368,10 @@ func (vals *ValidatorSet) Iterate(fn func(index int, val *Validator) bool) {
 
 // Verify that +2/3 of the set had signed the given signBytes.
 func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID, height int64, commit *Commit) error {
+
+	if err := commit.ValidateBasic(); err != nil {
+		return err
+	}
 	if vals.Size() != len(commit.Precommits) {
 		return fmt.Errorf("Invalid commit -- wrong set size: %v vs %v", vals.Size(), len(commit.Precommits))
 	}
@@ -380,20 +384,10 @@ func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID, height i
 	}
 
 	talliedVotingPower := int64(0)
-	round := commit.Round()
 
 	for idx, precommit := range commit.Precommits {
 		if precommit == nil {
 			continue // OK, some precommits can be missing.
-		}
-		if precommit.Height != height {
-			return fmt.Errorf("Invalid commit -- wrong height: want %v got %v", height, precommit.Height)
-		}
-		if precommit.Round != round {
-			return fmt.Errorf("Invalid commit -- wrong round: want %v got %v", round, precommit.Round)
-		}
-		if precommit.Type != PrecommitType {
-			return fmt.Errorf("Invalid commit -- not precommit @ index %v", idx)
 		}
 		_, val := vals.GetByIndex(idx)
 		// Validate signature.

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -565,7 +565,7 @@ func TestValidatorSetVerifyCommit(t *testing.T) {
 	vote.Signature = sig
 	commit := &Commit{
 		BlockID:    blockID,
-		Precommits: []*Vote{vote},
+		Precommits: []*CommitSig{vote.CommitSig()},
 	}
 
 	badChainID := "notmychainID"
@@ -573,7 +573,7 @@ func TestValidatorSetVerifyCommit(t *testing.T) {
 	badHeight := height + 1
 	badCommit := &Commit{
 		BlockID:    blockID,
-		Precommits: []*Vote{nil},
+		Precommits: []*CommitSig{nil},
 	}
 
 	// test some error cases

--- a/types/vote.go
+++ b/types/vote.go
@@ -59,6 +59,16 @@ type Vote struct {
 	Signature        []byte        `json:"signature"`
 }
 
+// CommitSig converts the Vote to a CommitSig.
+// If the Vote is nil, the CommitSig will be nil.
+func (vote *Vote) CommitSig() *CommitSig {
+	if vote == nil {
+		return nil
+	}
+	cs := CommitSig(*vote)
+	return &cs
+}
+
 func (vote *Vote) SignBytes(chainID string) []byte {
 	bz, err := cdc.MarshalBinaryLengthPrefixed(CanonicalizeVote(chainID, vote))
 	if err != nil {

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -541,13 +541,13 @@ func (voteSet *VoteSet) MakeCommit() *Commit {
 	}
 
 	// For every validator, get the precommit
-	votesCopy := make([]*CommitSig, len(voteSet.votes))
+	commitSigs := make([]*CommitSig, len(voteSet.votes))
 	for i, v := range voteSet.votes {
-		votesCopy[i] = v.CommitSig()
+		commitSigs[i] = v.CommitSig()
 	}
 	return &Commit{
 		BlockID:    *voteSet.maj23,
-		Precommits: votesCopy,
+		Precommits: commitSigs,
 	}
 }
 

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -541,8 +541,10 @@ func (voteSet *VoteSet) MakeCommit() *Commit {
 	}
 
 	// For every validator, get the precommit
-	votesCopy := make([]*Vote, len(voteSet.votes))
-	copy(votesCopy, voteSet.votes)
+	votesCopy := make([]*CommitSig, len(voteSet.votes))
+	for i, v := range voteSet.votes {
+		votesCopy[i] = v.CommitSig()
+	}
 	return &Commit{
 		BlockID:    *voteSet.maj23,
 		Precommits: votesCopy,

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -46,6 +46,8 @@ func exampleVote(t byte) *Vote {
 
 // Ensure that Vote and CommitSig have the same encoding.
 // This ensures using CommitSig isn't a breaking change.
+// This test will fail and can be removed once CommitSig contains only sigs and
+// timestamps.
 func TestVoteEncoding(t *testing.T) {
 	vote := examplePrecommit()
 	commitSig := vote.CommitSig()
@@ -53,7 +55,6 @@ func TestVoteEncoding(t *testing.T) {
 	bz1 := cdc.MustMarshalBinaryBare(vote)
 	bz2 := cdc.MustMarshalBinaryBare(commitSig)
 	assert.Equal(t, bz1, bz2)
-
 }
 
 func TestVoteSignable(t *testing.T) {

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/tmhash"
@@ -41,6 +42,18 @@ func exampleVote(t byte) *Vote {
 		ValidatorAddress: crypto.AddressHash([]byte("validator_address")),
 		ValidatorIndex:   56789,
 	}
+}
+
+// Ensure that Vote and CommitSig have the same encoding.
+// This ensures using CommitSig isn't a breaking change.
+func TestVoteEncoding(t *testing.T) {
+	vote := examplePrecommit()
+	commitSig := vote.CommitSig()
+	cdc := amino.NewCodec()
+	bz1 := cdc.MustMarshalBinaryBare(vote)
+	bz2 := cdc.MustMarshalBinaryBare(commitSig)
+	assert.Equal(t, bz1, bz2)
+
 }
 
 func TestVoteSignable(t *testing.T) {


### PR DESCRIPTION
This is some precursor work towards #1648. Ultimately we want to replace Vote in Commit with a struct that has only the signature and timestamp. Here we take some steps towards that by clarifying when we really need to get a vote from the commit.

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
