### PR TITLE
tm-monitor Makefile updated

### DIFF
--- a/tools/tm-monitor/Makefile
+++ b/tools/tm-monitor/Makefile
@@ -36,7 +36,7 @@ dist: build-all
 
 build-docker:
 	rm -f ./tm-monitor
-	docker run -it --rm -v "$(PWD)/../../:/go/src/github.com/tendermint/tendermint" -w "/go/src/github.com/tendermint/tendermint/tools/tm-monitor" -e "CGO_ENABLED=0" golang:alpine go build -ldflags "-s -w" -o tm-monitor
+	docker run -it --rm -v "$(PWD)/../../:/go/src/github.com/tendermint/tendermint" -w "/go/src/github.com/tendermint/tendermint/tools/tm-monitor" -e "GO111MODULE=on" -e "CGO_ENABLED=0" golang:1.12 go build -ldflags "-s -w" -o tm-monitor
 	docker build -t "tendermint/monitor" .
 
 clean:


### PR DESCRIPTION
Makefile `build-docker` target updated to use `go mod`:
- go111module on
- switch from `golang:alpine` to `golang:1.12` to have git

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
