### PR TITLE
mempool: remove only valid (Code==0) txs on Update

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -48,3 +48,5 @@
   * `Switch#DialPeerWithAddress` now only takes an address
 - [consensus] \#3067 getBeginBlockValidatorInfo loads validators from stateDB instead of state (@james-ray)
 - [pex] \#3603 Dial seeds when addrbook needs more addresses (@defunctzombie)
+- [mempool] \#3322 Remove only valid (Code==0) txs on Update
+  * Added `deliverTxResponses` argument to `Mempool#Update` method

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -49,4 +49,6 @@
 - [consensus] \#3067 getBeginBlockValidatorInfo loads validators from stateDB instead of state (@james-ray)
 - [pex] \#3603 Dial seeds when addrbook needs more addresses (@defunctzombie)
 - [mempool] \#3322 Remove only valid (Code==0) txs on Update
-  * Added `deliverTxResponses` argument to `Mempool#Update` method
+  * `Mempool#Update` and `BlockExecutor#Commit` now accept
+    `[]*abci.ResponseDeliverTx` - list of `DeliverTx` responses, which should
+    match `block.Txs`

--- a/mempool/cache_test.go
+++ b/mempool/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/abci/example/kvstore"
+	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/proxy"
 	"github.com/tendermint/tendermint/types"
 )
@@ -66,7 +67,7 @@ func TestCacheAfterUpdate(t *testing.T) {
 			tx := types.Tx{byte(v)}
 			updateTxs = append(updateTxs, tx)
 		}
-		mempool.Update(int64(tcIndex), updateTxs, nil, nil)
+		mempool.Update(int64(tcIndex), updateTxs, abciResponses(len(updateTxs), abci.CodeTypeOK), nil, nil)
 
 		for _, v := range tc.reAddIndices {
 			tx := types.Tx{byte(v)}

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -184,23 +184,29 @@ func TestMempoolUpdate(t *testing.T) {
 	defer cleanup()
 
 	// 1. Adds valid txs to the cache
-	mempool.Update(1, []types.Tx{[]byte{0x01}}, abciResponses(1, abci.CodeTypeOK), nil, nil)
-	err := mempool.CheckTx([]byte{0x01}, nil)
-	if assert.Error(t, err) {
-		assert.Equal(t, ErrTxInCache, err)
+	{
+		mempool.Update(1, []types.Tx{[]byte{0x01}}, abciResponses(1, abci.CodeTypeOK), nil, nil)
+		err := mempool.CheckTx([]byte{0x01}, nil)
+		if assert.Error(t, err) {
+			assert.Equal(t, ErrTxInCache, err)
+		}
 	}
 
 	// 2. Removes valid txs from the mempool
-	err = mempool.CheckTx([]byte{0x02}, nil)
-	require.NoError(t, err)
-	mempool.Update(1, []types.Tx{[]byte{0x02}}, abciResponses(1, abci.CodeTypeOK), nil, nil)
-	assert.Zero(t, mempool.Size())
+	{
+		err := mempool.CheckTx([]byte{0x02}, nil)
+		require.NoError(t, err)
+		mempool.Update(1, []types.Tx{[]byte{0x02}}, abciResponses(1, abci.CodeTypeOK), nil, nil)
+		assert.Zero(t, mempool.Size())
+	}
 
 	// 3. Removes invalid transactions from the cache, but leaves them in the mempool (if present)
-	err = mempool.CheckTx([]byte{0x03}, nil)
-	require.NoError(t, err)
-	mempool.Update(1, []types.Tx{[]byte{0x03}}, abciResponses(1, 1), nil, nil)
-	assert.Equal(t, 1, mempool.Size())
+	{
+		err := mempool.CheckTx([]byte{0x03}, nil)
+		require.NoError(t, err)
+		mempool.Update(1, []types.Tx{[]byte{0x03}}, abciResponses(1, 1), nil, nil)
+		assert.Equal(t, 1, mempool.Size())
+	}
 }
 
 func TestTxsAvailable(t *testing.T) {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -43,7 +43,7 @@ type Mempool interface {
 	// Update informs the mempool that the given txs were committed and can be discarded.
 	// NOTE: this should be called *after* block is committed by consensus.
 	// NOTE: unsafe; Lock/Unlock must be managed by caller
-	Update(blockHeight int64, blockTxs types.Txs, newPreFn PreCheckFunc, newPostFn PostCheckFunc) error
+	Update(blockHeight int64, blockTxs types.Txs, deliverTxResponses []*abci.ResponseDeliverTx, newPreFn PreCheckFunc, newPostFn PostCheckFunc) error
 
 	// FlushAppConn flushes the mempool connection to ensure async reqResCb calls are
 	// done. E.g. from CheckTx.

--- a/mock/mempool.go
+++ b/mock/mempool.go
@@ -27,6 +27,7 @@ func (Mempool) ReapMaxTxs(n int) types.Txs              { return types.Txs{} }
 func (Mempool) Update(
 	_ int64,
 	_ types.Txs,
+	_ []*abci.ResponseDeliverTx,
 	_ mempl.PreCheckFunc,
 	_ mempl.PostCheckFunc,
 ) error {

--- a/state/execution.go
+++ b/state/execution.go
@@ -156,7 +156,7 @@ func (blockExec *BlockExecutor) ApplyBlock(state State, blockID types.BlockID, b
 	}
 
 	// Lock mempool, commit app state, update mempoool.
-	appHash, err := blockExec.Commit(state, block)
+	appHash, err := blockExec.Commit(state, block, abciResponses.DeliverTx)
 	if err != nil {
 		return state, fmt.Errorf("Commit failed for application: %v", err)
 	}
@@ -188,6 +188,7 @@ func (blockExec *BlockExecutor) ApplyBlock(state State, blockID types.BlockID, b
 func (blockExec *BlockExecutor) Commit(
 	state State,
 	block *types.Block,
+	deliverTxResponses []*abci.ResponseDeliverTx,
 ) ([]byte, error) {
 	blockExec.mempool.Lock()
 	defer blockExec.mempool.Unlock()
@@ -222,6 +223,7 @@ func (blockExec *BlockExecutor) Commit(
 	err = blockExec.mempool.Update(
 		block.Height,
 		block.Txs,
+		deliverTxResponses,
 		TxPreCheck(state),
 		TxPostCheck(state),
 	)


### PR DESCRIPTION
so evil proposers can't drop valid txs in Commit stage.

Also remove invalid (Code!=0) txs from the cache so they can be
resubmitted.

Fixes #3322

@rickyyangz:

In the end of commit stage, we will update mempool to remove all the txs
in current block.

```go
// Update mempool.
err = blockExec.mempool.Update(
	block.Height,
	block.Txs,
	TxPreCheck(state),
	TxPostCheck(state),
)
```

Assum an account has 3 transactions in the mempool, the sequences are
100, 101 and 102 separately, So an evil proposal can only package the
101 and 102 transactions into its proposal block, and leave 100 still in
mempool, then the two txs will be removed from all validators' mempool
when commit. So the account lost the two valid txs.

@ebuchman:

In the longer term we may want to do something like #2639 so we can
validate txs before we commit the block. But even in this case we'd only
want to run the equivalent of CheckTx, which means the DeliverTx could
still fail even if the CheckTx passes depending on how the app handles
the ABCI Code semantics. So more work will be required around the ABCI
code. See also #2185

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
