### PR TITLE
 node: allow replacing existing p2p.Reactor(s) 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,10 @@ program](https://hackerone.com/tendermint).
   - [libs] \#3811 Remove `db` from libs in favor of `https://github.com/tendermint/tm-cmn`
 
 ### FEATURES:
+- [node] Allow replacing existing p2p.Reactor(s) using [`CustomReactors`
+  option](https://godoc.org/github.com/tendermint/tendermint/node#CustomReactors).
+  Warning: beware of accidental name clashes. Here is the list of existing
+  reactors: MEMPOOL, BLOCKCHAIN, CONSENSUS, EVIDENCE, PEX.
 
 ### IMPROVEMENTS:
 

--- a/node/doc.go
+++ b/node/doc.go
@@ -1,0 +1,40 @@
+/*
+Package node is the main entry point, where the Node struct, which
+represents a full node, is defined.
+
+Adding new p2p.Reactor(s)
+
+To add a new p2p.Reactor, use the CustomReactors option:
+
+		node, err := NewNode(
+				config,
+				privVal,
+				nodeKey,
+				clientCreator,
+				genesisDocProvider,
+				dbProvider,
+				metricsProvider,
+				logger,
+				CustomReactors(map[string]p2p.Reactor{"CUSTOM": customReactor}),
+		)
+
+Replacing existing p2p.Reactor(s)
+
+To replace the built-in p2p.Reactor, use the CustomReactors option:
+
+		node, err := NewNode(
+				config,
+				privVal,
+				nodeKey,
+				clientCreator,
+				genesisDocProvider,
+				dbProvider,
+				metricsProvider,
+				logger,
+				CustomReactors(map[string]p2p.Reactor{"BLOCKCHAIN": customBlockchainReactor}),
+		)
+
+The list of existing reactors can be found in CustomReactors documentation.
+
+*/
+package node

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -288,6 +288,7 @@ func TestNodeNewNodeCustomReactors(t *testing.T) {
 	defer os.RemoveAll(config.RootDir)
 
 	cr := p2pmock.NewReactor()
+	customBlockchainReactor := p2pmock.NewReactor()
 
 	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
 	require.NoError(t, err)
@@ -300,7 +301,7 @@ func TestNodeNewNodeCustomReactors(t *testing.T) {
 		DefaultDBProvider,
 		DefaultMetricsProvider(config.Instrumentation),
 		log.TestingLogger(),
-		CustomReactors(map[string]p2p.Reactor{"FOO": cr}),
+		CustomReactors(map[string]p2p.Reactor{"FOO": cr, "BLOCKCHAIN": customBlockchainReactor}),
 	)
 	require.NoError(t, err)
 
@@ -310,35 +311,9 @@ func TestNodeNewNodeCustomReactors(t *testing.T) {
 
 	assert.True(t, cr.IsRunning())
 	assert.Equal(t, cr, n.Switch().Reactor("FOO"))
-}
 
-func TestNodeNewNodeCustomReactorsReplacingExistingOne(t *testing.T) {
-	config := cfg.ResetTestRoot("node_new_node_custom_reactors_replacing_existing_one_test")
-	defer os.RemoveAll(config.RootDir)
-
-	cr := p2pmock.NewReactor()
-
-	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
-	require.NoError(t, err)
-
-	n, err := NewNode(config,
-		privval.LoadOrGenFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile()),
-		nodeKey,
-		proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir()),
-		DefaultGenesisDocProviderFunc(config),
-		DefaultDBProvider,
-		DefaultMetricsProvider(config.Instrumentation),
-		log.TestingLogger(),
-		CustomReactors(map[string]p2p.Reactor{"BLOCKCHAIN": cr}),
-	)
-	require.NoError(t, err)
-
-	err = n.Start()
-	require.NoError(t, err)
-	defer n.Stop()
-
-	assert.True(t, cr.IsRunning())
-	assert.Equal(t, cr, n.Switch().Reactor("BLOCKCHAIN"))
+	assert.True(t, customBlockchainReactor.IsRunning())
+	assert.Equal(t, customBlockchainReactor, n.Switch().Reactor("BLOCKCHAIN"))
 }
 
 func state(nVals int, height int64) (sm.State, dbm.DB) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -309,6 +309,7 @@ func TestNodeNewNodeCustomReactors(t *testing.T) {
 	defer n.Stop()
 
 	assert.True(t, cr.IsRunning())
+	assert.Equal(t, cr, n.Switch().Reactor("FOO"))
 }
 
 func TestNodeNewNodeCustomReactorsReplacingExistingOne(t *testing.T) {

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -152,11 +152,9 @@ func WithMetrics(metrics *Metrics) SwitchOption {
 // AddReactor adds the given reactor to the switch.
 // NOTE: Not goroutine safe.
 func (sw *Switch) AddReactor(name string, reactor Reactor) Reactor {
-	// Validate the reactor.
-	// No two reactors can share the same channel.
-	reactorChannels := reactor.GetChannels()
-	for _, chDesc := range reactorChannels {
+	for _, chDesc := range reactor.GetChannels() {
 		chID := chDesc.ID
+		// No two reactors can share the same channel.
 		if sw.reactorsByCh[chID] != nil {
 			panic(fmt.Sprintf("Channel %X has multiple reactors %v & %v", chID, sw.reactorsByCh[chID], reactor))
 		}
@@ -166,6 +164,23 @@ func (sw *Switch) AddReactor(name string, reactor Reactor) Reactor {
 	sw.reactors[name] = reactor
 	reactor.SetSwitch(sw)
 	return reactor
+}
+
+// RemoveReactor removes the given Reactor from the Switch.
+// NOTE: Not goroutine safe.
+func (sw *Switch) RemoveReactor(name string, reactor Reactor) {
+	for _, chDesc := range reactor.GetChannels() {
+		// remove channel description
+		for i := 0; i < len(sw.chDescs); i++ {
+			if chDesc.ID == sw.chDescs[i].ID {
+				sw.chDescs = append(sw.chDescs[:i], sw.chDescs[i+1:]...)
+				break
+			}
+		}
+		delete(sw.reactorsByCh, chDesc.ID)
+	}
+	delete(sw.reactors, name)
+	reactor.SetSwitch(nil)
 }
 
 // Reactors returns a map of reactors registered on the switch.


### PR DESCRIPTION
using [`CustomReactors` option](https://godoc.org/github.com/tendermint/tendermint/node#CustomReactors).

Warning: beware of accidental name clashes. Here is the list of existing
reactors: MEMPOOL, BLOCKCHAIN, CONSENSUS, EVIDENCE, PEX.

* [ ] Referenced an issue explaining the need for the change
* [ ] ~~Updated all relevant documentation in docs~~
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md