### PR TITLE
make persistent prop independent of conn direction

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -25,4 +25,8 @@
 - [state] [\#3537](https://github.com/tendermint/tendermint/pull/3537#issuecomment-482711833) LoadValidators: do not return an empty validator set
 - [p2p] \#3532 limit the number of attempts to connect to a peer in seed mode
   to 16 (as a result, the node will stop retrying after a 35 hours time window)
-- [consensus] \#2723, \#3451 and \#3317 Fix non-deterministic tests 
+- [consensus] \#2723, \#3451 and \#3317 Fix non-deterministic tests
+- [p2p] \#3362 make persistent prop independent of conn direction
+  * `Switch#DialPeersAsync` now only takes a list of peers and returns multiple errors
+  * `Switch#DialPeerWithAddress` now only takes an address
+- [rpc] \#3362 `/dial_seeds` & `/dial_peers` return errors if addresses are incorrect (except when IP lookup fails)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -29,5 +29,5 @@
   to 16 (as a result, the node will stop retrying after a 35 hours time window)
 - [consensus] \#2723, \#3451 and \#3317 Fix non-deterministic tests
 - [p2p] \#3362 make persistent prop independent of conn direction
-  * `Switch#DialPeersAsync` now only takes a list of peers and returns multiple errors
+  * `Switch#DialPeersAsync` now only takes a list of peers
   * `Switch#DialPeerWithAddress` now only takes an address

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,8 @@
 - [rpc] [\#3534](https://github.com/tendermint/tendermint/pull/3534) Add support for batched requests/responses in JSON RPC
 - [cli] [\#3160](https://github.com/tendermint/tendermint/issues/3160) Add `-config=<path-to-config>` option to `testnet` cmd (@gregdhill)
 - [cs/replay] \#3460 check appHash for each block
+- [rpc] \#3362 `/dial_seeds` & `/dial_peers` return errors if addresses are incorrect (except when IP lookup fails)
+- [node] \#3362 returns an error if `persistent_peers` list is invalid (except when IP lookup fails)
 
 ### BUG FIXES:
 - [state] [\#3537](https://github.com/tendermint/tendermint/pull/3537#issuecomment-482711833) LoadValidators: do not return an empty validator set
@@ -29,4 +31,3 @@
 - [p2p] \#3362 make persistent prop independent of conn direction
   * `Switch#DialPeersAsync` now only takes a list of peers and returns multiple errors
   * `Switch#DialPeerWithAddress` now only takes an address
-- [rpc] \#3362 `/dial_seeds` & `/dial_peers` return errors if addresses are incorrect (except when IP lookup fails)

--- a/docs/spec/p2p/config.md
+++ b/docs/spec/p2p/config.md
@@ -12,14 +12,14 @@ and upon incoming connection shares some peers and disconnects.
 
 ## Seeds
 
-`--p2p.seeds “1.2.3.4:26656,2.3.4.5:4444”`
+`--p2p.seeds “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:4444”`
 
 Dials these seeds when we need more peers. They should return a list of peers and then disconnect.
 If we already have enough peers in the address book, we may never need to dial them.
 
 ## Persistent Peers
 
-`--p2p.persistent_peers “1.2.3.4:26656,2.3.4.5:26656”`
+`--p2p.persistent_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”`
 
 Dial these peers and auto-redial them if the connection fails.
 These are intended to be trusted persistent peers that can help
@@ -30,9 +30,9 @@ backoff and will give up after a day of trying to connect.
 the user will be warned that seeds may auto-close connections
 and that the node may not be able to keep the connection persistent.
 
-## Private Persistent Peers
+## Private Peers
 
-`--p2p.private_persistent_peers “1.2.3.4:26656,2.3.4.5:26656”`
+`--p2p.private_peer_ids “id100000000000000000000000000000000,id200000000000000000000000000000000”`
 
-These are persistent peers that we do not add to the address book or
-gossip to other peers. They stay private to us.
+These are IDs of the peers that we do not add to the address book or gossip to
+other peers. They stay private to us.

--- a/node/node.go
+++ b/node/node.go
@@ -473,7 +473,7 @@ func NewNode(config *cfg.Config,
 	sw.SetNodeKey(nodeKey)
 	err = sw.AddPersistentPeers(splitAndTrimEmpty(config.P2P.PersistentPeers, ",", " "))
 	if err != nil {
-		return nil, errors.Wrap(err, "error in persistent_peers")
+		return nil, errors.Wrap(err, "could not add peers from persistent_peers config")
 	}
 
 	p2pLogger.Info("P2P Node ID", "ID", nodeKey.ID(), "file", config.NodeKeyFile())

--- a/node/node.go
+++ b/node/node.go
@@ -425,10 +425,6 @@ func createSwitch(config *cfg.Config,
 	sw.AddReactor("EVIDENCE", evidenceReactor)
 	sw.SetNodeInfo(nodeInfo)
 	sw.SetNodeKey(nodeKey)
-	err = sw.AddPersistentPeers(splitAndTrimEmpty(config.P2P.PersistentPeers, ",", " "))
-	if err != nil {
-		return nil, errors.Wrap(err, "could not add peers from persistent_peers config")
-	}
 
 	p2pLogger.Info("P2P Node ID", "ID", nodeKey.ID(), "file", config.NodeKeyFile())
 	return sw
@@ -582,6 +578,11 @@ func NewNode(config *cfg.Config,
 		config, transport, p2pMetrics, peerFilters, mempoolReactor, bcReactor,
 		consensusReactor, evidenceReactor, nodeInfo, nodeKey, p2pLogger,
 	)
+
+	err = sw.AddPersistentPeers(splitAndTrimEmpty(config.P2P.PersistentPeers, ",", " "))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not add peers from persistent_peers field")
+	}
 
 	addrBook := createAddrBookAndSetOnSwitch(config, sw, p2pLogger)
 

--- a/node/node.go
+++ b/node/node.go
@@ -471,10 +471,9 @@ func NewNode(config *cfg.Config,
 	sw.AddReactor("EVIDENCE", evidenceReactor)
 	sw.SetNodeInfo(nodeInfo)
 	sw.SetNodeKey(nodeKey)
-	errs := sw.AddPersistentPeers(splitAndTrimEmpty(config.P2P.PersistentPeers, ",", " "))
-	if len(errs) > 0 {
-		// do not bother with returning all errors at once
-		return nil, errors.Wrap(errs[0], "error in persistent_peers")
+	err = sw.AddPersistentPeers(splitAndTrimEmpty(config.P2P.PersistentPeers, ",", " "))
+	if err != nil {
+		return nil, errors.Wrap(err, "error in persistent_peers")
 	}
 
 	p2pLogger.Info("P2P Node ID", "ID", nodeKey.ID(), "file", config.NodeKeyFile())

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -531,8 +531,7 @@ func (r *PEXReactor) dialPeer(addr *p2p.NetAddress) error {
 		}
 	}
 
-	err := r.Switch.DialPeerWithAddress(addr, false)
-
+	err := r.Switch.DialPeerWithAddress(addr)
 	if err != nil {
 		if _, ok := err.(p2p.ErrCurrentlyDialingOrExistingAddress); ok {
 			return err
@@ -584,7 +583,7 @@ func (r *PEXReactor) dialSeeds() {
 	for _, i := range perm {
 		// dial a random seed
 		seedAddr := r.seedAddrs[i]
-		err := r.Switch.DialPeerWithAddress(seedAddr, false)
+		err := r.Switch.DialPeerWithAddress(seedAddr)
 		if err == nil {
 			return
 		}

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -398,7 +398,7 @@ func TestPEXReactorSeedModeFlushStop(t *testing.T) {
 	reactor := switches[0].Reactors()["pex"].(*PEXReactor)
 	peerID := switches[1].NodeInfo().ID()
 
-	err = switches[1].DialPeerWithAddress(switches[0].NetAddress(), false)
+	err = switches[1].DialPeerWithAddress(switches[0].NetAddress())
 	assert.NoError(t, err)
 
 	// sleep up to a second while waiting for the peer to send us a message.

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -343,8 +343,8 @@ func TestPEXReactorDoesNotDisconnectFromPersistentPeerInSeedMode(t *testing.T) {
 	require.NoError(t, peerSwitch.Start())
 	defer peerSwitch.Stop()
 
-	errs := sw.AddPersistentPeers([]string{peerSwitch.NetAddress().String()})
-	require.Empty(t, errs)
+	err = sw.AddPersistentPeers([]string{peerSwitch.NetAddress().String()})
+	require.NoError(t, err)
 
 	// 1. Test crawlPeers dials the peer
 	pexR.crawlPeers([]*p2p.NetAddress{peerSwitch.NetAddress()})

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -291,7 +291,8 @@ func TestPEXReactorSeedMode(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
-	pexR, book := createReactor(&PEXReactorConfig{SeedMode: true, SeedDisconnectWaitPeriod: 10 * time.Millisecond})
+	pexRConfig := &PEXReactorConfig{SeedMode: true, SeedDisconnectWaitPeriod: 10 * time.Millisecond}
+	pexR, book := createReactor(pexRConfig)
 	defer teardownReactor(book)
 
 	sw := createSwitchAndAddReactors(pexR)
@@ -315,7 +316,8 @@ func TestPEXReactorSeedMode(t *testing.T) {
 	pexR.attemptDisconnects()
 	assert.Equal(t, 1, sw.Peers().Size())
 
-	time.Sleep(100 * time.Millisecond)
+	// sleep for SeedDisconnectWaitPeriod
+	time.Sleep(pexRConfig.SeedDisconnectWaitPeriod + 1*time.Millisecond)
 
 	// 3. attemptDisconnects should disconnect after wait period
 	pexR.attemptDisconnects()
@@ -350,8 +352,6 @@ func TestPEXReactorDoesNotDisconnectFromPersistentPeerInSeedMode(t *testing.T) {
 	pexR.crawlPeers([]*p2p.NetAddress{peerSwitch.NetAddress()})
 	assert.Equal(t, 1, sw.Peers().Size())
 	assert.True(t, sw.Peers().Has(peerSwitch.NodeInfo().ID()))
-
-	time.Sleep(10 * time.Millisecond)
 
 	// 2. attemptDisconnects should not disconnect because the peer is persistent
 	pexR.attemptDisconnects()

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -656,7 +656,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 
 		// retry persistent peers after
 		// any dial error besides IsSelf()
-		if p.IsPersistent() {
+		if sw.isPeerPersistentFn()(addr) {
 			go sw.reconnectToPeer(addr)
 		}
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -77,6 +77,8 @@ type Switch struct {
 	nodeInfo     NodeInfo // our node info
 	nodeKey      *NodeKey // our node privkey
 	addrBook     AddrBook
+	// peers addresses with whom we'll maintain constant connection
+	persistentPeersAddrs []*NetAddress
 
 	transport Transport
 
@@ -104,16 +106,17 @@ func NewSwitch(
 	options ...SwitchOption,
 ) *Switch {
 	sw := &Switch{
-		config:        cfg,
-		reactors:      make(map[string]Reactor),
-		chDescs:       make([]*conn.ChannelDescriptor, 0),
-		reactorsByCh:  make(map[byte]Reactor),
-		peers:         NewPeerSet(),
-		dialing:       cmn.NewCMap(),
-		reconnecting:  cmn.NewCMap(),
-		metrics:       NopMetrics(),
-		transport:     transport,
-		filterTimeout: defaultFilterTimeout,
+		config:               cfg,
+		reactors:             make(map[string]Reactor),
+		chDescs:              make([]*conn.ChannelDescriptor, 0),
+		reactorsByCh:         make(map[byte]Reactor),
+		peers:                NewPeerSet(),
+		dialing:              cmn.NewCMap(),
+		reconnecting:         cmn.NewCMap(),
+		metrics:              NopMetrics(),
+		transport:            transport,
+		filterTimeout:        defaultFilterTimeout,
+		persistentPeersAddrs: make([]*NetAddress, 0),
 	}
 
 	// Ensure we have a completely undeterministic PRNG.
@@ -341,7 +344,7 @@ func (sw *Switch) reconnectToPeer(addr *NetAddress) {
 			return
 		}
 
-		err := sw.DialPeerWithAddress(addr, true)
+		err := sw.DialPeerWithAddress(addr)
 		if err == nil {
 			return // success
 		} else if _, ok := err.(ErrCurrentlyDialingOrExistingAddress); ok {
@@ -365,7 +368,7 @@ func (sw *Switch) reconnectToPeer(addr *NetAddress) {
 		sleepIntervalSeconds := math.Pow(reconnectBackOffBaseSeconds, float64(i))
 		sw.randomSleep(time.Duration(sleepIntervalSeconds) * time.Second)
 
-		err := sw.DialPeerWithAddress(addr, true)
+		err := sw.DialPeerWithAddress(addr)
 		if err == nil {
 			return // success
 		} else if _, ok := err.(ErrCurrentlyDialingOrExistingAddress); ok {
@@ -401,28 +404,37 @@ func isPrivateAddr(err error) bool {
 	return ok && te.PrivateAddr()
 }
 
-// DialPeersAsync dials a list of peers asynchronously in random order (optionally, making them persistent).
+// DialPeersAsync dials a list of peers asynchronously in random order.
 // Used to dial peers from config on startup or from unsafe-RPC (trusted sources).
-// TODO: remove addrBook arg since it's now set on the switch
-func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent bool) error {
+// ErrNetAddressLookup errors are ignored. However, if there are other errors,
+// all of them are returned.
+// Nop if there are no peers.
+func (sw *Switch) DialPeersAsync(peers []string) []error {
 	netAddrs, errs := NewNetAddressStrings(peers)
-	// only log errors, dial correct addresses
 	for _, err := range errs {
 		sw.Logger.Error("Error in peer's address", "err", err)
+		if _, ok := err.(ErrNetAddressLookup); ok {
+			continue
+		}
+		return errs
 	}
+	sw.dialPeersAsync(netAddrs)
+	return []error{}
+}
 
+func (sw *Switch) dialPeersAsync(netAddrs []*NetAddress) {
 	ourAddr := sw.NetAddress()
 
 	// TODO: this code feels like it's in the wrong place.
 	// The integration tests depend on the addrBook being saved
 	// right away but maybe we can change that. Recall that
 	// the addrBook is only written to disk every 2min
-	if addrBook != nil {
+	if sw.addrBook != nil {
 		// add peers to `addrBook`
 		for _, netAddr := range netAddrs {
 			// do not add our address or ID
 			if !netAddr.Same(ourAddr) {
-				if err := addrBook.AddAddress(netAddr, ourAddr); err != nil {
+				if err := sw.addrBook.AddAddress(netAddr, ourAddr); err != nil {
 					if isPrivateAddr(err) {
 						sw.Logger.Debug("Won't add peer's address to addrbook", "err", err)
 					} else {
@@ -433,7 +445,7 @@ func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent b
 		}
 		// Persist some peers to disk right away.
 		// NOTE: integration tests depend on this
-		addrBook.Save()
+		sw.addrBook.Save()
 	}
 
 	// permute the list, dial them in random order.
@@ -450,7 +462,7 @@ func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent b
 
 			sw.randomSleep(0)
 
-			err := sw.DialPeerWithAddress(addr, persistent)
+			err := sw.DialPeerWithAddress(addr)
 			if err != nil {
 				switch err.(type) {
 				case ErrSwitchConnectToSelf, ErrSwitchDuplicatePeerID, ErrCurrentlyDialingOrExistingAddress:
@@ -461,16 +473,13 @@ func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent b
 			}
 		}(i)
 	}
-	return nil
 }
 
 // DialPeerWithAddress dials the given peer and runs sw.addPeer if it connects
 // and authenticates successfully.
-// If `persistent == true`, the switch will always try to reconnect to this
-// peer if the connection ever fails.
 // If we're currently dialing this address or it belongs to an existing peer,
 // ErrCurrentlyDialingOrExistingAddress is returned.
-func (sw *Switch) DialPeerWithAddress(addr *NetAddress, persistent bool) error {
+func (sw *Switch) DialPeerWithAddress(addr *NetAddress) error {
 	if sw.IsDialingOrExistingAddress(addr) {
 		return ErrCurrentlyDialingOrExistingAddress{addr.String()}
 	}
@@ -478,7 +487,7 @@ func (sw *Switch) DialPeerWithAddress(addr *NetAddress, persistent bool) error {
 	sw.dialing.Set(string(addr.ID), addr)
 	defer sw.dialing.Delete(string(addr.ID))
 
-	return sw.addOutboundPeerWithConfig(addr, sw.config, persistent)
+	return sw.addOutboundPeerWithConfig(addr, sw.config)
 }
 
 // sleep for interval plus some random amount of ms on [0, dialRandomizerIntervalMilliseconds]
@@ -495,6 +504,34 @@ func (sw *Switch) IsDialingOrExistingAddress(addr *NetAddress) bool {
 		(!sw.config.AllowDuplicateIP && sw.peers.HasIP(addr.IP))
 }
 
+// AddPersistentPeers allows you to set persistent peers. If there's an error
+// in any of the given addrs, it will be returned along with other errors.
+// ErrNetAddressLookup errors are ignored. However, if there are other errors,
+// all of them are returned.
+func (sw *Switch) AddPersistentPeers(addrs []string) []error {
+	netAddrs, errs := NewNetAddressStrings(addrs)
+	for _, err := range errs {
+		sw.Logger.Error("Error in peer's address", "err", err)
+		if _, ok := err.(ErrNetAddressLookup); ok {
+			continue
+		}
+		return errs
+	}
+	sw.persistentPeersAddrs = netAddrs
+	return []error{}
+}
+
+func (sw *Switch) isPeerPersistentFn() func(*NetAddress) bool {
+	return func(na *NetAddress) bool {
+		for _, pa := range sw.persistentPeersAddrs {
+			if pa.Equals(na) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 func (sw *Switch) acceptRoutine() {
 	for {
 		p, err := sw.transport.Accept(peerConfig{
@@ -502,6 +539,7 @@ func (sw *Switch) acceptRoutine() {
 			onPeerError:  sw.StopPeerForError,
 			reactorsByCh: sw.reactorsByCh,
 			metrics:      sw.metrics,
+			isPersistent: sw.isPeerPersistentFn(),
 		})
 		if err != nil {
 			switch err := err.(type) {
@@ -583,11 +621,10 @@ func (sw *Switch) acceptRoutine() {
 // add the peer.
 // if dialing fails, start the reconnect loop. If handhsake fails, its over.
 // If peer is started succesffuly, reconnectLoop will start when
-// StopPeerForError is called
+// StopPeerForError is called.
 func (sw *Switch) addOutboundPeerWithConfig(
 	addr *NetAddress,
 	cfg *config.P2PConfig,
-	persistent bool,
 ) error {
 	sw.Logger.Info("Dialing peer", "address", addr)
 
@@ -600,7 +637,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 	p, err := sw.transport.Dial(*addr, peerConfig{
 		chDescs:      sw.chDescs,
 		onPeerError:  sw.StopPeerForError,
-		persistent:   persistent,
+		isPersistent: sw.isPeerPersistentFn(),
 		reactorsByCh: sw.reactorsByCh,
 		metrics:      sw.metrics,
 	})
@@ -619,7 +656,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 
 		// retry persistent peers after
 		// any dial error besides IsSelf()
-		if persistent {
+		if p.IsPersistent() {
 			go sw.reconnectToPeer(addr)
 		}
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -639,8 +639,8 @@ func (sw *Switch) acceptRoutine() {
 
 // dial the peer; make secret connection; authenticate against the dialed ID;
 // add the peer.
-// if dialing fails, start the reconnect loop. If handhsake fails, its over.
-// If peer is started succesffuly, reconnectLoop will start when
+// if dialing fails, start the reconnect loop. If handshake fails, it's over.
+// If peer is started successfully, reconnectLoop will start when
 // StopPeerForError is called.
 func (sw *Switch) addOutboundPeerWithConfig(
 	addr *NetAddress,

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -394,49 +394,33 @@ func TestSwitchStopPeerForError(t *testing.T) {
 	assert.EqualValues(t, 0, peersMetricValue())
 }
 
-func TestSwitchReconnectsToPersistentPeer(t *testing.T) {
-	assert, require := assert.New(t), require.New(t)
-
+func TestSwitchReconnectsToOutboundPersistentPeer(t *testing.T) {
 	sw := MakeSwitch(cfg, 1, "testing", "123.123.123", initSwitchFunc)
 	err := sw.Start()
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	defer sw.Stop()
 
-	// simulate remote peer
+	// 1. simulate failure by closing connection
 	rp := &remotePeer{PrivKey: ed25519.GenPrivKey(), Config: cfg}
 	rp.Start()
 	defer rp.Stop()
 
-	p, err := sw.transport.Dial(*rp.Addr(), peerConfig{
-		chDescs:      sw.chDescs,
-		onPeerError:  sw.StopPeerForError,
-		isPersistent: func(*NetAddress) bool { return true },
-		reactorsByCh: sw.reactorsByCh,
-	})
-	require.Nil(err)
+	errs := sw.AddPersistentPeers([]string{rp.Addr().String()})
+	require.Empty(t, errs)
 
-	require.Nil(sw.addPeer(p))
+	err = sw.DialPeerWithAddress(rp.Addr())
+	require.Nil(t, err)
+	time.Sleep(50 * time.Millisecond)
+	require.NotNil(t, sw.Peers().Get(rp.ID()))
 
-	require.NotNil(sw.Peers().Get(rp.ID()))
-
-	// simulate failure by closing connection
+	p := sw.Peers().List()[0]
 	p.(*peer).CloseConn()
 
-	// TODO: remove sleep, detect the disconnection, wait for reconnect
-	npeers := sw.Peers().Size()
-	for i := 0; i < 20; i++ {
-		time.Sleep(250 * time.Millisecond)
-		npeers = sw.Peers().Size()
-		if npeers > 0 {
-			break
-		}
-	}
-	assert.NotZero(npeers)
-	assert.False(p.IsRunning())
+	waitUntilSwitchHasAtLeastNPeers(sw, 1)
+	assert.False(t, p.IsRunning())        // old peer instance
+	assert.Equal(t, 1, sw.Peers().Size()) // new peer instance
 
-	// simulate another remote peer
+	// 2. simulate first time dial failure
 	rp = &remotePeer{
 		PrivKey: ed25519.GenPrivKey(),
 		Config:  cfg,
@@ -447,23 +431,48 @@ func TestSwitchReconnectsToPersistentPeer(t *testing.T) {
 	rp.Start()
 	defer rp.Stop()
 
-	// simulate first time dial failure
 	conf := config.DefaultP2PConfig()
 	conf.TestDialFail = true
 	err = sw.addOutboundPeerWithConfig(rp.Addr(), conf)
-	require.NotNil(err)
-
+	require.NotNil(t, err)
 	// DialPeerWithAddres - sw.peerConfig resets the dialer
+	waitUntilSwitchHasAtLeastNPeers(sw, 2)
+	assert.Equal(t, 2, sw.Peers().Size())
+}
 
-	// TODO: same as above
+func TestSwitchReconnectsToInboundPersistentPeer(t *testing.T) {
+	sw := MakeSwitch(cfg, 1, "testing", "123.123.123", initSwitchFunc)
+	err := sw.Start()
+	require.NoError(t, err)
+	defer sw.Stop()
+
+	// 1. simulate failure by closing the connection
+	rp := &remotePeer{PrivKey: ed25519.GenPrivKey(), Config: cfg}
+	rp.Start()
+	defer rp.Stop()
+
+	errs := sw.AddPersistentPeers([]string{rp.Addr().String()})
+	require.Empty(t, errs)
+
+	conn, err := rp.Dial(sw.NetAddress())
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+	require.NotNil(t, sw.Peers().Get(rp.ID()))
+
+	conn.Close()
+
+	waitUntilSwitchHasAtLeastNPeers(sw, 1)
+	assert.Equal(t, 1, sw.Peers().Size())
+}
+
+func waitUntilSwitchHasAtLeastNPeers(sw *Switch, n int) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(250 * time.Millisecond)
-		npeers = sw.Peers().Size()
-		if npeers > 1 {
+		has := sw.Peers().Size()
+		if has >= n {
 			break
 		}
 	}
-	assert.EqualValues(2, npeers)
 }
 
 func TestSwitchFullConnectivity(t *testing.T) {

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -465,6 +465,26 @@ func TestSwitchReconnectsToInboundPersistentPeer(t *testing.T) {
 	assert.Equal(t, 1, sw.Peers().Size())
 }
 
+func TestSwitchDialPeersAsync(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	sw := MakeSwitch(cfg, 1, "testing", "123.123.123", initSwitchFunc)
+	err := sw.Start()
+	require.NoError(t, err)
+	defer sw.Stop()
+
+	rp := &remotePeer{PrivKey: ed25519.GenPrivKey(), Config: cfg}
+	rp.Start()
+	defer rp.Stop()
+
+	errs := sw.DialPeersAsync([]string{rp.Addr().String()})
+	require.Empty(t, errs)
+	time.Sleep(dialRandomizerIntervalMilliseconds * time.Millisecond)
+	require.NotNil(t, sw.Peers().Get(rp.ID()))
+}
+
 func waitUntilSwitchHasAtLeastNPeers(sw *Switch, n int) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(250 * time.Millisecond)

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -405,8 +405,8 @@ func TestSwitchReconnectsToOutboundPersistentPeer(t *testing.T) {
 	rp.Start()
 	defer rp.Stop()
 
-	errs := sw.AddPersistentPeers([]string{rp.Addr().String()})
-	require.Empty(t, errs)
+	err = sw.AddPersistentPeers([]string{rp.Addr().String()})
+	require.NoError(t, err)
 
 	err = sw.DialPeerWithAddress(rp.Addr())
 	require.Nil(t, err)
@@ -451,8 +451,8 @@ func TestSwitchReconnectsToInboundPersistentPeer(t *testing.T) {
 	rp.Start()
 	defer rp.Stop()
 
-	errs := sw.AddPersistentPeers([]string{rp.Addr().String()})
-	require.Empty(t, errs)
+	err = sw.AddPersistentPeers([]string{rp.Addr().String()})
+	require.NoError(t, err)
 
 	conn, err := rp.Dial(sw.NetAddress())
 	require.NoError(t, err)
@@ -479,8 +479,8 @@ func TestSwitchDialPeersAsync(t *testing.T) {
 	rp.Start()
 	defer rp.Stop()
 
-	errs := sw.DialPeersAsync([]string{rp.Addr().String()})
-	require.Empty(t, errs)
+	err = sw.DialPeersAsync([]string{rp.Addr().String()})
+	require.NoError(t, err)
 	time.Sleep(dialRandomizerIntervalMilliseconds * time.Millisecond)
 	require.NotNil(t, sw.Peers().Get(rp.ID()))
 }

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -167,7 +167,7 @@ func TestSwitchFiltersOutItself(t *testing.T) {
 	rp.Start()
 
 	// addr should be rejected in addPeer based on the same ID
-	err := s1.DialPeerWithAddress(rp.Addr(), false)
+	err := s1.DialPeerWithAddress(rp.Addr())
 	if assert.Error(t, err) {
 		if err, ok := err.(ErrRejected); ok {
 			if !err.IsSelf() {
@@ -212,6 +212,7 @@ func TestSwitchPeerFilter(t *testing.T) {
 	p, err := sw.transport.Dial(*rp.Addr(), peerConfig{
 		chDescs:      sw.chDescs,
 		onPeerError:  sw.StopPeerForError,
+		isPersistent: sw.isPeerPersistentFn(),
 		reactorsByCh: sw.reactorsByCh,
 	})
 	if err != nil {
@@ -256,6 +257,7 @@ func TestSwitchPeerFilterTimeout(t *testing.T) {
 	p, err := sw.transport.Dial(*rp.Addr(), peerConfig{
 		chDescs:      sw.chDescs,
 		onPeerError:  sw.StopPeerForError,
+		isPersistent: sw.isPeerPersistentFn(),
 		reactorsByCh: sw.reactorsByCh,
 	})
 	if err != nil {
@@ -281,6 +283,7 @@ func TestSwitchPeerFilterDuplicate(t *testing.T) {
 	p, err := sw.transport.Dial(*rp.Addr(), peerConfig{
 		chDescs:      sw.chDescs,
 		onPeerError:  sw.StopPeerForError,
+		isPersistent: sw.isPeerPersistentFn(),
 		reactorsByCh: sw.reactorsByCh,
 	})
 	if err != nil {
@@ -326,6 +329,7 @@ func TestSwitchStopsNonPersistentPeerOnError(t *testing.T) {
 	p, err := sw.transport.Dial(*rp.Addr(), peerConfig{
 		chDescs:      sw.chDescs,
 		onPeerError:  sw.StopPeerForError,
+		isPersistent: sw.isPeerPersistentFn(),
 		reactorsByCh: sw.reactorsByCh,
 	})
 	require.Nil(err)
@@ -408,7 +412,7 @@ func TestSwitchReconnectsToPersistentPeer(t *testing.T) {
 	p, err := sw.transport.Dial(*rp.Addr(), peerConfig{
 		chDescs:      sw.chDescs,
 		onPeerError:  sw.StopPeerForError,
-		persistent:   true,
+		isPersistent: func(*NetAddress) bool { return true },
 		reactorsByCh: sw.reactorsByCh,
 	})
 	require.Nil(err)
@@ -446,7 +450,7 @@ func TestSwitchReconnectsToPersistentPeer(t *testing.T) {
 	// simulate first time dial failure
 	conf := config.DefaultP2PConfig()
 	conf.TestDialFail = true
-	err = sw.addOutboundPeerWithConfig(rp.Addr(), conf, true)
+	err = sw.addOutboundPeerWithConfig(rp.Addr(), conf)
 	require.NotNil(err)
 
 	// DialPeerWithAddres - sw.peerConfig resets the dialer

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -37,9 +37,9 @@ type accept struct {
 // events.
 // TODO(xla): Refactor out with more static Reactor setup and PeerBehaviour.
 type peerConfig struct {
-	chDescs      []*conn.ChannelDescriptor
-	onPeerError  func(Peer, interface{})
-	outbound     bool
+	chDescs     []*conn.ChannelDescriptor
+	onPeerError func(Peer, interface{})
+	outbound    bool
 	// isPersistent allows you to set a function, which, given socket address
 	// (for outbound peers) OR self-reported address (for inbound peers), tells
 	// if the peer is persistent or not.

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -185,10 +185,8 @@ func UnsafeDialSeeds(ctx *rpctypes.Context, seeds []string) (*ctypes.ResultDialS
 		return &ctypes.ResultDialSeeds{}, errors.New("No seeds provided")
 	}
 	logger.Info("DialSeeds", "seeds", seeds)
-	errs := p2pPeers.DialPeersAsync(seeds)
-	if len(errs) > 0 {
-		// do not bother with returning all errors at once
-		return &ctypes.ResultDialSeeds{}, errs[0]
+	if err := p2pPeers.DialPeersAsync(seeds); err != nil {
+		return &ctypes.ResultDialSeeds{}, err
 	}
 	return &ctypes.ResultDialSeeds{Log: "Dialing seeds in progress. See /net_info for details"}, nil
 }
@@ -198,10 +196,8 @@ func UnsafeDialPeers(ctx *rpctypes.Context, peers []string, persistent bool) (*c
 		return &ctypes.ResultDialPeers{}, errors.New("No peers provided")
 	}
 	logger.Info("DialPeers", "peers", peers, "persistent", persistent)
-	errs := p2pPeers.AddPersistentPeers(peers)
-	if len(errs) > 0 {
-		// do not bother with returning all errors at once
-		return &ctypes.ResultDialPeers{}, errs[0]
+	if err := p2pPeers.AddPersistentPeers(peers); err != nil {
+		return &ctypes.ResultDialPeers{}, err
 	}
 	// parsing errors are handled above by AddPersistentPeers
 	_ = p2pPeers.DialPeersAsync(peers)

--- a/rpc/core/net_test.go
+++ b/rpc/core/net_test.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/p2p"
+	rpctypes "github.com/tendermint/tendermint/rpc/lib/types"
+)
+
+func TestUnsafeDialSeeds(t *testing.T) {
+	sw := p2p.MakeSwitch(cfg.DefaultP2PConfig(), 1, "testing", "123.123.123",
+		func(n int, sw *p2p.Switch) *p2p.Switch { return sw })
+	err := sw.Start()
+	require.NoError(t, err)
+	defer sw.Stop()
+
+	logger = log.TestingLogger()
+	p2pPeers = sw
+
+	testCases := []struct {
+		seeds []string
+		isErr bool
+	}{
+		{[]string{}, true},
+		{[]string{"d51fb70907db1c6c2d5237e78379b25cf1a37ab4@127.0.0.1:41198"}, false},
+		{[]string{"127.0.0.1:41198"}, true},
+	}
+
+	for _, tc := range testCases {
+		res, err := UnsafeDialSeeds(&rpctypes.Context{}, tc.seeds)
+		if tc.isErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.NotNil(t, res)
+		}
+	}
+}
+
+func TestUnsafeDialPeers(t *testing.T) {
+	sw := p2p.MakeSwitch(cfg.DefaultP2PConfig(), 1, "testing", "123.123.123",
+		func(n int, sw *p2p.Switch) *p2p.Switch { return sw })
+	err := sw.Start()
+	require.NoError(t, err)
+	defer sw.Stop()
+
+	logger = log.TestingLogger()
+	p2pPeers = sw
+
+	testCases := []struct {
+		peers []string
+		isErr bool
+	}{
+		{[]string{}, true},
+		{[]string{"d51fb70907db1c6c2d5237e78379b25cf1a37ab4@127.0.0.1:41198"}, false},
+		{[]string{"127.0.0.1:41198"}, true},
+	}
+
+	for _, tc := range testCases {
+		res, err := UnsafeDialPeers(&rpctypes.Context{}, tc.peers, false)
+		if tc.isErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.NotNil(t, res)
+		}
+	}
+}

--- a/rpc/core/pipe.go
+++ b/rpc/core/pipe.go
@@ -44,8 +44,8 @@ type transport interface {
 }
 
 type peers interface {
-	AddPersistentPeers([]string) []error
-	DialPeersAsync([]string) []error
+	AddPersistentPeers([]string) error
+	DialPeersAsync([]string) error
 	NumPeers() (outbound, inbound, dialig int)
 	Peers() p2p.IPeerSet
 }

--- a/rpc/core/pipe.go
+++ b/rpc/core/pipe.go
@@ -44,7 +44,8 @@ type transport interface {
 }
 
 type peers interface {
-	DialPeersAsync(p2p.AddrBook, []string, bool) error
+	AddPersistentPeers([]string) []error
+	DialPeersAsync([]string) []error
 	NumPeers() (outbound, inbound, dialig int)
 	Peers() p2p.IPeerSet
 }


### PR DESCRIPTION
Previously only outbound peers can be persistent. 

Now, even if the peer is inbound, if it's marked as persistent, when/if conn is lost,
Tendermint will try to reconnect. **This part is actually optional and can be reverted.**

Plus, seed won't disconnect from inbound peer if it's marked as
persistent. Fixes #3362

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
