### PR TITLE
fix pool timer leak bug, resolve#3353

### DIFF
--- a/blockchain/pool.go
+++ b/blockchain/pool.go
@@ -299,6 +299,9 @@ func (pool *BlockPool) removePeer(peerID p2p.ID) {
 			requester.redo(peerID)
 		}
 	}
+	if p, exist := pool.peers[peerID]; exist && p.timeout != nil {
+		p.timeout.Stop()
+	}
 	delete(pool.peers, peerID)
 }
 


### PR DESCRIPTION
resolve issue #3353 
When remove peer, block pool simple remove bpPeer,
but do not stop timer, that cause stopError for recorrected
peers. Stop timer when remove from pool.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
