### PR TITLE
rpc: Fix response time grow over time

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,7 +20,8 @@
 
 ### BUG FIXES:
 
-- [state] Persist validators every 100000 blocks even if no changes to the set
+- [state] [\#3438](https://github.com/tendermint/tendermint/pull/3438) 
+  Persist validators every 100000 blocks even if no changes to the set
   occurred (@guagualvcha). This
   1) Prevents possible DoS attack using `/validators` or `/status` RPC
   endpoints. Before response time was growing linearly with height if no

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,8 +21,11 @@
 ### BUG FIXES:
 
 - [state] Persist validators every 100000 blocks even if no changes to the set
-  occurred. This prevents possible DoS attack using /validators RPC endpoint.
-  Before /validators response time was growing linearly if no changes were made
-  to validator set. (@guagualvcha)
+  occurred (@guagualvcha). This
+  1) Prevents possible DoS attack using `/validators` or `/status` RPC
+  endpoints. Before response time was growing linearly if no changes were made
+  to validator set.
+  2) Fixes performance degradation in `ExecCommitBlock` where we call
+  `LoadValidators`.
 - [p2p] \#2716 Check if we're already connected to peer right before dialing it (@melekes)
 - [docs] \#3514 Fix block.Header.Time description (@melekes)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,3 +27,7 @@ mempool load for external ABCI apps.
 ### BUG FIXES:
 
 - [mempool] \#3512 Fix panic from concurrent access to txsMap, a regression for external ABCI apps introduced in v0.31.1
+- [state] Persist validators every 100000 blocks even if no changes to the set
+  occurred. This prevents possible DoS attack using /validators RPC endpoint.
+  Before /validators response time was growing linearly if no changes were made
+  to validator set. (@guagualvcha)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,9 +23,9 @@
 - [state] Persist validators every 100000 blocks even if no changes to the set
   occurred (@guagualvcha). This
   1) Prevents possible DoS attack using `/validators` or `/status` RPC
-  endpoints. Before response time was growing linearly if no changes were made
-  to validator set.
+  endpoints. Before response time was growing linearly with height if no
+  changes were made to validator set.
   2) Fixes performance degradation in `ExecCommitBlock` where we call
-  `LoadValidators`.
+  `LoadValidators` for each `Evidence` in the block.
 - [p2p] \#2716 Check if we're already connected to peer right before dialing it (@melekes)
 - [docs] \#3514 Fix block.Header.Time description (@melekes)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -25,7 +25,7 @@
   occurred (@guagualvcha). This
   1) Prevents possible DoS attack using `/validators` or `/status` RPC
   endpoints. Before response time was growing linearly with height if no
-  changes were made to validator set.
+  changes were made to the validator set.
   2) Fixes performance degradation in `ExecCommitBlock` where we call
   `LoadValidators` for each `Evidence` in the block.
 - [p2p] \#2716 Check if we're already connected to peer right before dialing it (@melekes)

