### PR TITLE
Remove go func from finishAsyncCall()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build_race:
 	CGO_ENABLED=0 go build -race $(BUILD_FLAGS) -tags $(BUILD_TAGS) -o $(OUTPUT) ./cmd/tendermint
 
 install:
-	CGO_ENABLED=0 go install $(BUILD_FLAGS) -tags $(BUILD_TAGS) ./cmd/tendermint
+	CGO_ENABLED=0 go install  $(BUILD_FLAGS) -tags $(BUILD_TAGS) ./cmd/tendermint
 
 install_c:
 	CGO_ENABLED=1 go install $(BUILD_FLAGS) -tags "$(BUILD_TAGS) cleveldb" ./cmd/tendermint
@@ -61,7 +61,7 @@ build_abci:
 	@go build -mod=readonly -i ./abci/cmd/...
 
 install_abci:
-	@go install -mod=readonly ./abci/cmd/...
+	@go install -race -mod=readonly ./abci/cmd/...
 
 ########################################
 ### Distribution

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build_race:
 	CGO_ENABLED=0 go build -race $(BUILD_FLAGS) -tags $(BUILD_TAGS) -o $(OUTPUT) ./cmd/tendermint
 
 install:
-	CGO_ENABLED=0 go install  $(BUILD_FLAGS) -tags $(BUILD_TAGS) ./cmd/tendermint
+	CGO_ENABLED=0 go install $(BUILD_FLAGS) -tags $(BUILD_TAGS) ./cmd/tendermint
 
 install_c:
 	CGO_ENABLED=1 go install $(BUILD_FLAGS) -tags "$(BUILD_TAGS) cleveldb" ./cmd/tendermint
@@ -61,7 +61,7 @@ build_abci:
 	@go build -mod=readonly -i ./abci/cmd/...
 
 install_abci:
-	@go install -race -mod=readonly ./abci/cmd/...
+	@go install -mod=readonly ./abci/cmd/...
 
 ########################################
 ### Distribution

--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -228,18 +228,15 @@ func (cli *grpcClient) finishAsyncCall(req *types.Request, res *types.Response) 
 	reqres.Done()         // Release waiters
 	reqres.SetDone()      // so reqRes.SetCallback will run the callback
 
-	// go routine for callbacks
-	go func() {
-		// Notify reqRes listener if set
-		if cb := reqres.GetCallback(); cb != nil {
-			cb(res)
-		}
+	// Notify reqRes listener if set
+	if cb := reqres.GetCallback(); cb != nil {
+		cb(res)
+	}
 
-		// Notify client listener if set
-		if cli.resCb != nil {
-			cli.resCb(reqres.Request, res)
-		}
-	}()
+	// Notify client listener if set
+	if cli.resCb != nil {
+		cli.resCb(reqres.Request, res)
+	}
 	return reqres
 }
 

--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -228,15 +228,22 @@ func (cli *grpcClient) finishAsyncCall(req *types.Request, res *types.Response) 
 	reqres.Done()         // Release waiters
 	reqres.SetDone()      // so reqRes.SetCallback will run the callback
 
-	// Notify reqRes listener if set
-	if cb := reqres.GetCallback(); cb != nil {
-		cb(res)
-	}
+	// goroutine for callbacks
+	go func() {
+		cli.mtx.Lock()
+		defer cli.mtx.Unlock()
 
-	// Notify client listener if set
-	if cli.resCb != nil {
-		cli.resCb(reqres.Request, res)
-	}
+		// Notify client listener if set
+		if cli.resCb != nil {
+			cli.resCb(reqres.Request, res)
+		}
+
+		// Notify reqRes listener if set
+		if cb := reqres.GetCallback(); cb != nil {
+			cb(res)
+		}
+	}()
+
 	return reqres
 }
 


### PR DESCRIPTION
closes #357

- Remove go func(){}() that caused race condiditon

- To reproduce
	- add -race in make file to `install_abci`
	- Remove `CGO_ENABLED=0` & add -race to `install`

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
