### PR TITLE
[WIP] limit number of /subscribe clients and queries per client

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -323,6 +323,17 @@ type RPCConfig struct {
 	// Should be < {ulimit -Sn} - {MaxNumInboundPeers} - {MaxNumOutboundPeers} - {N of wal, db and other open files}
 	// 1024 - 40 - 10 - 50 = 924 = ~900
 	MaxOpenConnections int `mapstructure:"max_open_connections"`
+
+	// Maximum number of unique clientIDs that can /subscribe
+	MaxSubscriptionClients int `mapstructure:"max_subscription_clients"`
+
+	// Maximum number of unique queries a given client can /subscribe to (note
+	// all calls to /broadcast_tx_commit uses the same client, so this would
+	// limit the number of /broadcast_tx_commit calls that can be open at once)
+	MaxSubscriptionsPerClient int `mapstructure:"max_subscriptions_per_client"`
+
+	// How long to wait for a tx to be committed during /broadcast_tx_commit
+	TimeoutBroadcastTxCommit time.Duration `mapstructure:"timeout_broadcast_tx_commit"`
 }
 
 // DefaultRPCConfig returns a default configuration for the RPC server
@@ -337,6 +348,10 @@ func DefaultRPCConfig() *RPCConfig {
 
 		Unsafe:             false,
 		MaxOpenConnections: 900,
+
+		MaxSubscriptionClients:    100,
+		MaxSubscriptionsPerClient: 5,
+		TimeoutBroadcastTxCommit:  10 * time.Second,
 	}
 }
 
@@ -357,6 +372,15 @@ func (cfg *RPCConfig) ValidateBasic() error {
 	}
 	if cfg.MaxOpenConnections < 0 {
 		return errors.New("max_open_connections can't be negative")
+	}
+	if cfg.MaxSubscriptionClients < 0 {
+		return errors.New("max_subscription_clients can't be negative")
+	}
+	if cfg.MaxSubscriptionsPerClient < 0 {
+		return errors.New("max_subscriptions_per_client can't be negative")
+	}
+	if cfg.TimeoutBroadcastTxCommit < 0 {
+		return errors.New("timeout_broadcast_tx_commit can't be negative")
 	}
 	return nil
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -162,6 +162,17 @@ unsafe = {{ .RPC.Unsafe }}
 # 1024 - 40 - 10 - 50 = 924 = ~900
 max_open_connections = {{ .RPC.MaxOpenConnections }}
 
+# Maximum number of unique clientIDs that can /subscribe
+max_subscription_clients = {{ .RPC.MaxSubscriptionClients }}
+
+# Maximum number of unique queries a given client can /subscribe to (note
+# all calls to /broadcast_tx_commit uses the same client, so this would
+# limit the number of /broadcast_tx_commit calls that can be open at once)
+max_subscriptions_per_client = {{ .RPC.MaxSubscriptionsPerClient }}
+
+# How long to wait for a tx to be committed during /broadcast_tx_commit.
+timeout_broadcast_tx_commit = "{{ .RPC.TimeoutBroadcastTxCommit }}"
+
 ##### peer to peer configuration options #####
 [p2p]
 

--- a/docs/tendermint-core/configuration.md
+++ b/docs/tendermint-core/configuration.md
@@ -111,6 +111,17 @@ unsafe = false
 # 1024 - 40 - 10 - 50 = 924 = ~900
 max_open_connections = 900
 
+# Maximum number of unique clientIDs that can /subscribe
+max_subscription_clients = 100
+
+# Maximum number of unique queries a given client can /subscribe to (note
+# all calls to /broadcast_tx_commit uses the same client, so this would
+# limit the number of /broadcast_tx_commit calls that can be open at once)
+max_subscriptions_per_client = 5
+
+# How long to wait for a tx to be committed during /broadcast_tx_commit.
+timeout_broadcast_tx_commit = "10s"
+
 ##### peer to peer configuration options #####
 [p2p]
 

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -174,6 +174,18 @@ func (s *Server) BufferCapacity() int {
 	return s.cmdsCap
 }
 
+func (s *Server) NumClients() int {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return len(s.subscriptions)
+}
+
+func (s *Server) NumClientSubscriptions(clientID string) int {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return len(s.subscriptions[clientID])
+}
+
 // Subscribe creates a subscription for the given client. It accepts a channel
 // on which messages matching the given query can be received. An error will be
 // returned to the caller if the context is canceled or if subscription already

--- a/node/node.go
+++ b/node/node.go
@@ -659,6 +659,9 @@ func (n *Node) ConfigureRPC() {
 	rpccore.SetConsensusReactor(n.consensusReactor)
 	rpccore.SetEventBus(n.eventBus)
 	rpccore.SetLogger(n.Logger.With("module", "rpc"))
+	rpccore.MaxSubscriptionClients = n.config.RPC.MaxSubscriptionClients
+	rpccore.MaxSubscriptionsPerClient = n.config.RPC.MaxSubscriptionsPerClient
+	rpccore.TimeoutBroadcastTxCommit = n.config.RPC.TimeoutBroadcastTxCommit
 }
 
 func (n *Node) startRPC() ([]net.Listener, error) {

--- a/rpc/client/httpclient.go
+++ b/rpc/client/httpclient.go
@@ -295,6 +295,16 @@ func (w *WSEvents) OnStop() {
 	}
 }
 
