### PR TITLE
rpc: /dial_peers: only mark peers as persistent if flag is on

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -683,7 +683,10 @@ func (n *Node) OnStart() error {
 
 	// Always connect to persistent peers
 	// parsing errors are handled above by AddPersistentPeers
-	_ = n.sw.DialPeersAsync(splitAndTrimEmpty(n.config.P2P.PersistentPeers, ",", " "))
+	err = n.sw.DialPeersAsync(splitAndTrimEmpty(n.config.P2P.PersistentPeers, ",", " "))
+	if err != nil {
+		return errors.Wrap(err, "could not dial peers from persistent_peers field")
+	}
 
 	return nil
 }

--- a/node/node.go
+++ b/node/node.go
@@ -682,7 +682,6 @@ func (n *Node) OnStart() error {
 	}
 
 	// Always connect to persistent peers
-	// parsing errors are handled above by AddPersistentPeers
 	err = n.sw.DialPeersAsync(splitAndTrimEmpty(n.config.P2P.PersistentPeers, ",", " "))
 	if err != nil {
 		return errors.Wrap(err, "could not dial peers from persistent_peers field")

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -330,7 +330,8 @@ func TestPEXReactorDoesNotDisconnectFromPersistentPeerInSeedMode(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
-	pexR, book := createReactor(&PEXReactorConfig{SeedMode: true, SeedDisconnectWaitPeriod: 1 * time.Millisecond})
+	pexRConfig := &PEXReactorConfig{SeedMode: true, SeedDisconnectWaitPeriod: 1 * time.Millisecond}
+	pexR, book := createReactor(pexRConfig)
 	defer teardownReactor(book)
 
 	sw := createSwitchAndAddReactors(pexR)
@@ -352,6 +353,9 @@ func TestPEXReactorDoesNotDisconnectFromPersistentPeerInSeedMode(t *testing.T) {
 	pexR.crawlPeers([]*p2p.NetAddress{peerSwitch.NetAddress()})
 	assert.Equal(t, 1, sw.Peers().Size())
 	assert.True(t, sw.Peers().Has(peerSwitch.NodeInfo().ID()))
+
+	// sleep for SeedDisconnectWaitPeriod
+	time.Sleep(pexRConfig.SeedDisconnectWaitPeriod + 1*time.Millisecond)
 
 	// 2. attemptDisconnects should not disconnect because the peer is persistent
 	pexR.attemptDisconnects()

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -308,7 +308,7 @@ func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 			addr, err = peer.NodeInfo().NetAddress()
 			if err != nil {
 				sw.Logger.Error("Wanted to reconnect to inbound peer, but self-reported address is wrong",
-					"peer", peer, "addr", addr, "err", err)
+					"peer", peer, "err", err)
 				return
 			}
 		}

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -410,7 +410,6 @@ func TestSwitchReconnectsToOutboundPersistentPeer(t *testing.T) {
 
 	err = sw.DialPeerWithAddress(rp.Addr())
 	require.Nil(t, err)
-	time.Sleep(50 * time.Millisecond)
 	require.NotNil(t, sw.Peers().Get(rp.ID()))
 
 	p := sw.Peers().List()[0]
@@ -430,6 +429,9 @@ func TestSwitchReconnectsToOutboundPersistentPeer(t *testing.T) {
 	}
 	rp.Start()
 	defer rp.Stop()
+
+	err = sw.AddPersistentPeers([]string{rp.Addr().String()})
+	require.NoError(t, err)
 
 	conf := config.DefaultP2PConfig()
 	conf.TestDialFail = true

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -430,11 +430,8 @@ func TestSwitchReconnectsToOutboundPersistentPeer(t *testing.T) {
 	rp.Start()
 	defer rp.Stop()
 
-	err = sw.AddPersistentPeers([]string{rp.Addr().String()})
-	require.NoError(t, err)
-
 	conf := config.DefaultP2PConfig()
-	conf.TestDialFail = true
+	conf.TestDialFail = true // will trigger a reconnect
 	err = sw.addOutboundPeerWithConfig(rp.Addr(), conf)
 	require.NotNil(t, err)
 	// DialPeerWithAddres - sw.peerConfig resets the dialer

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -196,11 +196,14 @@ func UnsafeDialPeers(ctx *rpctypes.Context, peers []string, persistent bool) (*c
 		return &ctypes.ResultDialPeers{}, errors.New("No peers provided")
 	}
 	logger.Info("DialPeers", "peers", peers, "persistent", persistent)
-	if err := p2pPeers.AddPersistentPeers(peers); err != nil {
+	if persistent {
+		if err := p2pPeers.AddPersistentPeers(peers); err != nil {
+			return &ctypes.ResultDialPeers{}, err
+		}
+	}
+	if err := p2pPeers.DialPeersAsync(peers); err != nil {
 		return &ctypes.ResultDialPeers{}, err
 	}
-	// parsing errors are handled above by AddPersistentPeers
-	_ = p2pPeers.DialPeersAsync(peers)
 	return &ctypes.ResultDialPeers{Log: "Dialing peers in progress. See /net_info for details"}, nil
 }
 


### PR DESCRIPTION
also

- handle errors from DialPeersAsync
- remove nil addr from log msg
- fix TestPEXReactorDoesNotDisconnectFromPersistentPeerInSeedMode

This is a follow-up from
https://github.com/tendermint/tendermint/pull/3593#pullrequestreview-233556909

Fixes most of the https://github.com/tendermint/tendermint/issues/3617, except https://github.com/tendermint/tendermint/pull/3593#discussion_r280841401

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] ~~Updated all relevant documentation in docs~~
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] ~~Updated CHANGELOG_PENDING.md~~
