### PR TITLE
a new block sync protocol-hot_sync

### DIFF
--- a/blockchain/hot/candidate.go
+++ b/blockchain/hot/candidate.go
@@ -1,0 +1,397 @@
+package hot
+
+import (
+	"container/list"
+	"math/rand"
+	"sort"
+	"sync"
+	"time"
+
+	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/p2p"
+)
+
+const (
+	// the type of samples, Good means get sample result in limit time, otherwise is Bad event.
+	Bad eventType = iota
+	Good
+)
+
+const (
+	// the interval to recalculate average metrics, 10 is reasonable according to test.
+	recalculateInterval = 10
+	// the interval to pick decay peers
+	pickDecayPeerInterval = 5000
+	// only maxPermanentSetSize of best peers will stay in permanentSet
+	maxPermanentSetSize = 2
+	// only recent maxMetricsSampleSize of samples will be used to calculate the metrics
+	maxMetricsSampleSize = 100
+
+	// the time interval to keep consistent with peerSet in Switch
+	compensateInterval = 2
+)
+
+type eventType uint
+
+type CandidatePool struct {
+	cmn.BaseService
+	mtx sync.RWMutex
+
+	pickSequence int64
+
+	// newly added peer, will be candidates in next pick round.
+	freshSet map[p2p.ID]struct{}
+	// unavailable or poor performance peers, give a try periodically
+	decayedSet map[p2p.ID]struct{}
+	// stable and good performance peers
+	permanentSet map[p2p.ID]*peerMetrics
+
+	eventStream <-chan metricsEvent
+
+	metrics *Metrics
+	swh     *p2p.Switch
+}
+
+func NewCandidatePool(eventStream <-chan metricsEvent) *CandidatePool {
+	c := &CandidatePool{
+		eventStream: eventStream,
+		// a random init value to avoid network resource race.
+		pickSequence: rand.Int63n(pickDecayPeerInterval),
+		freshSet:     make(map[p2p.ID]struct{}, 0),
+		decayedSet:   make(map[p2p.ID]struct{}, 0),
+		permanentSet: make(map[p2p.ID]*peerMetrics, maxPermanentSetSize),
+		metrics:      NopMetrics(),
+	}
+	c.BaseService = *cmn.NewBaseService(nil, "CandidatePool", c)
+	return c
+}
+
+// OnStart implements cmn.Service.
+func (c *CandidatePool) OnStart() error {
+	go c.handleSampleRoutine()
+	go c.compensatePeerRoutine()
+
+	return nil
+}
+
+func (c *CandidatePool) AddPeer(pid p2p.ID) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.freshSet[pid] = struct{}{}
+}
+
+func (c *CandidatePool) RemovePeer(pid p2p.ID) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	delete(c.freshSet, pid)
+	c.tryRemoveFromDecayed(pid)
+	c.tryRemoveFromPermanent(pid)
+}
+
+func (c *CandidatePool) PickCandidates() []*p2p.ID {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.pickSequence = c.pickSequence + 1
+	permanentPeer := c.pickFromPermanentPeer()
+	// if there is no permanentPeer, need broadcast in decayed peers.
+	isBroadcast := permanentPeer == nil
+	decaysPeers := c.pickFromDecayedSet(isBroadcast)
+	freshPeers := c.pickFromFreshSet()
+	peers := make([]*p2p.ID, 0, 1)
+	if permanentPeer != nil {
+		peers = append(peers, permanentPeer)
+	}
+	peers = append(peers, decaysPeers...)
+	peers = append(peers, freshPeers...)
+	return peers
+}
+
+// The `AddPeer` and `RemovePeer` function of BaseReactor have concurrent issue:
+// a peer is removed and immediately added, `AddPeer` may execute before `RemovePeer`.
+// Can't fix this in `stopAndRemovePeer`, because may introduce other peer dial failed.
+// For `CandidatePool` it is really important to keep consistent with peerset in switch,
+// this routine is an insurance.
+func (c *CandidatePool) compensatePeerRoutine() {
+	if c.swh == nil {
+		// happened in test
+		return
+	}
+	compensateTicker := time.NewTicker(compensateInterval)
+	defer compensateTicker.Stop()
+	for {
+		select {
+		case <-c.Quit():
+			return
+		case <-compensateTicker.C:
+			func() {
+				c.mtx.Lock()
+				defer c.mtx.Unlock()
+				peers := c.swh.Peers().List()
+				for _, p := range peers {
+					if !c.exist(p.ID()) {
+						c.freshSet[p.ID()] = struct{}{}
+					}
+				}
+				for p := range c.permanentSet {
+					if !c.swh.Peers().Has(p) {
+						c.tryRemoveFromPermanent(p)
+					}
+				}
+				for p := range c.decayedSet {
+					if !c.swh.Peers().Has(p) {
+						c.tryRemoveFromDecayed(p)
+					}
+				}
+				for p := range c.freshSet {
+					if !c.swh.Peers().Has(p) {
+						delete(c.freshSet, p)
+					}
+				}
+			}()
+		}
+	}
+}
+
+func (c *CandidatePool) handleSampleRoutine() {
+	for {
+		select {
+		case <-c.Quit():
+			return
+		case e := <-c.eventStream:
+			c.handleMetricsEvent(e)
+		}
+	}
+}
+
+func (c *CandidatePool) handleMetricsEvent(e metricsEvent) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	pid := e.pid
+	if !c.exist(pid) {
+		c.Logger.Debug("receive a tryExpire metrics event, the peer is already removed", "peer", e.pid, "type", e.et)
+		return
+	}
+	if e.et == Bad {
+		if _, exist := c.decayedSet[pid]; !exist {
+			// just try to delete it, no need to check if it exist.
+			delete(c.freshSet, pid)
+			c.tryRemoveFromPermanent(pid)
+			c.decayedSet[pid] = struct{}{}
+			c.metrics.DecayPeerSetSize.Add(1)
+		} else {
+			// already in decayed set, nothing need to do.
+		}
+	} else if e.et == Good {
+		isFresh := c.isFresh(pid)
+		isDecayed := c.isDecayed(pid)
+		if isFresh || isDecayed {
+			if isFresh {
+				delete(c.freshSet, pid)
+			}
+			if isDecayed {
+				c.tryRemoveFromDecayed(pid)
+			}
+			metrics := newPeerMetrics()
+			metrics.addSample(e.dur)
+			added, kickPeer := c.tryAddPermanentPeer(pid, metrics)
+			if added {
+				c.Logger.Debug("new peer joined permanent peer set", "peer", pid)
+			}
+			// if some peers been kicked out, just join decayed peers.
+			if kickPeer != nil {
+				c.decayedSet[*kickPeer] = struct{}{}
+				c.metrics.DecayPeerSetSize.Add(1)
+			}
+		} else if metrics, exist := c.permanentSet[pid]; exist {
+			metrics.addSample(e.dur)
+		} else {
+			// should not happen
+			c.Logger.Error("receive event from peer which belongs to no peer set", "peer", e.pid)
+		}
+	} else {
+		c.Logger.Error("receive unknown metrics event type", "type", e.et)
+	}
+}
+
+func (c *CandidatePool) tryAddPermanentPeer(pid p2p.ID, metrics peerMetrics) (bool, *p2p.ID) {
+	if _, exist := c.permanentSet[pid]; exist {
+		c.Logger.Error("try to insert a metrics that already exists", "peer", pid)
+		// unexpected things happened, the best choice is degrade this peer and try to fix.
+		c.tryRemoveFromPermanent(pid)
+		return false, &pid
+	}
+	if len(c.permanentSet) >= maxPermanentSetSize {
+		//try to kick out the worst candidate.
+		maxDelay := metrics.average
+		kickPeer := pid
+		for p, m := range c.permanentSet {
+			if maxDelay < m.average {
+				maxDelay = m.average
+				kickPeer = p
+			}
+		}
+		if kickPeer != pid {
+			c.tryRemoveFromPermanent(kickPeer)
+			c.permanentSet[pid] = &metrics
+			c.metrics.PermanentPeerSetSize.Add(1)
+			c.metrics.PermanentPeers.With("peer_id", string(pid)).Set(1)
+			return true, &kickPeer
+		}
+		return false, &pid
+	} else {
+		c.permanentSet[pid] = &metrics
+		c.metrics.PermanentPeerSetSize.Add(1)
+		c.metrics.PermanentPeers.With("peer_id", string(pid)).Set(1)
+		return true, nil
+	}
+}
+
+func (c *CandidatePool) pickFromFreshSet() []*p2p.ID {
+	peers := make([]*p2p.ID, 0, len(c.freshSet))
+	for peer := range c.freshSet {
+		peers = append(peers, &peer)
+	}
+	return peers
+}
+
+func (c *CandidatePool) pickFromDecayedSet(broadcast bool) []*p2p.ID {
+	if len(c.decayedSet) == 0 {
+		return []*p2p.ID{}
+	}
+	peers := make([]*p2p.ID, 0, len(c.decayedSet))
+	for peer := range c.decayedSet {
+		peers = append(peers, &peer)
+	}
+	if !broadcast {
+		if c.pickSequence%pickDecayPeerInterval == 0 {
+			index := rand.Intn(len(peers))
+			return []*p2p.ID{peers[index]}
+		}
+		return []*p2p.ID{}
+	} else {
+		return peers
+	}
+}
+
+// larger average while less opportunity to be chosen. example:
+// peer         :          peerA  peerB  peerC
+// average delay:          1ns    1ns    8ns
+// percentage   :          0.1    0.1    0.8
+// diceSection  :          [0.9,  1.8,   2.0]
+// choose opportunity:     45%,   45%,   10%
+func (c *CandidatePool) pickFromPermanentPeer() *p2p.ID {
+	size := len(c.permanentSet)
+	if size == 0 {
+		return nil
+	}
+	diceSection := make([]float64, 0, size)
+	peers := make([]p2p.ID, 0, size)
+	var total, section float64
+	for _, m := range c.permanentSet {
+		total += float64(m.average)
+	}
+	// total could not be 0 actually, but assign with 1 if it unfortunately happened
+	if total == 0 {
+		total = 1
+	}
+	for p, m := range c.permanentSet {
+		peers = append(peers, p)
+		section = section + (1 - float64(m.average)/total)
+		diceSection = append(diceSection, section)
+	}
+	diceValue := rand.Float64() * diceSection[len(diceSection)-1]
+	choose := sort.SearchFloat64s(diceSection, diceValue)
+	return &peers[choose]
+}
+
+func (c *CandidatePool) exist(pid p2p.ID) bool {
+	if c.isPermanent(pid) {
+		return true
+	} else if c.isDecayed(pid) {
+		return true
+	} else if c.isFresh(pid) {
+		return true
+	}
+	return false
+}
+
+func (c *CandidatePool) isFresh(pid p2p.ID) bool {
+	_, exist := c.freshSet[pid]
+	return exist
+}
+
+func (c *CandidatePool) isDecayed(pid p2p.ID) bool {
+	_, exist := c.decayedSet[pid]
+	return exist
+}
+
+func (c *CandidatePool) isPermanent(pid p2p.ID) bool {
+	_, exist := c.permanentSet[pid]
+	return exist
+}
+
+func (c *CandidatePool) tryRemoveFromPermanent(pid p2p.ID) {
+	if c.isPermanent(pid) {
+		delete(c.permanentSet, pid)
+		c.metrics.PermanentPeerSetSize.Set(-1)
+		c.metrics.PermanentPeers.With("peer_id", string(pid)).Set(0)
+	}
+}
+
+func (c *CandidatePool) tryRemoveFromDecayed(pid p2p.ID) {
+	if c.isDecayed(pid) {
+		delete(c.decayedSet, pid)
+		c.metrics.DecayPeerSetSize.Set(-1)
+	}
+}
+
+// --------------------------------------------------
+type metricsEvent struct {
+	et  eventType
+	pid p2p.ID
+	dur int64 // nano second
+}
+
+type peerMetrics struct {
+	sampleSequence int64
+
+	samples *list.List
+	average int64 // nano second
+}
+
+func newPeerMetrics() peerMetrics {
+	return peerMetrics{
+		samples:        list.New(),
+		sampleSequence: rand.Int63n(recalculateInterval),
+	}
+}
+
+func (metrics *peerMetrics) addSample(dur int64) {
+	metrics.sampleSequence = metrics.sampleSequence + 1
+	// fast calculate average, but error accumulates
+	if metrics.samples.Len() >= maxMetricsSampleSize {
+		// shift old sample
+		popItem := metrics.samples.Front()
+		metrics.samples.Remove(popItem)
+		popDur := *popItem.Value.(*int64)
+		// no worry about int64 overflow, the max dur will not exceed math.MaxInt64/maxMetricsSampleSize
+		metrics.average = (metrics.average*int64(maxMetricsSampleSize) + (dur - popDur)) / int64(maxMetricsSampleSize)
+	} else {
+		length := int64(metrics.samples.Len())
+		metrics.average = (metrics.average*length + dur) / (length + 1)
+	}
+	metrics.samples.PushBack(&dur)
+
+	// correction error periodically
+	if metrics.sampleSequence%recalculateInterval == 0 {
+		var totalDur int64
+		// no worry about int64 overflow, the max dur will not exceed math.MaxInt64/maxMetricsSampleSize
+		s := metrics.samples.Front()
+		for s != nil {
+			sdur := *s.Value.(*int64)
+			totalDur += sdur
+			s = s.Next()
+		}
+		metrics.average = totalDur / int64(metrics.samples.Len())
+	}
+}

