### PR TITLE
remove RoundState from EventDataRoundState

### DIFF
--- a/consensus/types/round_state.go
+++ b/consensus/types/round_state.go
@@ -148,14 +148,10 @@ func (rs *RoundState) CompleteProposalEvent() types.EventDataCompleteProposal {
 
 // RoundStateEvent returns the H/R/S of the RoundState as an event.
 func (rs *RoundState) RoundStateEvent() types.EventDataRoundState {
-	// copy the RoundState.
-	// TODO: if we want to avoid this, we may need synchronous events after all
-	rsCopy := *rs
 	return types.EventDataRoundState{
-		Height:     rs.Height,
-		Round:      rs.Round,
-		Step:       rs.Step.String(),
-		RoundState: &rsCopy,
+		Height: rs.Height,
+		Round:  rs.Round,
+		Step:   rs.Step.String(),
 	}
 }
 

--- a/types/events.go
+++ b/types/events.go
@@ -87,9 +87,6 @@ type EventDataRoundState struct {
 	Height int64  `json:"height"`
 	Round  int    `json:"round"`
 	Step   string `json:"step"`
-
-	// private, not exposed to websockets
-	RoundState interface{} `json:"-"`
 }
 
 type ValidatorInfo struct {


### PR DESCRIPTION
Before we're using it to get a round state in tests. Now it can be done
by calling csX.GetRoundState(?) We will need to rewrite
TestStateSlashingPrevotes and TestStateSlashingPrecommits, which are
commented right now, to not rely on EventDataRoundState#RoundState
field.

Refs #1527

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
