### PR TITLE
rename WAL#Flush to WAL#FlushAndSync

### DIFF
--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -251,7 +251,7 @@ func (w *crashingWAL) WriteSync(m WALMessage) {
 
 func (w *crashingWAL) FlushAndSync() error { return w.next.FlushAndSync() }
 
-func (w *crashingWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd WALReader, found bool, err error) {
+func (w *crashingWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd io.ReadCloser, found bool, err error) {
 	return w.next.SearchForEndHeight(height, options)
 }
 

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -19,7 +19,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
-	auto "github.com/tendermint/tendermint/libs/autofile"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/privval"
@@ -200,6 +199,8 @@ type crashingWAL struct {
 	lastPanickedForMsgIndex int // last message for which we panicked
 }
 
+var _ WAL = &crashingWAL{}
+
 // WALWriteError indicates a WAL crash.
 type WALWriteError struct {
 	msg string
@@ -247,15 +248,15 @@ func (w *crashingWAL) WriteSync(m WALMessage) {
 	w.Write(m)
 }
 
-func (w *crashingWAL) Group() *auto.Group { return w.next.Group() }
-func (w *crashingWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (gr *auto.GroupReader, found bool, err error) {
+func (w *crashingWAL) FlushAndSync() error { return w.next.FlushAndSync() }
+
+func (w *crashingWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd WALReader, found bool, err error) {
 	return w.next.SearchForEndHeight(height, options)
 }
 
 func (w *crashingWAL) Start() error { return w.next.Start() }
 func (w *crashingWAL) Stop() error  { return w.next.Stop() }
 func (w *crashingWAL) Wait()        { w.next.Wait() }
-func (w *crashingWAL) Flush() error { return w.Group().Flush() }
 
 //------------------------------------------------------------------------------------------
 // Handshake Tests

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -910,7 +910,7 @@ func (cs *ConsensusState) defaultDecideProposal(height int64, round int) {
 	}
 
 	// Flush the WAL. Otherwise, we may not recompute the same proposal to sign, and the privValidator will refuse to sign anything.
-	cs.wal.Flush()
+	cs.wal.FlushAndSync()
 
 	// Make proposal
 	propBlockId := types.BlockID{Hash: block.Hash(), PartsHeader: blockParts.Header()}
@@ -1678,7 +1678,7 @@ func (cs *ConsensusState) addVote(vote *types.Vote, peerID p2p.ID) (added bool, 
 
 func (cs *ConsensusState) signVote(type_ types.SignedMsgType, hash []byte, header types.PartSetHeader) (*types.Vote, error) {
 	// Flush the WAL. Otherwise, we may not recompute the same vote to sign, and the privValidator will refuse to sign anything.
-	cs.wal.Flush()
+	cs.wal.FlushAndSync()
 
 	addr := cs.privValidator.GetPubKey().Address()
 	valIndex, _ := cs.Validators.GetByAddress(addr)

--- a/consensus/wal.go
+++ b/consensus/wal.go
@@ -53,20 +53,13 @@ func RegisterWALMessages(cdc *amino.Codec) {
 //--------------------------------------------------------
 // Simple write-ahead logger
 
-// WALReader is an interface that embeds io.Reader and allows to close it after
-// you're done reading.
-type WALReader interface {
-	io.Reader
-	Close() error
-}
-
 // WAL is an interface for any write-ahead logger.
 type WAL interface {
 	Write(WALMessage)
 	WriteSync(WALMessage)
 	FlushAndSync() error
 
-	SearchForEndHeight(height int64, options *WALSearchOptions) (rd WALReader, found bool, err error)
+	SearchForEndHeight(height int64, options *WALSearchOptions) (rd io.ReadCloser, found bool, err error)
 
 	// service methods
 	Start() error
@@ -217,7 +210,7 @@ type WALSearchOptions struct {
 // Group reader will be nil if found equals false.
 //
 // CONTRACT: caller must close group reader.
-func (wal *baseWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd WALReader, found bool, err error) {
+func (wal *baseWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd io.ReadCloser, found bool, err error) {
 	var (
 		msg *TimedWALMessage
 		gr  *auto.GroupReader
@@ -393,7 +386,7 @@ var _ WAL = nilWAL{}
 func (nilWAL) Write(m WALMessage)     {}
 func (nilWAL) WriteSync(m WALMessage) {}
 func (nilWAL) FlushAndSync() error    { return nil }
-func (nilWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd WALReader, found bool, err error) {
+func (nilWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd io.ReadCloser, found bool, err error) {
 	return nil, false, nil
 }
 func (nilWAL) Start() error { return nil }

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -193,7 +193,7 @@ func (w *byteBufferWAL) WriteSync(m WALMessage) {
 
 func (w *byteBufferWAL) FlushAndSync() error { return nil }
 
-func (w *byteBufferWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd WALReader, found bool, err error) {
+func (w *byteBufferWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd io.ReadCloser, found bool, err error) {
 	return nil, false, nil
 }
 

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	bc "github.com/tendermint/tendermint/blockchain"
 	cfg "github.com/tendermint/tendermint/config"
-	auto "github.com/tendermint/tendermint/libs/autofile"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
@@ -192,14 +191,12 @@ func (w *byteBufferWAL) WriteSync(m WALMessage) {
 	w.Write(m)
 }
 
-func (w *byteBufferWAL) Group() *auto.Group {
-	panic("not implemented")
-}
-func (w *byteBufferWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (gr *auto.GroupReader, found bool, err error) {
+func (w *byteBufferWAL) FlushAndSync() error { return nil }
+
+func (w *byteBufferWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd WALReader, found bool, err error) {
 	return nil, false, nil
 }
 
 func (w *byteBufferWAL) Start() error { return nil }
 func (w *byteBufferWAL) Stop() error  { return nil }
 func (w *byteBufferWAL) Wait()        {}
-func (w *byteBufferWAL) Flush() error { return nil }

--- a/consensus/wal_test.go
+++ b/consensus/wal_test.go
@@ -32,8 +32,10 @@ func TestWALTruncate(t *testing.T) {
 
 	walFile := filepath.Join(walDir, "wal")
 
-	//this magic number 4K can truncate the content when RotateFile. defaultHeadSizeLimit(10M) is hard to simulate.
-	//this magic number 1 * time.Millisecond make RotateFile check frequently. defaultGroupCheckDuration(5s) is hard to simulate.
+	// this magic number 4K can truncate the content when RotateFile.
+	// defaultHeadSizeLimit(10M) is hard to simulate.
+	// this magic number 1 * time.Millisecond make RotateFile check frequently.
+	// defaultGroupCheckDuration(5s) is hard to simulate.
 	wal, err := NewWAL(walFile,
 		autofile.GroupHeadSizeLimit(4096),
 		autofile.GroupCheckDuration(1*time.Millisecond),
@@ -49,14 +51,15 @@ func TestWALTruncate(t *testing.T) {
 		wal.Wait()
 	}()
 
-	//60 block's size nearly 70K, greater than group's headBuf size(4096 * 10), when headBuf is full, truncate content will Flush to the file.
-	//at this time, RotateFile is called, truncate content exist in each file.
+	// 60 block's size nearly 70K, greater than group's headBuf size(4096 * 10),
+	// when headBuf is full, truncate content will Flush to the file. at this
+	// time, RotateFile is called, truncate content exist in each file.
 	err = WALGenerateNBlocks(t, wal.Group(), 60)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Millisecond) //wait groupCheckDuration, make sure RotateFile run
 
-	wal.Group().Flush()
+	wal.FlushAndSync()
 
 	h := int64(50)
 	gr, found, err := wal.SearchForEndHeight(h, &WALSearchOptions{})

--- a/libs/autofile/cmd/logjack.go
+++ b/libs/autofile/cmd/logjack.go
@@ -57,7 +57,7 @@ func main() {
 		for {
 			n, err := os.Stdin.Read(buf)
 			group.Write(buf[:n])
-			group.Flush()
+			group.FlushAndSync()
 			if err != nil {
 				group.Stop()
 				if err == io.EOF {


### PR DESCRIPTION
- rename auto#Flush to auto#FlushAndSync
- cleanup WAL interface to not leak implementation details!
  * remove Group()
  * return io.ReadCloser instead of *auto.Group in SearchForEndHeight()
- add interface assertions

Refs #3337

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
