### PR TITLE
Add btcec to get_tools.sh

### DIFF
--- a/scripts/get_tools.sh
+++ b/scripts/get_tools.sh
@@ -64,3 +64,4 @@ installFromGithub golangci/golangci-lint 7b2421d55194c9dc385eff7720a037aa9244ca3
 installFromGithub petermattis/goid b0b1615b78e5ee59739545bb38426383b2cda4c9
 installFromGithub sasha-s/go-deadlock d68e2bc52ae3291765881b9056f2c1527f245f1e
 go get golang.org/x/tools/cmd/goimports
+go get github.com/btcsuite/btcd/btcec


### PR DESCRIPTION
Coming from a fresh environment, this package seems to be missing from the `pkg` folder to run `make` into `tools/tm-monitor`

I was looking into: https://github.com/tendermint/tendermint/issues/1937

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
