### PR TITLE
p2p: Peerbehaviour follow up (#3653)

### DIFF
--- a/behaviour/peer_behaviour.go
+++ b/behaviour/peer_behaviour.go
@@ -1,12 +1,10 @@
 package behaviour
 
 import (
-	"errors"
-	"sync"
-
 	"github.com/tendermint/tendermint/p2p"
 )
 
+// PeerBehaviour is a struct describing the behaviour of a peer.
 type PeerBehaviour struct {
 	peerID p2p.ID
 	reason interface{}
@@ -16,6 +14,7 @@ type badMessage struct {
 	explanation string
 }
 
+// BadMessage returns a badMessage PeerBehaviour.
 func BadMessage(peerID p2p.ID, explanation string) PeerBehaviour {
 	return PeerBehaviour{peerID: peerID, reason: badMessage{explanation}}
 }
@@ -24,6 +23,7 @@ type messageOutOfOrder struct {
 	explanation string
 }
 
+// MessageOutOfOrder returns a messagOutOfOrder PeerBehaviour.
 func MessageOutOfOrder(peerID p2p.ID, explanation string) PeerBehaviour {
 	return PeerBehaviour{peerID: peerID, reason: badMessage{explanation}}
 }
@@ -41,83 +41,7 @@ type blockPart struct {
 	explanation string
 }
 
-// BlockPart creates a PeerBehaviour with a blockPart reason.
+// BlockPart returns blockPart PeerBehaviour.
 func BlockPart(peerID p2p.ID, explanation string) PeerBehaviour {
 	return PeerBehaviour{peerID: peerID, reason: blockPart{explanation}}
-}
-
-// PeerBehaviourReporter provides an interface for reactors to report the behaviour
-// of peers synchronously to other components.
-type PeerBehaviourReporter interface {
-	Report(behaviour PeerBehaviour) error
-}
-
-// SwitchPeerBehaviouReporter reports peer behaviour to an internal Switch
-type SwitchPeerBehaviourReporter struct {
-	sw *p2p.Switch
-}
-
-// Return a new SwitchPeerBehaviourReporter instance which wraps the Switch.
-func NewSwitchPeerBehaviourReporter(sw *p2p.Switch) *SwitchPeerBehaviourReporter {
-	return &SwitchPeerBehaviourReporter{
-		sw: sw,
-	}
-}
-
-// Report reports the behaviour of a peer to the Switch
-func (spbr *SwitchPeerBehaviourReporter) Report(behaviour PeerBehaviour) error {
-	peer := spbr.sw.Peers().Get(behaviour.peerID)
-	if peer == nil {
-		return errors.New("Peer not found")
-	}
-
-	switch reason := behaviour.reason.(type) {
-	case consensusVote, blockPart:
-		spbr.sw.MarkPeerAsGood(peer)
-	case badMessage:
-		spbr.sw.StopPeerForError(peer, reason.explanation)
-	case messageOutOfOrder:
-		spbr.sw.StopPeerForError(peer, reason.explanation)
-	default:
-		return errors.New("Unknown reason reported")
-	}
-
-	return nil
-}
-
-// MockPeerBehaviourReporter serves a mock concrete implementation of the
-// PeerBehaviourReporter interface used in reactor tests to ensure reactors
-// report the correct behaviour in manufactured scenarios.
-type MockPeerBehaviourReporter struct {
-	mtx sync.RWMutex
-	pb  map[p2p.ID][]PeerBehaviour
-}
-
-// NewMockPeerBehaviourReporter returns a PeerBehaviourReporter which records all reported
-// behaviours in memory.
-func NewMockPeerBehaviourReporter() *MockPeerBehaviourReporter {
-	return &MockPeerBehaviourReporter{
-		pb: map[p2p.ID][]PeerBehaviour{},
-	}
-}
-
-// Report stores the PeerBehaviour produced by the peer identified by peerID.
-func (mpbr *MockPeerBehaviourReporter) Report(behaviour PeerBehaviour) {
-	mpbr.mtx.Lock()
-	defer mpbr.mtx.Unlock()
-	mpbr.pb[behaviour.peerID] = append(mpbr.pb[behaviour.peerID], behaviour)
-}
-
-// GetBehaviours returns all behaviours reported on the peer identified by peerID.
-func (mpbr *MockPeerBehaviourReporter) GetBehaviours(peerID p2p.ID) []PeerBehaviour {
-	mpbr.mtx.RLock()
-	defer mpbr.mtx.RUnlock()
-	if items, ok := mpbr.pb[peerID]; ok {
-		result := make([]PeerBehaviour, len(items))
-		copy(result, items)
-
-		return result
-	} else {
-		return []PeerBehaviour{}
-	}
 }

--- a/behaviour/peer_behaviour.go
+++ b/behaviour/peer_behaviour.go
@@ -71,13 +71,13 @@ func (spbr *SwitchPeerBehaviourReporter) Report(behaviour PeerBehaviour) error {
 		return errors.New("Peer not found")
 	}
 
-	switch behaviour.reason.(type) {
+	switch reason := behaviour.reason.(type) {
 	case consensusVote, blockPart:
 		spbr.sw.MarkPeerAsGood(peer)
 	case badMessage:
-		spbr.sw.StopPeerForError(peer, "Bad message")
+		spbr.sw.StopPeerForError(peer, reason.explanation)
 	case messageOutOfOrder:
-		spbr.sw.StopPeerForError(peer, "Message out of order")
+		spbr.sw.StopPeerForError(peer, reason.explanation)
 	default:
 		return errors.New("Unknown behaviour")
 	}

--- a/behaviour/peer_behaviour.go
+++ b/behaviour/peer_behaviour.go
@@ -79,7 +79,7 @@ func (spbr *SwitchPeerBehaviourReporter) Report(behaviour PeerBehaviour) error {
 	case messageOutOfOrder:
 		spbr.sw.StopPeerForError(peer, reason.explanation)
 	default:
-		return errors.New("Unknown behaviour")
+		return errors.New("Unknown reason reported")
 	}
 
 	return nil

--- a/behaviour/peer_behaviour.go
+++ b/behaviour/peer_behaviour.go
@@ -4,7 +4,7 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 )
 
-// PeerBehaviour is a struct describing the behaviour of a peer.
+// PeerBehaviour is a struct describing the behaviour of a peer performed.
 type PeerBehaviour struct {
 	peerID p2p.ID
 	reason interface{}

--- a/behaviour/peer_behaviour.go
+++ b/behaviour/peer_behaviour.go
@@ -4,7 +4,9 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 )
 
-// PeerBehaviour is a struct describing the behaviour of a peer performed.
+// PeerBehaviour is a struct describing a behaviour a peer performed.
+// `peerID` identifies the peer and reason characterizes the specific
+// behaviour performed by the peer.
 type PeerBehaviour struct {
 	peerID p2p.ID
 	reason interface{}
@@ -32,7 +34,7 @@ type consensusVote struct {
 	explanation string
 }
 
-// ConsensusVote creates a PeerBehaviour with a consensusVote reason.
+// ConsensusVote returns a consensusVote PeerBehaviour.
 func ConsensusVote(peerID p2p.ID, explanation string) PeerBehaviour {
 	return PeerBehaviour{peerID: peerID, reason: consensusVote{explanation}}
 }

--- a/behaviour/peer_behaviour_test.go
+++ b/behaviour/peer_behaviour_test.go
@@ -19,25 +19,26 @@ func TestMockPeerBehaviourReporter(t *testing.T) {
 		t.Error("Expected to have no behaviours reported")
 	}
 
-	pr.Report(peerID, bh.PeerBehaviourBadMessage)
+	badMessage := bh.BadMessage(peerID, "bad message")
+	pr.Report(badMessage)
 	behaviours = pr.GetBehaviours(peerID)
 	if len(behaviours) != 1 {
 		t.Error("Expected the peer have one reported behaviour")
 	}
 
-	if behaviours[0] != bh.PeerBehaviourBadMessage {
-		t.Error("Expected PeerBehaviourBadMessage to have been reported")
+	if behaviours[0] != badMessage {
+		t.Error("Expected Bad Message to have been reported")
 	}
 }
 
 type scriptedBehaviours struct {
-	PeerID     p2p.ID
-	Behaviours []bh.PeerBehaviour
+	peerID     p2p.ID
+	behaviours []bh.PeerBehaviour
 }
 
 type scriptItem struct {
-	PeerID    p2p.ID
-	Behaviour bh.PeerBehaviour
+	peerID    p2p.ID
+	behaviour bh.PeerBehaviour
 }
 
 // equalBehaviours returns true if a and b contain the same PeerBehaviours with
@@ -77,39 +78,43 @@ func equalBehaviours(a []bh.PeerBehaviour, b []bh.PeerBehaviour) bool {
 // of peer behaviours can be compared for the behaviours they contain and the
 // freequencies that those behaviours occur.
 func TestEqualPeerBehaviours(t *testing.T) {
-	equals := []struct {
-		left  []bh.PeerBehaviour
-		right []bh.PeerBehaviour
-	}{
-		// Empty sets
-		{[]bh.PeerBehaviour{}, []bh.PeerBehaviour{}},
-		// Single behaviours
-		{[]bh.PeerBehaviour{bh.PeerBehaviourVote}, []bh.PeerBehaviour{bh.PeerBehaviourVote}},
-		// Equal Frequencies
-		{[]bh.PeerBehaviour{bh.PeerBehaviourVote, bh.PeerBehaviourVote},
-			[]bh.PeerBehaviour{bh.PeerBehaviourVote, bh.PeerBehaviourVote}},
-		// Equal frequencies different orders
-		{[]bh.PeerBehaviour{bh.PeerBehaviourVote, bh.PeerBehaviourBlockPart},
-			[]bh.PeerBehaviour{bh.PeerBehaviourBlockPart, bh.PeerBehaviourVote}},
-	}
+	var (
+		peerID        p2p.ID = "MockPeer"
+		consensusVote        = bh.ConsensusVote(peerID, "voted")
+		blockPart            = bh.BlockPart(peerID, "blocked")
+		equals               = []struct {
+			left  []bh.PeerBehaviour
+			right []bh.PeerBehaviour
+		}{
+			// Empty sets
+			{[]bh.PeerBehaviour{}, []bh.PeerBehaviour{}},
+			// Single behaviours
+			{[]bh.PeerBehaviour{consensusVote}, []bh.PeerBehaviour{consensusVote}},
+			// Equal Frequencies
+			{[]bh.PeerBehaviour{consensusVote, consensusVote},
+				[]bh.PeerBehaviour{consensusVote, consensusVote}},
+			// Equal frequencies different orders
+			{[]bh.PeerBehaviour{consensusVote, blockPart},
+				[]bh.PeerBehaviour{blockPart, consensusVote}},
+		}
+		unequals = []struct {
+			left  []bh.PeerBehaviour
+			right []bh.PeerBehaviour
+		}{
+			// Comparing empty sets to non empty sets
+			{[]bh.PeerBehaviour{}, []bh.PeerBehaviour{consensusVote}},
+			// Different behaviours
+			{[]bh.PeerBehaviour{consensusVote}, []bh.PeerBehaviour{blockPart}},
+			// Same behaviour with different frequencies
+			{[]bh.PeerBehaviour{consensusVote},
+				[]bh.PeerBehaviour{consensusVote, consensusVote}},
+		}
+	)
 
 	for _, test := range equals {
 		if !equalBehaviours(test.left, test.right) {
 			t.Errorf("Expected %#v and %#v to be equal", test.left, test.right)
 		}
-	}
-
-	unequals := []struct {
-		left  []bh.PeerBehaviour
-		right []bh.PeerBehaviour
-	}{
-		// Comparing empty sets to non empty sets
-		{[]bh.PeerBehaviour{}, []bh.PeerBehaviour{bh.PeerBehaviourVote}},
-		// Different behaviours
-		{[]bh.PeerBehaviour{bh.PeerBehaviourVote}, []bh.PeerBehaviour{bh.PeerBehaviourBlockPart}},
-		// Same behaviour with different frequencies
-		{[]bh.PeerBehaviour{bh.PeerBehaviourVote},
-			[]bh.PeerBehaviour{bh.PeerBehaviourVote, bh.PeerBehaviourVote}},
 	}
 
 	for _, test := range unequals {
@@ -124,13 +129,18 @@ func TestEqualPeerBehaviours(t *testing.T) {
 // This test reproduces the conditions in which MockPeerBehaviourReporter will
 // be used within a Reactor Receive method tests to ensure thread safety.
 func TestMockPeerBehaviourReporterConcurrency(t *testing.T) {
-	behaviourScript := []scriptedBehaviours{
-		{"1", []bh.PeerBehaviour{bh.PeerBehaviourVote}},
-		{"2", []bh.PeerBehaviour{bh.PeerBehaviourVote, bh.PeerBehaviourVote, bh.PeerBehaviourVote, bh.PeerBehaviourVote}},
-		{"3", []bh.PeerBehaviour{bh.PeerBehaviourBlockPart, bh.PeerBehaviourVote, bh.PeerBehaviourBlockPart, bh.PeerBehaviourVote}},
-		{"4", []bh.PeerBehaviour{bh.PeerBehaviourVote, bh.PeerBehaviourVote, bh.PeerBehaviourVote, bh.PeerBehaviourVote}},
-		{"5", []bh.PeerBehaviour{bh.PeerBehaviourBlockPart, bh.PeerBehaviourVote, bh.PeerBehaviourBlockPart, bh.PeerBehaviourVote}},
-	}
+	var (
+		peerID          p2p.ID = "MockPeer"
+		consensusVote          = bh.ConsensusVote(peerID, "voted")
+		blockPart              = bh.BlockPart(peerID, "blocked")
+		behaviourScript        = []scriptedBehaviours{
+			{"1", []bh.PeerBehaviour{consensusVote}},
+			{"2", []bh.PeerBehaviour{consensusVote, consensusVote, consensusVote, consensusVote}},
+			{"3", []bh.PeerBehaviour{blockPart, consensusVote, blockPart, consensusVote}},
+			{"4", []bh.PeerBehaviour{consensusVote, consensusVote, consensusVote, consensusVote}},
+			{"5", []bh.PeerBehaviour{blockPart, consensusVote, blockPart, consensusVote}},
+		}
+	)
 
 	var receiveWg sync.WaitGroup
 	pr := bh.NewMockPeerBehaviourReporter()
@@ -144,7 +154,7 @@ func TestMockPeerBehaviourReporterConcurrency(t *testing.T) {
 			for {
 				select {
 				case pb := <-scriptItems:
-					pr.Report(pb.PeerID, pb.Behaviour)
+					pr.Report(pb.behaviour)
 				case <-done:
 					return
 				}
@@ -157,8 +167,8 @@ func TestMockPeerBehaviourReporterConcurrency(t *testing.T) {
 	go func() {
 		defer sendingWg.Done()
 		for _, item := range behaviourScript {
-			for _, reason := range item.Behaviours {
-				scriptItems <- scriptItem{item.PeerID, reason}
+			for _, reason := range item.behaviours {
+				scriptItems <- scriptItem{item.peerID, reason}
 			}
 		}
 	}()
@@ -172,10 +182,10 @@ func TestMockPeerBehaviourReporterConcurrency(t *testing.T) {
 	receiveWg.Wait()
 
 	for _, items := range behaviourScript {
-		reported := pr.GetBehaviours(items.PeerID)
-		if !equalBehaviours(reported, items.Behaviours) {
+		reported := pr.GetBehaviours(items.peerID)
+		if !equalBehaviours(reported, items.behaviours) {
 			t.Errorf("Expected peer %s to have behaved \nExpected: %#v \nGot %#v \n",
-				items.PeerID, items.Behaviours, reported)
+				items.peerID, items.behaviours, reported)
 		}
 	}
 }

--- a/behaviour/peer_behaviour_test.go
+++ b/behaviour/peer_behaviour_test.go
@@ -130,15 +130,15 @@ func TestEqualPeerBehaviours(t *testing.T) {
 // be used within a Reactor Receive method tests to ensure thread safety.
 func TestMockPeerBehaviourReporterConcurrency(t *testing.T) {
 	var (
-		peerID          p2p.ID = "MockPeer"
-		consensusVote          = bh.ConsensusVote(peerID, "voted")
-		blockPart              = bh.BlockPart(peerID, "blocked")
-		behaviourScript        = []scriptedBehaviours{
-			{"1", []bh.PeerBehaviour{consensusVote}},
-			{"2", []bh.PeerBehaviour{consensusVote, consensusVote, consensusVote, consensusVote}},
-			{"3", []bh.PeerBehaviour{blockPart, consensusVote, blockPart, consensusVote}},
-			{"4", []bh.PeerBehaviour{consensusVote, consensusVote, consensusVote, consensusVote}},
-			{"5", []bh.PeerBehaviour{blockPart, consensusVote, blockPart, consensusVote}},
+		behaviourScript = []struct {
+			peerID     p2p.ID
+			behaviours []bh.PeerBehaviour
+		}{
+			{"1", []bh.PeerBehaviour{bh.ConsensusVote("1", "")}},
+			{"2", []bh.PeerBehaviour{bh.ConsensusVote("2", ""), bh.ConsensusVote("2", ""), bh.ConsensusVote("2", "")}},
+			{"3", []bh.PeerBehaviour{bh.BlockPart("3", ""), bh.ConsensusVote("3", ""), bh.BlockPart("3", ""), bh.ConsensusVote("3", "")}},
+			{"4", []bh.PeerBehaviour{bh.ConsensusVote("4", ""), bh.ConsensusVote("4", ""), bh.ConsensusVote("4", ""), bh.ConsensusVote("4", "")}},
+			{"5", []bh.PeerBehaviour{bh.BlockPart("5", ""), bh.ConsensusVote("5", ""), bh.BlockPart("5", ""), bh.ConsensusVote("5", "")}},
 		}
 	)
 

--- a/behaviour/peer_behaviour_test.go
+++ b/behaviour/peer_behaviour_test.go
@@ -31,11 +31,6 @@ func TestMockPeerBehaviourReporter(t *testing.T) {
 	}
 }
 
-type scriptedBehaviours struct {
-	peerID     p2p.ID
-	behaviours []bh.PeerBehaviour
-}
-
 type scriptItem struct {
 	peerID    p2p.ID
 	behaviour bh.PeerBehaviour

--- a/behaviour/reporter.go
+++ b/behaviour/reporter.go
@@ -29,7 +29,7 @@ func NewSwitcReporter(sw *p2p.Switch) *SwitchReporter {
 func (spbr *SwitchReporter) Report(behaviour PeerBehaviour) error {
 	peer := spbr.sw.Peers().Get(behaviour.peerID)
 	if peer == nil {
-		return errors.New("Peer not found")
+		return errors.New("peer not found")
 	}
 
 	switch reason := behaviour.reason.(type) {

--- a/behaviour/reporter.go
+++ b/behaviour/reporter.go
@@ -40,7 +40,7 @@ func (spbr *SwitchReporter) Report(behaviour PeerBehaviour) error {
 	case messageOutOfOrder:
 		spbr.sw.StopPeerForError(peer, reason.explanation)
 	default:
-		return errors.New("Unknown reason reported")
+		return errors.New("unknown reason reported")
 	}
 
 	return nil

--- a/behaviour/reporter.go
+++ b/behaviour/reporter.go
@@ -46,7 +46,7 @@ func (spbr *SwitchReporter) Report(behaviour PeerBehaviour) error {
 	return nil
 }
 
-// MockReporter serves a mock concrete implementation of the Reporter
+// MockReporter is a concrete implementation of the Reporter
 // interface used in reactor tests to ensure reactors report the correct
 // behaviour in manufactured scenarios.
 type MockReporter struct {

--- a/behaviour/reporter.go
+++ b/behaviour/reporter.go
@@ -1,0 +1,84 @@
+package behaviour
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/tendermint/tendermint/p2p"
+)
+
+// Reporter provides an interface for reactors to report the behaviour
+// of peers synchronously to other components.
+type Reporter interface {
+	Report(behaviour PeerBehaviour) error
+}
+
+// SwitchReporter reports peer behaviour to an internal Switch.
+type SwitchReporter struct {
+	sw *p2p.Switch
+}
+
+// NewSwitchReporter return a new SwitchReporter instance which wraps the Switch.
+func NewSwitchPeerBehaviourReporter(sw *p2p.Switch) *SwitchReporter {
+	return &SwitchReporter{
+		sw: sw,
+	}
+}
+
+// Report reports the behaviour of a peer to the Switch.
+func (spbr *SwitchReporter) Report(behaviour PeerBehaviour) error {
+	peer := spbr.sw.Peers().Get(behaviour.peerID)
+	if peer == nil {
+		return errors.New("Peer not found")
+	}
+
+	switch reason := behaviour.reason.(type) {
+	case consensusVote, blockPart:
+		spbr.sw.MarkPeerAsGood(peer)
+	case badMessage:
+		spbr.sw.StopPeerForError(peer, reason.explanation)
+	case messageOutOfOrder:
+		spbr.sw.StopPeerForError(peer, reason.explanation)
+	default:
+		return errors.New("Unknown reason reported")
+	}
+
+	return nil
+}
+
+// MockReporter serves a mock concrete implementation of the Reporter
+// interface used in reactor tests to ensure reactors report the correct
+// behaviour in manufactured scenarios.
+type MockReporter struct {
+	mtx sync.RWMutex
+	pb  map[p2p.ID][]PeerBehaviour
+}
+
+// NewMockReporter returns a Reporter which records all reported
+// behaviours in memory.
+func NewMockReporter() *MockReporter {
+	return &MockReporter{
+		pb: map[p2p.ID][]PeerBehaviour{},
+	}
+}
+
+// Report stores the PeerBehaviour produced by the peer identified by peerID.
+func (mpbr *MockReporter) Report(behaviour PeerBehaviour) {
+	mpbr.mtx.Lock()
+	defer mpbr.mtx.Unlock()
+	mpbr.pb[behaviour.peerID] = append(mpbr.pb[behaviour.peerID], behaviour)
+}
+
+// GetBehaviours returns all behaviours reported on the peer identified by peerID.
+func (mpbr *MockReporter) GetBehaviours(peerID p2p.ID) []PeerBehaviour {
+	mpbr.mtx.RLock()
+	defer mpbr.mtx.RUnlock()
+	if items, ok := mpbr.pb[peerID]; ok {
+		result := make([]PeerBehaviour, len(items))
+		copy(result, items)
+
+		return result
+	} else {
+		return []PeerBehaviour{}
+	}
+}

--- a/behaviour/reporter.go
+++ b/behaviour/reporter.go
@@ -19,7 +19,7 @@ type SwitchReporter struct {
 }
 
 // NewSwitchReporter return a new SwitchReporter instance which wraps the Switch.
-func NewSwitchPeerBehaviourReporter(sw *p2p.Switch) *SwitchReporter {
+func NewSwitcReporter(sw *p2p.Switch) *SwitchReporter {
 	return &SwitchReporter{
 		sw: sw,
 	}

--- a/behaviour/reporter_test.go
+++ b/behaviour/reporter_test.go
@@ -37,7 +37,7 @@ type scriptItem struct {
 }
 
 // equalBehaviours returns true if a and b contain the same PeerBehaviours with
-// the same freequency and otherwise false.
+// the same freequencies and otherwise false.
 func equalBehaviours(a []bh.PeerBehaviour, b []bh.PeerBehaviour) bool {
 	aHistogram := map[bh.PeerBehaviour]int{}
 	bHistogram := map[bh.PeerBehaviour]int{}
@@ -120,9 +120,9 @@ func TestEqualPeerBehaviours(t *testing.T) {
 }
 
 // TestPeerBehaviourConcurrency constructs a scenario in which
-// multiple goroutines are using the same MockPeerBehaviourReporter instance.
-// This test reproduces the conditions in which MockPeerBehaviourReporter will
-// be used within a Reactor Receive method tests to ensure thread safety.
+// multiple goroutines are using the same MockReporter instance.
+// This test reproduces the conditions in which MockReporter will
+// be used within a Reactor `Receive` method tests to ensure thread safety.
 func TestMockPeerBehaviourReporterConcurrency(t *testing.T) {
 	var (
 		behaviourScript = []struct {

--- a/behaviour/reporter_test.go
+++ b/behaviour/reporter_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestMockReporter tests the MockReporter's ability to store reported
-// peer behaviour in memory indexed by the peerID
+// peer behaviour in memory indexed by the peerID.
 func TestMockReporter(t *testing.T) {
 	var peerID p2p.ID = "MockPeer"
 	pr := bh.NewMockReporter()

--- a/behaviour/reporter_test.go
+++ b/behaviour/reporter_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 )
 
-// TestMockPeerBehaviour tests the MockPeerBehaviour' ability to store reported
+// TestMockReporter tests the MockReporter's ability to store reported
 // peer behaviour in memory indexed by the peerID
-func TestMockPeerBehaviourReporter(t *testing.T) {
+func TestMockReporter(t *testing.T) {
 	var peerID p2p.ID = "MockPeer"
-	pr := bh.NewMockPeerBehaviourReporter()
+	pr := bh.NewMockReporter()
 
 	behaviours := pr.GetBehaviours(peerID)
 	if len(behaviours) != 0 {
@@ -138,7 +138,7 @@ func TestMockPeerBehaviourReporterConcurrency(t *testing.T) {
 	)
 
 	var receiveWg sync.WaitGroup
-	pr := bh.NewMockPeerBehaviourReporter()
+	pr := bh.NewMockReporter()
 	scriptItems := make(chan scriptItem)
 	done := make(chan int)
 	numConsumers := 3


### PR DESCRIPTION
This PR implements some of the changes previously mentioned in (#3653) and in comment of (#3552) 
to address a few key questions:

### Where do peer behaviours live?
The current implementation places reactor specific terms/concepts in the p2p package. In the ideal, the `p2p` package would be as domain agnostic as possible.

This PR creates a new package `behaviour` to  intermediate the relationship between the p2p package and reactors. PeerBehaviours are decidedly simple, containing only an explanation string. The handling of PeerBehaviour is centralized within the `behaviour` package providing clear separation between the reactors and the responsibility of managing peers based on domain knowledge.

### How are PeerBehaviours mapped to actions?
The original PR #3552 had each PeerBehaviour as an integer. This meant that passing `3` to `Report` could potentially stop a peer. This PR maps each response private struct ensuring that only explicit constructions of PeerBehaviour can trigger an action.


* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
