### PR TITLE
secret connection check all zeroes

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,3 +21,5 @@ Special thanks to external contributors on this release:
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+
+- [p2p] \#3347 Reject all-zero shared secrets in the Diffie-Hellman step of secret-connection

--- a/p2p/conn/secret_connection_test.go
+++ b/p2p/conn/secret_connection_test.go
@@ -100,8 +100,12 @@ func TestSecretConnectionHandshake(t *testing.T) {
 	}
 }
 
+// Test that shareEphPubKey rejects lower order publich keys based on an
+// (incomplete) blacklist.
 func TestShareLowOrderPubkey(t *testing.T) {
 	var fooConn, barConn = makeKVStoreConnPair()
+	defer fooConn.Close()
+	defer barConn.Close()
 	locEphPub, _ := genEphKeys()
 
 	// all blacklisted low order points:
@@ -123,6 +127,19 @@ func TestShareLowOrderPubkey(t *testing.T) {
 
 				return nil, nil, false
 			})
+	}
+}
+
+// Test that additionally that the Diffie-Hellman shared secret is non-zero.
+// The shared secret would be zero for lower order pub-keys (but tested against the blacklist only).
+func TestComputeDHFailsOnLowOrder(t *testing.T) {
+	_, locPrivKey := genEphKeys()
+	for _, remLowOrderPubKey := range blacklist {
+		shared, err := computeDHSecret(&remLowOrderPubKey, locPrivKey)
+		assert.Error(t, err)
+
+		assert.Equal(t, err, ErrSharedSecretIsZero)
+		assert.Empty(t, shared)
 	}
 }
 

--- a/p2p/conn/secret_connection_test.go
+++ b/p2p/conn/secret_connection_test.go
@@ -100,7 +100,7 @@ func TestSecretConnectionHandshake(t *testing.T) {
 	}
 }
 
-// Test that shareEphPubKey rejects lower order publich keys based on an
+// Test that shareEphPubKey rejects lower order public keys based on an
 // (incomplete) blacklist.
 func TestShareLowOrderPubkey(t *testing.T) {
 	var fooConn, barConn = makeKVStoreConnPair()


### PR DESCRIPTION
Additionally, to the blacklist of lower order points, check if the shared secret is all zeros.

This mitigates #3010 until we have https://github.com/tendermint/tendermint/issues/3315 and switch to noise (which will also solve this and other issues).

ref: https://github.com/tendermint/tendermint/pull/3040#issuecomment-461978628
ref: https://github.com/tendermint/tendermint/issues/3010 in particular https://github.com/tendermint/tendermint/issues/3010#issuecomment-447123959




* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
