### PR TITLE
Fix for wrong version tag

### DIFF
--- a/scripts/release_management/github-draft.py
+++ b/scripts/release_management/github-draft.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
   if not os.environ.has_key('GITHUB_TOKEN'):
     raise parser.error('environment variable GITHUB_TOKEN is required')
 
-  release = create_draft(args.org,args.repo,args.version)
+  release = create_draft(args.org,args.repo,args.branch,args.version)
 
   print(release["id"])
 

--- a/scripts/release_management/github-draft.py
+++ b/scripts/release_management/github-draft.py
@@ -29,10 +29,10 @@ def request(org, repo, data):
   return json.loads(responsedata)
 
 
-def create_draft(org,repo,version):
+def create_draft(org,repo,branch,version):
   draft = {
     'tag_name': version,
-    'target_commitish': 'master',
+    'target_commitish': '{0}'.format(branch),
     'name': '{0} (WARNING: ALPHA SOFTWARE)'.format(version),
     'body': '<a href=https://github.com/{0}/{1}/blob/master/CHANGELOG.md#{2}>https://github.com/{0}/{1}/blob/master/CHANGELOG.md#{2}</a>'.format(org,repo,version.replace('v','').replace('.','')),
     'draft': True,
@@ -45,6 +45,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   parser.add_argument("--org", default="tendermint", help="GitHub organization")
   parser.add_argument("--repo", default="tendermint", help="GitHub repository")
+  parser.add_argument("--branch", default=os.environ.get('CIRCLE_BRANCH'), help="Branch to build from, e.g.: v1.0")
   parser.add_argument("--version", default=os.environ.get('CIRCLE_TAG'), help="Version number for binary, e.g.: v1.0.0")
   args = parser.parse_args()
 


### PR DESCRIPTION
* [ ] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md

The Python script creating the release was always targeting the `master` branch for the release tag. This PR fixes that and rightfully redirects it to the release branch instead of `master`.