### PR TITLE
pex: dial seeds when address book needs more addresses

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,3 +19,5 @@
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+
+* [pex] #3603 Dial seeds when addressbook needs more addresses (@defunctzombie)

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -463,9 +463,10 @@ func (r *PEXReactor) ensurePeers() {
 		}
 	}
 
-	// If we are not connected to nor dialing anybody, fallback to dialing a seed.
-	if out+in+dial+len(toDial) == 0 {
-		r.Logger.Info("No addresses to dial nor connected peers. Falling back to seeds")
+	// If we are not dialing anyone and need more addresses - dial a seed
+	// This is done in addition to asking a peer for addresses to work-around peers not participating in PEX
+	if r.book.NeedMoreAddrs() && len(toDial) == 0 {
+		r.Logger.Info("No addresses to dial. Falling back to seeds")
 		r.dialSeeds()
 	}
 }


### PR DESCRIPTION
If we are low on addresses for peering, we need to discover more peers. The
previous behavior would query existing peers; however, if an existing peer
does not participate in peer exchange, then our node will not discover more peers.

This change consults both existing peers as well as seeds when there is a deficit
in address book addresses. This allows for discovering peers though existing channels
as well as via seeds if existing peers do not share addresses.

---

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
