### PR TITLE
config: move max_msg_bytes into mempool section

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,3 +20,4 @@ program](https://hackerone.com/tendermint).
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+- [config] \#3868 move misplaced `max_msg_bytes` into mempool section

--- a/config/toml.go
+++ b/config/toml.go
@@ -294,6 +294,9 @@ max_txs_bytes = {{ .Mempool.MaxTxsBytes }}
 # Size of the cache (used to filter transactions we saw earlier) in transactions
 cache_size = {{ .Mempool.CacheSize }}
 
+# Limit the size of TxMessage
+max_msg_bytes = {{ .Mempool.MaxMsgBytes }}
+
 ##### fast sync configuration options #####
 [fastsync]
 
@@ -301,9 +304,6 @@ cache_size = {{ .Mempool.CacheSize }}
 #   1) "v0" (default) - the legacy fast sync implementation
 #   2) "v1" - refactor of v0 version for better testability
 version = "{{ .FastSync.Version }}"
-
-# Limit the size of TxMessage
-max_msg_bytes = {{ .Mempool.MaxMsgBytes }}
 
 ##### consensus configuration options #####
 [consensus]

--- a/docs/tendermint-core/configuration.md
+++ b/docs/tendermint-core/configuration.md
@@ -240,6 +240,9 @@ max_txs_bytes = 1073741824
 # Size of the cache (used to filter transactions we saw earlier) in transactions
 cache_size = 10000
 
+# Limit the size of TxMessage
+max_msg_bytes = 1048576
+
 ##### fast sync configuration options #####
 [fastsync]
 
@@ -247,9 +250,6 @@ cache_size = 10000
 #   1) "v0" (default) - the legacy fast sync implementation
 #   2) "v1" - refactor of v0 version for better testability
 version = "v0"
-
-# Limit the size of TxMessage
-max_msg_bytes = 1048576
 
 ##### consensus configuration options #####
 [consensus]


### PR DESCRIPTION
It was incorrectly placed in fastsync section during
https://github.com/tendermint/tendermint/commit/4d7cd8055b4083376b788239207f72f423e6ce07#diff-092cdc48047eeb4c0bca311a2e1b8ae6
merge.

Fixes #3868

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [ ] ~~Updated all code comments where relevant~~
* [ ] ~~Wrote tests~~
* [x] Updated CHANGELOG_PENDING.md
