### PR TITLE
types: refactor PB2TM.ConsensusParams to take BlockTimeIota as an arg

### DIFF
--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -324,12 +324,7 @@ func (h *Handshaker) ReplayBlocks(
 			}
 
 			if res.ConsensusParams != nil {
-				// Preserve TimeIotaMs since it's not exposed to the application.
-				timeIotaMs := state.ConsensusParams.Block.TimeIotaMs
-				{
-					state.ConsensusParams = types.PB2TM.ConsensusParams(res.ConsensusParams)
-				}
-				state.ConsensusParams.Block.TimeIotaMs = timeIotaMs
+				state.ConsensusParams = types.PB2TM.ConsensusParams(res.ConsensusParams, state.ConsensusParams.Block.TimeIotaMs)
 			}
 			sm.SaveState(h.stateDB, state)
 		}

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -221,7 +221,9 @@ func (pb2tm) ValidatorUpdates(vals []abci.ValidatorUpdate) ([]*Validator, error)
 	return tmVals, nil
 }
 
-func (pb2tm) ConsensusParams(csp *abci.ConsensusParams) ConsensusParams {
+// BlockParams.TimeIotaMs is not exposed to the application. Therefore a caller
+// must provide it.
+func (pb2tm) ConsensusParams(csp *abci.ConsensusParams, blockTimeIotaMs int64) ConsensusParams {
 	params := ConsensusParams{
 		Block:     BlockParams{},
 		Evidence:  EvidenceParams{},
@@ -231,8 +233,9 @@ func (pb2tm) ConsensusParams(csp *abci.ConsensusParams) ConsensusParams {
 	// we must defensively consider any structs may be nil
 	if csp.Block != nil {
 		params.Block = BlockParams{
-			MaxBytes: csp.Block.MaxBytes,
-			MaxGas:   csp.Block.MaxGas,
+			MaxBytes:   csp.Block.MaxBytes,
+			MaxGas:     csp.Block.MaxGas,
+			TimeIotaMs: blockTimeIotaMs,
 		}
 	}
 

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -64,9 +64,7 @@ func TestABCIValidators(t *testing.T) {
 func TestABCIConsensusParams(t *testing.T) {
 	cp := DefaultConsensusParams()
 	abciCP := TM2PB.ConsensusParams(cp)
-	cp2 := PB2TM.ConsensusParams(abciCP)
-	// TimeIotaMs is not exposed to the application.
-	cp2.Block.TimeIotaMs = cp.Block.TimeIotaMs
+	cp2 := PB2TM.ConsensusParams(abciCP, cp.Block.TimeIotaMs)
 
 	assert.Equal(t, *cp, cp2)
 }


### PR DESCRIPTION
Fixes #3432

Thanks to @ebuchman for suggesting it!