--- a/state/store.go
+++ b/state/store.go
@@ -202,7 +202,7 @@ func LoadValidators(db dbm.DB, height int64) (*types.ValidatorSet, error) {
 			lastStoredHeight = valInfo.LastHeightChanged
 			if valInfo2 == nil {
 				panic(
-					fmt.Sprintf("Couldn't find validators at height %d as last changed from height %d",
+					fmt.Sprintf("Couldn't find validators at height %d (height %d was originally requested)",
 						lastStoredHeight,
 						height,
 					),

--- a/state/store.go
+++ b/state/store.go
@@ -198,6 +198,7 @@ func LoadValidators(db dbm.DB, height int64) (*types.ValidatorSet, error) {
 			// release and just panic. Old chains might panic otherwise if they
 			// haven't saved validators at intermediate (%valSetCheckpointInterval)
 			// height yet.
+			// https://github.com/tendermint/tendermint/issues/3543
 			valInfo2 = loadValidatorsInfo(db, valInfo.LastHeightChanged)
 			lastStoredHeight = valInfo.LastHeightChanged
 			if valInfo2 == nil {

--- a/state/store.go
+++ b/state/store.go
@@ -194,8 +194,12 @@ func LoadValidators(db dbm.DB, height int64) (*types.ValidatorSet, error) {
 		lastStoreHeight := lastStoreHeightFor(height, valInfo.LastHeightChanged)
 		valInfo2 := loadValidatorsInfo(db, lastStoreHeight)
 		if valInfo2 == nil {
-			// TODO (melekes): remove in the 0.33 major release
+			// TODO (melekes): remove the below if condition in the 0.33 major
+			// release and just panic. Old chains might panic otherwise if they
+			// haven't saved validators at intermediate (%valSetStoreInterval) height
+			// yet.
 			valInfo2 = loadValidatorsInfo(db, valInfo.LastHeightChanged)
+			lastStoreHeight = valInfo.LastHeightChanged
 			if valInfo2 == nil {
 				panic(
 					fmt.Sprintf("Couldn't find validators at height %d as last changed from height %d",

--- a/state/store.go
+++ b/state/store.go
@@ -245,10 +245,10 @@ func loadValidatorsInfo(db dbm.DB, height int64) *ValidatorsInfo {
 }
 
 // saveValidatorsInfo persists the validator set.
-// `height` is the effective height for which the validator is responsible for signing.
-// It should be called from s.Save(), right before the state itself is persisted.
-// If the validator set did not change after processing the latest block,
-// only the last height for which the validators changed is persisted.
+//
+// `height` is the effective height for which the validator is responsible for
+// signing. It should be called from s.Save(), right before the state itself is
+// persisted.
 func saveValidatorsInfo(db dbm.DB, height, lastHeightChanged int64, valSet *types.ValidatorSet) {
 	if lastHeightChanged > height {
 		panic("LastHeightChanged cannot be greater than ValidatorsInfo height")
@@ -256,6 +256,8 @@ func saveValidatorsInfo(db dbm.DB, height, lastHeightChanged int64, valSet *type
 	valInfo := &ValidatorsInfo{
 		LastHeightChanged: lastHeightChanged,
 	}
+	// Only persist validator set if it was updated or checkpoint height (see
+	// valSetCheckpointInterval) is reached.
 	if height == lastHeightChanged || height%valSetCheckpointInterval == 0 {
 		valInfo.ValidatorSet = valSet
 	}

--- a/state/store.go
+++ b/state/store.go
@@ -219,10 +219,7 @@ func LoadValidators(db dbm.DB, height int64) (*types.ValidatorSet, error) {
 
 func lastStoredHeightFor(height, lastHeightChanged int64) int64 {
 	checkpointHeight := height - height%valSetCheckpointInterval
-	if checkpointHeight > lastHeightChanged {
-		return checkpointHeight
-	}
-	return lastHeightChanged
+	return cmn.MaxInt64(checkpointHeight, lastHeightChanged)
 }
 
 // CONTRACT: Returned ValidatorsInfo can be mutated.

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -1,0 +1,38 @@
+package state
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	cfg "github.com/tendermint/tendermint/config"
+	dbm "github.com/tendermint/tendermint/libs/db"
+)
+
+func BenchmarkLoadValidators(b *testing.B) {
+	const valSetSize = 100
+	config := cfg.ResetTestRoot("state_")
+	defer os.RemoveAll(config.RootDir)
+	dbType := dbm.DBBackendType(config.DBBackend)
+	stateDB := dbm.NewDB("state", dbType, config.DBDir())
+	state, err := LoadStateFromDBOrGenesisFile(stateDB, config.GenesisFile())
+	if err != nil {
+		b.Fatal(err)
+	}
+	state.Validators = genValSet(valSetSize)
+	state.NextValidators = state.Validators.CopyIncrementProposerPriority(1)
+	SaveState(stateDB, state)
+
+	for i := 10; i < 10000000000; i *= 10 {
+		saveValidatorsInfo(stateDB, int64(i), state.LastHeightValidatorsChanged, state.NextValidators)
+
+		b.Run(fmt.Sprintf("height=%d", i), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				_, err := LoadValidators(stateDB, int64(i))
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -11,6 +11,7 @@ import (
 
 func BenchmarkLoadValidators(b *testing.B) {
 	const valSetSize = 100
+
 	config := cfg.ResetTestRoot("state_")
 	defer os.RemoveAll(config.RootDir)
 	dbType := dbm.DBBackendType(config.DBBackend)
@@ -23,7 +24,7 @@ func BenchmarkLoadValidators(b *testing.B) {
 	state.NextValidators = state.Validators.CopyIncrementProposerPriority(1)
 	SaveState(stateDB, state)
 
-	for i := 10; i < 10000000000; i *= 10 {
+	for i := 10; i < 10000000000; i *= 10 { // 10, 100, 1000, ...
 		saveValidatorsInfo(stateDB, int64(i), state.LastHeightValidatorsChanged, state.NextValidators)
 
 		b.Run(fmt.Sprintf("height=%d", i), func(b *testing.B) {

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -13,20 +13,26 @@ import (
 )
 
 func TestSaveValidatorsInfo(t *testing.T) {
-	// test we persist validators every 100000 blocks
+	// test we persist validators every valSetCheckpointInterval blocks
 	stateDB := dbm.NewMemDB()
 	val, _ := types.RandValidator(true, 10)
 	vals := types.NewValidatorSet([]*types.Validator{val})
 
 	// TODO(melekes): remove in 0.33 release
 	// https://github.com/tendermint/tendermint/issues/3543
+	saveValidatorsInfo(stateDB, 1, 1, vals)
+	saveValidatorsInfo(stateDB, 2, 1, vals)
 	assert.NotPanics(t, func() {
-		LoadValidators(stateDB, 100000)
+		_, err := LoadValidators(stateDB, 2)
+		if err != nil {
+			panic(err)
+		}
 	})
+	//ENDREMOVE
 
-	saveValidatorsInfo(stateDB, 100000, 1, vals)
+	saveValidatorsInfo(stateDB, valSetCheckpointInterval, 1, vals)
 
-	loadedVals, err := LoadValidators(stateDB, 100000)
+	loadedVals, err := LoadValidators(stateDB, valSetCheckpointInterval)
 	assert.NoError(t, err)
 	assert.NotZero(t, loadedVals.Size())
 }

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -5,9 +5,31 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	cfg "github.com/tendermint/tendermint/config"
 	dbm "github.com/tendermint/tendermint/libs/db"
+	"github.com/tendermint/tendermint/types"
 )
+
+func TestSaveValidatorsInfo(t *testing.T) {
+	// test we persist validators every 100000 blocks
+	stateDB := dbm.NewMemDB()
+	val, _ := types.RandValidator(true, 10)
+	vals := types.NewValidatorSet([]*types.Validator{val})
+
+	// TODO(melekes): remove in 0.33 release
+	// https://github.com/tendermint/tendermint/issues/3543
+	assert.NotPanics(t, func() {
+		LoadValidators(stateDB, 100000)
+	})
+
+	saveValidatorsInfo(stateDB, 100000, 1, vals)
+
+	loadedVals, err := LoadValidators(stateDB, 100000)
+	assert.NoError(t, err)
+	assert.NotZero(t, loadedVals.Size())
+}
 
 func BenchmarkLoadValidators(b *testing.B) {
 	const valSetSize = 100


### PR DESCRIPTION
/validators rpc response time grow with time.

Steps To Reproduce:

    start a new node from hight 1
    2.time curl 127.0.0.1:26657/validators, it takes 0.005s
    let the chain run for serveral days, and change no validators.in my scenario the height is : 1584840
    time curl 127.0.0.1:26857/validators, it takes 1.25s

The api consumes cpu resouces, in the long run, a small scale of DDOS can make the node
a zombie process.

Acturally the logic to do IncrementProposerPriority by height - valInfo.LastHeightChanged times will not replay the exactly ProposerPriority once there are two or more round.

Replaces https://github.com/tendermint/tendermint/pull/3438