### PR TITLE
support Index service recovery and indexHeight in Status api

### DIFF
--- a/rpc/core/pipe.go
+++ b/rpc/core/pipe.go
@@ -75,6 +75,7 @@ var (
 	consensusReactor *consensus.ConsensusReactor
 	eventBus         *types.EventBus // thread safe
 	mempool          mempl.Mempool
+	indexerHub       *sm.IndexHub
 
 	logger log.Logger
 
@@ -139,6 +140,10 @@ func SetLogger(l log.Logger) {
 
 func SetEventBus(b *types.EventBus) {
 	eventBus = b
+}
+
+func SetIndexHub(hub *sm.IndexHub) {
+	indexerHub = hub
 }
 
 // SetConfig sets an RPCConfig.

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -106,6 +106,7 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 			LatestBlockHeight: latestHeight,
 			LatestBlockTime:   latestBlockTime,
 			CatchingUp:        consensusReactor.FastSync(),
+			IndexHeight:       indexerHub.GetHeight(),
 		},
 		ValidatorInfo: ctypes.ValidatorInfo{
 			Address:     pubKey.Address(),

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -63,6 +63,7 @@ type SyncInfo struct {
 	LatestBlockHeight int64        `json:"latest_block_height"`
 	LatestBlockTime   time.Time    `json:"latest_block_time"`
 	CatchingUp        bool         `json:"catching_up"`
+	IndexHeight       int64        `json:"index_height"`
 }
 
 // Info about the node's validator

--- a/state/index.go
+++ b/state/index.go
@@ -1,0 +1,177 @@
+package state
+
+import (
+	"sync"
+
+	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/types"
+	dbm "github.com/tendermint/tm-cmn/db"
+)
+
+const (
+	// Actually the max lag is 2, use 10 for tolerance.
+	MaxIndexLag = 10
+)
+
+var indexHeight = []byte("indexHeight")
+
+type IndexService interface {
+	SetOnIndex(callback func(int64))
+}
+
+type IndexHub struct {
+	cmn.BaseService
+	mtx sync.Mutex
+
+	stateHeight  int64
+	expectHeight int64
+
+	// the total registered index service
+	numIdxSvc        int
+	indexTaskCounter map[int64]int
+	indexTaskEvents  chan int64
+
+	stateDB    dbm.DB
+	blockStore BlockStore
+	eventBus   types.BlockEventPublisher
+
+	metrics *Metrics
+}
+
+func NewIndexHub(initialHeight int64, stateDB dbm.DB, blockStore BlockStore, eventBus types.BlockEventPublisher, options ...IndexHubOption) *IndexHub {
+	ih := &IndexHub{
+		stateHeight:      initialHeight,
+		indexTaskCounter: make(map[int64]int),
+		indexTaskEvents:  make(chan int64, MaxIndexLag),
+		stateDB:          stateDB,
+		blockStore:       blockStore,
+		eventBus:         eventBus,
+		metrics:          NopMetrics(),
+	}
+	indexedHeight := ih.GetIndexedHeight()
+	if indexedHeight < 0 {
+		// no indexedHeight found, will do no recover
+		ih.expectHeight = ih.stateHeight + 1
+	} else {
+		ih.expectHeight = indexedHeight + 1
+	}
+	for _, option := range options {
+		option(ih)
+	}
+	ih.BaseService = *cmn.NewBaseService(nil, "indexHub", ih)
+	return ih
+}
+
+type IndexHubOption func(*IndexHub)
+
+func IndexHubWithMetrics(metrics *Metrics) IndexHubOption {
+	return func(ih *IndexHub) {
+		ih.metrics = metrics
+	}
+}
+
+func (ih *IndexHub) OnStart() error {
+	// start listen routine before recovering.
+	go ih.indexRoutine()
+	ih.recoverIndex()
+	return nil
+}
+
+func (ih *IndexHub) recoverIndex() {
+	for h := ih.expectHeight; h <= ih.stateHeight; h++ {
+		ih.Logger.Info("try to recover index", "height", h)
+		block := ih.blockStore.LoadBlock(h)
+		if block == nil {
+			ih.Logger.Error("index skip since the the block is missing", "height", h)
+		} else {
+			abciResponses, err := LoadABCIResponses(ih.stateDB, h)
+			if err != nil {
+				ih.Logger.Error("failed to load ABCIResponse, will use default")
+				abciResponses = NewABCIResponses(block)
+			}
+			abciValUpdates := abciResponses.EndBlock.ValidatorUpdates
+			validatorUpdates, err := types.PB2TM.ValidatorUpdates(abciValUpdates)
+			if err != nil {
+				ih.Logger.Error("failed to load validatorUpdates, will use nil by default")
+			}
+			fireEvents(ih.Logger, ih.eventBus, block, abciResponses, validatorUpdates)
+		}
+	}
+}
+
+func (ih *IndexHub) indexRoutine() {
+	for {
+		select {
+		case <-ih.Quit():
+			return
+		case h := <-ih.indexTaskEvents:
+			ih.Logger.Info("finish index", "height", h)
+			ih.SetIndexedHeight(h)
+			ih.metrics.IndexHeight.Set(float64(h))
+		}
+	}
+}
+
+func (ih *IndexHub) RegisterIndexSvc(idx IndexService) {
+	ih.mtx.Lock()
+	defer ih.mtx.Unlock()
+	if ih.IsRunning() {
+		panic("can't RegisterIndexSvc when IndexHub is running")
+	}
+	idx.SetOnIndex(ih.CountDownAt)
+	ih.numIdxSvc++
+}
+
+// `CountDownAt` is a callback in index service, keep it simple and fast.
+func (ih *IndexHub) CountDownAt(height int64) {
+	ih.mtx.Lock()
+	defer ih.mtx.Unlock()
+	count, exist := ih.indexTaskCounter[height]
+	if exist {
+		count = count - 1
+	} else {
+		count = ih.numIdxSvc - 1
+	}
+	// The higher block won't finish index before lower one.
+	if count == 0 && height == ih.expectHeight {
+		if exist {
+			delete(ih.indexTaskCounter, height)
+		}
+		ih.expectHeight = ih.expectHeight + 1
+		ih.indexTaskEvents <- height
+	} else {
+		ih.indexTaskCounter[height] = count
+	}
+}
+
+// set and get won't happen in the same time, won't lock
+func (ih *IndexHub) SetIndexedHeight(h int64) {
+	rawHeight, err := cdc.MarshalBinaryBare(h)
+	if err != nil {
+		panic(err)
+	}
+	ih.stateDB.Set(indexHeight, rawHeight)
+}
+
+// if never store `indexHeight` in index db, will return -1.
+func (ih *IndexHub) GetIndexedHeight() int64 {
+	rawHeight := ih.stateDB.Get(indexHeight)
+	if rawHeight == nil {
+		return -1
+	} else {
+		var height int64
+		err := cdc.UnmarshalBinaryBare(rawHeight, &height)
+		if err != nil {
+			// should not happen
+			panic(err)
+		}
+		return height
+	}
+}
+
+// get indexed height from memory to save time for RPC
+func (ih *IndexHub) GetHeight() int64 {
+	ih.mtx.Lock()
+	defer ih.mtx.Unlock()
+	return ih.expectHeight - 1
+}

--- a/state/index_test.go
+++ b/state/index_test.go
@@ -1,0 +1,79 @@
+package state
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/state/txindex"
+	"github.com/tendermint/tendermint/state/txindex/kv"
+	"github.com/tendermint/tendermint/types"
+	"github.com/tendermint/tm-cmn/db"
+)
+
+func TestSetHeight(t *testing.T) {
+
+	indexDb := db.NewMemDB()
+	indexHub := NewIndexHub(0, indexDb, nil, nil)
+	indexHub.SetLogger(log.TestingLogger())
+
+	realHeightAtFirst := indexHub.GetIndexedHeight()
+	assert.Equal(t, int64(-1), realHeightAtFirst)
+	height := int64(1024)
+	indexHub.SetIndexedHeight(height)
+	realHeight := indexHub.GetIndexedHeight()
+	assert.Equal(t, height, realHeight)
+}
+
+func TestCountDown(t *testing.T) {
+	// event bus
+	eventBus := types.NewEventBus()
+	eventBus.SetLogger(log.TestingLogger())
+	err := eventBus.Start()
+	require.NoError(t, err)
+	defer eventBus.Stop()
+
+	indexDb := db.NewMemDB()
+
+	// start tx index
+	txIndexer := kv.NewTxIndex(indexDb, kv.IndexAllTags())
+	txIndexSvc := txindex.NewIndexerService(txIndexer, eventBus)
+	txIndexSvc.SetLogger(log.TestingLogger())
+	err = txIndexSvc.Start()
+	require.NoError(t, err)
+	defer txIndexSvc.Stop()
+
+	// start index hub
+	indexHub := NewIndexHub(0, indexDb, nil, eventBus)
+	indexHub.SetLogger(log.TestingLogger())
+	indexHub.RegisterIndexSvc(txIndexSvc)
+	err = indexHub.Start()
+	assert.NoError(t, err)
+
+	// publish block with txs
+	for h := int64(1); h < 10; h++ {
+		numTxs := rand.Int63n(5)
+		eventBus.PublishEventNewBlockHeader(types.EventDataNewBlockHeader{
+			Header: types.Header{Height: h, NumTxs: numTxs},
+		})
+		for i := int64(0); i < numTxs; i++ {
+			txResult := &types.TxResult{
+				Height: h,
+				Index:  uint32(i),
+				Tx:     types.Tx("foo"),
+				Result: abci.ResponseDeliverTx{Code: 0},
+			}
+			eventBus.PublishEventTx(types.EventDataTx{TxResult: *txResult})
+		}
+		// In test case, 100ms is far enough for index
+		time.Sleep(100 * time.Millisecond)
+		assert.Equal(t, int64(h), indexHub.GetIndexedHeight())
+		// test no memory leak
+		assert.Equal(t, len(indexHub.indexTaskCounter), 0)
+	}
+}

--- a/state/index_test.go
+++ b/state/index_test.go
@@ -73,7 +73,12 @@ func TestCountDown(t *testing.T) {
 		// In test case, 100ms is far enough for index
 		time.Sleep(100 * time.Millisecond)
 		assert.Equal(t, int64(h), indexHub.GetIndexedHeight())
+		assert.Equal(t, int64(h), indexHub.GetHeight())
 		// test no memory leak
 		assert.Equal(t, len(indexHub.indexTaskCounter), 0)
 	}
+}
+
+func TestCountDownRegisterIndexSvc(t *testing.T) {
+
 }

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -17,6 +17,8 @@ const (
 type Metrics struct {
 	// Time between BeginBlock and EndBlock.
 	BlockProcessingTime metrics.Histogram
+	// The latest height of block that have been indexed
+	IndexHeight metrics.Gauge
 }
 
 // PrometheusMetrics returns Metrics build using Prometheus client library.
@@ -35,6 +37,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Help:      "Time between BeginBlock and EndBlock in ms.",
 			Buckets:   stdprometheus.LinearBuckets(1, 10, 10),
 		}, labels).With(labelsAndValues...),
