### PR TITLE
Release message changelog link fix

### DIFF
--- a/scripts/release_management/github-draft.py
+++ b/scripts/release_management/github-draft.py
@@ -34,7 +34,7 @@ def create_draft(org,repo,branch,version):
     'tag_name': version,
     'target_commitish': '{0}'.format(branch),
     'name': '{0} (WARNING: ALPHA SOFTWARE)'.format(version),
-    'body': '<a href=https://github.com/{0}/{1}/blob/master/CHANGELOG.md#{2}>https://github.com/{0}/{1}/blob/master/CHANGELOG.md#{2}</a>'.format(org,repo,version.replace('v','').replace('.','')),
+    'body': '<a href=https://github.com/{0}/{1}/blob/{2}/CHANGELOG.md#{3}>https://github.com/{0}/{1}/blob/{2}/CHANGELOG.md#{3}</a>'.format(org,repo,branch,version.replace('.','')),
     'draft': True,
     'prerelease': False
   }


### PR DESCRIPTION
<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md

Still part of the release_management update. The release message CHANGELOG link was incorrect, this fixes it.