### PR TITLE
remove invalid transactions from the mempool

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,3 +19,5 @@
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+- [mempool] \#3699 Revert the change where we only remove valid transactions
+  from the mempool once a block is committed.

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -200,12 +200,15 @@ func TestMempoolUpdate(t *testing.T) {
 		assert.Zero(t, mempool.Size())
 	}
 
-	// 3. Removes invalid transactions from the cache, but leaves them in the mempool (if present)
+	// 3. Removes invalid transactions from the cache and the mempool (if present)
 	{
 		err := mempool.CheckTx([]byte{0x03}, nil)
 		require.NoError(t, err)
 		mempool.Update(1, []types.Tx{[]byte{0x03}}, abciResponses(1, 1), nil, nil)
-		assert.Equal(t, 1, mempool.Size())
+		assert.Zero(t, mempool.Size())
+
+		err = mempool.CheckTx([]byte{0x03}, nil)
+		assert.NoError(t, err)
 	}
 }
 


### PR DESCRIPTION
Otherwise, we'll be trying to include them in each consecutive block.

The downside is that evil proposers will be able to drop valid
transactions (see #3322).

Reverts https://github.com/tendermint/tendermint/pull/3625

Fixes #3699

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
