### PR TITLE
Remove deprecated PanicXXX functions from codebase

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,7 @@
 * Apps
 
 * Go API
+- [libs/common] Removed PanicSanity, PanicCrisis, PanicConsensus and PanicQ
 
 * Blockchain Protocol
 
@@ -25,4 +26,4 @@
 - [state] [\#3537](https://github.com/tendermint/tendermint/pull/3537#issuecomment-482711833) LoadValidators: do not return an empty validator set
 - [p2p] \#3532 limit the number of attempts to connect to a peer in seed mode
   to 16 (as a result, the node will stop retrying after a 35 hours time window)
-- [consensus] \#2723, \#3451 and \#3317 Fix non-deterministic tests 
+- [consensus] \#2723, \#3451 and \#3317 Fix non-deterministic tests

--- a/blockchain/store.go
+++ b/blockchain/store.go
@@ -144,14 +144,14 @@ func (bs *BlockStore) LoadSeenCommit(height int64) *types.Commit {
 //             most recent height.  Otherwise they'd stall at H-1.
 func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) {
 	if block == nil {
-		cmn.PanicSanity("BlockStore can only save a non-nil block")
+		panic("BlockStore can only save a non-nil block")
 	}
 	height := block.Height
 	if g, w := height, bs.Height()+1; g != w {
-		cmn.PanicSanity(fmt.Sprintf("BlockStore can only save contiguous blocks. Wanted %v, got %v", w, g))
+		panic(fmt.Sprintf("BlockStore can only save contiguous blocks. Wanted %v, got %v", w, g))
 	}
 	if !blockParts.IsComplete() {
-		cmn.PanicSanity(fmt.Sprintf("BlockStore can only save complete block part sets"))
+		panic(fmt.Sprintf("BlockStore can only save complete block part sets"))
 	}
 
 	// Save block meta
@@ -188,7 +188,7 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 
 func (bs *BlockStore) saveBlockPart(height int64, index int, part *types.Part) {
 	if height != bs.Height()+1 {
-		cmn.PanicSanity(fmt.Sprintf("BlockStore can only save contiguous blocks. Wanted %v, got %v", bs.Height()+1, height))
+		panic(fmt.Sprintf("BlockStore can only save contiguous blocks. Wanted %v, got %v", bs.Height()+1, height))
 	}
 	partBytes := cdc.MustMarshalBinaryBare(part)
 	bs.db.Set(calcBlockPartKey(height, index), partBytes)
@@ -224,7 +224,7 @@ type BlockStoreStateJSON struct {
 func (bsj BlockStoreStateJSON) Save(db dbm.DB) {
 	bytes, err := cdc.MarshalJSON(bsj)
 	if err != nil {
-		cmn.PanicSanity(fmt.Sprintf("Could not marshal state bytes: %v", err))
+		panic(fmt.Sprintf("Could not marshal state bytes: %v", err))
 	}
 	db.SetSync(blockStoreKey, bytes)
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -28,13 +28,13 @@ func init() {
 // and panics if it fails.
 func EnsureRoot(rootDir string) {
 	if err := cmn.EnsureDir(rootDir, DefaultDirPerm); err != nil {
-		cmn.PanicSanity(err.Error())
+		panic(err.Error())
 	}
 	if err := cmn.EnsureDir(filepath.Join(rootDir, defaultConfigDir), DefaultDirPerm); err != nil {
-		cmn.PanicSanity(err.Error())
+		panic(err.Error())
 	}
 	if err := cmn.EnsureDir(filepath.Join(rootDir, defaultDataDir), DefaultDirPerm); err != nil {
-		cmn.PanicSanity(err.Error())
+		panic(err.Error())
 	}
 
 	configFilePath := filepath.Join(rootDir, defaultConfigFilePath)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -491,7 +491,7 @@ OUTER_LOOP:
 			if prs.ProposalBlockParts == nil {
 				blockMeta := conR.conS.blockStore.LoadBlockMeta(prs.Height)
 				if blockMeta == nil {
-					cmn.PanicCrisis(fmt.Sprintf("Failed to load block %d when blockStore is at %d",
+					panic(fmt.Sprintf("Failed to load block %d when blockStore is at %d",
 						prs.Height, conR.conS.blockStore.Height()))
 				}
 				ps.InitProposalBlockParts(blockMeta.BlockID.PartsHeader)
@@ -1110,7 +1110,7 @@ func (ps *PeerState) ensureCatchupCommitRound(height int64, round int, numValida
 		NOTE: This is wrong, 'round' could change.
 		e.g. if orig round is not the same as block LastCommit round.
 		if ps.CatchupCommitRound != -1 && ps.CatchupCommitRound != round {
-			cmn.PanicSanity(fmt.Sprintf("Conflicting CatchupCommitRound. Height: %v, Orig: %v, New: %v", height, ps.CatchupCommitRound, round))
+			panic(fmt.Sprintf("Conflicting CatchupCommitRound. Height: %v, Orig: %v, New: %v", height, ps.CatchupCommitRound, round))
 		}
 	*/
 	if ps.PRS.CatchupCommitRound == round {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -491,11 +491,11 @@ func (cs *ConsensusState) reconstructLastCommit(state sm.State) {
 		}
 		added, err := lastPrecommits.AddVote(seenCommit.ToVote(precommit))
 		if !added || err != nil {
-			cmn.PanicCrisis(fmt.Sprintf("Failed to reconstruct LastCommit: %v", err))
+			panic(fmt.Sprintf("Failed to reconstruct LastCommit: %v", err))
 		}
 	}
 	if !lastPrecommits.HasTwoThirdsMajority() {
-		cmn.PanicSanity("Failed to reconstruct LastCommit: Does not have +2/3 maj")
+		panic("Failed to reconstruct LastCommit: Does not have +2/3 maj")
 	}
 	cs.LastCommit = lastPrecommits
 }
@@ -504,13 +504,13 @@ func (cs *ConsensusState) reconstructLastCommit(state sm.State) {
 // The round becomes 0 and cs.Step becomes cstypes.RoundStepNewHeight.
 func (cs *ConsensusState) updateToState(state sm.State) {
 	if cs.CommitRound > -1 && 0 < cs.Height && cs.Height != state.LastBlockHeight {
-		cmn.PanicSanity(fmt.Sprintf("updateToState() expected state height of %v but found %v",
+		panic(fmt.Sprintf("updateToState() expected state height of %v but found %v",
 			cs.Height, state.LastBlockHeight))
 	}
 	if !cs.state.IsEmpty() && cs.state.LastBlockHeight+1 != cs.Height {
 		// This might happen when someone else is mutating cs.state.
 		// Someone forgot to pass in state.Copy() somewhere?!
-		cmn.PanicSanity(fmt.Sprintf("Inconsistent cs.state.LastBlockHeight+1 %v vs cs.Height %v",
+		panic(fmt.Sprintf("Inconsistent cs.state.LastBlockHeight+1 %v vs cs.Height %v",
 			cs.state.LastBlockHeight+1, cs.Height))
 	}
 
@@ -530,7 +530,7 @@ func (cs *ConsensusState) updateToState(state sm.State) {
 	lastPrecommits := (*types.VoteSet)(nil)
 	if cs.CommitRound > -1 && cs.Votes != nil {
 		if !cs.Votes.Precommits(cs.CommitRound).HasTwoThirdsMajority() {
-			cmn.PanicSanity("updateToState(state) called but last Precommit round didn't have +2/3")
+			panic("updateToState(state) called but last Precommit round didn't have +2/3")
 		}
 		lastPrecommits = cs.Votes.Precommits(cs.CommitRound)
 	}
@@ -1047,7 +1047,7 @@ func (cs *ConsensusState) enterPrevoteWait(height int64, round int) {
 		return
 	}
 	if !cs.Votes.Prevotes(round).HasTwoThirdsAny() {
-		cmn.PanicSanity(fmt.Sprintf("enterPrevoteWait(%v/%v), but Prevotes does not have any +2/3 votes", height, round))
+		panic(fmt.Sprintf("enterPrevoteWait(%v/%v), but Prevotes does not have any +2/3 votes", height, round))
 	}
 	logger.Info(fmt.Sprintf("enterPrevoteWait(%v/%v). Current: %v/%v/%v", height, round, cs.Height, cs.Round, cs.Step))
 
@@ -1103,7 +1103,7 @@ func (cs *ConsensusState) enterPrecommit(height int64, round int) {
 	// the latest POLRound should be this round.
 	polRound, _ := cs.Votes.POLInfo()
 	if polRound < round {
-		cmn.PanicSanity(fmt.Sprintf("This POLRound should be %v but got %v", round, polRound))
+		panic(fmt.Sprintf("This POLRound should be %v but got %v", round, polRound))
 	}
 
 	// +2/3 prevoted nil. Unlock and precommit nil.
@@ -1137,7 +1137,7 @@ func (cs *ConsensusState) enterPrecommit(height int64, round int) {
 		logger.Info("enterPrecommit: +2/3 prevoted proposal block. Locking", "hash", blockID.Hash)
 		// Validate the block.
 		if err := cs.blockExec.ValidateBlock(cs.state, cs.ProposalBlock); err != nil {
-			cmn.PanicConsensus(fmt.Sprintf("enterPrecommit: +2/3 prevoted for an invalid block: %v", err))
+			panic(fmt.Sprintf("enterPrecommit: +2/3 prevoted for an invalid block: %v", err))
 		}
 		cs.LockedRound = round
 		cs.LockedBlock = cs.ProposalBlock
@@ -1175,7 +1175,7 @@ func (cs *ConsensusState) enterPrecommitWait(height int64, round int) {
 		return
 	}
 	if !cs.Votes.Precommits(round).HasTwoThirdsAny() {
-		cmn.PanicSanity(fmt.Sprintf("enterPrecommitWait(%v/%v), but Precommits does not have any +2/3 votes", height, round))
+		panic(fmt.Sprintf("enterPrecommitWait(%v/%v), but Precommits does not have any +2/3 votes", height, round))
 	}
 	logger.Info(fmt.Sprintf("enterPrecommitWait(%v/%v). Current: %v/%v/%v", height, round, cs.Height, cs.Round, cs.Step))
 
@@ -1214,7 +1214,7 @@ func (cs *ConsensusState) enterCommit(height int64, commitRound int) {
 
 	blockID, ok := cs.Votes.Precommits(commitRound).TwoThirdsMajority()
 	if !ok {
-		cmn.PanicSanity("RunActionCommit() expects +2/3 precommits")
+		panic("RunActionCommit() expects +2/3 precommits")
 	}
 
 	// The Locked* fields no longer matter.
@@ -1247,7 +1247,7 @@ func (cs *ConsensusState) tryFinalizeCommit(height int64) {
 	logger := cs.Logger.With("height", height)
 
 	if cs.Height != height {
-		cmn.PanicSanity(fmt.Sprintf("tryFinalizeCommit() cs.Height: %v vs height: %v", cs.Height, height))
+		panic(fmt.Sprintf("tryFinalizeCommit() cs.Height: %v vs height: %v", cs.Height, height))
 	}
 
 	blockID, ok := cs.Votes.Precommits(cs.CommitRound).TwoThirdsMajority()
@@ -1277,16 +1277,16 @@ func (cs *ConsensusState) finalizeCommit(height int64) {
 	block, blockParts := cs.ProposalBlock, cs.ProposalBlockParts
 
 	if !ok {
-		cmn.PanicSanity(fmt.Sprintf("Cannot finalizeCommit, commit does not have two thirds majority"))
+		panic(fmt.Sprintf("Cannot finalizeCommit, commit does not have two thirds majority"))
 	}
 	if !blockParts.HasHeader(blockID.PartsHeader) {
-		cmn.PanicSanity(fmt.Sprintf("Expected ProposalBlockParts header to be commit header"))
+		panic(fmt.Sprintf("Expected ProposalBlockParts header to be commit header"))
 	}
 	if !block.HashesTo(blockID.Hash) {
-		cmn.PanicSanity(fmt.Sprintf("Cannot finalizeCommit, ProposalBlock does not hash to commit hash"))
+		panic(fmt.Sprintf("Cannot finalizeCommit, ProposalBlock does not hash to commit hash"))
 	}
 	if err := cs.blockExec.ValidateBlock(cs.state, block); err != nil {
-		cmn.PanicConsensus(fmt.Sprintf("+2/3 committed an invalid block: %v", err))
+		panic(fmt.Sprintf("+2/3 committed an invalid block: %v", err))
 	}
 
 	cs.Logger.Info(fmt.Sprintf("Finalizing commit of block with %d txs", block.NumTxs),

--- a/consensus/types/height_vote_set.go
+++ b/consensus/types/height_vote_set.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/types"
 )
@@ -83,7 +82,7 @@ func (hvs *HeightVoteSet) SetRound(round int) {
 	hvs.mtx.Lock()
 	defer hvs.mtx.Unlock()
 	if hvs.round != 0 && (round < hvs.round+1) {
-		cmn.PanicSanity("SetRound() must increment hvs.round")
+		panic("SetRound() must increment hvs.round")
 	}
 	for r := hvs.round + 1; r <= round; r++ {
 		if _, ok := hvs.roundVoteSets[r]; ok {
@@ -96,7 +95,7 @@ func (hvs *HeightVoteSet) SetRound(round int) {
 
 func (hvs *HeightVoteSet) addRound(round int) {
 	if _, ok := hvs.roundVoteSets[round]; ok {
-		cmn.PanicSanity("addRound() for an existing round")
+		panic("addRound() for an existing round")
 	}
 	// log.Debug("addRound(round)", "round", round)
 	prevotes := types.NewVoteSet(hvs.chainID, hvs.height, round, types.PrevoteType, hvs.valSet)
@@ -169,8 +168,7 @@ func (hvs *HeightVoteSet) getVoteSet(round int, type_ types.SignedMsgType) *type
 	case types.PrecommitType:
 		return rvs.Precommits
 	default:
-		cmn.PanicSanity(fmt.Sprintf("Unexpected vote type %X", type_))
-		return nil
+		panic(fmt.Sprintf("Unexpected vote type %X", type_))
 	}
 }
 

--- a/crypto/xsalsa20symmetric/symmetric.go
+++ b/crypto/xsalsa20symmetric/symmetric.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 
 	"github.com/tendermint/tendermint/crypto"
-	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
 // TODO, make this into a struct that implements crypto.Symmetric.
@@ -19,7 +18,7 @@ const secretLen = 32
 // The ciphertext is (secretbox.Overhead + 24) bytes longer than the plaintext.
 func EncryptSymmetric(plaintext []byte, secret []byte) (ciphertext []byte) {
 	if len(secret) != secretLen {
-		cmn.PanicSanity(fmt.Sprintf("Secret must be 32 bytes long, got len %v", len(secret)))
+		panic(fmt.Sprintf("Secret must be 32 bytes long, got len %v", len(secret)))
 	}
 	nonce := crypto.CRandBytes(nonceLen)
 	nonceArr := [nonceLen]byte{}
@@ -36,7 +35,7 @@ func EncryptSymmetric(plaintext []byte, secret []byte) (ciphertext []byte) {
 // The ciphertext is (secretbox.Overhead + 24) bytes longer than the plaintext.
 func DecryptSymmetric(ciphertext []byte, secret []byte) (plaintext []byte, err error) {
 	if len(secret) != secretLen {
-		cmn.PanicSanity(fmt.Sprintf("Secret must be 32 bytes long, got len %v", len(secret)))
+		panic(fmt.Sprintf("Secret must be 32 bytes long, got len %v", len(secret)))
 	}
 	if len(ciphertext) <= secretbox.Overhead+nonceLen {
 		return nil, errors.New("Ciphertext is too short")

--- a/libs/common/errors.go
+++ b/libs/common/errors.go
@@ -212,35 +212,3 @@ func (fe FmtError) String() string {
 func (fe FmtError) Format() string {
 	return fe.format
 }
-
-//----------------------------------------
-// Panic wrappers
-// XXX DEPRECATED
-
-// A panic resulting from a sanity check means there is a programmer error
-// and some guarantee is not satisfied.
-// XXX DEPRECATED
-func PanicSanity(v interface{}) {
-	panic(fmt.Sprintf("Panicked on a Sanity Check: %v", v))
-}
-
-// A panic here means something has gone horribly wrong, in the form of data corruption or
-// failure of the operating system. In a correct/healthy system, these should never fire.
-// If they do, it's indicative of a much more serious problem.
-// XXX DEPRECATED
-func PanicCrisis(v interface{}) {
-	panic(fmt.Sprintf("Panicked on a Crisis: %v", v))
-}
-
-// Indicates a failure of consensus. Someone was malicious or something has
-// gone horribly wrong. These should really boot us into an "emergency-recover" mode
-// XXX DEPRECATED
-func PanicConsensus(v interface{}) {
-	panic(fmt.Sprintf("Panicked on a Consensus Failure: %v", v))
-}
-
-// For those times when we're not sure if we should panic
-// XXX DEPRECATED
-func PanicQ(v interface{}) {
-	panic(fmt.Sprintf("Panicked questionably: %v", v))
-}

--- a/libs/common/random.go
+++ b/libs/common/random.go
@@ -300,7 +300,7 @@ func cRandBytes(numBytes int) []byte {
 	b := make([]byte, numBytes)
 	_, err := crand.Read(b)
 	if err != nil {
-		PanicCrisis(err)
+		panic(err)
 	}
 	return b
 }

--- a/libs/common/service.go
+++ b/libs/common/service.go
@@ -194,8 +194,7 @@ func (bs *BaseService) Reset() error {
 
 // OnReset implements Service by panicking.
 func (bs *BaseService) OnReset() error {
-	PanicSanity("The service cannot be reset")
-	return nil
+	panic("The service cannot be reset")
 }
 
 // IsRunning implements Service by returning true or false depending on the

--- a/libs/db/go_level_db.go
+++ b/libs/db/go_level_db.go
@@ -9,8 +9,6 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
-
-	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
 func init() {
@@ -67,7 +65,7 @@ func (db *GoLevelDB) Set(key []byte, value []byte) {
 	value = nonNilBytes(value)
 	err := db.db.Put(key, value, nil)
 	if err != nil {
-		cmn.PanicCrisis(err)
+		panic(err)
 	}
 }
 
@@ -77,7 +75,7 @@ func (db *GoLevelDB) SetSync(key []byte, value []byte) {
 	value = nonNilBytes(value)
 	err := db.db.Put(key, value, &opt.WriteOptions{Sync: true})
 	if err != nil {
-		cmn.PanicCrisis(err)
+		panic(err)
 	}
 }
 
@@ -86,7 +84,7 @@ func (db *GoLevelDB) Delete(key []byte) {
 	key = nonNilBytes(key)
 	err := db.db.Delete(key, nil)
 	if err != nil {
-		cmn.PanicCrisis(err)
+		panic(err)
 	}
 }
 
@@ -95,7 +93,7 @@ func (db *GoLevelDB) DeleteSync(key []byte) {
 	key = nonNilBytes(key)
 	err := db.db.Delete(key, &opt.WriteOptions{Sync: true})
 	if err != nil {
-		cmn.PanicCrisis(err)
+		panic(err)
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -912,7 +912,7 @@ func loadGenesisDoc(db dbm.DB) (*types.GenesisDoc, error) {
 	var genDoc *types.GenesisDoc
 	err := cdc.UnmarshalJSON(bytes, &genDoc)
 	if err != nil {
-		cmn.PanicCrisis(fmt.Sprintf("Failed to load genesis doc due to unmarshaling error: %v (bytes: %X)", err, bytes))
+		panic(fmt.Sprintf("Failed to load genesis doc due to unmarshaling error: %v (bytes: %X)", err, bytes))
 	}
 	return genDoc, nil
 }
@@ -921,7 +921,7 @@ func loadGenesisDoc(db dbm.DB) (*types.GenesisDoc, error) {
 func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) {
 	bytes, err := cdc.MarshalJSON(genDoc)
 	if err != nil {
-		cmn.PanicCrisis(fmt.Sprintf("Failed to save genesis doc due to marshaling error: %v", err))
+		panic(fmt.Sprintf("Failed to save genesis doc due to marshaling error: %v", err))
 	}
 	db.SetSync(genesisDocKey, bytes)
 }

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -707,7 +707,7 @@ type Channel struct {
 func newChannel(conn *MConnection, desc ChannelDescriptor) *Channel {
 	desc = desc.FillDefaults()
 	if desc.Priority <= 0 {
-		cmn.PanicSanity("Channel default priority must be a positive integer")
+		panic("Channel default priority must be a positive integer")
 	}
 	return &Channel{
 		conn:                    conn,

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	"errors"
-
-	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
 // NetAddress defines information about a peer on the network
@@ -48,7 +46,7 @@ func NewNetAddress(id ID, addr net.Addr) *NetAddress {
 	tcpAddr, ok := addr.(*net.TCPAddr)
 	if !ok {
 		if flag.Lookup("test.v") == nil { // normal run
-			cmn.PanicSanity(fmt.Sprintf("Only TCPAddrs are supported. Got: %v", addr))
+			panic(fmt.Sprintf("Only TCPAddrs are supported. Got: %v", addr))
 		} else { // in testing
 			netAddr := NewNetAddressIPPort(net.IP("0.0.0.0"), 0)
 			netAddr.ID = id

--- a/p2p/pex/file.go
+++ b/p2p/pex/file.go
@@ -53,14 +53,14 @@ func (a *addrBook) loadFromFile(filePath string) bool {
 	// Load addrBookJSON{}
 	r, err := os.Open(filePath)
 	if err != nil {
-		cmn.PanicCrisis(fmt.Sprintf("Error opening file %s: %v", filePath, err))
+		panic(fmt.Sprintf("Error opening file %s: %v", filePath, err))
 	}
 	defer r.Close() // nolint: errcheck
 	aJSON := &addrBookJSON{}
 	dec := json.NewDecoder(r)
 	err = dec.Decode(aJSON)
 	if err != nil {
-		cmn.PanicCrisis(fmt.Sprintf("Error reading file %s: %v", filePath, err))
+		panic(fmt.Sprintf("Error reading file %s: %v", filePath, err))
 	}
 
 	// Restore all the fields...

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -155,7 +155,7 @@ func (sw *Switch) AddReactor(name string, reactor Reactor) Reactor {
 	for _, chDesc := range reactorChannels {
 		chID := chDesc.ID
 		if sw.reactorsByCh[chID] != nil {
-			cmn.PanicSanity(fmt.Sprintf("Channel %X has multiple reactors %v & %v", chID, sw.reactorsByCh[chID], reactor))
+			panic(fmt.Sprintf("Channel %X has multiple reactors %v & %v", chID, sw.reactorsByCh[chID], reactor))
 		}
 		sw.chDescs = append(sw.chDescs, chDesc)
 		sw.reactorsByCh[chID] = reactor

--- a/p2p/trust/store.go
+++ b/p2p/trust/store.go
@@ -156,7 +156,7 @@ func (tms *TrustMetricStore) loadFromDB() bool {
 	peers := make(map[string]MetricHistoryJSON)
 	err := json.Unmarshal(bytes, &peers)
 	if err != nil {
-		cmn.PanicCrisis(fmt.Sprintf("Could not unmarshal Trust Metric Store DB data: %v", err))
+		panic(fmt.Sprintf("Could not unmarshal Trust Metric Store DB data: %v", err))
 	}
 
 	// If history data exists in the file,

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -226,7 +226,7 @@ func (ps *PartSet) IsComplete() bool {
 
 func (ps *PartSet) GetReader() io.Reader {
 	if !ps.IsComplete() {
-		cmn.PanicSanity("Cannot GetReader() on incomplete PartSet")
+		panic("Cannot GetReader() on incomplete PartSet")
 	}
 	return NewPartSetReader(ps.parts)
 }

--- a/types/validator.go
+++ b/types/validator.go
@@ -52,8 +52,7 @@ func (v *Validator) CompareProposerPriority(other *Validator) *Validator {
 		} else if result > 0 {
 			return other
 		} else {
-			cmn.PanicSanity("Cannot compare identical validators")
-			return nil
+			panic("Cannot compare identical validators")
 		}
 	}
 }

--- a/types/vote.go
+++ b/types/vote.go
@@ -93,7 +93,7 @@ func (vote *Vote) String() string {
 	case PrecommitType:
 		typeString = "Precommit"
 	default:
-		cmn.PanicSanity("Unknown vote type")
+		panic("Unknown vote type")
 	}
 
 	return fmt.Sprintf("Vote{%v:%X %v/%02d/%v(%v) %X %X @ %s}",

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -70,7 +70,7 @@ type VoteSet struct {
 // Constructs a new VoteSet struct used to accumulate votes for given height/round.
 func NewVoteSet(chainID string, height int64, round int, type_ SignedMsgType, valSet *ValidatorSet) *VoteSet {
 	if height == 0 {
-		cmn.PanicSanity("Cannot make VoteSet for height == 0, doesn't make sense.")
+		panic("Cannot make VoteSet for height == 0, doesn't make sense.")
 	}
 	return &VoteSet{
 		chainID:       chainID,
@@ -130,7 +130,7 @@ func (voteSet *VoteSet) Size() int {
 // NOTE: Vote must not be nil
 func (voteSet *VoteSet) AddVote(vote *Vote) (added bool, err error) {
 	if voteSet == nil {
-		cmn.PanicSanity("AddVote() on nil VoteSet")
+		panic("AddVote() on nil VoteSet")
 	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
@@ -196,7 +196,7 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 		return added, NewConflictingVoteError(val, conflicting, vote)
 	}
 	if !added {
-		cmn.PanicSanity("Expected to add non-conflicting vote")
+		panic("Expected to add non-conflicting vote")
 	}
 	return added, nil
 }
@@ -220,7 +220,7 @@ func (voteSet *VoteSet) addVerifiedVote(vote *Vote, blockKey string, votingPower
 	// Already exists in voteSet.votes?
 	if existing := voteSet.votes[valIndex]; existing != nil {
 		if existing.BlockID.Equals(vote.BlockID) {
-			cmn.PanicSanity("addVerifiedVote does not expect duplicate votes")
+			panic("addVerifiedVote does not expect duplicate votes")
 		} else {
 			conflicting = existing
 		}
@@ -290,7 +290,7 @@ func (voteSet *VoteSet) addVerifiedVote(vote *Vote, blockKey string, votingPower
 // NOTE: VoteSet must not be nil
 func (voteSet *VoteSet) SetPeerMaj23(peerID P2PID, blockID BlockID) error {
 	if voteSet == nil {
-		cmn.PanicSanity("SetPeerMaj23() on nil VoteSet")
+		panic("SetPeerMaj23() on nil VoteSet")
 	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
@@ -363,7 +363,7 @@ func (voteSet *VoteSet) GetByAddress(address []byte) *Vote {
 	defer voteSet.mtx.Unlock()
 	valIndex, val := voteSet.valSet.GetByAddress(address)
 	if val == nil {
-		cmn.PanicSanity("GetByAddress(address) returned nil")
+		panic("GetByAddress(address) returned nil")
 	}
 	return voteSet.votes[valIndex]
 }
@@ -530,14 +530,14 @@ func (voteSet *VoteSet) sumTotalFrac() (int64, int64, float64) {
 
 func (voteSet *VoteSet) MakeCommit() *Commit {
 	if voteSet.type_ != PrecommitType {
-		cmn.PanicSanity("Cannot MakeCommit() unless VoteSet.Type is PrecommitType")
+		panic("Cannot MakeCommit() unless VoteSet.Type is PrecommitType")
 	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
 
 	// Make sure we have a 2/3 majority
 	if voteSet.maj23 == nil {
-		cmn.PanicSanity("Cannot MakeCommit() unless a blockhash has +2/3")
+		panic("Cannot MakeCommit() unless a blockhash has +2/3")
 	}
 
 	// For every validator, get the precommit


### PR DESCRIPTION
As per discussion over [here](https://github.com/tendermint/tendermint/pull/3456#discussion_r278423492), we need to remove these `PanicXXX` functions and eliminate our dependence on them. In this PR, each and every `PanicXXX` function call is replaced with a simple `panic` call.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
