### PR TITLE
node: fix a bug where `nil` is recorded as node's address

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -37,3 +37,4 @@
 ### BUG FIXES:
 - [libs/db] \#3717 Fixed the BoltDB backend's Batch.Delete implementation (@Yawning)
 - [libs/db] \#3718 Fixed the BoltDB backend's Get and Iterator implementation (@Yawning)
+- [node] \#3716 Fix a bug where `nil` is recorded as node's address

--- a/node/node.go
+++ b/node/node.go
@@ -446,9 +446,6 @@ func createAddrBookAndSetOnSwitch(config *cfg.Config, sw *p2p.Switch,
 	addrBook := pex.NewAddrBook(config.P2P.AddrBookFile(), config.P2P.AddrBookStrict)
 	addrBook.SetLogger(p2pLogger.With("book", config.P2P.AddrBookFile()))
 
-	// Add ourselves to addrbook to prevent dialing ourselves
-	addrBook.AddOurAddress(sw.NetAddress())
-
 	sw.SetAddrBook(addrBook)
 
 	return addrBook
@@ -683,6 +680,10 @@ func (n *Node) OnStart() error {
 	}
 
 	n.isListening = true
+
+	// Add ourselves to addrbook to prevent dialing ourselves
+	// NOTE: sw.NetAddress is set by n.transport.Listen above
+	n.addrBook.AddOurAddress(n.sw.NetAddress())
 
 	if n.config.Mempool.WalEnabled() {
 		n.mempool.InitWAL() // no need to have the mempool wal during tests

--- a/node/node.go
+++ b/node/node.go
@@ -682,8 +682,7 @@ func (n *Node) OnStart() error {
 	n.isListening = true
 
 	// Add ourselves to addrbook to prevent dialing ourselves
-	// NOTE: sw.NetAddress is set by n.transport.Listen above
-	n.addrBook.AddOurAddress(n.sw.NetAddress())
+	n.addrBook.AddOurAddress(addr)
 
 	if n.config.Mempool.WalEnabled() {
 		n.mempool.InitWAL() // no need to have the mempool wal during tests


### PR DESCRIPTION
Solution

  `AddOurAddress` when we know it
  `sw.NetAddress` is `nil` in `createAddrBookAndSetOnSwitch`
  it's set by `n.transport.Listen` function, which is called during start

Fixes #3716

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] ~~Updated all relevant documentation in docs~~
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
