### PR TITLE
p2p: peer state init too late and pex message too soon

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,3 +27,4 @@
 - [p2p] \#3532 limit the number of attempts to connect to a peer in seed mode
   to 16 (as a result, the node will stop retrying after a 35 hours time window)
 - [consensus] \#2723, \#3451 and \#3317 Fix non-deterministic tests
+- [p2p] \#3346 Init data structures for peer before starting it (previously was done in AddPeer) (fixes #3346 and #3338; @guagualvcha)

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -268,4 +268,4 @@ func (br *ByzantineReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 func (br *ByzantineReactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
 	br.reactor.Receive(chID, peer, msgBytes)
 }
-func (br *ByzantineReactor) InitAddPeer(peer p2p.Peer) p2p.Peer { return peer }
+func (br *ByzantineReactor) InitPeer(peer p2p.Peer) p2p.Peer { return peer }

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -268,3 +268,4 @@ func (br *ByzantineReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 func (br *ByzantineReactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
 	br.reactor.Receive(chID, peer, msgBytes)
 }
+func (br *ByzantineReactor) InitAddPeer(peer p2p.Peer) p2p.Peer { return peer }

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -225,9 +225,6 @@ func (conR *ConsensusReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) 
 	conR.Logger.Debug("Receive", "src", src, "chId", chID, "msg", msg)
 
 	// Get peer states
-	if src.Get(types.PeerStateKey) == nil {
-		fmt.Println("============= nil result ========")
-	}
 	ps, ok := src.Get(types.PeerStateKey).(*PeerState)
 	if !ok {
 		panic(fmt.Sprintf("Peer %v has no state", src))

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -161,10 +161,10 @@ func (conR *ConsensusReactor) AddPeer(peer p2p.Peer) {
 		return
 	}
 
-	// Create peerState for peer
-	peerState := NewPeerState(peer).SetLogger(conR.Logger)
-	peer.Set(types.PeerStateKey, peerState)
-
+	peerState, ok := peer.Get(types.PeerStateKey).(*PeerState)
+	if !ok {
+		panic(fmt.Sprintf("Peer %v has no state", peer))
+	}
 	// Begin routines for this peer.
 	go conR.gossipDataRoutine(peer, peerState)
 	go conR.gossipVotesRoutine(peer, peerState)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -163,7 +163,7 @@ func (conR *ConsensusReactor) AddPeer(peer p2p.Peer) {
 
 	peerState, ok := peer.Get(types.PeerStateKey).(*PeerState)
 	if !ok {
-		panic(fmt.Sprintf("Peer %v has no state", peer))
+		panic(fmt.Sprintf("peer %v has no state", peer))
 	}
 	// Begin routines for this peer.
 	go conR.gossipDataRoutine(peer, peerState)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -225,6 +225,9 @@ func (conR *ConsensusReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) 
 	conR.Logger.Debug("Receive", "src", src, "chId", chID, "msg", msg)
 
 	// Get peer states
+	if src.Get(types.PeerStateKey) == nil {
+		fmt.Println("============= nil result ========")
+	}
 	ps, ok := src.Get(types.PeerStateKey).(*PeerState)
 	if !ok {
 		panic(fmt.Sprintf("Peer %v has no state", src))

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -177,7 +177,7 @@ func (conR *ConsensusReactor) AddPeer(peer p2p.Peer) {
 	}
 }
 
-func (conR *ConsensusReactor) InitAddPeer(peer p2p.Peer) p2p.Peer {
+func (conR *ConsensusReactor) InitPeer(peer p2p.Peer) p2p.Peer {
 	// Create peerState for peer
 	peerState := NewPeerState(peer).SetLogger(conR.Logger)
 	peer.Set(types.PeerStateKey, peerState)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -177,6 +177,13 @@ func (conR *ConsensusReactor) AddPeer(peer p2p.Peer) {
 	}
 }
 
+func (conR *ConsensusReactor) InitAddPeer(peer p2p.Peer) p2p.Peer {
+	// Create peerState for peer
+	peerState := NewPeerState(peer).SetLogger(conR.Logger)
+	peer.Set(types.PeerStateKey, peerState)
+	return peer
+}
+
 // RemovePeer implements Reactor
 func (conR *ConsensusReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 	if !conR.IsRunning() {

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -241,7 +241,7 @@ func TestReactorCreatesBlockWhenEmptyBlocksFalse(t *testing.T) {
 	}, css)
 }
 
-func TestReactorReconnectionPeerGetPeerState(t *testing.T) {
+func TestReactorReceiveDoesNotPanicIfAddPeerHasntBeenCalledYet(t *testing.T) {
 	N := 1
 	css, cleanup := randConsensusNet(N, "consensus_reactor_test", newMockTickerFunc(true), newCounter,
 		func(c *cfg.Config) {

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -11,9 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tendermint/tendermint/crypto/ed25519"
-	"github.com/tendermint/tendermint/p2p/mock"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -22,10 +19,12 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	bc "github.com/tendermint/tendermint/blockchain"
 	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
 	mempl "github.com/tendermint/tendermint/mempool"
 	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/p2p/mock"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/types"
 )

--- a/p2p/base_reactor.go
+++ b/p2p/base_reactor.go
@@ -29,8 +29,8 @@ type Reactor interface {
 	// CONTRACT: msgBytes are not nil.
 	Receive(chID byte, peer Peer, msgBytes []byte)
 
-	// InitAddPeer is called by switch before peer is started.
-	InitAddPeer(peer Peer) Peer
+	// InitPeer is called by switch before peer is started.
+	InitPeer(peer Peer) Peer
 }
 
 //--------------------------------------
@@ -54,4 +54,4 @@ func (*BaseReactor) GetChannels() []*conn.ChannelDescriptor        { return nil 
 func (*BaseReactor) AddPeer(peer Peer)                             {}
 func (*BaseReactor) RemovePeer(peer Peer, reason interface{})      {}
 func (*BaseReactor) Receive(chID byte, peer Peer, msgBytes []byte) {}
-func (*BaseReactor) InitAddPeer(peer Peer) Peer                    { return peer }
+func (*BaseReactor) InitPeer(peer Peer) Peer                       { return peer }

--- a/p2p/base_reactor.go
+++ b/p2p/base_reactor.go
@@ -28,6 +28,9 @@ type Reactor interface {
 	//
 	// CONTRACT: msgBytes are not nil.
 	Receive(chID byte, peer Peer, msgBytes []byte)
+
+	// InitAddPeer is called by switch before peer is started.
+	InitAddPeer(peer Peer) Peer
 }
 
 //--------------------------------------
@@ -51,3 +54,4 @@ func (*BaseReactor) GetChannels() []*conn.ChannelDescriptor        { return nil 
 func (*BaseReactor) AddPeer(peer Peer)                             {}
 func (*BaseReactor) RemovePeer(peer Peer, reason interface{})      {}
 func (*BaseReactor) Receive(chID byte, peer Peer, msgBytes []byte) {}
+func (*BaseReactor) InitAddPeer(peer Peer) Peer                    { return peer }

--- a/p2p/mock/peer.go
+++ b/p2p/mock/peer.go
@@ -40,6 +40,24 @@ func NewPeer(ip net.IP) *Peer {
 	return mp
 }
 
+func NewFixIdPeer(ip net.IP, id p2p.ID) *Peer {
+	var netAddr *p2p.NetAddress
+	if ip == nil {
+		_, netAddr = p2p.CreateRoutableAddr()
+	} else {
+		netAddr = p2p.NewNetAddressIPPort(ip, 26656)
+	}
+	netAddr.ID = id
+	mp := &Peer{
+		ip:   ip,
+		id:   id,
+		addr: netAddr,
+		kv:   make(map[string]interface{}),
+	}
+	mp.BaseService = cmn.NewBaseService(nil, "MockPeer", mp)
+	return mp
+}
+
 func (mp *Peer) FlushStop()                              { mp.Stop() }
 func (mp *Peer) TrySend(chID byte, msgBytes []byte) bool { return true }
 func (mp *Peer) Send(chID byte, msgBytes []byte) bool    { return true }

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -216,6 +216,13 @@ func (r *PEXReactor) logErrAddrBook(err error) {
 	}
 }
 
+func (r *PEXReactor) InitPeer(peer Peer) Peer {
+	id := string(peer.ID())
+	r.requestsSent.Delete(id)
+	r.lastReceivedRequests.Delete(id)
+	return peer
+}
+
 // RemovePeer implements Reactor.
 func (r *PEXReactor) RemovePeer(p Peer, reason interface{}) {
 	id := string(p.ID())

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -310,6 +310,7 @@ func (r *PEXReactor) receiveRequest(src Peer) error {
 	now := time.Now()
 	minInterval := r.minReceiveRequestInterval()
 	if now.Sub(lastReceived) < minInterval {
+		r.lastReceivedRequests.Delete(id)
 		return fmt.Errorf("Peer (%v) sent next PEX request too soon. lastReceived: %v, now: %v, minInterval: %v. Disconnecting",
 			src.ID(),
 			lastReceived,

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -223,13 +223,6 @@ func (r *PEXReactor) InitPeer(peer Peer) Peer {
 	return peer
 }
 
-// RemovePeer implements Reactor.
-func (r *PEXReactor) RemovePeer(p Peer, reason interface{}) {
-	id := string(p.ID())
-	r.requestsSent.Delete(id)
-	r.lastReceivedRequests.Delete(id)
-}
-
 // Receive implements Reactor by handling incoming PEX messages.
 func (r *PEXReactor) Receive(chID byte, src Peer, msgBytes []byte) {
 	msg, err := decodeMsg(msgBytes)

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -49,11 +49,11 @@ func TestPEXReactorStopPeerWithOutInitPeer(t *testing.T) {
 	nodeKey := p2p.NodeKey{PrivKey: ed25519.GenPrivKey()}
 	nodeId := nodeKey.ID()
 	stopForError := 0
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 100; i++ {
 		peer := mock.NewFixIdPeer(nil, nodeId)
 		// Only add to peerSet
 		p2p.AddPeerToSwitchPeerSet(sw, peer)
-		assert.True(t, sw.Peers().Has(peer.ID()))
+		assert.True(t, sw.Peers().Has(nodeId))
 
 		msg := cdc.MustMarshalBinaryBare(&pexRequestMessage{})
 
@@ -67,12 +67,9 @@ func TestPEXReactorStopPeerWithOutInitPeer(t *testing.T) {
 		if !sw.Peers().Has(peer.ID()) {
 			stopForError++
 		}
-
-		go sw.StopPeerForError(peer, "peer not available")
-		for sw.Peers().Has(peer.ID()) {
-		}
+		p2p.RemovePeerFromSwitchPeerSet(sw, peer)
 	}
-	assert.NotEqual(t, stopForError, 0)
+	assert.Equal(t, stopForError, 99)
 }
 
 func TestPEXReactorDoNotStopReconnectionPeer(t *testing.T) {
@@ -87,7 +84,7 @@ func TestPEXReactorDoNotStopReconnectionPeer(t *testing.T) {
 	nodeKey := p2p.NodeKey{PrivKey: ed25519.GenPrivKey()}
 	nodeId := nodeKey.ID()
 
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 1000; i++ {
 		peer := mock.NewFixIdPeer(nil, nodeId)
 		p2p.AddPeerToSwitch(sw, peer)
 		assert.True(t, sw.Peers().Has(peer.ID()))
@@ -102,9 +99,8 @@ func TestPEXReactorDoNotStopReconnectionPeer(t *testing.T) {
 		r.Receive(PexChannel, peer, msg)
 		assert.True(t, sw.Peers().Has(peer.ID()))
 
-		go sw.StopPeerForError(peer, "peer not available")
-		for sw.Peers().Has(peer.ID()) {
-		}
+		// simulate stop peer for error
+		p2p.RemovePeerFromSwitchPeerSet(sw, peer)
 	}
 }
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -701,7 +701,7 @@ func (sw *Switch) addPeer(p Peer) error {
 	sw.metrics.Peers.Add(float64(1))
 
 	for _, reactor := range sw.reactors {
-		p = reactor.InitAddPeer(p)
+		p = reactor.InitPeer(p)
 	}
 	// Start all the reactor protocols on the peer.
 	for _, reactor := range sw.reactors {

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -700,6 +700,9 @@ func (sw *Switch) addPeer(p Peer) error {
 	}
 	sw.metrics.Peers.Add(float64(1))
 
+	for _, reactor := range sw.reactors {
+		p = reactor.InitAddPeer(p)
+	}
 	// Start all the reactor protocols on the peer.
 	for _, reactor := range sw.reactors {
 		reactor.AddPeer(p)

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -27,8 +27,12 @@ func (ni mockNodeInfo) NetAddress() (*NetAddress, error)    { return ni.addr, ni
 func (ni mockNodeInfo) Validate() error                     { return nil }
 func (ni mockNodeInfo) CompatibleWith(other NodeInfo) error { return nil }
 
-func AddPeerToSwitch(sw *Switch, peer Peer) {
+func AddPeerToSwitchPeerSet(sw *Switch, peer Peer) {
 	sw.peers.Add(peer)
+}
+
+func AddPeerToSwitch(sw *Switch, peer Peer) error {
+	return sw.addPeer(peer)
 }
 
 func CreateRandomPeer(outbound bool) *peer {

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -31,6 +31,10 @@ func AddPeerToSwitchPeerSet(sw *Switch, peer Peer) {
 	sw.peers.Add(peer)
 }
 
+func RemovePeerFromSwitchPeerSet(sw *Switch, peer Peer) {
+	sw.peers.Remove(peer)
+}
+
 func AddPeerToSwitch(sw *Switch, peer Peer) error {
 	return sw.addPeer(peer)
 }


### PR DESCRIPTION
fix two issue    https://github.com/tendermint/tendermint/pull/3346 and 
https://github.com/tendermint/tendermint/issues/3338
 1、fix reconnection pex send too fast,
    error is caused lastReceivedRequests is still
    not deleted when a peer reconnected

2、Peer does not have a state yet. We set it in AddPeer.
    We need an new interface before mconnection is started
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
