### PR TITLE
(1/2) of replace errors.go with github.com/pkg/errors

### DIFF
--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/tendermint/tendermint/store"
 
 	"github.com/stretchr/testify/assert"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
-	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/mock"
 	"github.com/tendermint/tendermint/p2p"
@@ -60,7 +60,7 @@ func newBlockchainReactor(logger log.Logger, genDoc *types.GenesisDoc, privVals 
 	proxyApp := proxy.NewAppConns(cc)
 	err := proxyApp.Start()
 	if err != nil {
-		panic(cmn.ErrorWrap(err, "error start app"))
+		panic(errors.Wrap(err, "error start app"))
 	}
 
 	blockDB := dbm.NewMemDB()
@@ -69,7 +69,7 @@ func newBlockchainReactor(logger log.Logger, genDoc *types.GenesisDoc, privVals 
 
 	state, err := sm.LoadStateFromDBOrGenesisDoc(stateDB, genDoc)
 	if err != nil {
-		panic(cmn.ErrorWrap(err, "error constructing state from genesis file"))
+		panic(errors.Wrap(err, "error constructing state from genesis file"))
 	}
 
 	// Make the BlockchainReactor itself.
@@ -103,7 +103,7 @@ func newBlockchainReactor(logger log.Logger, genDoc *types.GenesisDoc, privVals 
 
 		state, err = blockExec.ApplyBlock(state, blockID, thisBlock)
 		if err != nil {
-			panic(cmn.ErrorWrap(err, "error apply block"))
+			panic(errors.Wrap(err, "error apply block"))
 		}
 
 		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)

--- a/blockchain/v1/reactor_test.go
+++ b/blockchain/v1/reactor_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
-	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/mock"
 	"github.com/tendermint/tendermint/p2p"
@@ -78,7 +78,7 @@ func newBlockchainReactor(logger log.Logger, genDoc *types.GenesisDoc, privVals 
 	proxyApp := proxy.NewAppConns(cc)
 	err := proxyApp.Start()
 	if err != nil {
-		panic(cmn.ErrorWrap(err, "error start app"))
+		panic(errors.Wrap(err, "error start app"))
 	}
 
 	blockDB := dbm.NewMemDB()
@@ -87,7 +87,7 @@ func newBlockchainReactor(logger log.Logger, genDoc *types.GenesisDoc, privVals 
 
 	state, err := sm.LoadStateFromDBOrGenesisDoc(stateDB, genDoc)
 	if err != nil {
-		panic(cmn.ErrorWrap(err, "error constructing state from genesis file"))
+		panic(errors.Wrap(err, "error constructing state from genesis file"))
 	}
 
 	// Make the BlockchainReactor itself.
@@ -117,7 +117,7 @@ func newBlockchainReactor(logger log.Logger, genDoc *types.GenesisDoc, privVals 
 
 		state, err = blockExec.ApplyBlock(state, blockID, thisBlock)
 		if err != nil {
-			panic(cmn.ErrorWrap(err, "error apply block"))
+			panic(errors.Wrap(err, "error apply block"))
 		}
 
 		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)

--- a/crypto/merkle/proof_key_path.go
+++ b/crypto/merkle/proof_key_path.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/pkg/errors"
 )
 
 /*
@@ -87,7 +87,7 @@ func (pth KeyPath) String() string {
 // Each key must use a known encoding.
 func KeyPathToKeys(path string) (keys [][]byte, err error) {
 	if path == "" || path[0] != '/' {
-		return nil, cmn.NewError("key path string must start with a forward slash '/'")
+		return nil, errors.New("key path string must start with a forward slash '/'")
 	}
 	parts := strings.Split(path[1:], "/")
 	keys = make([][]byte, len(parts))
@@ -96,13 +96,13 @@ func KeyPathToKeys(path string) (keys [][]byte, err error) {
 			hexPart := part[2:]
 			key, err := hex.DecodeString(hexPart)
 			if err != nil {
-				return nil, cmn.ErrorWrap(err, "decoding hex-encoded part #%d: /%s", i, part)
+				return nil, errors.Wrapf(err, "decoding hex-encoded part #%d: /%s", i, part)
 			}
 			keys[i] = key
 		} else {
 			key, err := url.PathUnescape(part)
 			if err != nil {
-				return nil, cmn.ErrorWrap(err, "decoding url-encoded part #%d: /%s", i, part)
+				return nil, errors.Wrapf(err, "decoding url-encoded part #%d: /%s", i, part)
 			}
 			keys[i] = []byte(key) // TODO Test this with random bytes, I'm not sure that it works for arbitrary bytes...
 		}

--- a/crypto/merkle/proof_test.go
+++ b/crypto/merkle/proof_test.go
@@ -3,9 +3,9 @@ package merkle
 import (
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	amino "github.com/tendermint/go-amino"
-	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
 const ProofOpDomino = "test:domino"
@@ -34,7 +34,7 @@ func DominoOpDecoder(pop ProofOp) (ProofOperator, error) {
 	var op DominoOp // a bit strange as we'll discard this, but it works.
 	err := amino.UnmarshalBinaryLengthPrefixed(pop.Data, &op)
 	if err != nil {
-		return nil, cmn.ErrorWrap(err, "decoding ProofOp.Data into SimpleValueOp")
+		return nil, errors.Wrap(err, "decoding ProofOp.Data into SimpleValueOp")
 	}
 	return NewDominoOp(string(pop.Key), op.Input, op.Output), nil
 }
@@ -50,10 +50,10 @@ func (dop DominoOp) ProofOp() ProofOp {
 
 func (dop DominoOp) Run(input [][]byte) (output [][]byte, err error) {
 	if len(input) != 1 {
-		return nil, cmn.NewError("Expected input of length 1")
+		return nil, errors.New("Expected input of length 1")
 	}
 	if string(input[0]) != dop.Input {
-		return nil, cmn.NewError("Expected input %v, got %v",
+		return nil, errors.Errorf("Expected input %v, got %v",
 			dop.Input, string(input[0]))
 	}
 	return [][]byte{[]byte(dop.Output)}, nil

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -222,7 +222,7 @@ func (sw *Switch) OnStart() error {
 	for _, reactor := range sw.reactors {
 		err := reactor.Start()
 		if err != nil {
-			return cmn.ErrorWrap(err, "failed to start %v", reactor)
+			return errors.Wrapf(err, "failed to start %v", reactor)
 		}
 	}
 

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"time"
+	"github.com/pkg/errors"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -233,7 +234,7 @@ func testPeerConn(
 	// Encrypt connection
 	conn, err = upgradeSecretConn(conn, cfg.HandshakeTimeout, ourNodePrivKey)
 	if err != nil {
-		return pc, cmn.ErrorWrap(err, "Error creating peer")
+		return pc, errors.Wrap(err, "Error creating peer")
 	}
 
 	// Only the information we already have

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"time"
+
 	"github.com/pkg/errors"
 
 	"github.com/tendermint/tendermint/crypto"

--- a/privval/messages.go
+++ b/privval/messages.go
@@ -1,7 +1,7 @@
 package privval
 
 import (
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/types"
 )

--- a/store/store.go
+++ b/store/store.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"sync"
 
-	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/pkg/errors"
+
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/types"
@@ -67,7 +68,7 @@ func (bs *BlockStore) LoadBlock(height int64) *types.Block {
 	if err != nil {
 		// NOTE: The existence of meta should imply the existence of the
 		// block. So, make sure meta is only saved after blocks are saved.
-		panic(cmn.ErrorWrap(err, "Error reading block"))
+		panic(errors.Wrap(err, "Error reading block"))
 	}
 	return block
 }
@@ -83,7 +84,7 @@ func (bs *BlockStore) LoadBlockPart(height int64, index int) *types.Part {
 	}
 	err := cdc.UnmarshalBinaryBare(bz, part)
 	if err != nil {
-		panic(cmn.ErrorWrap(err, "Error reading block part"))
+		panic(errors.Wrap(err, "Error reading block part"))
 	}
 	return part
 }
@@ -98,7 +99,7 @@ func (bs *BlockStore) LoadBlockMeta(height int64) *types.BlockMeta {
 	}
 	err := cdc.UnmarshalBinaryBare(bz, blockMeta)
 	if err != nil {
-		panic(cmn.ErrorWrap(err, "Error reading block meta"))
+		panic(errors.Wrap(err, "Error reading block meta"))
 	}
 	return blockMeta
 }
@@ -115,7 +116,7 @@ func (bs *BlockStore) LoadBlockCommit(height int64) *types.Commit {
 	}
 	err := cdc.UnmarshalBinaryBare(bz, commit)
 	if err != nil {
-		panic(cmn.ErrorWrap(err, "Error reading block commit"))
+		panic(errors.Wrap(err, "Error reading block commit"))
 	}
 	return commit
 }
@@ -131,7 +132,7 @@ func (bs *BlockStore) LoadSeenCommit(height int64) *types.Commit {
 	}
 	err := cdc.UnmarshalBinaryBare(bz, commit)
 	if err != nil {
-		panic(cmn.ErrorWrap(err, "Error reading block seen commit"))
+		panic(errors.Wrap(err, "Error reading block seen commit"))
 	}
 	return commit
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	db "github.com/tendermint/tm-db"
 	dbm "github.com/tendermint/tm-db"
 
 	cfg "github.com/tendermint/tendermint/config"
-	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/log"
 	sm "github.com/tendermint/tendermint/state"
 
@@ -53,7 +53,7 @@ func makeStateAndBlockStore(logger log.Logger) (sm.State, *BlockStore, cleanupFu
 	stateDB := dbm.NewMemDB()
 	state, err := sm.LoadStateFromDBOrGenesisFile(stateDB, config.GenesisFile())
 	if err != nil {
-		panic(cmn.ErrorWrap(err, "error constructing state from genesis file"))
+		panic(errors.Wrap(err, "error constructing state from genesis file"))
 	}
 	return state, NewBlockStore(blockDB), func() { os.RemoveAll(config.RootDir) }
 }

--- a/types/block.go
+++ b/types/block.go
@@ -748,7 +748,7 @@ func (sh SignedHeader) ValidateBasic(chainID string) error {
 	// ValidateBasic on the Commit.
 	err := sh.Commit.ValidateBasic()
 	if err != nil {
-		return cmn.ErrorWrap(err, "commit.ValidateBasic failed during SignedHeader.ValidateBasic")
+		return errors.Wrap(err, "commit.ValidateBasic failed during SignedHeader.ValidateBasic")
 	}
 	return nil
 }

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	tmtime "github.com/tendermint/tendermint/types/time"
@@ -64,10 +66,10 @@ func (genDoc *GenesisDoc) ValidatorHash() []byte {
 // and fills in defaults for optional fields left empty
 func (genDoc *GenesisDoc) ValidateAndComplete() error {
 	if genDoc.ChainID == "" {
-		return cmn.NewError("Genesis doc must include non-empty chain_id")
+		return errors.New("Genesis doc must include non-empty chain_id")
 	}
 	if len(genDoc.ChainID) > MaxChainIDLen {
-		return cmn.NewError("chain_id in genesis doc is too long (max: %d)", MaxChainIDLen)
+		return errors.Errorf("chain_id in genesis doc is too long (max: %d)", MaxChainIDLen)
 	}
 
 	if genDoc.ConsensusParams == nil {
@@ -78,10 +80,10 @@ func (genDoc *GenesisDoc) ValidateAndComplete() error {
 
 	for i, v := range genDoc.Validators {
 		if v.Power == 0 {
-			return cmn.NewError("The genesis file cannot contain validators with no voting power: %v", v)
+			return errors.Errorf("The genesis file cannot contain validators with no voting power: %v", v)
 		}
 		if len(v.Address) > 0 && !bytes.Equal(v.PubKey.Address(), v.Address) {
-			return cmn.NewError("Incorrect address for validator %v in the genesis file, should be %v", v, v.PubKey.Address())
+			return errors.Errorf("Incorrect address for validator %v in the genesis file, should be %v", v, v.PubKey.Address())
 		}
 		if len(v.Address) == 0 {
 			genDoc.Validators[i].Address = v.PubKey.Address()
@@ -117,11 +119,11 @@ func GenesisDocFromJSON(jsonBlob []byte) (*GenesisDoc, error) {
 func GenesisDocFromFile(genDocFile string) (*GenesisDoc, error) {
 	jsonBlob, err := ioutil.ReadFile(genDocFile)
 	if err != nil {
-		return nil, cmn.ErrorWrap(err, "Couldn't read GenesisDoc file")
+		return nil, errors.Wrap(err, "Couldn't read GenesisDoc file")
 	}
 	genDoc, err := GenesisDocFromJSON(jsonBlob)
 	if err != nil {
-		return nil, cmn.ErrorWrap(err, fmt.Sprintf("Error reading GenesisDoc at %v", genDocFile))
+		return nil, errors.Wrap(err, fmt.Sprintf("Error reading GenesisDoc at %v", genDocFile))
 	}
 	return genDoc, nil
 }


### PR DESCRIPTION
ref #3862

- step one in removing instances of errors.go in favor of github.com/pkg/errors

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
