### PR TITLE
rpc/net_info: change RemoteIP type from net.IP to String

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,3 +23,6 @@ Special thanks to external contributors on this release:
 ### BUG FIXES:
 - [consensus] \#3297 Flush WAL on stop to prevent data corruption during
   graceful shutdown
+- [rpc] \#3251 Fix /net_info#peers#remote_ip format. New format spec:
+  * dotted decimal ("192.0.2.1"), if ip is an IPv4 or IP4-mapped IPv6 address
+  * IPv6 ("2001:db8::1"), if ip is a valid IPv6 address

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -43,7 +43,8 @@ import (
 // }
 // ```
 func NetInfo() (*ctypes.ResultNetInfo, error) {
-	peers := []ctypes.Peer{}
+	out, in, _ := p2pPeers.NumPeers()
+	peers := make([]ctypes.Peer, 0, out+in)
 	for _, peer := range p2pPeers.Peers().List() {
 		nodeInfo, ok := peer.NodeInfo().(p2p.DefaultNodeInfo)
 		if !ok {
@@ -53,7 +54,7 @@ func NetInfo() (*ctypes.ResultNetInfo, error) {
 			NodeInfo:         nodeInfo,
 			IsOutbound:       peer.IsOutbound(),
 			ConnectionStatus: peer.Status(),
-			RemoteIP:         peer.RemoteIP(),
+			RemoteIP:         peer.RemoteIP().String(),
 		})
 	}
 	// TODO: Should we include PersistentPeers and Seeds in here?

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -29,18 +29,129 @@ import (
 //
 // ```json
 // {
-// 	"error": "",
-// 	"result": {
-//		"n_peers": "0",
-// 		"peers": [],
-// 		"listeners": [
-// 			"Listener(@10.0.2.15:26656)"
-// 		],
-// 		"listening": true
-// 	},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
+//   "jsonrpc": "2.0",
+//   "id": "",
+//   "result": {
+//   	"listening": true,
+//   	"listeners": [
+//   		"Listener(@)"
+//   	],
+//   	"n_peers": "3",
+//   	"peers": [
+//   		{
+//   			"node_info": {
+//   				"protocol_version": {
+//   					"p2p": "7",
+//   					"block": "8",
+//   					"app": "1"
+//   				},
+//   				"id": "93529da3435c090d02251a050342b6a488d4ab56",
+//   				"listen_addr": "tcp://0.0.0.0:26656",
+//   				"network": "chain-RFo6qC",
+//   				"version": "0.30.0",
+//   				"channels": "4020212223303800",
+//   				"moniker": "fc89e4ed23f2",
+//   				"other": {
+//   					"tx_index": "on",
+//   					"rpc_address": "tcp://0.0.0.0:26657"
+//   				}
+//   			},
+//   			"is_outbound": true,
+//   			"connection_status": {
+//   				"Duration": "3475230558",
+//   				"SendMonitor": {
+//   					"Active": true,
+//   					"Start": "2019-02-14T12:40:47.52Z",
+//   					"Duration": "3480000000",
+//   					"Idle": "240000000",
+//   					"Bytes": "4512",
+//   					"Samples": "9",
+//   					"InstRate": "1338",
+//   					"CurRate": "2046",
+//   					"AvgRate": "1297",
+//   					"PeakRate": "6570",
+//   					"BytesRem": "0",
+//   					"TimeRem": "0",
+//   					"Progress": 0
+//   				},
+//   				"RecvMonitor": {
+//   					"Active": true,
+//   					"Start": "2019-02-14T12:40:47.52Z",
+//   					"Duration": "3480000000",
+//   					"Idle": "280000000",
+//   					"Bytes": "4489",
+//   					"Samples": "10",
+//   					"InstRate": "1821",
+//   					"CurRate": "1663",
+//   					"AvgRate": "1290",
+//   					"PeakRate": "5512",
+//   					"BytesRem": "0",
+//   					"TimeRem": "0",
+//   					"Progress": 0
+//   				},
+//   				"Channels": [
+//   					{
+//   						"ID": 48,
+//   						"SendQueueCapacity": "1",
+//   						"SendQueueSize": "0",
+//   						"Priority": "5",
+//   						"RecentlySent": "0"
+//   					},
+//   					{
+//   						"ID": 64,
+//   						"SendQueueCapacity": "1000",
+//   						"SendQueueSize": "0",
+//   						"Priority": "10",
+//   						"RecentlySent": "14"
+//   					},
+//   					{
+//   						"ID": 32,
+//   						"SendQueueCapacity": "100",
+//   						"SendQueueSize": "0",
+//   						"Priority": "5",
+//   						"RecentlySent": "619"
+//   					},
+//   					{
+//   						"ID": 33,
+//   						"SendQueueCapacity": "100",
+//   						"SendQueueSize": "0",
+//   						"Priority": "10",
+//   						"RecentlySent": "1363"
+//   					},
+//   					{
+//   						"ID": 34,
+//   						"SendQueueCapacity": "100",
+//   						"SendQueueSize": "0",
+//   						"Priority": "5",
+//   						"RecentlySent": "2145"
+//   					},
+//   					{
+//   						"ID": 35,
+//   						"SendQueueCapacity": "2",
+//   						"SendQueueSize": "0",
+//   						"Priority": "1",
+//   						"RecentlySent": "0"
+//   					},
+//   					{
+//   						"ID": 56,
+//   						"SendQueueCapacity": "1",
+//   						"SendQueueSize": "0",
+//   						"Priority": "5",
+//   						"RecentlySent": "0"
+//   					},
+//   					{
+//   						"ID": 0,
+//   						"SendQueueCapacity": "10",
+//   						"SendQueueSize": "0",
+//   						"Priority": "1",
+//   						"RecentlySent": "10"
+//   					}
+//   				]
+//   			},
+//   			"remote_ip": "192.167.10.3"
+//   		},
+//      ...
+//   }
 // ```
 func NetInfo() (*ctypes.ResultNetInfo, error) {
 	out, in, _ := p2pPeers.NumPeers()

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -2,7 +2,6 @@ package core_types
 
 import (
 	"encoding/json"
-	"net"
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -111,7 +110,7 @@ type Peer struct {
 	NodeInfo         p2p.DefaultNodeInfo  `json:"node_info"`
 	IsOutbound       bool                 `json:"is_outbound"`
 	ConnectionStatus p2p.ConnectionStatus `json:"connection_status"`
-	RemoteIP         net.IP               `json:"remote_ip"`
+	RemoteIP         string               `json:"remote_ip"`
 }
 
 // Validators for a height


### PR DESCRIPTION
Before:
"AAAAAAAAAAAAAP//rB8ktw=="
which is amino-encoded net.IP byte slice

After:
"192.0.2.1"

Fixes #3251

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs
* [ ] ~~Updated all code comments where relevant~~
* [ ] ~~Wrote tests~~
* [x] Updated CHANGELOG_PENDING.md
