### PR TITLE
cli: Add option to not clear address book with unsafe reset

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,7 @@
 
 ### IMPROVEMENTS:
 - [rpc] [\#3534](https://github.com/tendermint/tendermint/pull/3534) Add support for batched requests/responses in JSON RPC
+- [cli] \#3606 (https://github.com/tendermint/tendermint/issues/3585) Add option to not clear address book with unsafe reset (@climber73)
 - [cli] [\#3160](https://github.com/tendermint/tendermint/issues/3160) Add `-config=<path-to-config>` option to `testnet` cmd (@gregdhill)
 - [cs/replay] \#3460 check appHash for each block
 

--- a/cmd/tendermint/commands/reset_priv_validator.go
+++ b/cmd/tendermint/commands/reset_priv_validator.go
@@ -18,6 +18,12 @@ var ResetAllCmd = &cobra.Command{
 	Run:   resetAll,
 }
 
+var keepAddrBook bool
+
+func init() {
+	ResetAllCmd.Flags().BoolVar(&keepAddrBook, "keep-addr-book", false, "Keep the address book intact")
+}
+
 // ResetPrivValidatorCmd resets the private validator files.
 var ResetPrivValidatorCmd = &cobra.Command{
 	Use:   "unsafe_reset_priv_validator",
@@ -41,7 +47,11 @@ func resetPrivValidator(cmd *cobra.Command, args []string) {
 // ResetAll removes address book files plus all data, and resets the privValdiator data.
 // Exported so other CLI tools can use it.
 func ResetAll(dbDir, addrBookFile, privValKeyFile, privValStateFile string, logger log.Logger) {
-	removeAddrBook(addrBookFile, logger)
+	if keepAddrBook {
+		logger.Info("The address book remains intact")
+	} else {
+		removeAddrBook(addrBookFile, logger)
+	}
 	if err := os.RemoveAll(dbDir); err == nil {
 		logger.Info("Removed all blockchain history", "dir", dbDir)
 	} else {


### PR DESCRIPTION
Adds `--keep-addr-book` flag to `unsafe_reset_all` command allowing not to clear address book