### PR TITLE
fix FlushStop

### DIFF
--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -88,6 +89,10 @@ type MConnection struct {
 	// doneSendRoutine to close.
 	quitSendRoutine chan struct{}
 	doneSendRoutine chan struct{}
+
+	// used to ensure FlushStop and OnStop
+	// are safe to call concurrently.
+	stopMtx sync.Mutex
 
 	flushTimer *cmn.ThrottleTimer // flush writes as necessary but throttled.
 	pingTimer  *cmn.RepeatTimer   // send pings periodically
@@ -210,8 +215,17 @@ func (c *MConnection) OnStart() error {
 // It additionally ensures that all successful
 // .Send() calls will get flushed before closing
 // the connection.
-// NOTE: it is not safe to call this method more than once.
 func (c *MConnection) FlushStop() {
+	c.stopMtx.Lock()
+	defer c.stopMtx.Unlock()
+
+	select {
+	case <-c.quitSendRoutine:
+		// already quit via OnStop
+		return
+	default:
+	}
+
 	c.BaseService.OnStop()
 	c.flushTimer.Stop()
 	c.pingTimer.Stop()
@@ -247,6 +261,9 @@ func (c *MConnection) FlushStop() {
 
 // OnStop implements BaseService
 func (c *MConnection) OnStop() {
+	c.stopMtx.Lock()
+	defer c.stopMtx.Unlock()
+
 	select {
 	case <-c.quitSendRoutine:
 		// already quit via FlushStop


### PR DESCRIPTION
Fixes #3231.

Problem was that OnStop could be called concurrently with FlushStop and this would lead to closing the flushThrottle close channel twice, which results in panic.

Here we introduce a test that replicates the issue (non-deterministically, but often), and a fix by introducing a stopMtx in the MConnection so that only one of FlushStop and OnStop can run at a time. Once one of them have run, the other will exit early, hence solving the issue.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
