### PR TITLE
consensus: call reconstructLastCommit after updateToState in SwitchToConsensus

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -100,10 +100,10 @@ func (conR *ConsensusReactor) OnStop() {
 // It resets the state, turns off fast_sync, and starts the consensus state-machine
 func (conR *ConsensusReactor) SwitchToConsensus(state sm.State, blocksSynced int) {
 	conR.Logger.Info("SwitchToConsensus")
-	conR.conS.reconstructLastCommit(state)
 	// NOTE: The line below causes broadcastNewRoundStepRoutine() to
 	// broadcast a NewRoundStepMessage.
 	conR.conS.updateToState(state)
+	conR.conS.reconstructLastCommit(state)
 
 	conR.mtx.Lock()
 	conR.fastSync = false


### PR DESCRIPTION
Reasons:

- otherwise `cs.LastCommit` will be `nil`???
- to align it with `NewConsensusState`

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