--- a/blockchain/hot/candidate_test.go
+++ b/blockchain/hot/candidate_test.go
@@ -1,0 +1,198 @@
+package hot
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/p2p"
+)
+
+func makeTestPeerId(num int) []p2p.ID {
+	if num <= 0 {
+		return []p2p.ID{}
+	}
+	pids := make([]p2p.ID, 0, num)
+	for i := 0; i < num; i++ {
+		pids = append(pids, p2p.ID(fmt.Sprintf("test id %v", i)))
+	}
+	return pids
+}
+func randomEvent() eventType {
+	if rand.Int()%2 == 0 {
+		return Good
+	} else {
+		return Bad
+	}
+}
+func TestPeerMetricsBasic(t *testing.T) {
+	pm := newPeerMetrics()
+	seq := pm.sampleSequence
+	sample := rand.Int63()
+	pm.addSample(sample)
+
+	assert.Equal(t, pm.average, sample)
+	assert.Equal(t, pm.samples.Len(), 1)
+	assert.Equal(t, pm.sampleSequence, seq+1)
+}
+
+func TestPeerMetricsNoOverflow(t *testing.T) {
+	pm := newPeerMetrics()
+	for i := 0; i < 10000; i++ {
+		// make sure it will not cause math overflow.
+		sample := rand.Int63n(math.MaxInt64 / maxMetricsSampleSize)
+		pm.addSample(sample)
+	}
+	assert.Equal(t, pm.samples.Len(), maxMetricsSampleSize)
+}
+
+func TestPeerMetricsParamResonableInMillisecondLevel(t *testing.T) {
+	var sum int64
+	pm := newPeerMetrics()
+	for i := 0; i < recalculateInterval-1; i++ {
+		sample := rand.Int63n(recalculateInterval-1) * time.Millisecond.Nanoseconds()
+		sum += sample
+		pm.addSample(sample)
+	}
+	average := sum / (recalculateInterval - 1)
+	// the diff is not too much
+	assert.True(t, (average-pm.average) < time.Millisecond.Nanoseconds()/10 && (average-pm.average) < time.Millisecond.Nanoseconds()/10)
+	// the average is not too small
+	assert.True(t, average > 100)
+}
+
+func TestPeerMetricsNoErrorAccumulate(t *testing.T) {
+	pm := newPeerMetrics()
+	for i := 0; i < 10000; i++ {
+		sample := rand.Int63n(math.MaxInt64 / maxMetricsSampleSize)
+		pm.addSample(sample)
+	}
+	var sum int64
+	// make sure it will recalculate when finish
+	pm.sampleSequence = 0
+	for i := 0; i < maxMetricsSampleSize; i++ {
+		sample := rand.Int63n(math.MaxInt64 / maxMetricsSampleSize)
+		sum += sample
+		pm.addSample(sample)
+	}
+	average := sum / maxMetricsSampleSize
+	assert.Equal(t, pm.average, average)
+}
+
+func TestCandidatePoolBasic(t *testing.T) {
+	sampleStream := make(chan metricsEvent)
+	candidatePool := NewCandidatePool(sampleStream)
+	candidatePool.Start()
+	defer candidatePool.Stop()
+
+	// control the pick decay logic
+	candidatePool.pickSequence = 0
+	totalPidNum := 85
+	goodPidNum := 21
+
+	testPids := makeTestPeerId(totalPidNum)
+	for _, p := range testPids {
+		candidatePool.AddPeer(p)
+	}
+	// peers stay in fresh set until an event come in
+	for i := 0; i < 2; i++ {
+		candidates := candidatePool.PickCandidates()
+		assert.Equal(t, len(candidates), totalPidNum)
+	}
+
+	for i := 0; i < goodPidNum; i++ {
+		sampleStream <- metricsEvent{Good, testPids[i], int64(i) * time.Millisecond.Nanoseconds()}
+	}
+	for i := goodPidNum; i < totalPidNum; i++ {
+		sampleStream <- metricsEvent{Bad, testPids[i], 0}
+	}
+	//wait for pool to handle
+	time.Sleep(10 * time.Millisecond)
+	for i := 0; i < 2; i++ {
+		candidates := candidatePool.PickCandidates()
+		// only one peer is selected
+		assert.Equal(t, len(candidates), 1)
+	}
+	assert.Equal(t, len(candidatePool.permanentSet), maxPermanentSetSize)
+	for i := 0; i < maxPermanentSetSize; i++ {
+		_, exist := candidatePool.permanentSet[testPids[i]]
+		assert.True(t, exist)
+	}
+	assert.Equal(t, len(candidatePool.decayedSet), totalPidNum-maxPermanentSetSize)
+	assert.Equal(t, len(candidatePool.freshSet), 0)
+}
+
+func TestCandidatePoolPickDecayPeriodically(t *testing.T) {
+	sampleStream := make(chan metricsEvent)
+	candidatePool := NewCandidatePool(sampleStream)
+	candidatePool.Start()
+	defer candidatePool.Stop()
+	testPids := makeTestPeerId(2)
+	candidatePool.AddPeer(testPids[0])
+	candidatePool.AddPeer(testPids[1])
+	sampleStream <- metricsEvent{Good, testPids[0], 1 * time.Millisecond.Nanoseconds()}
+	sampleStream <- metricsEvent{Bad, testPids[1], 0}
+
+	//wait for pool to handle
+	time.Sleep(10 * time.Millisecond)
+	// control the pick decay logic
+	candidatePool.pickSequence = 0
+
+	for i := 0; i < pickDecayPeerInterval-1; i++ {
+		peers := candidatePool.PickCandidates()
+		assert.Equal(t, len(peers), 1)
+	}
+	peers := candidatePool.PickCandidates()
+	assert.Equal(t, len(peers), 2)
+}
+
+func TestCandidatePoolNoDuplicatePeer(t *testing.T) {
+	sampleStream := make(chan metricsEvent)
+	candidatePool := NewCandidatePool(sampleStream)
+	candidatePool.Start()
+	defer candidatePool.Stop()
+	totalPidNum := 1000
+	testPids := makeTestPeerId(totalPidNum)
+	for _, p := range testPids {
+		candidatePool.AddPeer(p)
+	}
+	for i := 0; i < 100000; i++ {
+		dur := rand.Int63()
+		et := randomEvent()
+		peer := testPids[rand.Intn(totalPidNum)]
+		sampleStream <- metricsEvent{et, peer, dur}
+	}
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, len(candidatePool.freshSet)+len(candidatePool.decayedSet)+len(candidatePool.permanentSet), totalPidNum)
+}
+
+func TestCandidatePoolPickInScore(t *testing.T) {
+	sampleStream := make(chan metricsEvent)
+	candidatePool := NewCandidatePool(sampleStream)
+	candidatePool.Start()
+	defer candidatePool.Stop()
+	totalPidNum := maxPermanentSetSize
+	testPids := makeTestPeerId(totalPidNum)
+	for i, p := range testPids {
+		candidatePool.AddPeer(p)
+		sampleStream <- metricsEvent{Good, p, int64(i+1) * time.Millisecond.Nanoseconds()}
+	}
+	time.Sleep(10 * time.Millisecond)
+	candidatePool.PickCandidates()
+	pickRate := make(map[p2p.ID]int)
+	for i := 0; i < 100000; i++ {
+		peers := candidatePool.PickCandidates()
+		assert.Equal(t, 1, len(peers))
+		peer := *peers[0]
+		pickRate[peer] = pickRate[peer] + 1
+	}
+	for i := 0; i < maxPermanentSetSize; i++ {
+		fmt.Printf("index %d rate is %v\n", i, float64(pickRate[testPids[i]])/float64(100000))
+	}
+	for i := 0; i < maxPermanentSetSize-1; i++ {
+		assert.True(t, pickRate[testPids[i]] > pickRate[testPids[i+1]])
+	}
+}

--- a/blockchain/hot/metrics.go
+++ b/blockchain/hot/metrics.go
@@ -1,0 +1,120 @@
+package hot
+
+import (
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/discard"
+	"github.com/go-kit/kit/metrics/prometheus"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// MetricsSubsystem is a subsystem shared by all metrics exposed by this
+	// package.
+	MetricsSubsystem = "hot_sync"
+)
+
+// Metrics contains metrics exposed by this package.
+type Metrics struct {
+	// Height of the chain.
+	Height metrics.Gauge
+	// Time between this and the last block.
+	BlockIntervalSeconds metrics.Gauge
+	// Number of transactions.
+	NumTxs metrics.Gauge
+	// Size of the block.
+	BlockSizeBytes metrics.Gauge
+	// Total number of transactions.
+	TotalTxs metrics.Gauge
+	// The latest block height.
+	CommittedHeight metrics.Gauge
+
+	// The number of peers consider as good
+	PermanentPeerSetSize metrics.Gauge
+	// The detail peers consider as good
+	PermanentPeers metrics.Gauge
+	// The number of peers consider as bad
+	DecayPeerSetSize metrics.Gauge
+}
+
+// PrometheusMetrics returns Metrics build using Prometheus client library.
+// Optionally, labels can be provided along with their values ("foo",
+// "fooValue").
+func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
+	labels := []string{}
+	for i := 0; i < len(labelsAndValues); i += 2 {
+		labels = append(labels, labelsAndValues[i])
+	}
+	return &Metrics{
+		Height: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "height",
+			Help:      "Height of the chain.",
+		}, labels).With(labelsAndValues...),
+
+		BlockIntervalSeconds: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "block_interval_seconds",
+			Help:      "Time between this and the last block.",
+		}, labels).With(labelsAndValues...),
+
+		NumTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "num_txs",
+			Help:      "Number of transactions.",
+		}, labels).With(labelsAndValues...),
+		BlockSizeBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "block_size_bytes",
+			Help:      "Size of the block.",
+		}, labels).With(labelsAndValues...),
+		TotalTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "total_txs",
+			Help:      "Total number of transactions.",
+		}, labels).With(labelsAndValues...),
+		CommittedHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "latest_block_height",
+			Help:      "The latest block height.",
+		}, labels).With(labelsAndValues...),
+		PermanentPeerSetSize: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "permanent_set_size",
+			Help:      "The number of peers consider as good.",
+		}, labels).With(labelsAndValues...),
+		DecayPeerSetSize: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "decay_peer_set_size",
+			Help:      "The number of peers consider as bad",
+		}, labels).With(labelsAndValues...),
+		PermanentPeers: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "permanent_peers",
+			Help:      "The details of peers consider as bad",
+		}, append(labels, "peer_id")).With(labelsAndValues...),
+	}
+}
+
+// NopMetrics returns no-op Metrics.
+func NopMetrics() *Metrics {
+	return &Metrics{
+		Height:               discard.NewGauge(),
+		BlockIntervalSeconds: discard.NewGauge(),
+		NumTxs:               discard.NewGauge(),
+		BlockSizeBytes:       discard.NewGauge(),
+		TotalTxs:             discard.NewGauge(),
+		CommittedHeight:      discard.NewGauge(),
+		PermanentPeerSetSize: discard.NewGauge(),
+		PermanentPeers:       discard.NewGauge(),
+		DecayPeerSetSize:     discard.NewGauge(),
+	}
+}

