### PR TITLE
secp256k1: change build tags

### DIFF
--- a/crypto/secp256k1/secp256k1_cgo.go
+++ b/crypto/secp256k1/secp256k1_cgo.go
@@ -1,4 +1,4 @@
-// +build cgo
+// +build libsecp256k1
 
 package secp256k1
 

--- a/crypto/secp256k1/secp256k1_nocgo.go
+++ b/crypto/secp256k1/secp256k1_nocgo.go
@@ -1,4 +1,4 @@
-// +build !cgo
+// +build !libsecp256k1
 
 package secp256k1
 

--- a/crypto/secp256k1/secp256k1_nocgo_test.go
+++ b/crypto/secp256k1/secp256k1_nocgo_test.go
@@ -1,4 +1,4 @@
-// +build !cgo
+// +build !libsecp256k1
 
 package secp256k1
 


### PR DESCRIPTION
Change the build tag to be specific to the lib so we don't always try to build any time CGO is enabled. 
Ref #3273

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
