### PR TITLE
bandaid for non-deterministic clist test

### DIFF
--- a/libs/clist/clist_test.go
+++ b/libs/clist/clist_test.go
@@ -262,7 +262,7 @@ func TestWaitChan(t *testing.T) {
 			time.Sleep(time.Duration(cmn.RandIntn(25)) * time.Millisecond)
 		}
 		// apply a deterministic pause so the counter has time to catch up
-		time.Sleep(time.Duration(25) * time.Millisecond)
+		time.Sleep(25 * time.Millisecond)
 		close(done)
 	}()
 

--- a/libs/clist/clist_test.go
+++ b/libs/clist/clist_test.go
@@ -261,6 +261,8 @@ func TestWaitChan(t *testing.T) {
 			pushed++
 			time.Sleep(time.Duration(cmn.RandIntn(25)) * time.Millisecond)
 		}
+		// apply a deterministic pause so the counter has time to catch up
+		time.Sleep(time.Duration(25) * time.Millisecond)
 		close(done)
 	}()
 
@@ -273,7 +275,7 @@ FOR_LOOP:
 			next = next.Next()
 			seen++
 			if next == nil {
-				continue
+				t.Fatal("Next should not be nil when waiting on NextWaitChan")
 			}
 		case <-done:
 			break FOR_LOOP


### PR DESCRIPTION
Very simple bandaid for #2227
I think the errors are caused from a race condition in the test, not the actual `clist` data structure

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md