### PR TITLE
Add support for batched requests/responses in JSON RPC

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,5 +9,6 @@ Special thanks to external contributors on this release:
 ### FEATURES:
 
 ### IMPROVEMENTS:
+- [rpc] \#3280 Add support for batched requests/responses in JSON RPC
 
 ### BUG FIXES:

--- a/rpc/lib/server/handlers.go
+++ b/rpc/lib/server/handlers.go
@@ -162,7 +162,9 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, cdc *amino.Codec, logger lo
 			}
 			responses = append(responses, types.NewRPCSuccessResponse(cdc, request.ID, result))
 		}
-		WriteRPCResponseArrayHTTP(w, responses)
+		if len(responses) > 0 {
+			WriteRPCResponseArrayHTTP(w, responses)
+		}
 	}
 }
 

--- a/rpc/lib/server/handlers_test.go
+++ b/rpc/lib/server/handlers_test.go
@@ -154,6 +154,80 @@ func TestRPCNotification(t *testing.T) {
 	require.Equal(t, len(blob), 0, "a notification SHOULD NOT be responded to by the server")
 }
 
+func TestRPCNotificationInBatch(t *testing.T) {
+	mux := testMux()
+	tests := []struct {
+		payload     string
+		expectCount int
+	}{
+		{
+			`[
+				{"jsonrpc": "2.0","id": ""},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]}
+			 ]`,
+			1,
+		},
+		{
+			`[
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","id": ""},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]}
+			 ]`,
+			2,
+		},
+		{
+			`[
+				{"jsonrpc": "2.0","id": ""},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","id": ""},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]}
+			 ]`,
+			2,
+		},
+	}
+	for i, tt := range tests {
+		req, _ := http.NewRequest("POST", "http://localhost/", strings.NewReader(tt.payload))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		res := rec.Result()
+		// Always expecting back a JSONRPCResponse
+		assert.True(t, statusOK(res.StatusCode), "#%d: should always return 2XX", i)
+		blob, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Errorf("#%d: err reading body: %v", i, err)
+			continue
+		}
+
+		var responses []types.RPCResponse
+		// try to unmarshal an array first
+		err = json.Unmarshal(blob, &responses)
+		if err != nil {
+			// if we were actually expecting an array, but got an error
+			if tt.expectCount > 1 {
+				t.Errorf("#%d: expected an array, couldn't unmarshal it\nblob: %s", i, blob)
+				continue
+			} else {
+				// we were expecting an error here, so let's unmarshal a single response
+				var response types.RPCResponse
+				err = json.Unmarshal(blob, &response)
+				if err != nil {
+					t.Errorf("#%d: expected successful parsing of an RPCResponse\nblob: %s", i, blob)
+					continue
+				}
+				// have a single-element result
+				responses = []types.RPCResponse{response}
+			}
+		}
+		if tt.expectCount != len(responses) {
+			t.Errorf("#%d: expected %d response(s), but got %d\nblob: %s", i, tt.expectCount, len(responses), blob)
+			continue
+		}
+		for _, response := range responses {
+			assert.NotEqual(t, response, new(types.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
+		}
+	}
+}
+
 func TestUnknownRPCPath(t *testing.T) {
 	mux := testMux()
 	req, _ := http.NewRequest("GET", "http://localhost/unknownrpcpath", nil)

--- a/rpc/lib/server/http_server.go
+++ b/rpc/lib/server/http_server.go
@@ -104,6 +104,23 @@ func WriteRPCResponseHTTP(w http.ResponseWriter, res types.RPCResponse) {
 	w.Write(jsonBytes) // nolint: errcheck, gas
 }
 
+// WriteRPCResponseArrayHTTP will do the same as WriteRPCResponseHTTP, except it
+// can write arrays of responses for batched request/response interactions via
+// the JSON RPC.
+func WriteRPCResponseArrayHTTP(w http.ResponseWriter, res []types.RPCResponse) {
+	if len(res) == 1 {
+		WriteRPCResponseHTTP(w, res[0])
+	} else {
+		jsonBytes, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			panic(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write(jsonBytes) // nolint: errcheck, gas
+	}
+}
+
 //-----------------------------------------------------------------------------
 
 // Wraps an HTTP handler, adding error logging.


### PR DESCRIPTION
As per #3213, this PR will add support for batched JSON RPC requests/responses.

The suggestion here is to alter the HTTP RPC client interface to have a `batching` mode, which allows for the same calls as previously, but instead of sending the requests immediately, the `JSONRPCClient` will buffer the `RPCRequest` objects until `c.SendBatch()` is called:

```go
c := client.NewHTTP(rpcAddr, "/websocket")
c.StartBatch()
_, err := c.BroadcastTxCommit(tx1)
_, err = c.BroadcastTxCommit(tx2)
// nothing sent yet
results, err := c.SendBatch()
// batch is now sent, and one can iterate through `results` here...
// ...
// this request is now sent immediately, since we're no longer in batch mode
res, err := c.BroadcastTxCommit(tx3)
```

There are a few more things I'd like to test before I'd consider this finished though - will push those tests shortly.

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
