### PR TITLE
rpc: client disable compression

### DIFF
--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -74,7 +74,9 @@ func makeHTTPClient(remoteAddr string) (string, *http.Client) {
 	protocol, address, dialer := makeHTTPDialer(remoteAddr)
 	return protocol + "://" + address, &http.Client{
 		Transport: &http.Transport{
-			Dial: dialer,
+			// Set to true to prevent GZIP-bomb DoS attacks
+			DisableCompression: true,
+			Dial:               dialer,
 		},
 	}
 }


### PR DESCRIPTION
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->
By default, the http go client support Gzip-compressed Http response. 
The cli and light binary does not disable this support via the DisableCompression
property of the HTTPTransport object. As soon as it send a Http Request to a user-controlled
server, it become possible to cause a Denial of Service via a GZIP bomb.

Steps To Reproduce:
Code:
```
<?php
header("Content-Encoding: gzip");
echo file_get_contents("hello.gz")
?>
```

file： hello.gz
the file is 9MB in size but will expand to 9GB as soon as it decompressed.

start lightd or cli with --node to this server, the process will crash.
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
