### PR TITLE
R4R: Resolve broadcastTxRoutine leakage issue

### DIFF
--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -112,6 +112,10 @@ func (memR *MempoolReactor) broadcastTxRoutine(peer p2p.Peer) {
 
 	var next *clist.CElement
 	for {
+		// In case of both next.NextWaitChan() and peer.Quit() are variable at the same time
+		if !memR.IsRunning() || !peer.IsRunning() {
+			return
+		}
 		// This happens because the CElement we were looking at got garbage
 		// collected (removed). That is, .NextWait() returned nil. Go ahead and
 		// start from the beginning.


### PR DESCRIPTION
Ref: #3306, https://github.com/irisnet/tendermint/pull/44/commits/fdbb67655db45726173895fd4ca6458180a8fc11

I ran an irishub validator. After the validator node ran several days, I dump the whole goroutine stack. I found that there were hundreds of broadcastTxRoutine. However, the connected peer quantity was less than 30. So I belive that there must be broadcastTxRoutine leakage issue.

According to my analysis, I think the root cause of this issue locate in below code:
```
		select {
		case <-next.NextWaitChan():
			// see the start of the for loop for nil check
			next = next.Next()
		case <-peer.Quit():
			return
		case <-memR.Quit():
			return
		}
```
As we know, if multiple paths are avaliable in the same time, then a random path will be selected. Suppose that `next.NextWaitChan()` and `peer.Quit()` are both avaliable, and `next.NextWaitChan()` is chosen. 
```
                // send memTx
		msg := &TxMessage{Tx: memTx.tx}
		success := peer.Send(MempoolChannel, cdc.MustMarshalBinaryBare(msg))
		if !success {
			time.Sleep(peerCatchupSleepIntervalMS * time.Millisecond)
			continue
		}
```
Then `next` will be non-empty and the peer send operation won't be success. As a result, this go routine will be track into infinite loop and won't be released. 

My proposal is to check `peer.Quit()` and `memR.Quit()` in every loop no matter whether `next` is nil.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
