### PR TITLE
ci: Pin golang version to 1.12 line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/github.com/tendermint/tendermint
   docker:
-    - image: circleci/golang
+    - image: circleci/golang:1.12
   environment:
     GOBIN: /tmp/workspace/bin
 
@@ -195,7 +195,7 @@ jobs:
             name: run localnet and exit on failure
             command: |
               set -x
-              docker run --rm -v "$PWD":/go/src/github.com/tendermint/tendermint -w /go/src/github.com/tendermint/tendermint golang make build-linux
+              docker run --rm -v "$PWD":/go/src/github.com/tendermint/tendermint -w /go/src/github.com/tendermint/tendermint golang:1.12 make build-linux
               make localnet-start &
               ./scripts/localnet-blocks-test.sh 40 5 10 localhost
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,8 @@
 
 ### IMPROVEMENTS:
 - [rpc] [\#3534](https://github.com/tendermint/tendermint/pull/3534) Add support for batched requests/responses in JSON RPC
+- [circle] [\#3578](https://github.com/tendermint/tendermint/pull/3578) Pin
+  golang version to 1.12
 
 ### BUG FIXES:
 - [state] [\#3537](https://github.com/tendermint/tendermint/pull/3537#issuecomment-482711833) LoadValidators: do not return an empty validator set


### PR DESCRIPTION
We want to avoid accidental upgrades of the runtime beyond patch versions and rather delibrately upgrade once we have confidence the new minor version is stable enough to be considered for our test and build automation.

Fixes #3564 

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