+// TODO: remove
+func (w *WSEvents) NumClients() int {
+	return 1
+}
+
+// TODO: remove
+func (w *WSEvents) NumClientSubscriptions(clientID string) int {
+	return len(w.subscriptions)
+}
+
 func (w *WSEvents) Subscribe(ctx context.Context, subscriber string, query tmpubsub.Query, out chan<- interface{}) error {
 	q := query.String()
 

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -92,6 +92,13 @@ import (
 // <aside class="notice">WebSocket only</aside>
 func Subscribe(wsCtx rpctypes.WSRPCContext, query string) (*ctypes.ResultSubscribe, error) {
 	addr := wsCtx.GetRemoteAddr()
+
+	if eventBusFor(wsCtx).NumClients() > MaxSubscriptionClients {
+		return nil, fmt.Errorf("max_subscription_clients %d reached", MaxSubscriptionClients)
+	} else if eventBusFor(wsCtx).NumClientSubscriptions(addr) > MaxSubscriptionsPerClient {
+		return nil, fmt.Errorf("max_subscriptions_per_client %d reached", MaxSubscriptionsPerClient)
+	}
+
 	logger.Info("Subscribe to query", "remote", addr, "query", query)
 
 	q, err := tmquery.New(query)

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -166,12 +166,21 @@ func BroadcastTxSync(tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 // |-----------+------+---------+----------+-----------------|
 // | tx        | Tx   | nil     | true     | The transaction |
 func BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+	// XXX: should be the remote IP address of the caller
+	subscriber := "mempool"
+
+	if eventBus.NumClients() > MaxSubscriptionClients {
+		return nil, fmt.Errorf("max_subscription_clients %d reached", MaxSubscriptionClients)
+	} else if eventBus.NumClientSubscriptions(subscriber) > MaxSubscriptionsPerClient {
+		return nil, fmt.Errorf("max_subscriptions_per_client %d reached", MaxSubscriptionsPerClient)
+	}
+
 	// Subscribe to tx being committed in block.
 	ctx, cancel := context.WithTimeout(context.Background(), subscribeTimeout)
 	defer cancel()
 	deliverTxResCh := make(chan interface{}, 1)
 	q := types.EventQueryTxFor(tx)
-	err := eventBus.Subscribe(ctx, "mempool", q, deliverTxResCh)
+	err := eventBus.Subscribe(ctx, subscriber, q, deliverTxResCh)
 	if err != nil {
 		err = errors.Wrap(err, "failed to subscribe to tx")
 		logger.Error("Error on broadcast_tx_commit", "err", err)
@@ -187,7 +196,7 @@ func BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
 				break LOOP
 			}
 		}
-		eventBus.Unsubscribe(context.Background(), "mempool", q)
+		eventBus.Unsubscribe(context.Background(), subscriber, q)
 	}()
 
 	// Broadcast tx and wait for CheckTx result

--- a/rpc/core/pipe.go
+++ b/rpc/core/pipe.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"time"
+
 	"github.com/tendermint/tendermint/consensus"
 	"github.com/tendermint/tendermint/crypto"
 	dbm "github.com/tendermint/tendermint/libs/db"
@@ -71,6 +73,11 @@ var (
 	mempool          *mempl.Mempool
 
 	logger log.Logger
+
+	// XXX: godoc comment
+	MaxSubscriptionClients    int
+	MaxSubscriptionsPerClient int
+	TimeoutBroadcastTxCommit  time.Duration
 )
 
 func SetStateDB(db dbm.DB) {

--- a/rpc/lib/types/types.go
+++ b/rpc/lib/types/types.go
@@ -249,6 +249,9 @@ type EventSubscriber interface {
 	Subscribe(ctx context.Context, subscriber string, query tmpubsub.Query, out chan<- interface{}) error
 	Unsubscribe(ctx context.Context, subscriber string, query tmpubsub.Query) error
 	UnsubscribeAll(ctx context.Context, subscriber string) error
+
+	NumClients() int
+	NumClientSubscriptions(clientID string) int
 }
 
 // websocket-only RPCFuncs take this as the first parameter.

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -15,6 +15,9 @@ type EventBusSubscriber interface {
 	Subscribe(ctx context.Context, subscriber string, query tmpubsub.Query, out chan<- interface{}) error
 	Unsubscribe(ctx context.Context, subscriber string, query tmpubsub.Query) error
 	UnsubscribeAll(ctx context.Context, subscriber string) error
+
+	NumClients() int
+	NumClientSubscriptions(clientID string) int
 }
 
 // EventBus is a common bus for all events going through the system. All calls
@@ -50,6 +53,14 @@ func (b *EventBus) OnStart() error {
 
 func (b *EventBus) OnStop() {
 	b.pubsub.Stop()
+}
+
+func (b *EventBus) NumClients() int {
+	return b.pubsub.NumClients()
+}
+
+func (b *EventBus) NumClientSubscriptions(clientID string) int {
+	return b.pubsub.NumClientSubscriptions(clientID)
 }
 
 func (b *EventBus) Subscribe(ctx context.Context, subscriber string, query tmpubsub.Query, out chan<- interface{}) error {


### PR DESCRIPTION
Add the following config variables (under [rpc] section):
  * max_subscription_clients
  * max_subscriptions_per_client
  * timeout_broadcast_tx_commit

Fixes #2826

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
