### PR TITLE
blockchain: Comment out logger in test code that causes a race condition

### DIFF
--- a/blockchain/pool_test.go
+++ b/blockchain/pool_test.go
@@ -42,7 +42,9 @@ func (p testPeer) runInputRoutine() {
 func (p testPeer) simulateInput(input inputData) {
 	block := &types.Block{Header: types.Header{Height: input.request.Height}}
 	input.pool.AddBlock(input.request.PeerID, block, 123)
-	input.t.Logf("Added block from peer %v (height: %v)", input.request.PeerID, input.request.Height)
+	// TODO: uncommenting this creates a race which is detected by: https://github.com/golang/go/blob/2bd767b1022dd3254bcec469f0ee164024726486/src/testing/testing.go#L854-L856
+	// see: https://github.com/tendermint/tendermint/issues/3390#issue-418379890
+	// input.t.Logf("Added block from peer %v (height: %v)", input.request.PeerID, input.request.Height)
 }
 
 type testPeers map[p2p.ID]testPeer


### PR DESCRIPTION
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

This comments out a line that triggered the golang race detector. This is OK because:
 - the commented line is only in test-code and we usually do not need the log output
 - the blockchain reactor will undergo a major refactoring and the lines will probably become obsolete & be deleted anyways
 - until the refactoring we can keep the commented line in case we need to debug sth. (@ancazamfir @milosevic)

"resolves" and close #3390 

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