--- a/blockchain/hot/pool.go
+++ b/blockchain/hot/pool.go
@@ -1,0 +1,1042 @@
+package hot
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/tendermint/tendermint/blockchain"
+	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/p2p"
+	st "github.com/tendermint/tendermint/state"
+	"github.com/tendermint/tendermint/types"
+)
+
+const (
+	// SyncPattern is the work pattern of BlockPool.
+	// 1. Mute: will only answer subscribe requests from others, will not sync from others or from consensus channel.
+	// 2. Hot:  handle subscribe requests from other peer as a publisher, also subscribe block messages
+	//    from other peers as a subscriber.
+	// 3. Consensus: handle subscribe requests from other peer as a publisher, but subscribe block message from
+	//    consensus channel.
+	// The viable transitions between are:
+	//                                Hot --> Consensus
+	//                                 ^    ^
+	//                                 |   /
+	//                                 |  /
+	//                                Mute
+	Mute SyncPattern = iota
+	Hot
+	Consensus
+)
+
+const (
+	// the time interval to correct current state.
+	tryRepairInterval = 1 * time.Second
+
+	maxCachedSealedBlock = 100
+
+	// the max num of blocks can subscribed in advance.
+	maxSubscribeForesight = 40
+	// the max num of blocks other peers can subscribe from us ahead of current height.
+	// should greater than maxSubscribeForesight.
+	maxPublishForesight = 80
+
+	eventBusSubscribeCap = 1000
+
+	subscriber = "HotSyncService"
+	selfId     = p2p.ID("self")
+)
+
+type SyncPattern uint
+
+type BlockPool struct {
+	cmn.BaseService
+	mtx       sync.Mutex
+	st        SyncPattern
+	eventBus  *types.EventBus
+	store     *blockchain.BlockStore
+	blockExec *st.BlockExecutor
+
+	blockTimeout time.Duration
+
+	//--- state ---
+	// the verified blockState received recently
+	blockStates        map[int64]*blockState
+	subscriberPeerSets map[int64]map[p2p.ID]struct{}
+	state              st.State
+	blocksSynced       int32
+	subscribedHeight   int64
+	height             int64
+
+	//--- internal communicate ---
+	blockStateSealCh     chan *blockState
+	publisherStateSealCh chan *publisherState
+	decayedPeers         chan decayedPeer
+	messagesCh           chan<- Message
+
+	//--- peer metrics ---
+	candidatePool *CandidatePool
+	sampleStream  chan<- metricsEvent
+
+	//--- other metrics --
+	metrics *Metrics
+
+	//--- for switch ---
+	switchCh chan struct{}
+	switchWg sync.WaitGroup
+}
+
+func NewBlockPool(store *blockchain.BlockStore, blockExec *st.BlockExecutor, state st.State, messagesCh chan<- Message, st SyncPattern, blockTimeout time.Duration) *BlockPool {
+	const capacity = 1000
+	sampleStream := make(chan metricsEvent, capacity)
+	candidates := NewCandidatePool(sampleStream)
+	bp := &BlockPool{
+		store:                store,
+		height:               state.LastBlockHeight,
+		blockExec:            blockExec,
+		state:                state,
+		subscribedHeight:     state.LastBlockHeight,
+		blockStates:          make(map[int64]*blockState, maxCachedSealedBlock),
+		subscriberPeerSets:   make(map[int64]map[p2p.ID]struct{}, 0),
+		publisherStateSealCh: make(chan *publisherState, capacity),
+		messagesCh:           messagesCh,
+		candidatePool:        candidates,
+		sampleStream:         sampleStream,
+		switchCh:             make(chan struct{}, 1),
+		decayedPeers:         make(chan decayedPeer, capacity),
+		blockStateSealCh:     make(chan *blockState, capacity),
+		blockTimeout:         blockTimeout,
+		st:                   st,
+		metrics:              NopMetrics(),
+	}
+	bp.BaseService = *cmn.NewBaseService(nil, "HotBlockPool", bp)
+	return bp
+}
+
+func (pool *BlockPool) setEventBus(eventBus *types.EventBus) {
+	pool.eventBus = eventBus
+}
+
+func (pool *BlockPool) setMetrics(metrics *Metrics) {
+	pool.metrics = metrics
+	pool.candidatePool.metrics = metrics
+}
+
+//---------------Service implement ----------------
+func (pool *BlockPool) OnStart() error {
+	if pool.st == Consensus {
+		pool.Logger.Info("block pool start in consensus pattern")
+		go pool.consensusSyncRoutine()
+	} else if pool.st == Hot {
+		pool.Logger.Info("block pool start in hotSync pattern")
+		pool.switchWg.Add(1)
+		pool.candidatePool.Start()
+		go pool.hotSyncRoutine()
+	} else {
+		pool.Logger.Info("block pool start in mute pattern")
+	}
+	return nil
+}
+
+func (pool *BlockPool) OnStop() {
+	if pool.candidatePool.IsRunning() {
+		pool.candidatePool.Stop()
+	}
+}
+
+func (pool *BlockPool) SetLogger(l log.Logger) {
+	pool.BaseService.Logger = l.With("module", "blockPool")
+	pool.candidatePool.SetLogger(l.With("module", "candidatePool"))
+}
+
+func (pool *BlockPool) AddPeer(peer p2p.Peer) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	// no matter what sync pattern now, need maintain candidatePool.
+	pool.candidatePool.AddPeer(peer.ID())
+}
+
+func (pool *BlockPool) RemovePeer(peer p2p.Peer) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	// no matter what sync pattern now, need maintain candidatePool.
+	pool.candidatePool.RemovePeer(peer.ID())
+	if pool.st == Hot {
+		pool.decayedPeers <- decayedPeer{peerId: peer.ID()}
+	}
+	for _, subscribers := range pool.subscriberPeerSets {
+		delete(subscribers, peer.ID())
+	}
+}
+
+// ------  switch logic -----
+func (pool *BlockPool) SwitchToHotSync(state st.State, blockSynced int32) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	if pool.st != Mute {
+		panic(fmt.Sprintf("can't switch to hotsync pattern, current sync pattern is %d", pool.st))
+	}
+	pool.Logger.Info("switch to hot sync pattern")
+	pool.st = Hot
+	pool.state = state
+	pool.subscribedHeight = state.LastBlockHeight
+	pool.blocksSynced = blockSynced
+	pool.height = state.LastBlockHeight
+
+	pool.switchWg.Add(1)
+	pool.candidatePool.Start()
+	go pool.hotSyncRoutine()
+}
+
+func (pool *BlockPool) SwitchToConsensusSync(state *st.State) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	if pool.st == Consensus {
+		panic("already in consensus sync, can't switch to consensus sync")
+	}
+	var copyState st.State
+	// means switch from hot sync
+	if state == nil {
+		copyState = pool.state
+	} else {
+		copyState = state.Copy()
+	}
+	pool.switchCh <- struct{}{}
+	// wait until hotSyncRoutine ends.
+	pool.switchWg.Wait()
+	// clean block states from expecting height.
+	pool.resetBlockStates()
+
+	pool.Logger.Info("switch to consensus sync pattern")
+	pool.st = Consensus
+	pool.state = copyState
+	pool.height = copyState.LastBlockHeight
+	pool.subscribedHeight = copyState.LastBlockHeight
+
+	if pool.candidatePool.IsRunning() {
+		pool.candidatePool.Stop()
+	}
+	go pool.consensusSyncRoutine()
+}
+
+//------- handle request from other peer -----
+func (pool *BlockPool) handleSubscribeBlock(fromHeight, toHeight int64, src p2p.Peer) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	if pool.st == Mute {
+		for height := fromHeight; height <= toHeight; height++ {
+			if height < pool.store.Height() {
+				pool.sendBlockFromStore(height, src)
+			} else {
+				// Won't answer no block message immediately.
+				// Afraid of the peer will subscribe again immediately, which
+				// will cause message burst.
+				return
+			}
+		}
+		return
+	}
+	for height := fromHeight; height <= toHeight; height++ {
+		blockState := pool.blockStates[height]
+		if blockState != nil && blockState.isSealed() {
+			pool.sendMessages(src.ID(), &blockCommitResponseMessage{blockState.block, blockState.commit})
+		} else if height <= pool.currentHeight() {
+			// Todo: load blockChainMessage from store takes time, should we introduce go pool and do asynchronously?
+			pool.sendBlockFromStore(height, src)
+		} else if height < pool.currentHeight()+maxPublishForesight {
+			// even if the peer have subscribe at the height before, in consideration of
+			// network/protocol robustness, still sent what we have again.
+			if blockState != nil {
+				if blockState.latestBlock != nil {
+					pool.sendMessages(src.ID(), &blockCommitResponseMessage{Block: blockState.latestBlock})
+				}
+				if blockState.latestCommit != nil {
+					pool.sendMessages(src.ID(), &blockCommitResponseMessage{Commit: blockState.latestCommit})
+				}
+			}
+			pool.Logger.Debug("handle peer subscribe block", "peer", src.ID(), "height", height)
+			if peers, exist := pool.subscriberPeerSets[height]; exist {
+				peers[src.ID()] = struct{}{}
+			} else {
+				pool.subscriberPeerSets[height] = map[p2p.ID]struct{}{src.ID(): {}}
+			}
+		} else {
+			// will not handle higher subscribe request
+			pool.sendMessages(src.ID(), &noBlockResponseMessage{height})
+			return
+		}
+	}
+	return
+}
+
+func (pool *BlockPool) handleUnSubscribeBlock(height int64, src p2p.Peer) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	if pool.st == Mute {
+		return
+	}
+	pool.Logger.Debug("handle peer unsubscribe block", "peer", src.ID(), "height", height)
+	if subscribers, exist := pool.subscriberPeerSets[height]; exist {
+		delete(subscribers, src.ID())
+	}
+}
+
+func (pool *BlockPool) handleBlockCommit(block *types.Block, commit *types.Commit, src p2p.Peer) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	if pool.st != Hot {
+		return
+	}
+	var height int64
+	// have checked, block and commit can't both be nil
+	if block != nil {
+		height = block.Height
+	} else {
+		height = commit.Height()
+	}
+	if ps := pool.getPublisherAtHeight(height, src.ID()); ps != nil {
+		if block != nil {
+			ps.receiveBlock(block)
+		}
+		if commit != nil {
+			ps.receiveCommit(commit)
+		}
+	} else {
+		pool.Logger.Info("receive block/commit that is not expected", "peer", src.ID(), "height", height)
+	}
+}
+
+func (pool *BlockPool) handleNoBlock(height int64, src p2p.Peer) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	if pool.st != Hot {
+		return
+	}
+	if ps := pool.getPublisherAtHeight(height, src.ID()); ps != nil {
+		ps.receiveNoBlock()
+	} else {
+		pool.Logger.Info("receive no block message that is not expected", "peer", src.ID(), "height", height)
+	}
+}
+
+func (pool *BlockPool) handleBlockFromSelf(height int64, block *types.Block) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	bc, exist := pool.blockStates[height]
+	if !exist {
+		bc = pool.newBlockStateAtHeight(height)
+	}
+	ps, exist := bc.pubStates[selfId]
+	if !exist {
+		ps = NewPeerPublisherState(bc, selfId, pool.Logger, pool.blockTimeout, pool)
+		bc.pubStates[selfId] = ps
+	}
+	ps.receiveBlock(block)
+}
+
+func (pool *BlockPool) handleCommitFromSelf(height int64, commit *types.Commit) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	bc, exist := pool.blockStates[height]
+	if !exist {
+		bc = pool.newBlockStateAtHeight(height)
+	}
+	ps, exist := bc.pubStates[selfId]
+	if !exist {
+		ps = NewPeerPublisherState(bc, selfId, pool.Logger, pool.blockTimeout, pool)
+		bc.pubStates[selfId] = ps
+	}
+	ps.receiveCommit(commit)
+}
+
+//  -------------------------------------------------
+func (pool *BlockPool) hotSyncRoutine() {
+	tryRepairTicker := time.NewTicker(tryRepairInterval)
+	defer tryRepairTicker.Stop()
+	pool.subscribeBlockInForesightExclusive()
+	for {
+		if !pool.IsRunning() {
+			break
+		}
+		select {
+		case bs := <-pool.blockStateSealCh:
+			pool.compensatePublish(bs)
+			pool.applyBlock(bs)
+			pool.recordMetrics(bs.block)
+			pool.incBlocksSynced()
+			pool.incCurrentHeight()
+			pool.trimStaleState()
+			// try subscribe more
+			pool.subscribeBlockInForesightExclusive()
+			pool.wakeupNextBlockState()
+		case ps := <-pool.publisherStateSealCh:
+			pool.updatePeerMetrics(ps)
+			if ps.broken {
+				pool.decayedPeers <- decayedPeer{ps.pid, ps.bs.height}
+			}
+		case peer := <-pool.decayedPeers:
+			pool.tryReschedule(peer)
+		case <-tryRepairTicker.C:
+			pool.tryRepair()
+		case <-pool.switchCh:
+			pool.Logger.Info("stopping hotsync routine")
+			pool.switchWg.Done()
+			return
+		}
+	}
+}
+
+func (pool *BlockPool) consensusSyncRoutine() {
+	blockSub, err := pool.eventBus.Subscribe(context.Background(), subscriber, types.EventQueryCompleteProposal, eventBusSubscribeCap)
+	if err != nil {
+		panic(err)
+	}
+	commitSub, err := pool.eventBus.Subscribe(context.Background(), subscriber, types.EventQueryMajorPrecommits, eventBusSubscribeCap)
+	if err != nil {
+		panic(err)
+	}
+	for {
+		if !pool.IsRunning() {
+			break
+		}
+		select {
+		case bs := <-pool.blockStateSealCh:
+			// there is no guarantee that this routine happens before consensus reactor start.
+			// should tolerate miss some blocks at first.
+			// so we use setCurrentHeight instead of incHeight.
+			pool.setCurrentHeight(bs.height)
+			pool.compensatePublish(bs)
+			pool.trimStaleState()
+		case <-pool.publisherStateSealCh:
+			// just drain the channel
+		case blockData := <-blockSub.Out():
+			blockProposal := blockData.Data().(types.EventDataCompleteProposal)
+			block := blockProposal.Block
+			height := blockProposal.Height
+			pool.handleBlockFromSelf(height, &block)
+		case commitData := <-commitSub.Out():
+			precommit := commitData.Data().(types.EventDataMajorPrecommits)
+			// if maj23 is zero, means will have another round.
+			if maj23, ok := precommit.Votes.TwoThirdsMajority(); ok && !maj23.IsZero() {
+				height := precommit.Height
+				commit := precommit.Votes.MakeCommit()
+				pool.handleCommitFromSelf(height, commit)
+			}
+		}
+	}
+
+}
+
+//-------------------------------------
+func (pool *BlockPool) resetBlockStates() {
+	for height := pool.expectingHeight(); height <= pool.subscribedHeight; height++ {
+		if pubs := pool.getPublishersAtHeight(height); pubs != nil {
+			for _, ps := range pubs {
+				if ps.timeout != nil {
+					ps.timeout.Stop()
+				}
+				if !ps.sealed {
+					pool.sendMessages(ps.pid, &blockUnSubscribeMessage{Height: ps.bs.height})
+				}
+			}
+		}
+		delete(pool.blockStates, height)
+	}
+}
+
+func (pool *BlockPool) tryReschedule(peer decayedPeer) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	height := peer.fromHeight
+	if height == 0 {
+		height = pool.expectingHeight()
+	}
+	pool.Logger.Info("try reschedule for block", "from_height", height, "to_height", pool.subscribedHeight, "peer", peer.peerId)
+	for ; height <= pool.subscribedHeight; height++ {
+		if pubStates := pool.getPublishersAtHeight(height); pubStates != nil {
+			if ps, exist := pubStates[peer.peerId]; exist {
+				if ps.timeout != nil {
+					ps.timeout.Stop()
+				}
+				// if the peer is removed, try send unsubscribeMessage actually will do nothing.
+				pool.sendMessages(peer.peerId, &blockUnSubscribeMessage{Height: height})
+				delete(pubStates, ps.pid)
+				// is is possible the current height blockstate is sealed, but current height is not update yet.
+				// if it is sealed, just skip
+				if !ps.bs.isSealed() && len(pubStates) == 0 {
+					// empty now, choose new peers for this height.
+					pool.subscribeBlockAtHeight(height, nil)
+				}
+			}
+		}
+	}
+}
+
+func (pool *BlockPool) tryRepair() {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	// have't block any blocks yet.
+	if pool.currentHeight() == pool.subscribedHeight {
+		pool.subscribeBlockInForesight()
+	} else {
+		// reschedule may failed because of no peer available, need subscribe again during repair
+		for h := pool.expectingHeight(); h <= pool.subscribedHeight; h++ {
+			if pubStates := pool.getPublishersAtHeight(h); len(pubStates) == 0 {
+				pool.Logger.Info("try resubscribe for block", "height", h)
+				pool.subscribeBlockAtHeight(h, nil)
+			}
+		}
+	}
+}
+
+func (pool *BlockPool) wakeupNextBlockState() {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	pool.Logger.Info("Wake next block", "height", pool.expectingHeight())
+	if bs := pool.blockStates[pool.expectingHeight()]; bs != nil {
+		// new round, sent new start time
+		bs.startTime = time.Now()
+		if pubs := pool.getPublishersAtHeight(pool.expectingHeight()); pubs != nil {
+			for _, ps := range pubs {
+				ps.wakeup()
+			}
+		}
+	}
+}
+
+func (pool *BlockPool) sendBlockFromStore(height int64, src p2p.Peer) {
+	block := pool.store.LoadBlock(height)
+	if block == nil {
+		pool.sendMessages(src.ID(), &noBlockResponseMessage{height})
+		return
+	}
+	blockAfter := pool.store.LoadBlock(height + 1)
+	if blockAfter == nil {
+		pool.sendMessages(src.ID(), &noBlockResponseMessage{height})
+		return
+	}
+	pool.sendMessages(src.ID(), &blockCommitResponseMessage{Block: block, Commit: blockAfter.LastCommit})
+}
+
+// applyBlock takes most of time, make thin lock in updateState.
+func (pool *BlockPool) applyBlock(bs *blockState) {
+	pool.Logger.Info("Apply block", "height", bs.block.Height)
+	blockParts := bs.block.MakePartSet(types.BlockPartSizeBytes)
+	pool.store.SaveBlock(bs.block, blockParts, bs.commit)
+	// get the hash without persisting the state
+	newState, err := pool.blockExec.ApplyBlock(pool.state, *bs.blockId, bs.block)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to process committed blockChainMessage (%d:%X): %v", bs.block.Height, bs.block.Hash(), err))
+	}
+	pool.updateState(newState)
+}
+
+func (pool *BlockPool) updateState(state st.State) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	pool.state = state
+}
+
+// the subscribe strategy:
+//
+// one candidate:
+// 1. if `subscribedHeight-currentHeight > maxSubscribeForesight/2`, means have subscribe many blocks now, do nothing
+// 2. else [subscribedHeight + 1, currentHeight+maxSubscribeForesight] subscribe request will be send.
+//
+// more than one candidates: only block at `subscribedHeight + 1` will be subscribed.
+func (pool *BlockPool) subscribeBlockInForesight() {
+	peers := pool.candidatePool.PickCandidates()
+	if len(peers) == 0 {
+		pool.Logger.Error("no peers is available", "height", pool.currentHeight())
+		return
+	}
+	var fromHeight, toHeight int64
+	if len(peers) == 1 {
+		peer := peers[0]
+		if pool.subscribedHeight-pool.currentHeight() > maxSubscribeForesight/2 {
+			return
+		} else {
+			fromHeight = pool.subscribedHeight + 1
+			toHeight = pool.currentHeight() + maxSubscribeForesight
+		}
+		for h := fromHeight; h <= toHeight; h++ {
+			bc := pool.newBlockStateAtHeight(h)
+			bc.pubStates[*peer] = NewPeerPublisherState(bc, *peer, pool.Logger, pool.blockTimeout, pool)
+		}
+		pool.sendMessages(*peer, &blockSubscribeMessage{fromHeight, toHeight})
+		pool.subscribedHeight = toHeight
+		return
+	} else if len(peers) > 1 {
+		if pool.subscribedHeight+1 <= pool.currentHeight()+maxSubscribeForesight {
+			height := pool.subscribedHeight + 1
+			pool.subscribeBlockAtHeight(height, peers)
+			pool.subscribedHeight = height
+		}
+		return
+	}
+}
+
+func (pool *BlockPool) subscribeBlockInForesightExclusive() {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	pool.subscribeBlockInForesight()
+
+}
+
+func (pool *BlockPool) newBlockStateAtHeight(height int64) *blockState {
+	newBc := NewBlockState(height, pool.Logger, pool)
+	pool.blockStates[height] = newBc
+	return newBc
+}
+
+func (pool *BlockPool) subscribeBlockAtHeight(height int64, peers []*p2p.ID) {
+	if peers == nil {
+		peers = pool.candidatePool.PickCandidates()
+	}
+	if len(peers) == 0 {
+		pool.Logger.Error("no peers is available", "height", pool.currentHeight())
+		return
+	}
+	messages := make([]Message, 0, len(peers))
+	bc := pool.newBlockStateAtHeight(height)
+	for _, peer := range peers {
+		ps := NewPeerPublisherState(bc, *peer, pool.Logger, pool.blockTimeout, pool)
+		bc.pubStates[*peer] = ps
+		messages = append(messages, Message{&blockSubscribeMessage{height, height}, *peer})
+	}
+	for _, m := range messages {
+		pool.sendMessages(m.peerId, m.blockChainMessage)
+	}
+}
+
+// May publish order and commit in incorrect order, try correct it once we know the true block and commit.
+// It is expensive to maintain all received blocks before receiving a
+// valid commit, this is a trade off between complexity, memory and network.
+func (pool *BlockPool) compensatePublish(bs *blockState) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	if !bytes.Equal(bs.block.Hash(), bs.latestBlock.Hash()) {
+		bs.pool.publishBlock(bs.height, bs.block)
+	}
+	if !bytes.Equal(bs.commit.Hash(), bs.latestCommit.Hash()) {
+		bs.pool.publishCommit(bs.height, bs.commit)
+	}
+	delete(bs.pool.subscriberPeerSets, bs.height)
+}
+
+func (pool *BlockPool) publishBlock(height int64, block *types.Block) {
+	if subscribers := pool.subscriberPeerSets[height]; len(subscribers) > 0 {
+		for p := range subscribers {
+			pool.sendMessages(p, &blockCommitResponseMessage{Block: block})
+		}
+	}
+}
+
+func (pool *BlockPool) publishCommit(height int64, commit *types.Commit) {
+	if subscribers := pool.subscriberPeerSets[height]; len(subscribers) > 0 {
+		for p := range subscribers {
+			pool.sendMessages(p, &blockCommitResponseMessage{Commit: commit})
+		}
+	}
+}
+
+func (pool *BlockPool) trimStaleState() {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	trimHeight := pool.currentHeight() - maxCachedSealedBlock
+	if trimHeight > 0 {
+		if pubStates := pool.getPublishersAtHeight(trimHeight); pubStates != nil {
+			for _, ps := range pubStates {
+				if pool.st == Hot {
+					ps.tryExpire()
+				}
+			}
+		}
+		delete(pool.blockStates, trimHeight)
+	}
+}
+
+func (pool *BlockPool) getPublishersAtHeight(height int64) map[p2p.ID]*publisherState {
+	if bs, exist := pool.blockStates[height]; exist {
+		return bs.pubStates
+	}
+	return nil
+}
+
+func (pool *BlockPool) getPublisherAtHeight(height int64, pid p2p.ID) *publisherState {
+	if pubs := pool.getPublishersAtHeight(height); pubs != nil {
+		return pubs[pid]
+	}
+	return nil
+}
+
+//  where use currentHeight have already locked
+func (pool *BlockPool) currentHeight() int64 {
+	return pool.height
+}
+
+func (pool *BlockPool) incCurrentHeight() {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	pool.height++
+}
+
+func (pool *BlockPool) setCurrentHeight(height int64) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	pool.height = height
+}
+
+// most of the usage have locked. Only newBlockStateAtHeight do not, but the usage can't
+// currently excuted with incCurrentHeight, it is safe.
+func (pool *BlockPool) expectingHeight() int64 {
+	return pool.height + 1
+}
+
+func (pool *BlockPool) incBlocksSynced() int32 {
+	return atomic.AddInt32(&pool.blocksSynced, 1)
+}
+
+func (pool *BlockPool) getBlockSynced() int32 {
+	return atomic.LoadInt32(&pool.blocksSynced)
+}
+
+func (pool *BlockPool) getSyncPattern() SyncPattern {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	return pool.st
+}
+
+func (pool *BlockPool) verifyCommit(blockID types.BlockID, commit *types.Commit) error {
+	return pool.state.Validators.VerifyCommit(pool.state.ChainID, blockID, pool.currentHeight()+1, commit)
+}
+
+func (pool *BlockPool) sendMessages(pid p2p.ID, msgs ...BlockchainMessage) {
+	for _, msg := range msgs {
+		select {
+		case pool.messagesCh <- Message{msg, pid}:
+		default:
+			pool.Logger.Error("Failed to send commit/blockChainMessage since messagesCh is full", "peer", pid)
+		}
+	}
+}
+
+func (pool *BlockPool) updatePeerMetrics(ps *publisherState) {
+	var et eventType
+	var dur int64
+	if ps.broken {
+		et = Bad
+	} else {
+		et = Good
+		dur = time.Now().Sub(ps.bs.startTime).Nanoseconds()
+		// this should not happened, but defend it.
+		if dur <= 0 {
+			dur = 1
+		}
+	}
+	select {
+	case ps.pool.sampleStream <- metricsEvent{et, ps.pid, dur}:
+	default:
+		ps.logger.Error("failed to send good sample event", "peer", ps.pid, "height", ps.bs.height)
+	}
+	return
+}
+
+func (pool *BlockPool) recordMetrics(block *types.Block) {
+	height := block.Height
+	if height > 1 {
+		var lastBlockTime time.Time
+		if lastBs, exist := pool.blockStates[height-1]; exist {
+			lastBlockTime = lastBs.block.Time
+		} else {
+			lastBlockTime = pool.store.LoadBlockMeta(height - 1).Header.Time
+		}
+		pool.metrics.BlockIntervalSeconds.Set(
+			block.Time.Sub(lastBlockTime).Seconds(),
+		)
+	}
+	pool.metrics.NumTxs.Set(float64(block.NumTxs))
+	pool.metrics.BlockSizeBytes.Set(float64(block.Size()))
+	pool.metrics.TotalTxs.Set(float64(block.TotalTxs))
+	pool.metrics.CommittedHeight.Set(float64(height))
+	pool.metrics.Height.Set(float64(height + 1))
+}
+
+//----------------------------------------
+// blockState track the response of multi peers about block/commit at specified
+// height that blockPool subscribed.
+type blockState struct {
+	//--- ops fields
+	mux       sync.Mutex
+	logger    log.Logger
+	startTime time.Time
+
+	pool   *BlockPool
+	sealed bool
+
+	//--- data fields
+	height  int64
+	commit  *types.Commit
+	block   *types.Block
+	blockId *types.BlockID
+
+	// recently received commit and blockChainMessage
+	latestCommit *types.Commit
+	latestBlock  *types.Block
+
+	pubStates map[p2p.ID]*publisherState
+}
+
+func NewBlockState(height int64, logger log.Logger, pool *BlockPool) *blockState {
+	bc := &blockState{
+		height:    height,
+		logger:    logger,
+		pool:      pool,
+		pubStates: make(map[p2p.ID]*publisherState, 0),
+	}
+	if pool.expectingHeight() == height {
+		bc.startTime = time.Now()
+	}
+	return bc
+}
+
+func (bs *blockState) setLatestBlock(block *types.Block) {
+	bs.mux.Lock()
+	defer bs.mux.Unlock()
+	if bs.sealed {
+		return
+	}
+	if bs.latestBlock == nil || !bytes.Equal(bs.latestBlock.Hash(), block.Hash()) {
+		bs.latestBlock = block
+		// notice blockChainMessage state change
+		bs.pool.publishBlock(bs.height, block)
+	}
+}
+
+func (bs *blockState) setLatestCommit(commit *types.Commit) {
+	bs.mux.Lock()
+	defer bs.mux.Unlock()
+	if bs.sealed {
+		return
+	}
+	if bs.latestCommit == nil || !bytes.Equal(bs.latestCommit.Hash(), commit.Hash()) {
+		bs.latestCommit = commit
+		// notice blockChainMessage state change
+		bs.pool.publishCommit(bs.height, commit)
+	}
+}
+
+func (bs *blockState) seal() {
+	bs.mux.Lock()
+	defer bs.mux.Unlock()
+	if bs.sealed == true {
+		return
+	}
+	bs.sealed = true
+	bs.logger.Debug("sealing blockChainMessage commit", "height", bs.height)
+	bs.pool.blockStateSealCh <- bs
+}
+
+func (bs *blockState) isSealed() bool {
+	bs.mux.Lock()
+	defer bs.mux.Unlock()
+	return bs.sealed
+}
+
+//----------------------------------------
+// publisherState is used to track the continuous response of a peer about block/commit at specified
+// height that blockpool subscribed. The peer plays as a publisher.
+type publisherState struct {
+	mux        sync.Mutex
+	logger     log.Logger
+	timeoutDur time.Duration
+
+	bs   *blockState
+	pool *BlockPool
+
+	timeout *time.Timer
+	isWake  bool
+
+	broken bool
+	sealed bool
+
+	pid    p2p.ID
+	commit *types.Commit
+	block  *types.Block
+}
+
+func NewPeerPublisherState(bc *blockState, pid p2p.ID, logger log.Logger, timeoutDur time.Duration, pool *BlockPool) *publisherState {
+	ps := &publisherState{
+		logger:     logger,
+		pid:        pid,
+		bs:         bc,
+		pool:       pool,
+		timeoutDur: timeoutDur,
+	}
+	if pool.expectingHeight() == bc.height || pid == selfId {
+		if pool.st == Hot {
+			ps.startTimer()
+		}
+		ps.isWake = true
+	}
+	return ps
+}
+
+func (ps *publisherState) wakeup() {
+	ps.mux.Lock()
+	defer ps.mux.Unlock()
+	ps.startTimer()
+	ps.isWake = true
+	ps.trySeal()
+}
+
+// if the ps still not trig timeout, but is going to trim,
+// consider it as bad peer, and update metrics by itself.
+func (ps *publisherState) tryExpire() {
+	ps.mux.Lock()
+	defer ps.mux.Unlock()
+	if !ps.sealed {
+		// stop the timer in case it leaks
+		if ps.timeout != nil {
+			ps.timeout.Stop()
+		}
+		ps.broken = true
+		ps.pool.updatePeerMetrics(ps)
+	}
+}
+
+func (ps *publisherState) onTimeout() {
+	ps.mux.Lock()
+	defer ps.mux.Unlock()
+	if ps.sealed {
+		return
+	}
+	ps.broken = true
+	ps.seal()
+}
+
+func (ps *publisherState) receiveBlock(block *types.Block) {
+	ps.mux.Lock()
+	defer ps.mux.Unlock()
+	if ps.sealed {
+		ps.logger.Debug("received blockChainMessage that is already sealed", "peer", ps.pid, "height", ps.bs.height)
+		return
+	}
+	ps.block = block
+	ps.bs.setLatestBlock(block)
+	ps.trySeal()
+}
+
+func (ps *publisherState) receiveNoBlock() {
+	ps.mux.Lock()
+	defer ps.mux.Unlock()
+	if ps.sealed {
+		return
+	}
+	ps.broken = true
+	ps.seal()
+}
+
+func (ps *publisherState) receiveCommit(commit *types.Commit) {
+	ps.mux.Lock()
+	defer ps.mux.Unlock()
+	if ps.sealed {
+		ps.logger.Debug("received commit that is already sealed", "peer", ps.pid, "height", ps.bs.height)
+		return
+	}
+	ps.commit = commit
+	ps.bs.setLatestCommit(commit)
+	ps.trySeal()
+}
+
+func (ps *publisherState) trySeal() {
+	if ps.bs.isSealed() {
+		ps.tryLaterSeal()
+	} else {
+		ps.tryFirstSeal()
+	}
+}
+
+func (ps *publisherState) tryLaterSeal() {
+	if ps.block == nil || ps.commit == nil {
+		return
+	}
+	blockId := makeBlockID(ps.block)
+	// For a later sealed request, just choose to compare the the blockChainMessage id to
+	// decide whether it is a good peer. Fully verification is costly and
+	// no strong need to do so since we only used to judge if the peer is good or not.
+	if blockId.Equals(ps.commit.BlockID) && blockId.Equals(*ps.bs.blockId) {
+		ps.seal()
+		return
+	} else {
+		// maybe blockChainMessage is late, won't seal.
+		ps.logger.Info("received inconsistent blockChainMessage/commit", "peer", ps.pid, "height", ps.bs.height)
+		return
+	}
+}
+
+func (ps *publisherState) tryFirstSeal() {
+	if ps.block == nil || ps.commit == nil {
+		return
+	}
+	// not now
+	if !ps.isWake {
+		return
+	}
+	blockId := makeBlockID(ps.block)
+	if ps.pid == selfId {
+		if !blockId.Equals(ps.commit.BlockID) {
+			return
+		}
+	} else if err := ps.pool.verifyCommit(*blockId, ps.commit); err != nil {
+		// maybe blockChainMessage is late, won't seal.
+		ps.logger.Info("received inconsistent blockChainMessage/commit", "peer", ps.pid, ps.bs.height)
+		return
+	}
+	ps.bs.commit = ps.commit
+	ps.bs.block = ps.block
+	ps.bs.blockId = blockId
+	ps.seal()
+	ps.bs.seal()
+	return
+}
+
+// only start timer when blockpool reach at this height.
+func (ps *publisherState) startTimer() {
+	if ps.timeout != nil {
+		ps.timeout.Reset(ps.timeoutDur)
+	} else {
+		ps.timeout = time.AfterFunc(ps.timeoutDur, ps.onTimeout)
+	}
+}
+
+func (ps *publisherState) seal() {
+	if ps.timeout != nil {
+		ps.timeout.Stop()
+	}
+	ps.sealed = true
+	ps.logger.Debug("publisher state sealing", "peer", ps.pid, "height", ps.bs.height)
+	ps.pool.publisherStateSealCh <- ps
+}
+
+// -----------------------
+type Message struct {
+	blockChainMessage BlockchainMessage
+	peerId            p2p.ID
+}
+
+type decayedPeer struct {
+	peerId     p2p.ID
+	fromHeight int64
+}
+
+func makeBlockID(block *types.Block) *types.BlockID {
+	blockParts := block.MakePartSet(types.BlockPartSizeBytes)
+	blockPartsHeader := blockParts.Header()
+	return &types.BlockID{Hash: block.Hash(), PartsHeader: blockPartsHeader}
+}

