### PR TITLE
do not panic if the peer does not have a state in Receive

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,3 +21,4 @@ Special thanks to external contributors on this release:
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+- [consensus] \#3304 do not panic if the peer does not have a state in Receive

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -217,10 +217,13 @@ func (conR *ConsensusReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) 
 
 	conR.Logger.Debug("Receive", "src", src, "chId", chID, "msg", msg)
 
-	// Get peer states
+	// Get peer state
 	ps, ok := src.Get(types.PeerStateKey).(*PeerState)
 	if !ok {
-		panic(fmt.Sprintf("Peer %v has no state", src))
+		// Peer does not have a state yet. We set it in AddPeer, but because the
+		// peer is started before we add it to reactors, we can receive a message
+		// before AddPeer is called.
+		return
 	}
 
 	switch chID {


### PR DESCRIPTION
Peer does not have a state yet. We set it in AddPeer, but because the
peer is started before we add it to reactors, we can receive a message
before AddPeer is called.

Refs #3304

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
