### PR TITLE
Revert State Changes from Latest Block

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -442,6 +442,26 @@ func updateState(
 	}, nil
 }
 
+func revertState(
+	state State,
+	reverted *types.Block,
+	newHead *types.Block,
+) State {
+	var lastValidators *types.ValidatorSet
+	lastValidators, _ := LoadValidators(blockExec.db, lastValidatorsInfo.LastHeightChanged)
+	return State{
+		Version:          state.Version,
+		ChainID:          state.ChainID,
+		LastBlockHeight:  state.LastBlockHeight - 1,
+		LastBlockTotalTx: state.LastBlockTotalTx - len(reverted.Data.Txs),
+		LastBlockID:      reverted.Header.LastBlockID,
+		LastBlockTime:    newHead.Header.LastBlockTime,
+		NextValidators:   state.Validators.Copy(),
+		Validators:       state.LastValidators.Copy(),
+		LastValidators:   lastValidators.Copy(),
+	}
+}
+
 // Fire NewBlock, NewBlockHeader.
 // Fire TxEvent for every tx.
 // NOTE: if Tendermint crashes before commit, some or all of these events may be published again.

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -2,7 +2,6 @@ package state_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -68,7 +67,7 @@ func TestRevertBlock(t *testing.T) {
 	require.Nil(t, err)
 
 	revertedState, _ := blockExec.RevertBlock(state2, block2, block1)
-	require.True(t, state1.Equals(revertedState), fmt.Sprintf("Expected:\n %v\n\nActual:\n%v", state1, revertedState))
+	require.True(t, state1.Equals(revertedState), "Expected:\n%v\n\nActual:\n%v", state1, revertedState)
 
 	// TODO: check changes in ValSet and ConsensusParams
 }

--- a/state/helpers_test.go
+++ b/state/helpers_test.go
@@ -40,33 +40,33 @@ func makeAndCommitGoodBlock(
 	proposerAddr []byte,
 	blockExec *sm.BlockExecutor,
 	privVals map[string]types.PrivValidator,
-	evidence []types.Evidence) (sm.State, types.BlockID, *types.Commit, error) {
+	evidence []types.Evidence) (sm.State, *types.Block, types.BlockID, *types.Commit, error) {
 	// A good block passes
-	state, blockID, err := makeAndApplyGoodBlock(state, height, lastCommit, proposerAddr, blockExec, evidence)
+	state, block, blockID, err := makeAndApplyGoodBlock(state, height, lastCommit, proposerAddr, blockExec, evidence)
 	if err != nil {
-		return state, types.BlockID{}, nil, err
+		return state, nil, types.BlockID{}, nil, err
 	}
 
 	// Simulate a lastCommit for this block from all validators for the next height
 	commit, err := makeValidCommit(height, blockID, state.Validators, privVals)
 	if err != nil {
-		return state, types.BlockID{}, nil, err
+		return state, nil, types.BlockID{}, nil, err
 	}
-	return state, blockID, commit, nil
+	return state, block, blockID, commit, nil
 }
 
 func makeAndApplyGoodBlock(state sm.State, height int64, lastCommit *types.Commit, proposerAddr []byte,
-	blockExec *sm.BlockExecutor, evidence []types.Evidence) (sm.State, types.BlockID, error) {
+	blockExec *sm.BlockExecutor, evidence []types.Evidence) (sm.State, *types.Block, types.BlockID, error) {
 	block, _ := state.MakeBlock(height, makeTxs(height), lastCommit, evidence, proposerAddr)
 	if err := blockExec.ValidateBlock(state, block); err != nil {
-		return state, types.BlockID{}, err
+		return state, nil, types.BlockID{}, err
 	}
 	blockID := types.BlockID{Hash: block.Hash(), PartsHeader: types.PartSetHeader{}}
 	state, err := blockExec.ApplyBlock(state, blockID, block)
 	if err != nil {
-		return state, types.BlockID{}, err
+		return state, nil, types.BlockID{}, err
 	}
-	return state, blockID, nil
+	return state, block, blockID, nil
 }
 
 func makeValidCommit(height int64, blockID types.BlockID, vals *types.ValidatorSet, privVals map[string]types.PrivValidator) (*types.Commit, error) {

--- a/state/store.go
+++ b/state/store.go
@@ -170,6 +170,12 @@ func saveABCIResponses(db dbm.DB, height int64, abciResponses *ABCIResponses) {
 	db.SetSync(calcABCIResponsesKey(height), abciResponses.Bytes())
 }
 
+// DeleteABCIResponses should delete previously persisted ABCIResponses from database.
+// Should only be called by RevertBlock
+fund deleteABCIResponses(db dbm.DB, height int64) {
+	db.DeleteSync(calcABCIResponsesKey(height))
+}
+
 //-----------------------------------------------------------------------------
 
 // ValidatorsInfo represents the latest validator set, or the last height it changed
@@ -261,6 +267,12 @@ func saveValidatorsInfo(db dbm.DB, height, lastHeightChanged int64, valSet *type
 	db.Set(calcValidatorsKey(height), valInfo.Bytes())
 }
 
+// DeleteValidatorsInfp should delete previously persisted ValidatorsInfo from database.
+// Should only be called by RevertBlock
+fund deleteABCIResponses(db dbm.DB, height int64) {
+	db.DeleteSync(calcValidatorsKey(height))
+}
+
 //-----------------------------------------------------------------------------
 
 // ConsensusParamsInfo represents the latest consensus params, or the last height it changed
@@ -330,4 +342,10 @@ func saveConsensusParamsInfo(db dbm.DB, nextHeight, changeHeight int64, params t
 		paramsInfo.ConsensusParams = params
 	}
 	db.Set(calcConsensusParamsKey(nextHeight), paramsInfo.Bytes())
+}
+
+// DeleteConsensusParamsInfo should delete previously persisted ConsesnsusParamsInfo from database.
+// Should only be called by RevertBlock
+fund deleteABCIResponses(db dbm.DB, nextHeight int64) {
+	db.DeleteSync(calcConensusParamsKey(nextHeight))
 }

