### PR TITLE
Quick fix to swagger docs

### DIFF
--- a/docs/spec/rpc/swagger.yaml
+++ b/docs/spec/rpc/swagger.yaml
@@ -2230,7 +2230,7 @@ definitions:
                 type: "object"
             type: "object"
         type: "object"
-  UnconfirmedTransactionsResponse:
+  NumUnconfirmedTransactionsResponse:
     type: object
     required:
       - "jsonrpc"
@@ -2248,7 +2248,6 @@ definitions:
           - "n_txs"
           - "total"
           - "total_bytes"
-        #          - "txs"
         properties:
           n_txs:
             type: "string"
@@ -2268,7 +2267,7 @@ definitions:
         #            example:
         #              - "gAPwYl3uCjCMTXENChSMnIkb5ZpYHBKIZqecFEV2tuZr7xIUA75/FmYq9WymsOBJ0XSJ8yV8zmQKMIxNcQ0KFIyciRvlmlgcEohmp5wURXa25mvvEhQbrvwbvlNiT+Yjr86G+YQNx7kRVgowjE1xDQoUjJyJG+WaWBwSiGannBRFdrbma+8SFK2m+1oxgILuQLO55n8mWfnbIzyPCjCMTXENChSMnIkb5ZpYHBKIZqecFEV2tuZr7xIUQNGfkmhTNMis4j+dyMDIWXdIPiYKMIxNcQ0KFIyciRvlmlgcEohmp5wURXa25mvvEhS8sL0D0wwgGCItQwVowak5YB38KRIUCg4KBXVhdG9tEgUxMDA1NBDoxRgaagom61rphyECn8x7emhhKdRCB2io7aS/6Cpuq5NbVqbODmqOT3jWw6kSQKUresk+d+Gw0BhjiggTsu8+1voW+VlDCQ1GRYnMaFOHXhyFv7BCLhFWxLxHSAYT8a5XqoMayosZf9mANKdXArA="
         type: "object"
-  NumUnconfirmedTransactionsResponse:
+  UnconfirmedTransactionsResponse:
     type: object
     required:
       - "jsonrpc"
@@ -2304,7 +2303,6 @@ definitions:
               type: string
               x-nullable: true
             example:
-              - null
               - "gAPwYl3uCjCMTXENChSMnIkb5ZpYHBKIZqecFEV2tuZr7xIUA75/FmYq9WymsOBJ0XSJ8yV8zmQKMIxNcQ0KFIyciRvlmlgcEohmp5wURXa25mvvEhQbrvwbvlNiT+Yjr86G+YQNx7kRVgowjE1xDQoUjJyJG+WaWBwSiGannBRFdrbma+8SFK2m+1oxgILuQLO55n8mWfnbIzyPCjCMTXENChSMnIkb5ZpYHBKIZqecFEV2tuZr7xIUQNGfkmhTNMis4j+dyMDIWXdIPiYKMIxNcQ0KFIyciRvlmlgcEohmp5wURXa25mvvEhS8sL0D0wwgGCItQwVowak5YB38KRIUCg4KBXVhdG9tEgUxMDA1NBDoxRgaagom61rphyECn8x7emhhKdRCB2io7aS/6Cpuq5NbVqbODmqOT3jWw6kSQKUresk+d+Gw0BhjiggTsu8+1voW+VlDCQ1GRYnMaFOHXhyFv7BCLhFWxLxHSAYT8a5XqoMayosZf9mANKdXArA="
         type: "object"
   TxSearchResponse:

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -346,7 +346,7 @@ func UnconfirmedTxs(ctx *rpctypes.Context, limit int) (*ctypes.ResultUnconfirmed
 // client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // err := client.Start()
 // if err != nil {
-//   // handle error
+// // handle error
 // }
 // defer client.Stop()
 // result, err := client.UnconfirmedTxs()
@@ -361,8 +361,8 @@ func UnconfirmedTxs(ctx *rpctypes.Context, limit int) (*ctypes.ResultUnconfirmed
 //   "result" : {
 //     "n_txs" : "0",
 //     "total_bytes" : "0",
-//     "txs" : null,
 //     "total" : "0"
+//     "txs" : null,
 //   }
 // }
 // ```


### PR DESCRIPTION
- switch the data that was represented in `/unconfirmed_txs` and `num_unconfirmed_txs`

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
