### PR TITLE
Update height and round for tm-signer-harness

### DIFF
--- a/tools/tm-signer-harness/internal/test_harness.go
+++ b/tools/tm-signer-harness/internal/test_harness.go
@@ -198,8 +198,8 @@ func (th *TestHarness) TestSignProposal() error {
 	hash := tmhash.Sum([]byte("hash"))
 	prop := &types.Proposal{
 		Type:     types.ProposalType,
-		Height:   12345,
-		Round:    23456,
+		Height:   100,
+		Round:    0,
 		POLRound: -1,
 		BlockID: types.BlockID{
 			Hash: hash,
@@ -240,8 +240,8 @@ func (th *TestHarness) TestSignVote() error {
 		hash := tmhash.Sum([]byte("hash"))
 		vote := &types.Vote{
 			Type:   voteType,
-			Height: 12345,
-			Round:  23456,
+			Height: 101,
+			Round:  0,
 			BlockID: types.BlockID{
 				Hash: hash,
 				PartsHeader: types.PartSetHeader{


### PR DESCRIPTION
In order to re-enable the test harness for the KMS (see tendermint/kms#227), we need some marginally more realistic proposals and votes. This is because the KMS does some additional sanity checks now to ensure the height and round are increasing over time.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