--- a/state/store.go
+++ b/state/store.go
@@ -172,7 +172,7 @@ func saveABCIResponses(db dbm.DB, height int64, abciResponses *ABCIResponses) {
 
 // DeleteABCIResponses should delete previously persisted ABCIResponses from database.
 // Should only be called by RevertBlock
-fund deleteABCIResponses(db dbm.DB, height int64) {
+func deleteABCIResponses(db dbm.DB, height int64) {
 	db.DeleteSync(calcABCIResponsesKey(height))
 }
 
@@ -267,9 +267,9 @@ func saveValidatorsInfo(db dbm.DB, height, lastHeightChanged int64, valSet *type
 	db.Set(calcValidatorsKey(height), valInfo.Bytes())
 }
 
-// DeleteValidatorsInfp should delete previously persisted ValidatorsInfo from database.
+// DeleteValidatorsInfo should delete previously persisted ValidatorsInfo from database.
 // Should only be called by RevertBlock
-fund deleteABCIResponses(db dbm.DB, height int64) {
+func deleteValidatorsInfo(db dbm.DB, height int64) {
 	db.DeleteSync(calcValidatorsKey(height))
 }
 
@@ -346,6 +346,6 @@ func saveConsensusParamsInfo(db dbm.DB, nextHeight, changeHeight int64, params t
 
 // DeleteConsensusParamsInfo should delete previously persisted ConsesnsusParamsInfo from database.
 // Should only be called by RevertBlock
-fund deleteABCIResponses(db dbm.DB, nextHeight int64) {
-	db.DeleteSync(calcConensusParamsKey(nextHeight))
+func deleteConsensusParamsInfo(db dbm.DB, nextHeight int64) {
+	db.DeleteSync(calcConsensusParamsKey(nextHeight))
 }

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -78,7 +78,7 @@ func TestValidateBlockHeader(t *testing.T) {
 			A good block passes
 		*/
 		var err error
-		state, _, lastCommit, err = makeAndCommitGoodBlock(state, height, lastCommit, proposerAddr, blockExec, privVals, nil)
+		state, _, _, lastCommit, err = makeAndCommitGoodBlock(state, height, lastCommit, proposerAddr, blockExec, privVals, nil)
 		require.NoError(t, err, "height %d", height)
 	}
 }
@@ -123,7 +123,7 @@ func TestValidateBlockCommit(t *testing.T) {
 		*/
 		var err error
 		var blockID types.BlockID
-		state, blockID, lastCommit, err = makeAndCommitGoodBlock(state, height, lastCommit, proposerAddr, blockExec, privVals, nil)
+		state, _, blockID, lastCommit, err = makeAndCommitGoodBlock(state, height, lastCommit, proposerAddr, blockExec, privVals, nil)
 		require.NoError(t, err, "height %d", height)
 
 		/*
@@ -190,7 +190,7 @@ func TestValidateBlockEvidence(t *testing.T) {
 		}
 
 		var err error
-		state, _, lastCommit, err = makeAndCommitGoodBlock(state, height, lastCommit, proposerAddr, blockExec, privVals, evidence)
+		state, _, _, lastCommit, err = makeAndCommitGoodBlock(state, height, lastCommit, proposerAddr, blockExec, privVals, evidence)
 		require.NoError(t, err, "height %d", height)
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -210,7 +210,7 @@ func (bs *BlockStore) RevertBlock() (reverted *types.Block, newHead *types.Block
 
 	// Delete block meta
 	blockMeta := bs.LoadBlockMeta(latest)
-	blockID = blockMeta.BlockID
+	blockID := blockMeta.BlockID
 	bs.db.Delete(calcBlockMetaKey(latest))
 
 	// Delete block parts
@@ -221,8 +221,8 @@ func (bs *BlockStore) RevertBlock() (reverted *types.Block, newHead *types.Block
 	// Delete block commit
 	bs.db.Delete(calcBlockCommitKey(latest - 1))
 
-	// Update BlockStateStateJSON descriptor
-	BlockStateStateJSON{Height: latest - 1}.Save(bs.db)
+	// Update BlockStoreStateJSON descriptor
+	BlockStoreStateJSON{Height: latest - 1}.Save(bs.db)
 
 	// Update height
 	bs.mtx.Lock()
@@ -231,6 +231,7 @@ func (bs *BlockStore) RevertBlock() (reverted *types.Block, newHead *types.Block
 
 	// Flush
 	bs.db.SetSync(nil, nil)
+	return
 
 }
 
@@ -259,6 +260,11 @@ var blockStoreKey = []byte("blockStore")
 // BlockStoreStateJSON is the block store state JSON structure.
 type BlockStoreStateJSON struct {
 	Height int64 `json:"height"`
+}
+
+// Returns blockStoreKey for testing purposes
+func BlockStoreKey() []byte {
+	return blockStoreKey
 }
 
 // Save persists the blockStore state to the database as JSON.

--- a/types/block.go
+++ b/types/block.go
@@ -257,6 +257,22 @@ func (b *Block) StringShort() string {
 	return fmt.Sprintf("Block#%v", b.Hash())
 }
 
+// Equals returns whether two blocks are equal. Useful for testing
+func (b *Block) Equals(b2 *Block) bool {
+	if b2 == nil {
+		return false
+	}
+	bz1, err := b.Marshal()
+	if err != nil {
+		return false
+	}
+	bz2, err := b2.Marshal()
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(bz1, bz2)
+}
+
 //-----------------------------------------------------------
 // These methods are for Protobuf Compatibility
 


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

This PR aims to add a command to revert the latest block. This will undo any changes in Tendermint State and block store from the last time `ApplyBlock` was called. It should also rollback ApplicationState changes though that is currently unimplemented since further discussion is necessary on how that should be accomplished.

Reasons for why reverting a block would be useful are explained here: https://github.com/tendermint/tendermint/issues/3196 and https://github.com/tendermint/tendermint/issues/3845

Prior work: https://github.com/tendermint/tendermint/pull/3332


* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
