### PR TITLE
p2p: Bring back NodeInfo NetAddress form the dead

### DIFF
--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -24,7 +24,12 @@ func MaxNodeInfoSize() int {
 // and determines if we're compatible.
 type NodeInfo interface {
 	ID() ID
+	nodeInfoAddress
 	nodeInfoTransport
+}
+
+type nodeInfoAddress interface {
+	NetAddress() (*NetAddress, error)
 }
 
 // nodeInfoTransport validates a nodeInfo and checks
@@ -209,20 +214,9 @@ OUTER_LOOP:
 // it includes the authenticated peer ID and the self-reported
 // ListenAddr. Note that the ListenAddr is not authenticated and
 // may not match that address actually dialed if its an outbound peer.
-func (info DefaultNodeInfo) NetAddress() *NetAddress {
+func (info DefaultNodeInfo) NetAddress() (*NetAddress, error) {
 	idAddr := IDAddressString(info.ID(), info.ListenAddr)
-	netAddr, err := NewNetAddressString(idAddr)
-	if err != nil {
-		switch err.(type) {
-		case ErrNetAddressLookup:
-			// XXX If the peer provided a host name and the lookup fails here
-			// we're out of luck.
-			// TODO: use a NetAddress in DefaultNodeInfo
-		default:
-			panic(err) // everything should be well formed by now
-		}
-	}
-	return netAddr
+	return NewNetAddressString(idAddr)
 }
 
 //-----------------------------------------------------------

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -55,7 +55,7 @@ type AddrBook interface {
 	PickAddress(biasTowardsNewAddrs int) *p2p.NetAddress
 
 	// Mark address
-	MarkGood(*p2p.NetAddress)
+	MarkGood(p2p.ID)
 	MarkAttempt(*p2p.NetAddress)
 	MarkBad(*p2p.NetAddress)
 
@@ -296,11 +296,11 @@ func (a *addrBook) PickAddress(biasTowardsNewAddrs int) *p2p.NetAddress {
 
 // MarkGood implements AddrBook - it marks the peer as good and
 // moves it into an "old" bucket.
-func (a *addrBook) MarkGood(addr *p2p.NetAddress) {
+func (a *addrBook) MarkGood(id p2p.ID) {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
-	ka := a.addrLookup[addr.ID]
+	ka := a.addrLookup[id]
 	if ka == nil {
 		return
 	}

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -41,7 +41,7 @@ func TestAddrBookPickAddress(t *testing.T) {
 	assert.NotNil(t, addr, "expected an address")
 
 	// pick an address when we only have old address
-	book.MarkGood(addrSrc.addr)
+	book.MarkGood(addrSrc.addr.ID)
 	addr = book.PickAddress(0)
 	assert.NotNil(t, addr, "expected an address")
 	addr = book.PickAddress(50)
@@ -126,7 +126,7 @@ func TestAddrBookPromoteToOld(t *testing.T) {
 	// Promote half of them
 	for i, addrSrc := range randAddrs {
 		if i%2 == 0 {
-			book.MarkGood(addrSrc.addr)
+			book.MarkGood(addrSrc.addr.ID)
 		}
 	}
 
@@ -330,7 +330,7 @@ func TestAddrBookGetSelectionWithBias(t *testing.T) {
 	randAddrsLen := len(randAddrs)
 	for i, addrSrc := range randAddrs {
 		if int((float64(i)/float64(randAddrsLen))*100) >= 20 {
-			book.MarkGood(addrSrc.addr)
+			book.MarkGood(addrSrc.addr.ID)
 		}
 	}
 
@@ -569,7 +569,7 @@ func createAddrBookWithMOldAndNNewAddrs(t *testing.T, nOld, nNew int) (book *add
 	randAddrs := randNetAddressPairs(t, nOld)
 	for _, addr := range randAddrs {
 		book.AddAddress(addr.addr, addr.src)
-		book.MarkGood(addr.addr)
+		book.MarkGood(addr.addr.ID)
 	}
 
 	randAddrs = randNetAddressPairs(t, nNew)

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -539,7 +539,7 @@ func testCreateSeed(dir string, id int, knownAddrs, srcAddrs []*p2p.NetAddress) 
 			book.SetLogger(log.TestingLogger())
 			for j := 0; j < len(knownAddrs); j++ {
 				book.AddAddress(knownAddrs[j], srcAddrs[j])
-				book.MarkGood(knownAddrs[j])
+				book.MarkGood(knownAddrs[j].ID)
 			}
 			sw.SetAddrBook(book)
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -48,7 +48,7 @@ type AddrBook interface {
 	AddAddress(addr *NetAddress, src *NetAddress) error
 	AddOurAddress(*NetAddress)
 	OurAddress(*NetAddress) bool
-	MarkGood(*NetAddress)
+	MarkGood(ID)
 	RemoveAddress(*NetAddress)
 	HasAddress(*NetAddress) bool
 	Save()
@@ -385,7 +385,7 @@ func (sw *Switch) SetAddrBook(addrBook AddrBook) {
 // like contributed to consensus.
 func (sw *Switch) MarkPeerAsGood(peer Peer) {
 	if sw.addrBook != nil {
-		sw.addrBook.MarkGood(peer.SocketAddr())
+		sw.addrBook.MarkGood(peer.ID())
 	}
 }
 

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -626,7 +626,7 @@ func (book *addrBookMock) OurAddress(addr *NetAddress) bool {
 	_, ok := book.ourAddrs[addr.String()]
 	return ok
 }
-func (book *addrBookMock) MarkGood(*NetAddress) {}
+func (book *addrBookMock) MarkGood(ID) {}
 func (book *addrBookMock) HasAddress(addr *NetAddress) bool {
 	_, ok := book.addrs[addr.String()]
 	return ok

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -23,7 +23,7 @@ type mockNodeInfo struct {
 }
 
 func (ni mockNodeInfo) ID() ID                              { return ni.addr.ID }
-func (ni mockNodeInfo) NetAddress() *NetAddress             { return ni.addr }
+func (ni mockNodeInfo) NetAddress() (*NetAddress, error)    { return ni.addr, nil }
 func (ni mockNodeInfo) Validate() error                     { return nil }
 func (ni mockNodeInfo) CompatibleWith(other NodeInfo) error { return nil }
 


### PR DESCRIPTION
A prior change to address accidental DNS lookups introduced the SocketAddr on peer, which was then used to add it to the addressbook. Which in turn swallowed the self reported port of the peer, which is important on a reconnect. This change revives the NetAddress on NodeInfo which the Peer carries, but now returns an error to avoid nil dereferencing another issue observed in the past. Additionally we could potentially address #3532, yet the original problem statemenf of that issue stands.

As a drive-by optimisation `MarkAsGood` now takes only a `p2p.ID` which makes it interface a bit stricter and leaner.
