### PR TITLE
Fix #3613

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-pkg-cache
+            - v4-pkg-cache
       - run:
           name: tools
           command: |
@@ -43,7 +43,7 @@ jobs:
             - bin
             - profiles
       - save_cache:
-          key: v3-pkg-cache
+          key: v4-pkg-cache
           paths:
             - /go/pkg
       - save_cache:
@@ -57,7 +57,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - restore_cache:
-          key: v3-pkg-cache
+          key: v4-pkg-cache
       - restore_cache:
           key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -73,7 +73,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - restore_cache:
-          key: v3-pkg-cache
+          key: v4-pkg-cache
       - restore_cache:
           key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -89,7 +89,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - restore_cache:
-          key: v3-pkg-cache
+          key: v4-pkg-cache
       - restore_cache:
           key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -106,7 +106,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - restore_cache:
-          key: v3-pkg-cache
+          key: v4-pkg-cache
       - restore_cache:
           key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -121,7 +121,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - restore_cache:
-          key: v3-pkg-cache
+          key: v4-pkg-cache
       - restore_cache:
           key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends bsdmainutils
@@ -136,7 +136,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - restore_cache:
-          key: v3-pkg-cache
+          key: v4-pkg-cache
       - restore_cache:
           key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run: mkdir -p /tmp/logs
@@ -161,7 +161,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - restore_cache:
-          key: v3-pkg-cache
+          key: v4-pkg-cache
       - restore_cache:
           key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -208,7 +208,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - restore_cache:
-          key: v3-pkg-cache
+          key: v4-pkg-cache
       - restore_cache:
           key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -272,6 +272,10 @@ jobs:
           root: .
           paths:
             - "release-version.source"
+      - save_cache:
+            key: v2-release-deps-{{ checksum "go.sum" }}
+            paths:
+              - "/go/pkg/mod"
 
   build_artifacts:
     <<: *defaults
@@ -280,7 +284,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-release-deps-{{ .Branch }}-{{ .Revision }}
+            - v2-release-deps-{{ checksum "go.sum" }}
       - attach_workspace:
           at: /tmp/workspace
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ jobs:
       - run: mkdir -p /tmp/workspace/bin
       - run: mkdir -p /tmp/workspace/profiles
       - checkout
+      - restore_cache:
+          keys:
+            - v3-pkg-cache
       - run:
           name: tools
           command: |
@@ -39,12 +42,24 @@ jobs:
           paths:
             - bin
             - profiles
+      - save_cache:
+          key: v3-pkg-cache
+          paths:
+            - /go/pkg
+      - save_cache:
+          key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - /go/src/github.com/tendermint/tendermint
 
   build_slate:
     <<: *defaults
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - restore_cache:
+          key: v3-pkg-cache
+      - restore_cache:
+          key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: slate docs
           command: |
@@ -57,6 +72,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - restore_cache:
+          key: v3-pkg-cache
+      - restore_cache:
+          key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: metalinter
           command: |
@@ -69,6 +88,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - restore_cache:
+          key: v3-pkg-cache
+      - restore_cache:
+          key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Run abci apps tests
           command: |
@@ -82,6 +105,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - restore_cache:
+          key: v3-pkg-cache
+      - restore_cache:
+          key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Run abci-cli tests
           command: |
@@ -93,6 +120,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - restore_cache:
+          key: v3-pkg-cache
+      - restore_cache:
+          key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends bsdmainutils
       - run:
           name: Run tests
@@ -104,6 +135,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - restore_cache:
+          key: v3-pkg-cache
+      - restore_cache:
+          key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run: mkdir -p /tmp/logs
       - run:
           name: Run tests
@@ -125,6 +160,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - restore_cache:
+          key: v3-pkg-cache
+      - restore_cache:
+          key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Run tests
           command: bash test/persist/test_failure_indices.sh
@@ -168,6 +207,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - restore_cache:
+          key: v3-pkg-cache
+      - restore_cache:
+          key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: gather
           command: |
@@ -235,6 +278,9 @@ jobs:
     parallelism: 4
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-release-deps-{{ .Branch }}-{{ .Revision }}
       - attach_workspace:
           at: /tmp/workspace
       - run:


### PR DESCRIPTION
This PR builds on top of #3613. It:

 - reverts 45117bd which deactivated all caches
 - brings back the dependency cache (but make it use modules instead of the `vendor/` directory)
 - bumps versions of caches related to modules as recommended by https://circleci.com/docs/2.0/caching/#clearing-cache (to clear all caches)