+		IndexHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "index_height",
+			Help:      "The latest height of block that have been indexed",
+		}, append(labels)).With(labelsAndValues...),
 	}
 }
 
@@ -42,5 +50,6 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 func NopMetrics() *Metrics {
 	return &Metrics{
 		BlockProcessingTime: discard.NewHistogram(),
+		IndexHeight:         discard.NewGauge(),
 	}
 }

--- a/state/txindex/indexer_service.go
+++ b/state/txindex/indexer_service.go
@@ -19,6 +19,8 @@ type IndexerService struct {
 
 	idr      TxIndexer
 	eventBus *types.EventBus
+
+	onIndex func(int64)
 }
 
 // NewIndexerService returns a new service instance.
@@ -65,6 +67,9 @@ func (is *IndexerService) OnStart() error {
 			} else {
 				is.Logger.Info("Indexed block", "height", header.Height)
 			}
+			if is.onIndex != nil {
+				is.onIndex(header.Height)
+			}
 		}
 	}()
 	return nil
@@ -75,4 +80,8 @@ func (is *IndexerService) OnStop() {
 	if is.eventBus.IsRunning() {
 		_ = is.eventBus.UnsubscribeAll(context.Background(), subscriber)
 	}
+}
+
+func (is *IndexerService) SetOnIndex(callback func(int64)) {
+	is.onIndex = callback
 }


### PR DESCRIPTION
### Description
resolve . https://github.com/tendermint/tendermint/issues/3823

1. Will recover index data from restart or crash
2. Add field--'indexHeight'  to status API.
3. Add indexHegiht metrics. 
### Rationale
This pr have passed though following end to end test cases:

1. Upgrade from old binary, no recover will do.  checked
2. If previous do not use index and now change to use the index, no recover will do. checked
3. If index data lost, it will recover. checked 
4. If data have indexed, but didn't write the height, redo index has no side effect. checked
5. RPC API has changed.   checked
6. Metrics have changed.  checked
7. write to statedb will not cause consensus issues. checked

## Why indexHub.
For our tendermint fork, we have block index service, for other fork, may extend other index service. But all these should register in indexHub.

### Example

api of 'Status ' changed:

 ```json
 {
 "jsonrpc": "2.0",
 "id": "",
"result": {
...
 "sync_info": {
   		"latest_block_hash": "F51538DA498299F4C57AC8162AAFA0254CE08286",
   		"latest_app_hash": "0000000000000000",
   		"latest_block_height": "18",
   		"latest_block_time": "2018-09-17T11:42:19.149920551Z",
   		"catching_up": false,
   		"index_height": "18"
   	},
...
}
```
