### PR TITLE
update levigo to 1.0.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -154,11 +154,12 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:39b27d1381a30421f9813967a5866fba35dc1d4df43a6eefe3b7a5444cb07214"
+  digest = "1:a74b5a8e34ee5843cd6e65f698f3e75614f812ff170c2243425d75bc091e9af2"
   name = "github.com/jmhodges/levigo"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c42d9e0ca023e2198120196f842701bb4c55d7b9"
+  revision = "853d788c5c416eaaee5b044570784a96c7a26975"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,6 +75,10 @@
   name = "github.com/prometheus/client_golang"
   version = "^0.9.1"
 
+[[constraint]]
+  name = "github.com/jmhodges/levigo"
+  version = "^1.0.0"
+
 ###################################
 ## Some repos dont have releases.
 ## Pin to revision
@@ -86,10 +90,6 @@
 [[constraint]]
   name = "golang.org/x/crypto"
   revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
-
-[[override]]
-  name = "github.com/jmhodges/levigo"
-  revision = "c42d9e0ca023e2198120196f842701bb4c55d7b9"
 
 # last revision used by go-crypto
 [[constraint]]


### PR DESCRIPTION
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

Although the version we were pinning to is from Nov. 2016 there were no substantial changes:
 -  https://github.com/jmhodges/levigo/commit/2b8c778f79d26d89cd5fd82accd3946374774c15 added go-modules support (no code changes)
- https://github.com/jmhodges/levigo/commit/853d788c5c416eaaee5b044570784a96c7a26975 added a badge to the readme

closes #3381 

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
