### PR TITLE
p2p/pex: save addrbook OnStop

### DIFF
--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -147,6 +147,7 @@ func (a *addrBook) OnStart() error {
 
 // OnStop implements Service.
 func (a *addrBook) OnStop() {
+	a.Save()
 	a.BaseService.OnStop()
 }
 


### PR DESCRIPTION
Save the address book when stopping the addrBook service. This persists
any addresses added since the last time the address book was saved.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
