### PR TITLE
p2p: remove noisy error log

### DIFF
--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -412,7 +412,8 @@ func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent b
 			// do not add our address or ID
 			if !netAddr.Same(ourAddr) {
 				if err := addrBook.AddAddress(netAddr, ourAddr); err != nil {
-					sw.Logger.Error("Can't add peer's address to addrbook", "err", err)
+					// non-routable, self, full book, private, etc.
+					sw.Logger.Debug("Can't add peer's address to addrbook", "err", err)
 				}
 			}
 		}


### PR DESCRIPTION
When node start with persistent peer that is private ip, there will be error log like:
```
E[2019-03-21|09:02:55.560] Can't add peer's address to addrbook         module=p2p err="Cannot add non-routable address 4390afd570366e50f13e05b592a6bc06fb77d02c@172.27.41.104:27146"
```
I don't think it is an error, so use debug level log.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
