### PR TITLE
Remove double lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,22 +67,6 @@ jobs:
             export PATH="$GOBIN:$PATH"
             make build-slate
 
-  lint:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - restore_cache:
-          key: v4-pkg-cache
-      - restore_cache:
-          key: v3-tree-{{ .Environment.CIRCLE_SHA1 }}
-      - run:
-          name: metalinter
-          command: |
-            set -ex
-            export PATH="$GOBIN:$PATH"
-            make lint
-
   test_abci_apps:
     <<: *defaults
     steps:
@@ -98,8 +82,8 @@ jobs:
             export PATH="$GOBIN:$PATH"
             bash abci/tests/test_app/test.sh
 
-# if this test fails, fix it and update the docs at:
-# https://github.com/tendermint/tendermint/blob/develop/docs/abci-cli.md
+  # if this test fails, fix it and update the docs at:
+  # https://github.com/tendermint/tendermint/blob/develop/docs/abci-cli.md
   test_abci_cli:
     <<: *defaults
     steps:
@@ -169,24 +153,24 @@ jobs:
           command: bash test/persist/test_failure_indices.sh
 
   localnet:
-      working_directory: /home/circleci/.go_workspace/src/github.com/tendermint/tendermint
-      machine:
-        image: circleci/classic:latest
-      environment:
-        GOBIN: /home/circleci/.go_workspace/bin
-        GOPATH: /home/circleci/.go_workspace/
-        GOOS: linux
-        GOARCH: amd64
-      parallelism: 1
-      steps:
-        - checkout
-        - run:
-            name: run localnet and exit on failure
-            command: |
-              set -x
-              docker run --rm -v "$PWD":/go/src/github.com/tendermint/tendermint -w /go/src/github.com/tendermint/tendermint golang make build-linux
-              make localnet-start &
-              ./scripts/localnet-blocks-test.sh 40 5 10 localhost
+    working_directory: /home/circleci/.go_workspace/src/github.com/tendermint/tendermint
+    machine:
+      image: circleci/classic:latest
+    environment:
+      GOBIN: /home/circleci/.go_workspace/bin
+      GOPATH: /home/circleci/.go_workspace/
+      GOOS: linux
+      GOARCH: amd64
+    parallelism: 1
+    steps:
+      - checkout
+      - run:
+          name: run localnet and exit on failure
+          command: |
+            set -x
+            docker run --rm -v "$PWD":/go/src/github.com/tendermint/tendermint -w /go/src/github.com/tendermint/tendermint golang make build-linux
+            make localnet-start &
+            ./scripts/localnet-blocks-test.sh 40 5 10 localhost
 
   test_p2p:
     environment:
@@ -273,9 +257,9 @@ jobs:
           paths:
             - "release-version.source"
       - save_cache:
-            key: v2-release-deps-{{ checksum "go.sum" }}
-            paths:
-              - "/go/pkg/mod"
+          key: v2-release-deps-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
 
   build_artifacts:
     <<: *defaults
@@ -358,9 +342,6 @@ workflows:
                 - master
                 - develop
       - setup_dependencies
-      - lint:
-          requires:
-            - setup_dependencies
       - test_abci_apps:
           requires:
             - setup_dependencies


### PR DESCRIPTION
- Circel CI and Golangci were doing linting jobs, removed circleci

This cannot be merged until it is removed from circleci.

@mircea-c can you remove it from circleci?

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
