### PR TITLE
rpc/client: include NetworkClient interface into Client interface

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,6 +5,7 @@
 ### BREAKING CHANGES:
 
 * CLI/RPC/Config
+- [rpc/client] \#3458 Include NetworkClient interface into Client interface
 
 * Apps
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,12 +5,12 @@
 ### BREAKING CHANGES:
 
 * CLI/RPC/Config
-- [rpc/client] \#3458 Include NetworkClient interface into Client interface
 
 * Apps
 
 * Go API
 - [libs/common] Remove RepeatTimer (also TimerMaker and Ticker interface)
+- [rpc/client] \#3458 Include NetworkClient interface into Client interface
 
 * Blockchain Protocol
 

--- a/rpc/client/httpclient.go
+++ b/rpc/client/httpclient.go
@@ -52,11 +52,7 @@ func NewHTTP(remote, wsEndpoint string) *HTTP {
 	}
 }
 
-var (
-	_ Client        = (*HTTP)(nil)
-	_ NetworkClient = (*HTTP)(nil)
-	_ EventsClient  = (*HTTP)(nil)
-)
+var _ Client = (*HTTP)(nil)
 
 func (c *HTTP) Status() (*ctypes.ResultStatus, error) {
 	result := new(ctypes.ResultStatus)

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -72,17 +72,15 @@ type StatusClient interface {
 type Client interface {
 	cmn.Service
 	ABCIClient
-	SignClient
-	HistoryClient
-	StatusClient
 	EventsClient
+	HistoryClient
+	NetworkClient
+	SignClient
+	StatusClient
 }
 
 // NetworkClient is general info about the network state.  May not
 // be needed usually.
-//
-// Not included in the Client interface, but generally implemented
-// by concrete implementations.
 type NetworkClient interface {
 	NetInfo() (*ctypes.ResultNetInfo, error)
 	DumpConsensusState() (*ctypes.ResultDumpConsensusState, error)

--- a/rpc/client/localclient.go
+++ b/rpc/client/localclient.go
@@ -58,11 +58,7 @@ func NewLocal(node *nm.Node) *Local {
 	}
 }
 
-var (
-	_ Client        = (*Local)(nil)
-	_ NetworkClient = (*Local)(nil)
-	_ EventsClient  = (*Local)(nil)
-)
+var _ Client = (*Local)(nil)
 
 // SetLogger allows to set a logger on the client.
 func (c *Local) SetLogger(l log.Logger) {

--- a/rpc/client/mock/client.go
+++ b/rpc/client/mock/client.go
@@ -108,6 +108,18 @@ func (c Client) NetInfo() (*ctypes.ResultNetInfo, error) {
 	return core.NetInfo(&rpctypes.Context{})
 }
 
+func (c Client) ConsensusState() (*ctypes.ResultConsensusState, error) {
+	return core.ConsensusState(&rpctypes.Context{})
+}
+
+func (c Client) DumpConsensusState() (*ctypes.ResultDumpConsensusState, error) {
+	return core.DumpConsensusState(&rpctypes.Context{})
+}
+
+func (c Client) Health() (*ctypes.ResultHealth, error) {
+	return core.Health(&rpctypes.Context{})
+}
+
 func (c Client) DialSeeds(seeds []string) (*ctypes.ResultDialSeeds, error) {
 	return core.UnsafeDialSeeds(&rpctypes.Context{}, seeds)
 }


### PR DESCRIPTION
I think it's nice when the `Client` interface has all the methods. If someone does not need a particular method/set of methods, she can use individual interfaces (e.g. NetworkClient, MempoolClient) or write her own interface.

**technically breaking**

Fixes #3458

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
