### PR TITLE
Do not write 'Couldn't connect to any seeds' if there are no seeds

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,7 +20,7 @@ program](https://hackerone.com/tendermint).
 
 ### IMPROVEMENTS:
 
-- [p2p] Do not write 'Couldn't connect to any seeds' error loge if there are no seeds in config file
+- [p2p] Do not write 'Couldn't connect to any seeds' error log if there are no seeds in config file
 - [abci] \#3809 Recover from application panics in `server/socket_server.go` to allow socket cleanup (@ruseinov)
 - [rpc] \#2252 Add `/broadcast_evidence` endpoint to submit double signing and other types of evidence
 - [rpc] \#3818 Make `max_body_bytes` and `max_header_bytes` configurable

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,7 @@ program](https://hackerone.com/tendermint).
 
 ### IMPROVEMENTS:
 
+- [p2p] Do not write 'Couldn't connect to any seeds' error loge if there are no seeds in config file
 - [abci] \#3809 Recover from application panics in `server/socket_server.go` to allow socket cleanup (@ruseinov)
 - [rpc] \#2252 Add `/broadcast_evidence` endpoint to submit double signing and other types of evidence
 - [rpc] \#3818 Make `max_body_bytes` and `max_header_bytes` configurable

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,7 +20,7 @@ program](https://hackerone.com/tendermint).
 
 ### IMPROVEMENTS:
 
-- [p2p] Do not write 'Couldn't connect to any seeds' error log if there are no seeds in config file
+- [p2p] \#3834 Do not write 'Couldn't connect to any seeds' error log if there are no seeds in config file
 - [abci] \#3809 Recover from application panics in `server/socket_server.go` to allow socket cleanup (@ruseinov)
 - [rpc] \#2252 Add `/broadcast_evidence` endpoint to submit double signing and other types of evidence
 - [rpc] \#3818 Make `max_body_bytes` and `max_header_bytes` configurable

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -594,7 +594,10 @@ func (r *PEXReactor) dialSeeds() {
 		}
 		r.Switch.Logger.Error("Error dialing seed", "err", err, "seed", seedAddr)
 	}
-	r.Switch.Logger.Error("Couldn't connect to any seeds")
+	// do not write error message if there were no seeds specified in config
+	if len(r.seedAddrs) > 0 {
+		r.Switch.Logger.Error("Couldn't connect to any seeds")
+	}
 }
 
 // AttemptsToDial returns the number of attempts to dial specific address. It


### PR DESCRIPTION
* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG_PENDING.md

I'm setting up all peers dynamically by calling `dial_peers`, so `p2p.seeds` in configs is empty, and I'm seeing error log a lot in logs.