### PR TITLE
[p2p] Peer behaviour test tweaks

### DIFF
--- a/p2p/peer_behaviour_test.go
+++ b/p2p/peer_behaviour_test.go
@@ -72,6 +72,52 @@ func equalBehaviours(a []p2p.PeerBehaviour, b []p2p.PeerBehaviour) bool {
 	return true
 }
 
+// TestEqualPeerBehaviours tests that equalBehaviours can tell that two slices
+// of peer behaviours can be compared for the behaviours they contain and the
+// freequencies that those behaviours occur.
+func TestEqualPeerBehaviours(t *testing.T) {
+	equals := []struct {
+		left  []p2p.PeerBehaviour
+		right []p2p.PeerBehaviour
+	}{
+		// Empty sets
+		{[]p2p.PeerBehaviour{}, []p2p.PeerBehaviour{}},
+		// Single behaviours
+		{[]p2p.PeerBehaviour{p2p.PeerBehaviourVote}, []p2p.PeerBehaviour{p2p.PeerBehaviourVote}},
+		// Equal Frequencies
+		{[]p2p.PeerBehaviour{p2p.PeerBehaviourVote, p2p.PeerBehaviourVote},
+			[]p2p.PeerBehaviour{p2p.PeerBehaviourVote, p2p.PeerBehaviourVote}},
+		// Equal frequencies different orders
+		{[]p2p.PeerBehaviour{p2p.PeerBehaviourVote, p2p.PeerBehaviourBlockPart},
+			[]p2p.PeerBehaviour{p2p.PeerBehaviourBlockPart, p2p.PeerBehaviourVote}},
+	}
+
+	for _, test := range equals {
+		if !equalBehaviours(test.left, test.right) {
+			t.Errorf("Expected %#v and %#v to be equal", test.left, test.right)
+		}
+	}
+
+	unequals := []struct {
+		left  []p2p.PeerBehaviour
+		right []p2p.PeerBehaviour
+	}{
+		// Comparing empty sets to non empty sets
+		{[]p2p.PeerBehaviour{}, []p2p.PeerBehaviour{p2p.PeerBehaviourVote}},
+		// Different behaviours
+		{[]p2p.PeerBehaviour{p2p.PeerBehaviourVote}, []p2p.PeerBehaviour{p2p.PeerBehaviourBlockPart}},
+		// Same behaviour with different frequencies
+		{[]p2p.PeerBehaviour{p2p.PeerBehaviourVote},
+			[]p2p.PeerBehaviour{p2p.PeerBehaviourVote, p2p.PeerBehaviourVote}},
+	}
+
+	for _, test := range unequals {
+		if equalBehaviours(test.left, test.right) {
+			t.Errorf("Expected %#v and %#v to be unequal", test.left, test.right)
+		}
+	}
+}
+
 // TestPeerBehaviourConcurrency constructs a scenario in which
 // multiple goroutines are using the same MockPeerBehaviourReporter instance.
 // This test reproduces the conditions in which MockPeerBehaviourReporter will

--- a/p2p/peer_behaviour_test.go
+++ b/p2p/peer_behaviour_test.go
@@ -39,22 +39,37 @@ type scriptItem struct {
 	Behaviour p2p.PeerBehaviour
 }
 
+// equalBehaviours returns true if a and b contain the same PeerBehaviours with
+// the same freequency and otherwise false.
 func equalBehaviours(a []p2p.PeerBehaviour, b []p2p.PeerBehaviour) bool {
-	if len(a) != len(b) {
+	aHistogram := map[p2p.PeerBehaviour]int{}
+	bHistogram := map[p2p.PeerBehaviour]int{}
+
+	for _, behaviour := range a {
+		aHistogram[behaviour] += 1
+	}
+
+	for _, behaviour := range b {
+		bHistogram[behaviour] += 1
+	}
+
+	if len(aHistogram) != len(bHistogram) {
 		return false
 	}
 
-	var same int = 0
-	for _, aBehaviour := range a {
-		for _, bBehaviour := range b {
-			if aBehaviour == bBehaviour {
-				same++
-				break
-			}
+	for _, behaviour := range a {
+		if aHistogram[behaviour] != bHistogram[behaviour] {
+			return false
 		}
 	}
 
-	return same == len(a)
+	for _, behaviour := range b {
+		if bHistogram[behaviour] != aHistogram[behaviour] {
+			return false
+		}
+	}
+
+	return true
 }
 
 // TestPeerBehaviourConcurrency constructs a scenario in which


### PR DESCRIPTION
Peer behaviour test tweaks towards #3653.

Address the remaining test issues mentioned in #3552 notably:
* switch to p2p_test package
* Use `Error` instead of `Errorf` when not using formatting
* Add expected/got errors to
* `TestMockPeerBehaviourReporterConcurrency` test

Also addresses a bug in `equalBehaviours` in which only the lengths of the behaviours was being tested and not the actual contents.

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
