### PR TITLE
tendermint testnet: Allow for better hostname control

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -35,7 +35,7 @@
 - [p2p] [\#3552](https://github.com/tendermint/tendermint/pull/3552) Add PeerBehaviour Interface (@brapse)
 - [rpc] [\#3534](https://github.com/tendermint/tendermint/pull/3534) Add support for batched requests/responses in JSON RPC
 - [cli] \#3585 Add option to not clear address book with unsafe reset (@climber73)
-- [cli] [\#3160](https://github.com/tendermint/tendermint/issues/3160) Add `-config=<path-to-config>` option to `testnet` cmd (@gregdhill)
+- [cli] [\#3160](https://github.com/tendermint/tendermint/issues/3160) Add `--config=<path-to-config>` option to `testnet` cmd (@gregdhill)
 - [cs/replay] \#3460 check appHash for each block
 - [rpc] \#3362 `/dial_seeds` & `/dial_peers` return errors if addresses are incorrect (except when IP lookup fails)
 - [node] \#3362 returns an error if `persistent_peers` list is invalid (except when IP lookup fails)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -34,6 +34,7 @@
 - [p2p] [\#3463](https://github.com/tendermint/tendermint/pull/3463) Do not log "Can't add peer's address to addrbook" error for a private peer
 - [p2p] [\#3552](https://github.com/tendermint/tendermint/pull/3552) Add PeerBehaviour Interface (@brapse)
 - [rpc] [\#3534](https://github.com/tendermint/tendermint/pull/3534) Add support for batched requests/responses in JSON RPC
+- [cli] [\#3661](https://github.com/tendermint/tendermint/pull/3661) Add `--hostname-suffix` and `--hostname` options to `testnet` cmd for greater flexibility
 - [cli] \#3585 Add option to not clear address book with unsafe reset (@climber73)
 - [cli] [\#3160](https://github.com/tendermint/tendermint/issues/3160) Add `--config=<path-to-config>` option to `testnet` cmd (@gregdhill)
 - [cs/replay] \#3460 check appHash for each block

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -34,7 +34,9 @@
 - [p2p] [\#3463](https://github.com/tendermint/tendermint/pull/3463) Do not log "Can't add peer's address to addrbook" error for a private peer
 - [p2p] [\#3552](https://github.com/tendermint/tendermint/pull/3552) Add PeerBehaviour Interface (@brapse)
 - [rpc] [\#3534](https://github.com/tendermint/tendermint/pull/3534) Add support for batched requests/responses in JSON RPC
-- [cli] [\#3661](https://github.com/tendermint/tendermint/pull/3661) Add `--hostname-suffix` and `--hostname` options to `testnet` cmd for greater flexibility
+- [cli] [\#3661](https://github.com/tendermint/tendermint/pull/3661) Add
+  `--hostname-suffix`, `--hostname` and `--random-monikers` options to `testnet`
+  cmd for greater peer address/identity generation flexibility.
 - [cli] \#3585 Add option to not clear address book with unsafe reset (@climber73)
 - [cli] [\#3160](https://github.com/tendermint/tendermint/issues/3160) Add `--config=<path-to-config>` option to `testnet` cmd (@gregdhill)
 - [cs/replay] \#3460 check appHash for each block

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -203,20 +203,20 @@ func hostnameOrIP(i int) string {
 	if len(hostnames) > 0 && i < len(hostnames) {
 		return hostnames[i]
 	}
-	if startingIPAddress != "" {
-		ip := net.ParseIP(startingIPAddress)
-		ip = ip.To4()
-		if ip == nil {
-			fmt.Printf("%v: non ipv4 address\n", startingIPAddress)
-			os.Exit(1)
-		}
-
-		for j := 0; j < i; j++ {
-			ip[3]++
-		}
-		return ip.String()
+	if startingIPAddress == "" {
+		return fmt.Sprintf("%s%d", hostnamePrefix, i)
 	}
-	return fmt.Sprintf("%s%d", hostnamePrefix, i)
+	ip := net.ParseIP(startingIPAddress)
+	ip = ip.To4()
+	if ip == nil {
+		fmt.Printf("%v: non ipv4 address\n", startingIPAddress)
+		os.Exit(1)
+	}
+
+	for j := 0; j < i; j++ {
+		ip[3]++
+	}
+	return ip.String()
 }
 
 func persistentPeersString(config *cfg.Config) (string, error) {

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -52,11 +52,11 @@ func init() {
 	TestnetFilesCmd.Flags().BoolVar(&populatePersistentPeers, "populate-persistent-peers", true,
 		"Update config of each node with the list of persistent peers build using either hostname-prefix or starting-ip-address")
 	TestnetFilesCmd.Flags().StringVar(&hostnamePrefix, "hostname-prefix", "node",
-		"Hostname prefix (node results in persistent peers list ID0@node0:26656, ID1@node1:26656, ...)")
+		"Hostname prefix (\"node\" results in persistent peers list ID0@node0:26656, ID1@node1:26656, ...)")
 	TestnetFilesCmd.Flags().StringVar(&hostnameSuffix, "hostname-suffix", "",
 		"Hostname suffix (\".xyz.com\" results in persistent peers list ID0@node0.xyz.com:26656, ID1@node1.xyz.com:26656, ...)")
 	TestnetFilesCmd.Flags().StringVar(&startingIPAddress, "starting-ip-address", "",
-		"Starting IP address (192.168.0.1 results in persistent peers list ID0@192.168.0.1:26656, ID1@192.168.0.2:26656, ...)")
+		"Starting IP address (\"192.168.0.1\" results in persistent peers list ID0@192.168.0.1:26656, ID1@192.168.0.2:26656, ...)")
 	TestnetFilesCmd.Flags().StringArrayVar(&hostnames, "hostname", []string{},
 		"Manually override all hostnames of validators and non-validators (use --hostname multiple times for multiple hosts)")
 	TestnetFilesCmd.Flags().IntVar(&p2pPort, "p2p-port", 26656,

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -27,6 +27,7 @@ var (
 
 	populatePersistentPeers bool
 	hostnamePrefix          string
+	hostnameSuffix          string
 	startingIPAddress       string
 	hostnames               []string
 	p2pPort                 int
@@ -52,6 +53,8 @@ func init() {
 		"Update config of each node with the list of persistent peers build using either hostname-prefix or starting-ip-address")
 	TestnetFilesCmd.Flags().StringVar(&hostnamePrefix, "hostname-prefix", "node",
 		"Hostname prefix (node results in persistent peers list ID0@node0:26656, ID1@node1:26656, ...)")
+	TestnetFilesCmd.Flags().StringVar(&hostnameSuffix, "hostname-suffix", "",
+		"Hostname suffix (\".xyz.com\" results in persistent peers list ID0@node0.xyz.com:26656, ID1@node1.xyz.com:26656, ...)")
 	TestnetFilesCmd.Flags().StringVar(&startingIPAddress, "starting-ip-address", "",
 		"Starting IP address (192.168.0.1 results in persistent peers list ID0@192.168.0.1:26656, ID1@192.168.0.2:26656, ...)")
 	TestnetFilesCmd.Flags().StringArrayVar(&hostnames, "hostname", []string{},
@@ -204,7 +207,7 @@ func hostnameOrIP(i int) string {
 		return hostnames[i]
 	}
 	if startingIPAddress == "" {
-		return fmt.Sprintf("%s%d", hostnamePrefix, i)
+		return fmt.Sprintf("%s%d%s", hostnamePrefix, i, hostnameSuffix)
 	}
 	ip := net.ParseIP(startingIPAddress)
 	ip = ip.To4()


### PR DESCRIPTION
This attempts to address issue #3660. It adds two additional flags to the `tendermint testnet` command:

1. `--hostname-suffix` - to automatically append a suffix to each and every generated (non-IP) hostname
2. `--hostname` - a [StringArray](https://godoc.org/github.com/spf13/pflag#StringArrayVar) parameter to manually override all peer hostnames. Using this flag causes `tendermint testnet` to completely ignore the `--hostname-prefix`, `--hostname-suffix` and `--starting-ip-address` fields.

**Example 1 with `--hostname-suffix`:**

```bash
> tendermint testnet --v 4 --n 0 --o /tmp/testnet \
    --hostname-prefix mynode \
    --hostname-suffix .xyz.com

> cat /tmp/testnet/node0/config/config.toml | grep persistent_peers
persistent_peers = "42311234da9693ff1affa073f7ef9984a0674582@mynode0.xyz.com:26656,470c1c72deacad25c61673c0b452d5ef99b6053a@mynode1.xyz.com:26656,4a60e1b25e8af75d8688f8c81e93b6c45a8e2991@mynode2.xyz.com:26656,a8d586a3ed4b47b0b04b049445d27113ac031f03@mynode3.xyz.com:26656"
```

**Example 2 with `--hostname`:**

```bash
> tendermint testnet --v 4 --n 0 --o /tmp/testnet \
    --hostname alpha.xyz.com \
    --hostname beta.xyz.com \
    --hostname alpha.abcd.com \
    --hostname beta.abcd.com

> cat /tmp/testnet/node0/config/config.toml | grep persistent_peers
persistent_peers = "42311234da9693ff1affa073f7ef9984a0674582@alpha.xyz.com:26656,470c1c72deacad25c61673c0b452d5ef99b6053a@beta.xyz.com:26656,4a60e1b25e8af75d8688f8c81e93b6c45a8e2991@alpha.abcd.com:26656,a8d586a3ed4b47b0b04b049445d27113ac031f03@beta.abcd.com:26656"
```

* [x] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
