### PR TITLE
fix TestWALPeriodicSync

### DIFF
--- a/consensus/wal_test.go
+++ b/consensus/wal_test.go
@@ -156,17 +156,18 @@ func TestWALPeriodicSync(t *testing.T) {
 	wal.SetFlushInterval(walTestFlushInterval)
 	wal.SetLogger(log.TestingLogger())
 
-	require.NoError(t, wal.Start())
-	defer func() {
-		wal.Stop()
-		wal.Wait()
-	}()
-
+	// Generate some data
 	err = WALGenerateNBlocks(t, wal.Group(), 5)
 	require.NoError(t, err)
 
 	// We should have data in the buffer now
 	assert.NotZero(t, wal.Group().Buffered())
+
+	require.NoError(t, wal.Start())
+	defer func() {
+		wal.Stop()
+		wal.Wait()
+	}()
 
 	time.Sleep(walTestFlushInterval + (10 * time.Millisecond))
 


### PR DESCRIPTION
The test was sometimes failing due to processFlushTicks being called too
early. The solution is to call wal#Start later in the test.
