### PR TITLE
docs: Fix broken links (#3482)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,3 +26,4 @@
 ### BUG FIXES:
 
 - [blockchain] \#2699 update the maxHeight when a peer is removed
+- [docs] \#3482 fix broken links

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,4 +26,4 @@
 ### BUG FIXES:
 
 - [blockchain] \#2699 update the maxHeight when a peer is removed
-- [docs] \#3482 fix broken links
+- [docs] \#3482 fix broken links (@brapse)

--- a/docs/networks/docker-compose.md
+++ b/docs/networks/docker-compose.md
@@ -4,7 +4,7 @@ With Docker Compose, you can spin up local testnets with a single command.
 
 ## Requirements
 
-1. [Install tendermint](/introduction/install.md)
+1. [Install tendermint](../introduction/install.md)
 2. [Install docker](https://docs.docker.com/engine/installation/)
 3. [Install docker-compose](https://docs.docker.com/compose/install/)
 

--- a/docs/networks/docker-compose.md
+++ b/docs/networks/docker-compose.md
@@ -4,7 +4,7 @@ With Docker Compose, you can spin up local testnets with a single command.
 
 ## Requirements
 
-1. [Install tendermint](/docs/introduction/install.md)
+1. [Install tendermint](/introduction/install.md)
 2. [Install docker](https://docs.docker.com/engine/installation/)
 3. [Install docker-compose](https://docs.docker.com/compose/install/)
 

--- a/docs/spec/blockchain/blockchain.md
+++ b/docs/spec/blockchain/blockchain.md
@@ -103,7 +103,7 @@ type PartSetHeader struct {
 }
 ```
 
-See [MerkleRoot](/docs/spec/blockchain/encoding.md#MerkleRoot) for details.
+See [MerkleRoot](/spec/blockchain/encoding.md#MerkleRoot) for details.
 
 ## Time
 
@@ -163,7 +163,7 @@ a _precommit_ has `vote.Type == 2`.
 
 Signatures in Tendermint are raw bytes representing the underlying signature.
 
-See the [signature spec](/docs/spec/blockchain/encoding.md#key-types) for more.
+See the [signature spec](/spec/blockchain/encoding.md#key-types) for more.
 
 ## EvidenceData
 
@@ -190,7 +190,7 @@ type DuplicateVoteEvidence struct {
 }
 ```
 
-See the [pubkey spec](/docs/spec/blockchain/encoding.md#key-types) for more.
+See the [pubkey spec](/spec/blockchain/encoding.md#key-types) for more.
 
 ## Validation
 
@@ -209,7 +209,7 @@ the current version of the `state` corresponds to the state
 after executing transactions from the `prevBlock`.
 Elements of an object are accessed as expected,
 ie. `block.Header`.
-See the [definition of `State`](/docs/spec/blockchain/state.md).
+See the [definition of `State`](/spec/blockchain/state.md).
 
 ### Header
 

--- a/docs/spec/blockchain/blockchain.md
+++ b/docs/spec/blockchain/blockchain.md
@@ -103,7 +103,7 @@ type PartSetHeader struct {
 }
 ```
 
-See [MerkleRoot](/spec/blockchain/encoding.md#MerkleRoot) for details.
+See [MerkleRoot](./encoding.md#MerkleRoot) for details.
 
 ## Time
 
@@ -163,7 +163,7 @@ a _precommit_ has `vote.Type == 2`.
 
 Signatures in Tendermint are raw bytes representing the underlying signature.
 
-See the [signature spec](/spec/blockchain/encoding.md#key-types) for more.
+See the [signature spec](./encoding.md#key-types) for more.
 
 ## EvidenceData
 
@@ -190,7 +190,7 @@ type DuplicateVoteEvidence struct {
 }
 ```
 
-See the [pubkey spec](/spec/blockchain/encoding.md#key-types) for more.
+See the [pubkey spec](./encoding.md#key-types) for more.
 
 ## Validation
 
@@ -209,7 +209,7 @@ the current version of the `state` corresponds to the state
 after executing transactions from the `prevBlock`.
 Elements of an object are accessed as expected,
 ie. `block.Header`.
-See the [definition of `State`](/spec/blockchain/state.md).
+See the [definition of `State`](./state.md).
 
 ### Header
 

--- a/docs/spec/blockchain/encoding.md
+++ b/docs/spec/blockchain/encoding.md
@@ -339,6 +339,6 @@ type CanonicalVote struct {
 
 The field ordering and the fixed sized encoding for the first three fields is optimized to ease parsing of SignBytes
 in HSMs. It creates fixed offsets for relevant fields that need to be read in this context.
-For more details, see the [signing spec](/spec/consensus/signing.md).
+For more details, see the [signing spec](../consensus/signing.md).
 Also, see the motivating discussion in
 [#1622](https://github.com/tendermint/tendermint/issues/1622).

--- a/docs/spec/blockchain/encoding.md
+++ b/docs/spec/blockchain/encoding.md
@@ -339,6 +339,6 @@ type CanonicalVote struct {
 
 The field ordering and the fixed sized encoding for the first three fields is optimized to ease parsing of SignBytes
 in HSMs. It creates fixed offsets for relevant fields that need to be read in this context.
-For more details, see the [signing spec](/docs/spec/consensus/signing.md).
+For more details, see the [signing spec](/spec/consensus/signing.md).
 Also, see the motivating discussion in
 [#1622](https://github.com/tendermint/tendermint/issues/1622).

--- a/docs/spec/consensus/abci.md
+++ b/docs/spec/consensus/abci.md
@@ -1,1 +1,1 @@
-[Moved](/spec/software/abci.md)
+[Moved](../software/abci.md)

--- a/docs/spec/consensus/abci.md
+++ b/docs/spec/consensus/abci.md
@@ -1,1 +1,1 @@
-[Moved](/docs/spec/software/abci.md)
+[Moved](/spec/software/abci.md)

--- a/docs/spec/consensus/wal.md
+++ b/docs/spec/consensus/wal.md
@@ -1,1 +1,1 @@
-[Moved](/docs/spec/software/wal.md)
+[Moved](/spec/software/wal.md)

--- a/docs/spec/consensus/wal.md
+++ b/docs/spec/consensus/wal.md
@@ -1,1 +1,1 @@
-[Moved](/spec/software/wal.md)
+[Moved](../software/wal.md)


### PR DESCRIPTION
A bunch of links were broken in the documentation, they included the `docs` prefix. 
Fixes #3482 

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] ~~Wrote tests~~
* [x] Updated CHANGELOG_PENDING.md