--- a/blockchain/hot/pool_test.go
+++ b/blockchain/hot/pool_test.go
@@ -1,0 +1,608 @@
+package hot
+
+import (
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/blockchain"
+	cfg "github.com/tendermint/tendermint/config"
+	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/mock"
+	pmock "github.com/tendermint/tendermint/p2p/mock"
+	"github.com/tendermint/tendermint/proxy"
+	sm "github.com/tendermint/tendermint/state"
+	"github.com/tendermint/tendermint/types"
+	tmtime "github.com/tendermint/tendermint/types/time"
+	dbm "github.com/tendermint/tm-cmn/db"
+)
+
+var (
+	config *cfg.Config
+)
+
+func TestBlockPoolHotSyncBasic(t *testing.T) {
+	// prepare
+	config = cfg.ResetTestRoot(t.Name())
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	initBlockHeight := int64(10)
+	poolPair := newBlockchainPoolPair(log.TestingLogger(), genDoc, privVals, initBlockHeight)
+
+	pool := poolPair.pool
+	messageChan := poolPair.messageQueue
+	pool.Start()
+	defer pool.Stop()
+	testPeer := pmock.NewPeer(nil)
+	pool.AddPeer(testPeer)
+
+	// consume subscribe message
+	<-messageChan
+
+	//handle subscribe message
+	subscriber := pmock.NewPeer(nil)
+	totalTestBlock := int64(10)
+	pool.handleSubscribeBlock(initBlockHeight+1, initBlockHeight+totalTestBlock, subscriber)
+
+	for i := int64(0); i < totalTestBlock; i++ {
+		height := pool.currentHeight()
+		block, commit, _ := nextBlock(poolPair.pool.state, poolPair.pool.store, poolPair.pool.blockExec, poolPair.privVals[0])
+		expectedBlockMess1 := blockCommitResponseMessage{Block: block}
+		expectedBlockMess2 := blockCommitResponseMessage{Commit: commit}
+		pool.handleBlockCommit(block, commit, testPeer)
+		var receive1, receive2 bool
+		for m := range messageChan {
+			if bm, ok := m.blockChainMessage.(*blockCommitResponseMessage); ok {
+				if !receive1 {
+					assert.Equal(t, *bm, expectedBlockMess1)
+					receive1 = true
+				} else if !receive2 {
+					assert.Equal(t, *bm, expectedBlockMess2)
+					receive2 = true
+				}
+				if receive1 && receive2 {
+					break
+				}
+			}
+		}
+		for {
+			if height+1 != pool.currentHeight() {
+				time.Sleep(10 * time.Millisecond)
+			} else {
+				break
+			}
+		}
+	}
+	assert.Equal(t, int64(pool.blocksSynced), totalTestBlock)
+}
+
+func TestBlockPoolHotSyncTimeout(t *testing.T) {
+	// prepare
+	config = cfg.ResetTestRoot(t.Name())
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	initBlockHeight := int64(10)
+	poolPair := newBlockchainPoolPair(log.TestingLogger(), genDoc, privVals, initBlockHeight)
+
+	pool := poolPair.pool
+	messageChan := poolPair.messageQueue
+	pool.Start()
+	defer pool.Stop()
+	testPeer := pmock.NewPeer(nil)
+	pool.AddPeer(testPeer)
+
+	// send subscribe message for several times
+	expectedMessages := make([]BlockchainMessage, 0, 1+2*maxSubscribeForesight)
+	expectedMessages = append(expectedMessages, &blockSubscribeMessage{FromHeight: initBlockHeight + 1, ToHeight: initBlockHeight + maxSubscribeForesight})
+	for j := 0; j < 3; j++ {
+		for i := int64(0); i < maxSubscribeForesight; i++ {
+			expectedMessages = append(expectedMessages, &blockUnSubscribeMessage{Height: initBlockHeight + i + 1})
+			expectedMessages = append(expectedMessages, &blockSubscribeMessage{FromHeight: initBlockHeight + i + 1, ToHeight: initBlockHeight + i + 1})
+		}
+	}
+	for _, expect := range expectedMessages {
+		m := <-messageChan
+		assert.Equal(t, m.blockChainMessage, expect)
+	}
+}
+
+func TestBlockPoolHotSyncSubscribePastBlock(t *testing.T) {
+	config = cfg.ResetTestRoot(t.Name())
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	initBlockHeight := int64(100)
+	poolPair := newBlockchainPoolPair(log.TestingLogger(), genDoc, privVals, initBlockHeight)
+
+	pool := poolPair.pool
+	messageChan := poolPair.messageQueue
+	pool.Start()
+	defer pool.Stop()
+
+	subscriber := pmock.NewPeer(nil)
+	pool.handleSubscribeBlock(1, initBlockHeight, subscriber)
+
+	expectBlockMessage := make([]blockCommitResponseMessage, initBlockHeight-1)
+	for i := int64(1); i < int64(initBlockHeight); i++ {
+		first := pool.store.LoadBlock(i)
+		second := pool.store.LoadBlock(i + 1)
+		expectBlockMessage[i-1].Block = first
+		expectBlockMessage[i-1].Commit = second.LastCommit
+	}
+	var index int
+	for m := range messageChan {
+		if blockMes, ok := m.blockChainMessage.(*blockCommitResponseMessage); ok {
+			assert.Equal(t, *blockMes, expectBlockMessage[index])
+			index++
+			if int64(index) >= initBlockHeight-1 {
+				break
+			}
+		}
+	}
+}
+
+func TestBlockPoolHotSyncSubscribeTooFarBlock(t *testing.T) {
+	config = cfg.ResetTestRoot(t.Name())
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	initBlockHeight := int64(10)
+	poolPair := newBlockchainPoolPair(log.TestingLogger(), genDoc, privVals, initBlockHeight)
+
+	pool := poolPair.pool
+	messageChan := poolPair.messageQueue
+	pool.Start()
+	defer pool.Stop()
+
+	subscriber := pmock.NewPeer(nil)
+	pool.handleSubscribeBlock(initBlockHeight+1, initBlockHeight+2*maxPublishForesight, subscriber)
+	for m := range messageChan {
+		if noBlock, ok := m.blockChainMessage.(*noBlockResponseMessage); ok {
+			assert.Equal(t, noBlock.Height, initBlockHeight+maxPublishForesight)
+			return
+		}
+	}
+}
+
+func TestBlockPoolHotSyncUnSubscribe(t *testing.T) {
+	config = cfg.ResetTestRoot(t.Name())
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	initBlockHeight := int64(10)
+	poolPair := newBlockchainPoolPair(log.TestingLogger(), genDoc, privVals, initBlockHeight)
+
+	pool := poolPair.pool
+	pool.Start()
+	defer pool.Stop()
+
+	subscriber := pmock.NewPeer(nil)
+	totalTestBlock := int64(10)
+	pool.handleSubscribeBlock(initBlockHeight+1, initBlockHeight+totalTestBlock, subscriber)
+	for i := initBlockHeight + 1; i <= initBlockHeight+totalTestBlock; i++ {
+		pool.handleUnSubscribeBlock(i, subscriber)
+		assert.Zero(t, len(pool.subscriberPeerSets[i]))
+	}
+}
+
+func TestBlockPoolHotSyncRemovePeer(t *testing.T) {
+	config = cfg.ResetTestRoot(t.Name())
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	initBlockHeight := int64(10)
+	poolPair := newBlockchainPoolPair(log.TestingLogger(), genDoc, privVals, initBlockHeight)
+
+	pool := poolPair.pool
+	messageChan := poolPair.messageQueue
+	pool.Start()
+	defer pool.Stop()
+
+	testPeer := pmock.NewPeer(nil)
+	pool.AddPeer(testPeer)
+	// wait for peer have a try
+	time.Sleep(2 * tryRepairInterval)
+	pool.RemovePeer(testPeer)
+	// drain subscribe message
+	<-messageChan
+	for i := int64(0); i < maxSubscribeForesight; i++ {
+		m := <-messageChan
+		noBlock, ok := m.blockChainMessage.(*blockUnSubscribeMessage)
+		assert.True(t, ok)
+		assert.Equal(t, noBlock.Height, initBlockHeight+i+1)
+	}
+}
+
+func TestBlockPoolConsensusSyncBasic(t *testing.T) {
+	eventBus := types.NewEventBus()
+	err := eventBus.Start()
+	require.NoError(t, err)
+	defer eventBus.Stop()
+
+	config = cfg.ResetTestRoot(t.Name())
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	initBlockHeight := int64(10)
+	poolPair := newBlockchainPoolPair(log.TestingLogger(), genDoc, privVals, initBlockHeight)
+
+	pool := poolPair.pool
+	pool.st = Consensus
+	pool.setEventBus(eventBus)
+	messageChan := poolPair.messageQueue
+	pool.Start()
+	defer pool.Stop()
+	//handle subscribe message
+	subscriber := pmock.NewPeer(nil)
+	totalTestBlock := int64(10)
+	pool.handleSubscribeBlock(initBlockHeight+1, initBlockHeight+totalTestBlock, subscriber)
+
+	for i := int64(0); i < totalTestBlock; i++ {
+		height := pool.currentHeight()
+		block, commit, vs := nextBlock(poolPair.pool.state, poolPair.pool.store, poolPair.pool.blockExec, poolPair.privVals[0])
+		expectedBlockMess1 := blockCommitResponseMessage{Block: block}
+		//generate hash
+		commit.Hash()
+		expectedBlockMess2 := blockCommitResponseMessage{Commit: commit}
+		err := eventBus.PublishEventCompleteProposal(types.EventDataCompleteProposal{Height: block.Height, Block: *block})
+		assert.NoError(t, err)
+		err = eventBus.PublishEventMajorPrecommits(types.EventDataMajorPrecommits{Height: block.Height, Votes: *vs})
+		assert.NoError(t, err)
+		pool.applyBlock(&blockState{
+			block:   block,
+			commit:  commit,
+			blockId: makeBlockID(block),
+		})
+		var receive1, receive2 bool
+		for m := range messageChan {
+			if bm, ok := m.blockChainMessage.(*blockCommitResponseMessage); ok {
+				if !receive1 {
+					assert.Equal(t, *bm, expectedBlockMess1)
+					receive1 = true
+				} else if !receive2 {
+					assert.Equal(t, *bm, expectedBlockMess2)
+					receive2 = true
+				}
+				if receive1 && receive2 {
+					break
+				}
+			}
+		}
+		for {
+			if height+1 != pool.currentHeight() {
+				time.Sleep(10 * time.Millisecond)
+			} else {
+				break
+			}
+		}
+	}
+}
+
+func TestBlockPoolSubscribeFromCache(t *testing.T) {
+	config = cfg.ResetTestRoot(t.Name())
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	initBlockHeight := int64(10)
+	poolPair := newBlockchainPoolPair(log.TestingLogger(), genDoc, privVals, initBlockHeight)
+
+	pool := poolPair.pool
+	messageChan := poolPair.messageQueue
+	pool.Start()
+	defer pool.Stop()
+	testPeer := pmock.NewPeer(nil)
+	pool.AddPeer(testPeer)
+
+	// consume subscribe message
+	<-messageChan
+
+	totalTestBlock := int64(10)
+
+	expectedBlockMess := make([]blockCommitResponseMessage, 0, totalTestBlock)
+	for i := int64(0); i < totalTestBlock; i++ {
+		height := pool.currentHeight()
+		block, commit, _ := nextBlock(poolPair.pool.state, poolPair.pool.store, poolPair.pool.blockExec, poolPair.privVals[0])
+		expectedBlockMess = append(expectedBlockMess, blockCommitResponseMessage{Block: block, Commit: commit})
+		pool.handleBlockCommit(block, commit, testPeer)
+
+		for {
+			if height+1 != pool.currentHeight() {
+				time.Sleep(10 * time.Millisecond)
+			} else {
+				break
+			}
+		}
+	}
+	//handle subscribe message
+	subscriber := pmock.NewPeer(nil)
+	pool.handleSubscribeBlock(initBlockHeight+1, initBlockHeight+totalTestBlock, subscriber)
+	for i := int64(0); i < totalTestBlock; i++ {
+		for m := range messageChan {
+			if bm, ok := m.blockChainMessage.(*blockCommitResponseMessage); ok {
+				assert.Equal(t, *bm, expectedBlockMess[i])
+				break
+			}
+		}
+	}
+}
+
+func TestBlockPoolSwitch(t *testing.T) {
+	config = cfg.ResetTestRoot(t.Name())
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	initBlockHeight := int64(10)
+	poolPair := newBlockchainPoolPair(log.TestingLogger(), genDoc, privVals, initBlockHeight)
+
+	pool := poolPair.pool
+	messageChan := poolPair.messageQueue
+	pool.st = Mute
+	pool.Start()
+	defer pool.Stop()
+	testPeer := pmock.NewPeer(nil)
+	pool.AddPeer(testPeer)
+
+	time.Sleep(10 * time.Millisecond)
+	pool.SwitchToHotSync(pool.state, 100)
+	// consume subscribe message
+	<-messageChan
+
+	//handle subscribe message
+	subscriber := pmock.NewPeer(nil)
+	totalTestBlock := int64(10)
+	pool.handleSubscribeBlock(initBlockHeight+1, initBlockHeight+totalTestBlock, subscriber)
+
+	for i := int64(0); i < totalTestBlock; i++ {
+		height := pool.currentHeight()
+		block, commit, _ := nextBlock(poolPair.pool.state, poolPair.pool.store, poolPair.pool.blockExec, poolPair.privVals[0])
+		expectedBlockMess1 := blockCommitResponseMessage{Block: block}
+		expectedBlockMess2 := blockCommitResponseMessage{Commit: commit}
+		pool.handleBlockCommit(block, commit, testPeer)
+		var receive1, receive2 bool
+		for m := range messageChan {
+			if bm, ok := m.blockChainMessage.(*blockCommitResponseMessage); ok {
+				if !receive1 {
+					assert.Equal(t, *bm, expectedBlockMess1)
+					receive1 = true
+				} else if !receive2 {
+					assert.Equal(t, *bm, expectedBlockMess2)
+					receive2 = true
+				}
+				if receive1 && receive2 {
+					break
+				}
+			}
+		}
+		for {
+			if height+1 != pool.currentHeight() {
+				time.Sleep(10 * time.Millisecond)
+			} else {
+				break
+			}
+		}
+	}
+	assert.Equal(t, int64(pool.blocksSynced), totalTestBlock+100)
+	eventBus := types.NewEventBus()
+	err := eventBus.Start()
+	require.NoError(t, err)
+	defer eventBus.Stop()
+	pool.setEventBus(eventBus)
+
+	pool.SwitchToConsensusSync(nil)
+	time.Sleep(10 * time.Millisecond)
+	subscriber = pmock.NewPeer(nil)
+	totalTestBlock = int64(10)
+	pool.handleSubscribeBlock(pool.currentHeight()+1, pool.currentHeight()+totalTestBlock, subscriber)
+
+	for i := int64(0); i < totalTestBlock; i++ {
+		height := pool.currentHeight()
+		block, commit, vs := nextBlock(poolPair.pool.state, poolPair.pool.store, poolPair.pool.blockExec, poolPair.privVals[0])
+		expectedBlockMess1 := blockCommitResponseMessage{Block: block}
+		//generate hash
+		commit.Hash()
+		expectedBlockMess2 := blockCommitResponseMessage{Commit: commit}
+		err := eventBus.PublishEventCompleteProposal(types.EventDataCompleteProposal{Height: block.Height, Block: *block})
+		assert.NoError(t, err)
+		err = eventBus.PublishEventMajorPrecommits(types.EventDataMajorPrecommits{Height: block.Height, Votes: *vs})
+		assert.NoError(t, err)
+		pool.applyBlock(&blockState{
+			block:   block,
+			commit:  commit,
+			blockId: makeBlockID(block),
+		})
+		var receive1, receive2 bool
+		for m := range messageChan {
+			if bm, ok := m.blockChainMessage.(*blockCommitResponseMessage); ok {
+				if !receive1 {
+					eq := assert.Equal(t, *bm, expectedBlockMess1)
+					receive1 = true
+					if !eq {
+						return
+					}
+				} else if !receive2 {
+					eq := assert.Equal(t, *bm, expectedBlockMess2)
+					receive2 = true
+					receive1 = true
+					if !eq {
+						return
+					}
+				}
+				if receive1 && receive2 {
+					break
+				}
+			}
+		}
+		for {
+			if height+1 != pool.currentHeight() {
+				time.Sleep(10 * time.Millisecond)
+			} else {
+				break
+			}
+		}
+	}
+
+}
+
+func randGenesisDoc(numValidators int, randPower bool, minPower int64) (*types.GenesisDoc, []types.PrivValidator) {
+	validators := make([]types.GenesisValidator, numValidators)
+	privValidators := make([]types.PrivValidator, numValidators)
+	for i := 0; i < numValidators; i++ {
+		val, privVal := types.RandValidator(randPower, minPower)
+		validators[i] = types.GenesisValidator{
+			PubKey: val.PubKey,
+			Power:  val.VotingPower,
+		}
+		privValidators[i] = privVal
+	}
+	sort.Sort(types.PrivValidatorsByAddress(privValidators))
+
+	return &types.GenesisDoc{
+		GenesisTime: tmtime.Now(),
+		ChainID:     config.ChainID(),
+		Validators:  validators,
+	}, privValidators
+}
+
+func makeTxs(height int64) (txs []types.Tx) {
+	for i := 0; i < 10; i++ {
+		txs = append(txs, types.Tx([]byte{byte(height), byte(i)}))
+	}
+	return txs
+}
+
+func makeBlock(height int64, state sm.State, lastCommit *types.Commit) *types.Block {
+	block, _ := state.MakeBlock(height, makeTxs(height), lastCommit, nil, state.Validators.GetProposer().Address)
+	return block
+}
+
+func makeVote(header *types.Header, blockID types.BlockID, valset *types.ValidatorSet, privVal types.PrivValidator) *types.Vote {
+	addr := privVal.GetPubKey().Address()
+	idx, _ := valset.GetByAddress(addr)
+	vote := &types.Vote{
+		ValidatorAddress: addr,
+		ValidatorIndex:   idx,
+		Height:           header.Height,
+		Round:            1,
+		Timestamp:        tmtime.Now(),
+		Type:             types.PrecommitType,
+		BlockID:          blockID,
+	}
+
+	privVal.SignVote(header.ChainID, vote)
+
+	return vote
+}
+
+func newBlockchainPoolPair(logger log.Logger, genDoc *types.GenesisDoc, privVals []types.PrivValidator, maxBlockHeight int64) BlockPoolPair {
+	if len(privVals) != 1 {
+		panic("only support one validator")
+	}
+	app := &testApp{}
+	cc := proxy.NewLocalClientCreator(app)
+	proxyApp := proxy.NewAppConns(cc)
+	err := proxyApp.Start()
+	if err != nil {
+		panic(cmn.ErrorWrap(err, "error start app"))
+	}
+	blockDB := dbm.NewMemDB()
+	stateDB := dbm.NewMemDB()
+	blockStore := blockchain.NewBlockStore(blockDB)
+	state, err := sm.LoadStateFromDBOrGenesisDoc(stateDB, genDoc)
+	if err != nil {
+		panic(cmn.ErrorWrap(err, "error constructing state from genesis file"))
+	}
+
+	// Make the BlockPool itself.
+	// NOTE we have to create and commit the blocks first because
+	// pool.height is determined from the store.
+	db := dbm.NewMemDB()
+	blockExec := sm.NewBlockExecutor(db, log.TestingLogger(), proxyApp.Consensus(),
+		mock.Mempool{}, sm.MockEvidencePool{})
+	sm.SaveState(db, state)
+
+	// let's add some blocks in
+	for blockHeight := int64(1); blockHeight <= maxBlockHeight; blockHeight++ {
+		lastCommit := types.NewCommit(types.BlockID{}, nil)
+		if blockHeight > 1 {
+			lastBlockMeta := blockStore.LoadBlockMeta(blockHeight - 1)
+			lastBlock := blockStore.LoadBlock(blockHeight - 1)
+
+			vote := makeVote(&lastBlock.Header, lastBlockMeta.BlockID, state.Validators, privVals[0]).CommitSig()
+			lastCommit = types.NewCommit(lastBlockMeta.BlockID, []*types.CommitSig{vote})
+		}
+
+		thisBlock := makeBlock(blockHeight, state, lastCommit)
+
+		thisParts := thisBlock.MakePartSet(types.BlockPartSizeBytes)
+		blockID := types.BlockID{thisBlock.Hash(), thisParts.Header()}
+
+		state, err = blockExec.ApplyBlock(state, blockID, thisBlock)
+		if err != nil {
+			panic(cmn.ErrorWrap(err, "error apply block"))
+		}
+
+		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)
+	}
+	messagesCh := make(chan Message, messageQueueSize)
+	bcPool := NewBlockPool(blockStore, blockExec, state.Copy(), messagesCh, Hot, 2*time.Second)
+	bcPool.SetLogger(logger.With("module", "blockpool"))
+
+	return BlockPoolPair{bcPool, proxyApp, messagesCh, privVals}
+}
+
+type BlockPoolPair struct {
+	pool         *BlockPool
+	app          proxy.AppConns
+	messageQueue chan Message
+	privVals     []types.PrivValidator
+}
+
+func nextBlock(state sm.State, blockStore *blockchain.BlockStore, blockExec *sm.BlockExecutor, pri types.PrivValidator) (*types.Block, *types.Commit, *types.VoteSet) {
+	height := blockStore.Height()
+	lastBlockMeta := blockStore.LoadBlockMeta(height)
+	lastBlock := blockStore.LoadBlock(height)
+	vote := makeVote(&lastBlock.Header, lastBlockMeta.BlockID, state.Validators, pri).CommitSig()
+	lastCommit := types.NewCommit(lastBlockMeta.BlockID, []*types.CommitSig{vote})
+	thisBlock := makeBlock(height+1, state, lastCommit)
+
+	thisBlockId := makeBlockID(thisBlock)
+	thisVote := makeVote(&thisBlock.Header, *thisBlockId, state.Validators, pri)
+	thisCommitSig := thisVote.CommitSig()
+	thisCommit := types.NewCommit(*makeBlockID(thisBlock), []*types.CommitSig{thisCommitSig})
+	thisVoteSet := types.NewVoteSet(thisBlock.ChainID, thisBlock.Height, 1, types.PrecommitType, state.Validators)
+	thisVoteSet.AddVote(thisVote)
+	return thisBlock, thisCommit, thisVoteSet
+}
+
+type testApp struct {
+	abci.BaseApplication
+}
+
+var _ abci.Application = (*testApp)(nil)
+
+func (app *testApp) Info(req abci.RequestInfo) (resInfo abci.ResponseInfo) {
+	return abci.ResponseInfo{}
+}
+
+func (app *testApp) BeginBlock(req abci.RequestBeginBlock) abci.ResponseBeginBlock {
+	return abci.ResponseBeginBlock{}
+}
+
+func (app *testApp) EndBlock(req abci.RequestEndBlock) abci.ResponseEndBlock {
+	return abci.ResponseEndBlock{}
+}
+
+func (app *testApp) DeliverTx(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {
+	return abci.ResponseDeliverTx{}
+}
+
+func (app *testApp) CheckTx(tx abci.RequestCheckTx) abci.ResponseCheckTx {
+	return abci.ResponseCheckTx{}
+}
+
+func (app *testApp) Commit() abci.ResponseCommit {
+	return abci.ResponseCommit{}
+}
+
+func (app *testApp) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQuery) {
+	return
+}

