### PR TITLE
Fix p2p id check

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -29,3 +29,4 @@ Special thanks to external contributors on this release:
   * IPv6 ("2001:db8::1"), if ip is a valid IPv6 address
 * [cmd] \#3314 Return an
   error on `show_validator` when the private validator file does not exist
+* [p2p] \#3321 Authenticate a peer against its NetAddress.ID while dialing 

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -194,7 +194,7 @@ func (mt *MultiplexTransport) Dial(
 		return nil, err
 	}
 
-	secretConn, nodeInfo, err := mt.upgrade(c, addr)
+	secretConn, nodeInfo, err := mt.upgrade(c, &addr)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +355,7 @@ func (mt *MultiplexTransport) upgrade(
 	// For outgoing conns, ensure connection key matches dialed key.
 	connID := PubKeyToID(secretConn.RemotePubKey())
 	if dialedAddr != nil {
-		if dialedID := dialedAddr.ID(); connID != dialedID {
+		if dialedID := dialedAddr.ID; connID != dialedID {
 			return nil, nil, ErrRejected{
 				conn: c,
 				id:   connID,

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -194,7 +194,7 @@ func (mt *MultiplexTransport) Dial(
 		return nil, err
 	}
 
-	secretConn, nodeInfo, err := mt.upgrade(c)
+	secretConn, nodeInfo, err := mt.upgrade(c, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (mt *MultiplexTransport) acceptPeers() {
 
 			err := mt.filterConn(c)
 			if err == nil {
-				secretConn, nodeInfo, err = mt.upgrade(c)
+				secretConn, nodeInfo, err = mt.upgrade(c, nil)
 			}
 
 			select {
@@ -279,9 +279,9 @@ func (mt *MultiplexTransport) acceptPeers() {
 
 // Cleanup removes the given address from the connections set and
 // closes the connection.
-func (mt *MultiplexTransport) Cleanup(peer Peer) {
-	mt.conns.RemoveAddr(peer.RemoteAddr())
-	_ = peer.CloseConn()
+func (mt *MultiplexTransport) Cleanup(p Peer) {
+	mt.conns.RemoveAddr(p.RemoteAddr())
+	_ = p.CloseConn()
 }
 
 func (mt *MultiplexTransport) cleanup(c net.Conn) error {
@@ -335,6 +335,7 @@ func (mt *MultiplexTransport) filterConn(c net.Conn) (err error) {
 
 func (mt *MultiplexTransport) upgrade(
 	c net.Conn,
+	dialedAddr *NetAddress,
 ) (secretConn *conn.SecretConnection, nodeInfo NodeInfo, err error) {
 	defer func() {
 		if err != nil {
@@ -348,6 +349,23 @@ func (mt *MultiplexTransport) upgrade(
 			conn:          c,
 			err:           fmt.Errorf("secrect conn failed: %v", err),
 			isAuthFailure: true,
+		}
+	}
+
+	// For outgoing conns, ensure connection key matches dialed key.
+	connID := PubKeyToID(secretConn.RemotePubKey())
+	if dialedAddr != nil {
+		if dialedID := dialedAddr.ID(); connID != dialedID {
+			return nil, nil, ErrRejected{
+				conn: c,
+				id:   connID,
+				err: fmt.Errorf(
+					"conn.ID (%v) dialed ID (%v) missmatch",
+					connID,
+					dialedID,
+				),
+				isAuthFailure: true,
+			}
 		}
 	}
 
@@ -369,7 +387,7 @@ func (mt *MultiplexTransport) upgrade(
 	}
 
 	// Ensure connection key matches self reported key.
-	if connID := PubKeyToID(secretConn.RemotePubKey()); connID != nodeInfo.ID() {
+	if connID != nodeInfo.ID() {
 		return nil, nil, ErrRejected{
 			conn: c,
 			id:   connID,

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -412,8 +412,7 @@ func TestTransportMultiplexDialRejectWrongID(t *testing.T) {
 	)
 
 	wrongID := PubKeyToID(ed25519.GenPrivKey().PubKey())
-	dialerAddrAndID := string(wrongID) + "@" + mt.listener.Addr().String()
-	addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
+	addr, err := NewNetAddressStringWithOptionalID(IDAddressString(wrongID, mt.listener.Addr().String()))
 	if err != nil {
 		t.Fatalf("invalid address with ID: %v", err)
 	}
@@ -606,7 +605,7 @@ func testSetupMultiplexTransport(t *testing.T) *MultiplexTransport {
 		)
 	)
 
-	addr, err := NewNetAddressStringWithOptionalID(IDAddressString(id, "@127.0.0.1:0"))
+	addr, err := NewNetAddressStringWithOptionalID(IDAddressString(id, "127.0.0.1:0"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -160,8 +160,7 @@ func TestTransportMultiplexAcceptMultiple(t *testing.T) {
 					},
 				)
 			)
-			dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
-			addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
+			addr, err := NewNetAddressStringWithOptionalID(IDAddressString(mt.nodeKey.ID(), mt.listener.Addr().String()))
 			if err != nil {
 				errc <- err
 				return
@@ -230,8 +229,7 @@ func TestTransportMultiplexAcceptNonBlocking(t *testing.T) {
 
 	// Simulate slow Peer.
 	go func() {
-		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
-		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
+		addr, err := NewNetAddressStringWithOptionalID(IDAddressString(mt.nodeKey.ID(), mt.listener.Addr().String()))
 		if err != nil {
 			errc <- err
 			return
@@ -282,8 +280,7 @@ func TestTransportMultiplexAcceptNonBlocking(t *testing.T) {
 				},
 			)
 		)
-		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
-		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
+		addr, err := NewNetAddressStringWithOptionalID(IDAddressString(mt.nodeKey.ID(), mt.listener.Addr().String()))
 		if err != nil {
 			errc <- err
 			return
@@ -329,8 +326,7 @@ func TestTransportMultiplexValidateNodeInfo(t *testing.T) {
 			)
 		)
 
-		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
-		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
+		addr, err := NewNetAddressStringWithOptionalID(IDAddressString(mt.nodeKey.ID(), mt.listener.Addr().String()))
 		if err != nil {
 			errc <- err
 			return
@@ -373,8 +369,7 @@ func TestTransportMultiplexRejectMissmatchID(t *testing.T) {
 				PrivKey: ed25519.GenPrivKey(),
 			},
 		)
-		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
-		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
+		addr, err := NewNetAddressStringWithOptionalID(IDAddressString(mt.nodeKey.ID(), mt.listener.Addr().String()))
 		if err != nil {
 			errc <- err
 			return
@@ -451,9 +446,7 @@ func TestTransportMultiplexRejectIncompatible(t *testing.T) {
 				},
 			)
 		)
-
-		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
-		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
+		addr, err := NewNetAddressStringWithOptionalID(IDAddressString(mt.nodeKey.ID(), mt.listener.Addr().String()))
 		if err != nil {
 			errc <- err
 			return
@@ -484,8 +477,7 @@ func TestTransportMultiplexRejectSelf(t *testing.T) {
 	errc := make(chan error)
 
 	go func() {
-		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
-		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
+		addr, err := NewNetAddressStringWithOptionalID(IDAddressString(mt.nodeKey.ID(), mt.listener.Addr().String()))
 		if err != nil {
 			errc <- err
 			return
@@ -603,9 +595,10 @@ func TestTransportHandshake(t *testing.T) {
 func testSetupMultiplexTransport(t *testing.T) *MultiplexTransport {
 	var (
 		pv = ed25519.GenPrivKey()
+		id = PubKeyToID(pv.PubKey())
 		mt = newMultiplexTransport(
 			testNodeInfo(
-				PubKeyToID(pv.PubKey()), "transport",
+				id, "transport",
 			),
 			NodeKey{
 				PrivKey: pv,
@@ -613,7 +606,7 @@ func testSetupMultiplexTransport(t *testing.T) *MultiplexTransport {
 		)
 	)
 
-	addr, err := NewNetAddressStringWithOptionalID(string(PubKeyToID(pv.PubKey())) + "@127.0.0.1:0")
+	addr, err := NewNetAddressStringWithOptionalID(IDAddressString(id, "@127.0.0.1:0"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -160,8 +160,8 @@ func TestTransportMultiplexAcceptMultiple(t *testing.T) {
 					},
 				)
 			)
-
-			addr, err := NewNetAddressStringWithOptionalID(mt.listener.Addr().String())
+			dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
+			addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
 			if err != nil {
 				errc <- err
 				return
@@ -230,7 +230,8 @@ func TestTransportMultiplexAcceptNonBlocking(t *testing.T) {
 
 	// Simulate slow Peer.
 	go func() {
-		addr, err := NewNetAddressStringWithOptionalID(mt.listener.Addr().String())
+		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
+		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
 		if err != nil {
 			errc <- err
 			return
@@ -281,8 +282,8 @@ func TestTransportMultiplexAcceptNonBlocking(t *testing.T) {
 				},
 			)
 		)
-
-		addr, err := NewNetAddressStringWithOptionalID(mt.listener.Addr().String())
+		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
+		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
 		if err != nil {
 			errc <- err
 			return
@@ -328,7 +329,8 @@ func TestTransportMultiplexValidateNodeInfo(t *testing.T) {
 			)
 		)
 
-		addr, err := NewNetAddressStringWithOptionalID(mt.listener.Addr().String())
+		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
+		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
 		if err != nil {
 			errc <- err
 			return
@@ -371,8 +373,8 @@ func TestTransportMultiplexRejectMissmatchID(t *testing.T) {
 				PrivKey: ed25519.GenPrivKey(),
 			},
 		)
-
-		addr, err := NewNetAddressStringWithOptionalID(mt.listener.Addr().String())
+		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
+		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
 		if err != nil {
 			errc <- err
 			return
@@ -417,7 +419,8 @@ func TestTransportMultiplexRejectIncompatible(t *testing.T) {
 			)
 		)
 
-		addr, err := NewNetAddressStringWithOptionalID(mt.listener.Addr().String())
+		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
+		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
 		if err != nil {
 			errc <- err
 			return
@@ -448,7 +451,8 @@ func TestTransportMultiplexRejectSelf(t *testing.T) {
 	errc := make(chan error)
 
 	go func() {
-		addr, err := NewNetAddressStringWithOptionalID(mt.listener.Addr().String())
+		dialerAddrAndID := string(mt.nodeKey.ID()) + "@" + mt.listener.Addr().String()
+		addr, err := NewNetAddressStringWithOptionalID(dialerAddrAndID)
 		if err != nil {
 			errc <- err
 			return
@@ -576,7 +580,7 @@ func testSetupMultiplexTransport(t *testing.T) *MultiplexTransport {
 		)
 	)
 
-	addr, err := NewNetAddressStringWithOptionalID("127.0.0.1:0")
+	addr, err := NewNetAddressStringWithOptionalID(string(PubKeyToID(pv.PubKey())) + "@127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
ref: https://github.com/tendermint/tendermint/issues/3010#issuecomment-464287627

> I tried searching for code where we authenticate a peer against its NetAddress.ID and couldn't find it. I don't see a reason to switch to Noise, but a need to ensure that the node's ID is authenticated e.g. after dialing from the address book.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
