### PR TITLE
localnet: fix $LOG variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "26656-26657:26656-26657"
     environment:
       - ID=0
-      - LOG=$${LOG:-tendermint.log}
+      - LOG=${LOG:-tendermint.log}
     volumes:
       - ./build:/tendermint:Z
     networks:
@@ -22,7 +22,7 @@ services:
       - "26659-26660:26656-26657"
     environment:
       - ID=1
-      - LOG=$${LOG:-tendermint.log}
+      - LOG=${LOG:-tendermint.log}
     volumes:
       - ./build:/tendermint:Z
     networks:
@@ -34,7 +34,7 @@ services:
     image: "tendermint/localnode"
     environment:
       - ID=2
-      - LOG=$${LOG:-tendermint.log}
+      - LOG=${LOG:-tendermint.log}
     ports:
       - "26661-26662:26656-26657"
     volumes:
@@ -48,7 +48,7 @@ services:
     image: "tendermint/localnode"
     environment:
       - ID=3
-      - LOG=$${LOG:-tendermint.log}
+      - LOG=${LOG:-tendermint.log}
     ports:
       - "26663-26664:26656-26657"
     volumes:


### PR DESCRIPTION
Fixes #3421

Before: it was creating a file named ${LOG:-tendermint.log} in .build/nodeX
After: it creates a file named tendermint.log

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