--- a/blockchain/hot/reactor.go
+++ b/blockchain/hot/reactor.go
@@ -1,0 +1,352 @@
+package hot
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/tendermint/go-amino"
+	"github.com/tendermint/tendermint/blockchain"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/p2p"
+	sm "github.com/tendermint/tendermint/state"
+	"github.com/tendermint/tendermint/types"
+)
+
+const (
+	// HotBlockchainChannel is a channel for blocks/commits and status updates under hot sync mode.
+	HotBlockchainChannel = byte(0x41)
+
+	messageQueueSize = 1000
+
+	switchToConsensusIntervalSeconds = 1
+
+	maxSubscribeBlocks = 50
+
+	// NOTE: keep up to date with blockCommitResponseMessage
+	blockCommitResponseMessagePrefixSize = 4
+	blockCommitMessageFieldKeySize       = 2
+	// the size of commit is dynamic, assume no more than 1M.
+	commitSizeBytes = 1024 * 1024
+	maxMsgSize      = types.MaxBlockSizeBytes +
+		blockCommitResponseMessagePrefixSize +
+		blockCommitMessageFieldKeySize +
+		commitSizeBytes
+)
+
+type consensusReactor interface {
+	// for when we switch from hotBlockchain reactor and hot sync to
+	// the consensus machine
+	SwitchToConsensus(sm.State, int)
+}
+
+// BlockchainReactor handles low latency catchup when there is small lag.
+type BlockchainReactor struct {
+	p2p.BaseReactor
+
+	pool          *BlockPool
+	privValidator types.PrivValidator
+
+	messagesCh <-chan Message
+}
+
+type BlockChainOption func(*BlockchainReactor)
+
+// NewBlockChainReactor returns new reactor instance.
+func NewBlockChainReactor(state sm.State, blockExec *sm.BlockExecutor, store *blockchain.BlockStore, hotSync, fastSync bool, blockTimeout time.Duration, options ...BlockChainOption) *BlockchainReactor {
+
+	if state.LastBlockHeight != store.Height() {
+		panic(fmt.Sprintf("state (%v) and store (%v) height mismatch", state.LastBlockHeight,
+			store.Height()))
+	}
+
+	messagesCh := make(chan Message, messageQueueSize)
+	var st SyncPattern
+	if fastSync {
+		st = Mute
+	} else if hotSync {
+		st = Hot
+	} else {
+		st = Consensus
+	}
+	pool := NewBlockPool(store, blockExec, state, messagesCh, st, blockTimeout)
+
+	hbcR := &BlockchainReactor{
+		messagesCh: messagesCh,
+		pool:       pool,
+	}
+
+	for _, option := range options {
+		option(hbcR)
+	}
+
+	hbcR.BaseReactor = *p2p.NewBaseReactor("HotSyncBlockChainReactor", hbcR)
+	return hbcR
+}
+
+// WithMetrics sets the metrics.
+func WithMetrics(metrics *Metrics) BlockChainOption {
+	return func(hbcR *BlockchainReactor) { hbcR.pool.setMetrics(metrics) }
+}
+
+// WithMetrics sets the metrics.
+func WithEventBus(eventBs *types.EventBus) BlockChainOption {
+	return func(hbcR *BlockchainReactor) { hbcR.pool.setEventBus(eventBs) }
+}
+
+func (hbcR *BlockchainReactor) SetPrivValidator(priv types.PrivValidator) {
+	hbcR.privValidator = priv
+}
+
+// SetLogger implements cmn.Service by setting the logger on reactor and pool.
+func (hbcR *BlockchainReactor) SetLogger(l log.Logger) {
+	hbcR.BaseService.Logger = l
+	hbcR.pool.SetLogger(l)
+}
+
+// OnStart implements cmn.Service.
+func (hbcR *BlockchainReactor) OnStart() error {
+	err := hbcR.pool.Start()
+	if err != nil {
+		return err
+	}
+	go hbcR.poolRoutine()
+	return nil
+}
+
+// OnStop implements cmn.Service.
+func (hbcR *BlockchainReactor) OnStop() {
+	hbcR.pool.Stop()
+}
+
+// GetChannels implements Reactor
+func (hbcR *BlockchainReactor) GetChannels() []*p2p.ChannelDescriptor {
+	return []*p2p.ChannelDescriptor{
+		{
+			ID:                  HotBlockchainChannel,
+			Priority:            10,
+			SendQueueCapacity:   1000,
+			RecvBufferCapacity:  50 * 4096,
+			RecvMessageCapacity: maxMsgSize,
+		},
+	}
+}
+
+func (hbcR *BlockchainReactor) AddPeer(peer p2p.Peer) {
+	hbcR.pool.AddPeer(peer)
+}
+
+func (hbcR *BlockchainReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
+	hbcR.pool.RemovePeer(peer)
+}
+
+// Receive implements Reactor by handling 5 types of messages (look below).
+func (hbcR *BlockchainReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) {
+	msg, err := decodeMsg(msgBytes)
+	if err != nil {
+		hbcR.Logger.Error("Error decoding message", "src", src, "chId", chID, "msg", msg, "err", err, "bytes", msgBytes)
+		hbcR.Switch.StopPeerForError(src, err)
+		return
+	}
+
+	if err = msg.ValidateBasic(); err != nil {
+		hbcR.Logger.Error("Peer sent us invalid msg", "peer", src, "msg", msg, "err", err)
+		hbcR.Switch.StopPeerForError(src, err)
+		return
+	}
+	switch msg := msg.(type) {
+	case *blockSubscribeMessage:
+		hbcR.Logger.Debug("receive blockSubscribeMessage from peer", "peer", src.ID(), "from_height", msg.FromHeight, "to_height", msg.ToHeight)
+		hbcR.pool.handleSubscribeBlock(msg.FromHeight, msg.ToHeight, src)
+	case *blockCommitResponseMessage:
+		hbcR.Logger.Debug("receive blockCommitResponseMessage from peer", "peer", src.ID(), "height", msg.Height())
+		hbcR.pool.handleBlockCommit(msg.Block, msg.Commit, src)
+	case *noBlockResponseMessage:
+		hbcR.Logger.Debug("receive noBlockResponseMessage from peer", "peer", src.ID(), "height", msg.Height)
+		hbcR.pool.handleNoBlock(msg.Height, src)
+	case *blockUnSubscribeMessage:
+		hbcR.Logger.Debug("receive blockUnSubscribeMessage from peer", "peer", src.ID(), "height", msg.Height)
+		hbcR.pool.handleUnSubscribeBlock(msg.Height, src)
+	default:
+		hbcR.Logger.Error(fmt.Sprintf("Unknown message type %v", reflect.TypeOf(msg)))
+	}
+}
+
+func (hbcR *BlockchainReactor) SetSwitch(sw *p2p.Switch) {
+	hbcR.Switch = sw
+	hbcR.pool.candidatePool.swh = sw
+}
+
+func (hbcR *BlockchainReactor) SwitchToHotSync(state sm.State, blockSynced int32) {
+	hbcR.pool.SwitchToHotSync(state, blockSynced)
+}
+
+func (hbcR *BlockchainReactor) SwitchToConsensusSync(state sm.State) {
+	hbcR.pool.SwitchToConsensusSync(&state)
+}
+
+func (hbcR *BlockchainReactor) poolRoutine() {
+	switchToConsensusTicker := time.NewTicker(switchToConsensusIntervalSeconds * time.Second)
+	defer switchToConsensusTicker.Stop()
+	for {
+		select {
+		case <-hbcR.Quit():
+			return
+		case <-hbcR.pool.Quit():
+			return
+		case message := <-hbcR.messagesCh:
+			peer := hbcR.Switch.Peers().Get(message.peerId)
+			if peer == nil {
+				continue
+			}
+			msgBytes := cdc.MustMarshalBinaryBare(message.blockChainMessage)
+			hbcR.Logger.Debug(fmt.Sprintf("send message %s", message.blockChainMessage.String()), "peer", peer.ID())
+			queued := peer.TrySend(HotBlockchainChannel, msgBytes)
+			if !queued {
+				hbcR.Logger.Debug("Send queue is full or no hot sync channel, drop blockChainMessage request", "peer", peer.ID())
+			}
+		case <-switchToConsensusTicker.C:
+			if hbcR.pool.getSyncPattern() == Hot && hbcR.privValidator != nil && hbcR.pool.state.Validators.HasAddress(hbcR.privValidator.GetPubKey().Address()) {
+				hbcR.Logger.Info("hot sync switching to consensus sync")
+				conR, ok := hbcR.Switch.Reactor("CONSENSUS").(consensusReactor)
+				if ok {
+					hbcR.pool.SwitchToConsensusSync(nil)
+					conR.SwitchToConsensus(hbcR.pool.state, int(hbcR.pool.getBlockSynced()))
+				} else {
+					// should only happen during testing
+				}
+			}
+		}
+	}
+}
+
+// BlockchainMessage is a generic message for this reactor.
+type BlockchainMessage interface {
+	ValidateBasic() error
+	String() string
+}
+
+//-------------------------------------
+
+// Subscribe block at specified height range
+type blockSubscribeMessage struct {
+	FromHeight int64
+	ToHeight   int64
+}
+
+func (m *blockSubscribeMessage) ValidateBasic() error {
+	if m.FromHeight < 0 {
+		return errors.New("Negative Height")
+	}
+	if m.ToHeight < m.FromHeight {
+		return errors.New("Height is greater than ToHeight")
+	}
+	if m.ToHeight-m.FromHeight > maxSubscribeBlocks {
+		return errors.New("Subscribe too many blocks")
+	}
+	return nil
+}
+
+func (m *blockSubscribeMessage) String() string {
+	return fmt.Sprintf("[blockSubscribeMessage from %v, to %v]", m.FromHeight, m.ToHeight)
+}
+
+//-------------------------------------
+
+// UnSubscribe block at specified height
+// Why not in range?
+// Because of peer pick strategy, will not subscribe continuous blocks from peer that considered as unknown or bad.
+// And because of reschedule strategy, the previous continuous subscription become discontinuous.
+type blockUnSubscribeMessage struct {
+	Height int64
+}
+
+func (m *blockUnSubscribeMessage) ValidateBasic() error {
+	if m.Height < 0 {
+		return errors.New("Negative Height")
+	}
+	return nil
+}
+
+func (m *blockUnSubscribeMessage) String() string {
+	return fmt.Sprintf("[blockUnSubscribeMessage at %v]", m.Height)
+}
+
+//-------------------------------------
+type noBlockResponseMessage struct {
+	Height int64
+}
+
+func (m *noBlockResponseMessage) ValidateBasic() error {
+	if m.Height < 0 {
+		return errors.New("Negative Height")
+	}
+	return nil
+}
+
+func (m *noBlockResponseMessage) String() string {
+	return fmt.Sprintf("[noBlockResponseMessage %v]", m.Height)
+}
+
+//-------------------------------------
+
+type blockCommitResponseMessage struct {
+	Block  *types.Block
+	Commit *types.Commit
+}
+
+func (m *blockCommitResponseMessage) Height() int64 {
+	// have checked, block and commit can't both be nil
+	if m.Block != nil {
+		return m.Block.Height
+	} else {
+		return m.Commit.Height()
+	}
+}
+
+func (m *blockCommitResponseMessage) ValidateBasic() error {
+	if m.Block == nil && m.Commit == nil {
+		return errors.New("Both Commit and Block field are missing")
+	}
+
+	if m.Commit != nil && m.Block != nil {
+		blockId := makeBlockID(m.Block)
+		if !blockId.Equals(m.Commit.BlockID) {
+			return errors.New("BlockID mismatch")
+		}
+	}
+	if m.Commit != nil {
+		if err := m.Commit.ValidateBasic(); err != nil {
+			return err
+		}
+	}
+	if m.Block != nil {
+		if err := m.Block.ValidateBasic(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *blockCommitResponseMessage) String() string {
+	return fmt.Sprintf("[blockCommitResponseMessage %v]", m.Height())
+}
+
+//-------------------------------------
+
+func RegisterHotBlockchainMessages(cdc *amino.Codec) {
+	cdc.RegisterInterface((*BlockchainMessage)(nil), nil)
+	cdc.RegisterConcrete(&blockSubscribeMessage{}, "tendermint/blockchain/hotBlockSubscribe", nil)
+	cdc.RegisterConcrete(&blockUnSubscribeMessage{}, "tendermint/blockchain/hotBlockUnSubscribe", nil)
+	cdc.RegisterConcrete(&blockCommitResponseMessage{}, "tendermint/blockchain/hotBlockCommitResponse", nil)
+	cdc.RegisterConcrete(&noBlockResponseMessage{}, "tendermint/blockchain/hotNoBlockResponse", nil)
+}
+
+func decodeMsg(bz []byte) (msg BlockchainMessage, err error) {
+	if len(bz) > maxMsgSize {
+		return msg, fmt.Errorf("Msg exceeds max size (%d > %d)", len(bz), maxMsgSize)
+	}
+	err = cdc.UnmarshalBinaryBare(bz, &msg)
+	return
+}

--- a/blockchain/hot/reactor_test.go
+++ b/blockchain/hot/reactor_test.go
@@ -1,0 +1,264 @@
+package hot
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/tendermint/tendermint/mock"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tendermint/tendermint/blockchain"
+	cfg "github.com/tendermint/tendermint/config"
+	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/proxy"
+	sm "github.com/tendermint/tendermint/state"
+	"github.com/tendermint/tendermint/types"
+	dbm "github.com/tendermint/tm-cmn/db"
+)
+
+func TestHotSyncReactorBasic(t *testing.T) {
+	config = cfg.ResetTestRoot("blockchain_reactor_test")
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+
+	maxBlockHeight := int64(65)
+
+	reactorPairs := make([]BlockChainReactorPair, 2)
+
+	eventBus1 := types.NewEventBus()
+	err := eventBus1.Start()
+	defer eventBus1.Stop()
+	assert.NoError(t, err)
+	eventBus2 := types.NewEventBus()
+	err = eventBus2.Start()
+	defer eventBus2.Stop()
+	assert.NoError(t, err)
+	reactorPairs[0] = newBlockchainReactorPair(log.TestingLogger(), genDoc, privVals, maxBlockHeight, eventBus1, true, false)
+	reactorPairs[1] = newBlockchainReactorPair(log.TestingLogger(), genDoc, privVals, 0, eventBus2, true, false)
+
+	p2p.MakeConnectedSwitches(config.P2P, 2, func(i int, s *p2p.Switch) *p2p.Switch {
+		s.AddReactor("hot", reactorPairs[i].reactor)
+		return s
+
+	}, p2p.Connect2Switches)
+
+	defer func() {
+		for _, r := range reactorPairs {
+			r.reactor.Stop()
+			r.app.Stop()
+		}
+	}()
+
+	tests := []struct {
+		height   int64
+		existent bool
+	}{
+		{maxBlockHeight + 2, false},
+		{10, true},
+		{1, true},
+		{100, false},
+	}
+
+	for {
+		if reactorPairs[1].reactor.pool.currentHeight() == maxBlockHeight-1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	for _, tt := range tests {
+		block := reactorPairs[1].reactor.pool.store.LoadBlock(tt.height)
+		if tt.existent {
+			assert.True(t, block != nil)
+		} else {
+			assert.True(t, block == nil)
+		}
+	}
+}
+
+func TestHotSyncReactorSwitch(t *testing.T) {
+	config = cfg.ResetTestRoot("blockchain_reactor_test")
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+
+	maxBlockHeight := int64(65)
+
+	reactorPairs := make([]BlockChainReactorPair, 2)
+
+	eventBus0 := types.NewEventBus()
+	err := eventBus0.Start()
+	defer eventBus0.Stop()
+	assert.NoError(t, err)
+	eventBus1 := types.NewEventBus()
+	err = eventBus1.Start()
+	defer eventBus1.Stop()
+	assert.NoError(t, err)
+	reactorPairs[0] = newBlockchainReactorPair(log.TestingLogger(), genDoc, privVals, maxBlockHeight, eventBus0, true, false)
+	reactorPairs[1] = newBlockchainReactorPair(log.TestingLogger(), genDoc, privVals, 0, eventBus1, true, true)
+
+	p2p.MakeConnectedSwitches(config.P2P, 2, func(i int, s *p2p.Switch) *p2p.Switch {
+		s.AddReactor("hot", reactorPairs[i].reactor)
+		return s
+
+	}, p2p.Connect2Switches)
+
+	defer func() {
+		for _, r := range reactorPairs {
+			r.reactor.Stop()
+			r.app.Stop()
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, reactorPairs[1].reactor.pool.currentHeight(), int64(0))
+
+	for i := int64(0); i < 10; i++ {
+		first := reactorPairs[0].reactor.pool.store.LoadBlock(i + 1)
+		bId := makeBlockID(first)
+		second := reactorPairs[0].reactor.pool.store.LoadBlock(i + 2)
+		reactorPairs[1].reactor.pool.applyBlock(&blockState{block: first, commit: second.LastCommit, blockId: bId})
+	}
+
+	reactorPairs[1].reactor.SwitchToHotSync(reactorPairs[1].reactor.pool.state, 10)
+
+	tests := []struct {
+		height   int64
+		existent bool
+	}{
+		{maxBlockHeight + 2, false},
+		{10, true},
+		{1, true},
+		{100, false},
+	}
+
+	for {
+		if reactorPairs[1].reactor.pool.currentHeight() == maxBlockHeight-1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	for _, tt := range tests {
+		block := reactorPairs[1].reactor.pool.store.LoadBlock(tt.height)
+		if tt.existent {
+			assert.True(t, block != nil)
+		} else {
+			assert.True(t, block == nil)
+		}
+	}
+
+	reactorPairs[0].reactor.SwitchToConsensusSync(reactorPairs[0].reactor.pool.state)
+
+	pool := reactorPairs[0].reactor.pool
+	consensusHeight := int64(100)
+	for i := int64(0); i < consensusHeight; i++ {
+		height := pool.currentHeight()
+		block, commit, vs := nextBlock(pool.state, pool.store, pool.blockExec, reactorPairs[0].privVals[0])
+
+		err := eventBus0.PublishEventCompleteProposal(types.EventDataCompleteProposal{Height: block.Height, Block: *block})
+		assert.NoError(t, err)
+		err = eventBus0.PublishEventMajorPrecommits(types.EventDataMajorPrecommits{Height: block.Height, Votes: *vs})
+		assert.NoError(t, err)
+		pool.applyBlock(&blockState{
+			block:   block,
+			commit:  commit,
+			blockId: makeBlockID(block),
+		})
+		for {
+			if height+1 != pool.currentHeight() {
+				time.Sleep(10 * time.Millisecond)
+			} else {
+				break
+			}
+		}
+	}
+
+	tests2 := []struct {
+		height   int64
+		existent bool
+	}{
+		{reactorPairs[1].reactor.pool.currentHeight(), true},
+		{122, true},
+		{50, true},
+		{200, false},
+	}
+
+	for {
+		if reactorPairs[1].reactor.pool.currentHeight() == maxBlockHeight+consensusHeight {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	for _, tt := range tests2 {
+		block := reactorPairs[1].reactor.pool.store.LoadBlock(tt.height)
+		if tt.existent {
+			assert.True(t, block != nil)
+		} else {
+			assert.True(t, block == nil)
+		}
+	}
+}
+
+type BlockChainReactorPair struct {
+	reactor  *BlockchainReactor
+	app      proxy.AppConns
+	privVals []types.PrivValidator
+}
+
+func newBlockchainReactorPair(logger log.Logger, genDoc *types.GenesisDoc, privVals []types.PrivValidator, maxBlockHeight int64, eventBus *types.EventBus, hotsync, fastSync bool) BlockChainReactorPair {
+	if len(privVals) != 1 {
+		panic("only support one validator")
+	}
+	app := &testApp{}
+	cc := proxy.NewLocalClientCreator(app)
+	proxyApp := proxy.NewAppConns(cc)
+	err := proxyApp.Start()
+	if err != nil {
+		panic(cmn.ErrorWrap(err, "error start app"))
+	}
+	blockDB := dbm.NewMemDB()
+	stateDB := dbm.NewMemDB()
+	blockStore := blockchain.NewBlockStore(blockDB)
+	state, err := sm.LoadStateFromDBOrGenesisDoc(stateDB, genDoc)
+	if err != nil {
+		panic(cmn.ErrorWrap(err, "error constructing state from genesis file"))
+	}
+
+	// Make the BlockPool itself.
+	// NOTE we have to create and commit the blocks first because
+	// pool.height is determined from the store.
+	db := dbm.NewMemDB()
+	blockExec := sm.NewBlockExecutor(db, log.TestingLogger(), proxyApp.Consensus(),
+		mock.Mempool{}, sm.MockEvidencePool{})
+	sm.SaveState(db, state)
+	// let's add some blocks in
+	for blockHeight := int64(1); blockHeight <= maxBlockHeight; blockHeight++ {
+		lastCommit := types.NewCommit(types.BlockID{}, nil)
+		if blockHeight > 1 {
+			lastBlockMeta := blockStore.LoadBlockMeta(blockHeight - 1)
+			lastBlock := blockStore.LoadBlock(blockHeight - 1)
+
+			vote := makeVote(&lastBlock.Header, lastBlockMeta.BlockID, state.Validators, privVals[0]).CommitSig()
+			lastCommit = types.NewCommit(lastBlockMeta.BlockID, []*types.CommitSig{vote})
+		}
+
+		thisBlock := makeBlock(blockHeight, state, lastCommit)
+
+		thisParts := thisBlock.MakePartSet(types.BlockPartSizeBytes)
+		blockID := types.BlockID{thisBlock.Hash(), thisParts.Header()}
+
+		state, err = blockExec.ApplyBlock(state, blockID, thisBlock)
+		if err != nil {
+			panic(cmn.ErrorWrap(err, "error apply block"))
+		}
+		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)
+	}
+	bcReactor := NewBlockChainReactor(state.Copy(), blockExec, blockStore, hotsync, fastSync, 2*time.Second, WithEventBus(eventBus))
+	bcReactor.SetLogger(logger.With("module", "hotsync"))
+	return BlockChainReactorPair{bcReactor, proxyApp, privVals}
+}

--- a/blockchain/hot/wire.go
+++ b/blockchain/hot/wire.go
@@ -1,0 +1,13 @@
+package hot
+
+import (
+	"github.com/tendermint/go-amino"
+	"github.com/tendermint/tendermint/types"
+)
+
+var cdc = amino.NewCodec()
+
+func init() {
+	RegisterHotBlockchainMessages(cdc)
+	types.RegisterBlockAmino(cdc)
+}

--- a/blockchain/reactor_test.go
+++ b/blockchain/reactor_test.go
@@ -121,7 +121,7 @@ func newBlockchainReactor(logger log.Logger, genDoc *types.GenesisDoc, privVals 
 		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)
 	}
 
-	bcReactor := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
+	bcReactor := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync, false, false)
 	bcReactor.SetLogger(logger.With("module", "blockchain"))
 
 	return BlockchainReactorPair{bcReactor, proxyApp}
@@ -256,21 +256,6 @@ func TestBadBlockStopsPeer(t *testing.T) {
 	}
 
 	assert.True(t, lastReactorPair.reactor.Switch.Peers().Size() < len(reactorPairs)-1)
-}
-
-//----------------------------------------------
-// utility funcs
-
-func makeTxs(height int64) (txs []types.Tx) {
-	for i := 0; i < 10; i++ {
-		txs = append(txs, types.Tx([]byte{byte(height), byte(i)}))
-	}
-	return txs
-}
-
-func makeBlock(height int64, state sm.State, lastCommit *types.Commit) *types.Block {
-	block, _ := state.MakeBlock(height, makeTxs(height), lastCommit, nil, state.Validators.GetProposer().Address)
-	return block
 }
 
 type testApp struct {

--- a/blockchain/store_test.go
+++ b/blockchain/store_test.go
@@ -46,6 +46,21 @@ func makeStateAndBlockStore(logger log.Logger) (sm.State, *BlockStore, cleanupFu
 	return state, NewBlockStore(blockDB), func() { os.RemoveAll(config.RootDir) }
 }
 
+//----------------------------------------------
+// utility funcs
+
+func makeTxs(height int64) (txs []types.Tx) {
+	for i := 0; i < 10; i++ {
+		txs = append(txs, types.Tx([]byte{byte(height), byte(i)}))
+	}
+	return txs
+}
+
+func makeBlock(height int64, state sm.State, lastCommit *types.Commit) *types.Block {
+	block, _ := state.MakeBlock(height, makeTxs(height), lastCommit, nil, state.Validators.GetProposer().Address)
+	return block
+}
+
 func TestLoadBlockStoreStateJSON(t *testing.T) {
 	db := db.NewMemDB()
 

--- a/config/config.go
+++ b/config/config.go
@@ -153,6 +153,18 @@ type BaseConfig struct {
 	// and verifying their commits
 	FastSync bool `mapstructure:"fast_sync"`
 
+	// it is for fullnode/witness who do not need consensus to sync block.
+	HotSyncReactor bool `mapstructure:"hot_sync_reactor"`
+
+	// only take effect when HotSyncReactor is true.
+	// If true, will sync blocks use hot sync protocol
+	// If false, still use tendermint consensus protocol, but can still handle other peers sync request.
+	HotSync bool `mapstructure:"hot_sync"`
+
+	// the max wait time for subscribe a block.
+	// only take effect when hot_sync is true
+	HotSyncTimeout time.Duration `mapstructure:"hot_sync_timeout"`
+
 	// Database backend: goleveldb | cleveldb | boltdb
 	// * goleveldb (github.com/syndtr/goleveldb - most popular implementation)
 	//   - pure go
@@ -217,6 +229,9 @@ func DefaultBaseConfig() BaseConfig {
 		LogFormat:          LogFormatPlain,
 		ProfListenAddress:  "",
 		FastSync:           true,
+		HotSync:            false,
+		HotSyncReactor:     false,
+		HotSyncTimeout:     3 * time.Second,
 		FilterPeers:        false,
 		DBBackend:          "goleveldb",
 		DBPath:             "data",
@@ -275,6 +290,9 @@ func (cfg BaseConfig) ValidateBasic() error {
 	case LogFormatPlain, LogFormatJSON:
 	default:
 		return errors.New("unknown log_format (must be 'plain' or 'json')")
+	}
+	if !cfg.HotSyncReactor && cfg.HotSync {
+		return errors.New("config hot_sync can't be true while hot_sync_reactor is false")
 	}
 	return nil
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -81,6 +81,19 @@ moniker = "{{ .BaseConfig.Moniker }}"
 # and verifying their commits
 fast_sync = {{ .BaseConfig.FastSync }}
 
+# Only take effect when HotSyncReactor is true.
+# If true, will sync blocks use hot sync protocol
+# If false, still use tendermint consensus protocol, but can still handle other peers sync request.
+hot_sync = {{.BaseConfig.HotSync}}
+
+# The max wait time for subscribe a block.
+# Only take effect when hot_sync is true
+hot_sync_timeout = "{{.BaseConfig.HotSyncTimeout}}"
+
+# It will benefit fullnode and witness who do not need consensus by saving network and cpu resources.
+# Recommend the node that is not validator to turn on.
+hot_sync_reactor = {{.BaseConfig.HotSyncReactor}}
+
 # Database backend: goleveldb | cleveldb | boltdb
 # * goleveldb (github.com/syndtr/goleveldb - most popular implementation)
 #   - pure go

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1652,6 +1652,12 @@ func (cs *ConsensusState) addVote(vote *types.Vote, peerID p2p.ID) (added bool, 
 
 		blockID, ok := precommits.TwoThirdsMajority()
 		if ok {
+			cs.eventBus.PublishEventMajorPrecommits(types.EventDataMajorPrecommits{
+				Height: cs.Height,
+				Round:  cs.Round,
+				Step:   cs.Step.String(),
+				Votes:  *precommits.Copy(),
+			})
 			// Executed as TwoThirdsMajority could be from a higher round
 			cs.enterNewRound(height, vote.Round)
 			cs.enterPrecommit(height, vote.Round)

--- a/consensus/types/round_state.go
+++ b/consensus/types/round_state.go
@@ -143,6 +143,7 @@ func (rs *RoundState) CompleteProposalEvent() types.EventDataCompleteProposal {
 		Round:   rs.Round,
 		Step:    rs.Step.String(),
 		BlockID: blockId,
+		Block:   *rs.ProposalBlock,
 	}
 }
 

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -192,6 +192,10 @@ func (b *EventBus) PublishEventCompleteProposal(data EventDataCompleteProposal) 
 	return b.Publish(EventCompleteProposal, data)
 }
 
+func (b *EventBus) PublishEventMajorPrecommits(data EventDataMajorPrecommits) error {
+	return b.Publish(EventMajorPrecommits, data)
+}
+
 func (b *EventBus) PublishEventPolka(data EventDataRoundState) error {
 	return b.Publish(EventPolka, data)
 }

--- a/types/events.go
+++ b/types/events.go
@@ -34,6 +34,7 @@ const (
 	EventTimeoutWait      = "TimeoutWait"
 	EventUnlock           = "Unlock"
 	EventValidBlock       = "ValidBlock"
+	EventMajorPrecommits  = "MajorPrecommits"
 	EventVote             = "Vote"
 )
 
@@ -108,6 +109,15 @@ type EventDataCompleteProposal struct {
 	Step   string `json:"step"`
 
 	BlockID BlockID `json:"block_id"`
+	Block   Block   `json:"block"`
+}
+
+type EventDataMajorPrecommits struct {
+	Height int64  `json:"height"`
+	Round  int    `json:"round"`
+	Step   string `json:"step"`
+
+	Votes VoteSet `json:"votes"`
 }
 
 type EventDataVote struct {
@@ -137,6 +147,7 @@ const (
 
 var (
 	EventQueryCompleteProposal    = QueryForEvent(EventCompleteProposal)
+	EventQueryMajorPrecommits     = QueryForEvent(EventMajorPrecommits)
 	EventQueryLock                = QueryForEvent(EventLock)
 	EventQueryNewBlock            = QueryForEvent(EventNewBlock)
 	EventQueryNewBlockHeader      = QueryForEvent(EventNewBlockHeader)

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -119,6 +119,21 @@ func (voteSet *VoteSet) Size() int {
 	return voteSet.valSet.Size()
 }
 
+func (voteSet *VoteSet) Copy() *VoteSet {
+	if voteSet == nil {
+		return nil
+	}
+	return &VoteSet{
+		chainID: voteSet.chainID,
+		height:  voteSet.height,
+		round:   voteSet.round,
+		type_:   voteSet.type_,
+		valSet:  voteSet.valSet,
+		votes:   voteSet.votes,
+		maj23:   voteSet.maj23,
+	}
+}
+
 // Returns added=true if vote is valid and new.
 // Otherwise returns err=ErrVote[
 //		UnexpectedStep | InvalidIndex | InvalidAddress |


### PR DESCRIPTION
# Abstract
A new protocol called HotSync to help gossip blocks in low latency for fullnode/witness/sentry nodes, while cost less network, memory and cpu 
resources than Tendermint consensus protocol.

# Motivation

For now a peer get two methods to sync or generate blocks:

1. FastSync protocol. If a node is many blocks behind the tip of the chain, FastSync allows them to catchup quickly by 
downloading blocks in parallel and verifying their commits. But once a node catching up with the chain, it has to switch to
consensus protocol even it is not a validator at that height, because FastSync has to get two continuous to verify a block,
and should aware the height of other peers, so that have high delay to sync the latest block.

2. Consensus protocol. A peer decide to generate a block according to the proposal, block parts and votes it has received.
There is almost no delay between validators and none validator peers to decide a new block, but it pay a heavy price for this.
Consensus protocol is complicated, and at least three new routines are needed for each peers, more cpu consumption. And each 
peer should send redundant message to make the network aware of state, and much redundant gossip data will be send too.
Also consensus should write WAL file to record received votes, block parts and round step change, even it is useless for none 
validator.

In one word, we would like to make a cheap hardware can easily to run a fullnode, and a sentry node can drive more peers than before.
For a classical network, the validators are protected by sentry nodes, ideally all validators should connect to each other directly,
so that we would like to provide HotSync to help node outside the core network to sync blocks.

# Specification
The main idea of HotSync is:

1. A peer will subscribe blocks[fromHeightA, toHeightB] from candidate peers. The candidate peers are wisely chosen.
2. A peer can handle subscribe requests, and answer what it have now, once receive message that the subscribers are interested,
   will publish to them immediately.
3. To make low delay, two kind of message will be deliver: `ProposalBlock`, `Commit`。
4. A sentry peer should should subscribe event `EventDataCompleteProposal` and `EventDataMajorPrecommits` from consensus reactor.
   Once a sentry peer receive complete proposal block parts, it will broadcast `ProposalBlock` to it's subscribers. Once a sentry peer
   receive 2/3+ precommit, it will broadcast `Commit` to its `subscribers`.

## CandidatePool

`CandidatePool` is designed to help HotSync to decide whom it will subscribe blocks from.

There are `freshSet`, `decayedSet` and `permanentSet` in `CandidatePool`.

- `freshSet`: newly added peers will stay in `freshSet`.
- `decayedSet`: unavailable or poor performance peers will stay in `decayedSet`.
- `permanentSet`: stable and good performance peers will stay in `permanentSet`.

The choose strategy is:
1. First try to pick a peer from `permanentSet` according to the score of each peer.
2. If there is no permanent peer is picked, all decayed peers will be chosen. Otherwise give  
   a decayed peer a try periodically. 
3. All peers in `freshSet` will be chosen.

Everytime HotSync receive a valid block from a peer or a timeout event happend, it will fire a `sampleEvent` to
`CandidatePool`. `CandidatePool` can handle `sampleEvent` to update `freshSet`, `decayedSet` and `permanentSet`, and 
the score of each peer.

## SyncPattern
Define the `SyncPattern` of HotSync:

1. Mute: will only answer subscribe requests from others, will not sync from others or from consensus channel.
2. Hot:  handle subscribe requests from other peer as a publisher, also subscribe block messages
from other peers as a subscriber.
3. Consensus: handle subscribe requests from other peer as a publisher, but subscribe block message from consensus channel.

The viable transitions between are:
                                Hot --> Consensus
                                 ^    ^
                                 |   /
                                 |  /
                                Mute
                                
## Message

- `blockSubscribeMessage`, subscribe block at specified height range.
- `blockUnSubscribeMessage`, unsubscribe block at specified height.
- `blockCommitResponseMessage`, publish block or commit message to subscriber.
- `noBlockResponseMessage`, if the subscribe height is too far or load nothing from db, will answer `noBlockResponseMessage`.

## Key Data Structure

- `publisherState` if a peer subscribe a block from other peer, will create a `publisherState` for each peer to track the response. 
Once timeout or receive valid block from that peer, will try to seal `publisherState` and fire an `sample event` to `CandidatePool`.
- `blockState` if a peer subscribe block at specified height, will create a `blockState` to track if receive valid block at
this height. There are one `blockState` and one more `publisherState` for each height, the first seal action will cause the seal of
`blockState`.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
