### PR TITLE
do not pin repos without releases to exact revisions

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -76,34 +76,14 @@
   version = "^0.9.1"
 
 ###################################
-## Some repos dont have releases.
-## Pin to revision
+## Repos which don't have releases.
 
-[[constraint]]
-  name = "github.com/btcsuite/btcd"
-  revision = "ed77733ec07dfc8a513741138419b8d9d3de9d2d"
-
-[[constraint]]
-  name = "golang.org/x/crypto"
-  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
-
-[[override]]
-  name = "github.com/jmhodges/levigo"
-  revision = "c42d9e0ca023e2198120196f842701bb4c55d7b9"
-
-# last revision used by go-crypto
-[[constraint]]
-  name = "github.com/btcsuite/btcutil"
-  revision = "d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4"
-
-
-[[constraint]]
-  name = "github.com/rcrowley/go-metrics"
-  revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
-
-[[constraint]]
-  name = "golang.org/x/net"
-  revision = "292b43bbf7cb8d35ddf40f8d5100ef3837cced3f"
+## - github.com/btcsuite/btcd
+## - golang.org/x/crypto
+## - github.com/jmhodges/levigo
+## - github.com/btcsuite/btcutil
+## - github.com/rcrowley/go-metrics
+## - golang.org/x/net
 
 [prune]
   go-tests = true


### PR DESCRIPTION
We're pinning repos without releases because it's very easy to upgrade all the dependencies by executing `dep ensure --upgrade`. Instead, we should just never run this command directly, only `dep ensure --upgrade <some repo>`. And we can defend that in PRs.

Refs https://github.com/tendermint/tendermint/pull/3374

The problem with pinning to exact revisions: people who import Tendermint as a library (e.g. `abci/types`) are stuck with these revisions even though the code they import may not even use them.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
