### PR TITLE
cs: remove log.Error to avoid TestReactorValidatorSetChanges timing out

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -671,8 +671,8 @@ func (cs *ConsensusState) handleMsg(mi msgInfo) {
 	defer cs.mtx.Unlock()
 
 	var (
-		err   error
 		added bool
+		err   error
 	)
 	msg, peerID := mi.Msg, mi.PeerID
 	switch msg := msg.(type) {
@@ -714,11 +714,15 @@ func (cs *ConsensusState) handleMsg(mi msgInfo) {
 		// the peer is sending us CatchupCommit precommits.
 		// We could make note of this and help filter in broadcastHasVoteMessage().
 	default:
-		cs.Logger.Error("Unknown msg type", reflect.TypeOf(msg))
+		cs.Logger.Error("Unknown msg type", "type", reflect.TypeOf(msg))
+		return
 	}
+
 	if err != nil {
+		// Stringify err to avoid TestReactorValidatorSetChanges test timed out
+		// after 5m0s.
 		cs.Logger.Error("Error with msg", "height", cs.Height, "round", cs.Round,
-			"peer", peerID, "err", err, "msg", msg)
+			"peer", peerID, "err", err.Error(), "msg", msg)
 	}
 }
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -670,26 +670,31 @@ func (cs *ConsensusState) handleMsg(mi msgInfo) {
 	cs.mtx.Lock()
 	defer cs.mtx.Unlock()
 
+	var (
+		added bool
+		err   error
+	)
 	msg, peerID := mi.Msg, mi.PeerID
 	switch msg := msg.(type) {
 	case *ProposalMessage:
 		// will not cause transition.
 		// once proposal is set, we can receive block parts
-		cs.setProposal(msg.Proposal)
+		err = cs.setProposal(msg.Proposal)
 	case *BlockPartMessage:
 		// if the proposal is complete, we'll enterPrevote or tryFinalizeCommit
-		added, err := cs.addProposalBlockPart(msg, peerID)
+		added, err = cs.addProposalBlockPart(msg, peerID)
 		if added {
 			cs.statsMsgQueue <- mi
 		}
 
 		if err != nil && msg.Round != cs.Round {
 			cs.Logger.Debug("Received block part from wrong round", "height", cs.Height, "csRound", cs.Round, "blockRound", msg.Round)
+			err = nil
 		}
 	case *VoteMessage:
 		// attempt to add the vote and dupeout the validator if its a duplicate signature
 		// if the vote gives us a 2/3-any or 2/3-one, we transition
-		added, err := cs.tryAddVote(msg.Vote, peerID)
+		added, err = cs.tryAddVote(msg.Vote, peerID)
 		if added {
 			cs.statsMsgQueue <- mi
 		}
@@ -710,6 +715,14 @@ func (cs *ConsensusState) handleMsg(mi msgInfo) {
 		// We could make note of this and help filter in broadcastHasVoteMessage().
 	default:
 		cs.Logger.Error("Unknown msg type", "type", reflect.TypeOf(msg))
+		return
+	}
+
+	if err != nil {
+		// Causes TestReactorValidatorSetChanges to timeout
+		// https://github.com/tendermint/tendermint/issues/3406
+		// cs.Logger.Error("Error with msg", "height", cs.Height, "round", cs.Round,
+		// 	"peer", peerID, "err", err, "msg", msg)
 	}
 }
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -722,7 +722,7 @@ func (cs *ConsensusState) handleMsg(mi msgInfo) {
 		// Stringify err to avoid TestReactorValidatorSetChanges test timed out
 		// after 5m0s.
 		cs.Logger.Error("Error with msg", "height", cs.Height, "round", cs.Round,
-			"peer", peerID, "err", err.Error(), "msg", msg)
+			"peer", peerID, "err", err.Error(), "msg", fmt.Sprintf("%v", msg))
 	}
 }
 


### PR DESCRIPTION
See https://github.com/tendermint/tendermint/pull/3386#discussion_r263254903 for original discussion. Back then I thought #3386 has nothing to do with the TestReactorValidatorSetChanges test timeout, but now it's more or less clear. I still don't understand how/why log.Error statement is causing it. Note before #3386 we're not calling log.Error because of the shadowing.

[build_49553_step_105_container_3.txt.zip](https://github.com/tendermint/tendermint/files/2951514/build_49553_step_105_container_3.txt.zip)
