### PR TITLE
p2p/conn: don't hold stopMtx while waiting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,11 +228,14 @@ test_race:
 
 # uses https://github.com/sasha-s/go-deadlock/ to detect potential deadlocks
 test_with_deadlock:
+	make set_with_deadlock
+	make test
+	make cleanup_after_test_with_deadlock
+
+set_with_deadlock:
 	find . -name "*.go" | grep -v "vendor/" | xargs -n 1 sed -i.bak 's/sync.RWMutex/deadlock.RWMutex/'
 	find . -name "*.go" | grep -v "vendor/" | xargs -n 1 sed -i.bak 's/sync.Mutex/deadlock.Mutex/'
 	find . -name "*.go" | grep -v "vendor/" | xargs -n 1 goimports -w
-	make test
-	make cleanup_after_test_with_deadlock
 
 # cleanes up after you ran test_with_deadlock
 cleanup_after_test_with_deadlock:

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -85,8 +85,8 @@ type MConnection struct {
 	errored       uint32
 	config        MConnConfig
 
-	// Closing quitSendRoutine will cause
-	// doneSendRoutine to close.
+	// Closing quitSendRoutine will cause the sendRoutine to eventually quit.
+	// doneSendRoutine is closed when the sendRoutine actually quits.
 	quitSendRoutine chan struct{}
 	doneSendRoutine chan struct{}
 
@@ -437,7 +437,6 @@ FOR_LOOP:
 			c.sendMonitor.Update(int(_n))
 			c.flush()
 		case <-c.quitSendRoutine:
-			close(c.doneSendRoutine)
 			break FOR_LOOP
 		case <-c.send:
 			// Send some PacketMsgs
@@ -463,6 +462,7 @@ FOR_LOOP:
 
 	// Cleanup
 	c.stopPongTimer()
+	close(c.doneSendRoutine)
 }
 
 // Returns true if messages from channels were exhausted.

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -166,9 +166,6 @@ func NewMConnectionWithConfig(conn net.Conn, chDescs []*ChannelDescriptor, onRec
 		onError:       onError,
 		config:        config,
 		created:       time.Now(),
-
-		quitSendRoutine: make(chan struct{}),
-		doneSendRoutine: make(chan struct{}),
 	}
 
 	// Create channels
@@ -207,6 +204,8 @@ func (c *MConnection) OnStart() error {
 	c.pingTimer = cmn.NewRepeatTimer("ping", c.config.PingInterval)
 	c.pongTimeoutCh = make(chan bool, 1)
 	c.chStatsTimer = cmn.NewRepeatTimer("chStats", updateStats)
+	c.quitSendRoutine = make(chan struct{})
+	c.doneSendRoutine = make(chan struct{})
 	go c.sendRoutine()
 	go c.recvRoutine()
 	return nil


### PR DESCRIPTION
Test TestPEXReactorSeedModeFlushStop is non-deterministically failing with timeout. Note before we were holding the stopMtx while waiting for the sendRoutine to finish. Here we change it to not do that. It was also possible before to exit out of the sendRoutine due to error without ever closing the doneSendRoutine, so here we also ensure that doneSendRoutine is closed at the end of the sendRoutine!


* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
