### PR TITLE
update gogo/protobuf version from v1.2.1 to v1.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/github.com/tendermint/tendermint
   docker:
-    - image: circleci/golang:1.13
+    - image: circleci/golang
   environment:
     GOBIN: /tmp/workspace/bin
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/github.com/tendermint/tendermint
   docker:
-    - image: circleci/golang
+    - image: circleci/golang:1.13
   environment:
     GOBIN: /tmp/workspace/bin
 

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -385,7 +386,7 @@ func DefaultRPCConfig() *RPCConfig {
 	return &RPCConfig{
 		ListenAddress:          "tcp://127.0.0.1:26657",
 		CORSAllowedOrigins:     []string{},
-		CORSAllowedMethods:     []string{"HEAD", "GET", "POST"},
+		CORSAllowedMethods:     []string{http.MethodHead, http.MethodGet, http.MethodPost},
 		CORSAllowedHeaders:     []string{"Origin", "Accept", "Content-Type", "X-Requested-With", "X-Server-Time"},
 		GRPCListenAddress:      "",
 		GRPCMaxOpenConnections: 900,

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-kit/kit v0.6.0
 	github.com/go-logfmt/logfmt v0.3.0
 	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/gogo/protobuf v1.2.1
+	github.com/gogo/protobuf v1.3.0
 	github.com/golang/protobuf v1.3.2
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/gorilla/websocket v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
+github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -59,6 +61,7 @@ github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
@@ -140,6 +143,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/scripts/get_tools.sh
+++ b/scripts/get_tools.sh
@@ -57,8 +57,8 @@ installFromGithub square/certstrap 338204a88c4349b1c135eac1e8c14c693ad007da
 # used to build tm-monitor & tm-bench binaries
 installFromGithub mitchellh/gox 51ed453898ca5579fea9ad1f08dff6b121d9f2e8
 
-## golangci-lint v1.13.2
-installFromGithub golangci/golangci-lint 7b2421d55194c9dc385eff7720a037aa9244ca3c cmd/golangci-lint
+## golangci-lint v1.17.1
+installFromGithub golangci/golangci-lint 4ba2155996359eabd8800d1fbf3e3a9777c80490 cmd/golangci-lint
 
 ## make test_with_deadlock
 ## XXX: https://github.com/tendermint/tendermint/issues/3242

--- a/scripts/get_tools.sh
+++ b/scripts/get_tools.sh
@@ -49,7 +49,8 @@ installFromGithub() {
 }
 
 ######################## DEVELOPER TOOLS #####################################
-installFromGithub gogo/protobuf 61dbc136cf5d2f08d68a011382652244990a53a9 protoc-gen-gogo
+## protobuf v1.3.0
+installFromGithub gogo/protobuf 0ca988a254f991240804bf9821f3450d87ccbb1b protoc-gen-gogo
 
 installFromGithub square/certstrap e27060a3643e814151e65b9807b6b06d169580a7
 

--- a/scripts/get_tools.sh
+++ b/scripts/get_tools.sh
@@ -52,7 +52,7 @@ installFromGithub() {
 ## protobuf v1.3.0
 installFromGithub gogo/protobuf 0ca988a254f991240804bf9821f3450d87ccbb1b protoc-gen-gogo
 
-installFromGithub square/certstrap e27060a3643e814151e65b9807b6b06d169580a7
+installFromGithub square/certstrap 338204a88c4349b1c135eac1e8c14c693ad007da
 
 # used to build tm-monitor & tm-bench binaries
 installFromGithub mitchellh/gox 51ed453898ca5579fea9ad1f08dff6b121d9f2e8

--- a/scripts/get_tools.sh
+++ b/scripts/get_tools.sh
@@ -63,9 +63,11 @@ installFromGithub mitchellh/gox d8caaff5a9dc98f4cfa1fcce6e7265a04689f641
 ## golangci-lint v1.17.1
 # installFromGithub golangci/golangci-lint 4ba2155996359eabd8800d1fbf3e3a9777c80490 cmd/golangci-lint
 
+## Trying to install golangci with Go 1.13 gives:
+## go: cannot find main module, but found .git/config in /go/src/github.com/petermattis/goid
 ## make test_with_deadlock
 ## XXX: https://github.com/tendermint/tendermint/issues/3242
-installFromGithub petermattis/goid b0b1615b78e5ee59739545bb38426383b2cda4c9
-installFromGithub sasha-s/go-deadlock d68e2bc52ae3291765881b9056f2c1527f245f1e
-go get golang.org/x/tools/cmd/goimports
-installFromGithub snikch/goodman 10e37e294daa3c9a90abded60ff9924bafab3888 cmd/goodman
+# installFromGithub petermattis/goid b0b1615b78e5ee59739545bb38426383b2cda4c9
+# installFromGithub sasha-s/go-deadlock d68e2bc52ae3291765881b9056f2c1527f245f1e
+# go get golang.org/x/tools/cmd/goimports
+# installFromGithub snikch/goodman 10e37e294daa3c9a90abded60ff9924bafab3888 cmd/goodman

--- a/scripts/get_tools.sh
+++ b/scripts/get_tools.sh
@@ -55,7 +55,8 @@ installFromGithub gogo/protobuf 0ca988a254f991240804bf9821f3450d87ccbb1b protoc-
 installFromGithub square/certstrap 338204a88c4349b1c135eac1e8c14c693ad007da
 
 # used to build tm-monitor & tm-bench binaries
-installFromGithub mitchellh/gox 51ed453898ca5579fea9ad1f08dff6b121d9f2e8
+## gox v1.0.1
+installFromGithub mitchellh/gox d8caaff5a9dc98f4cfa1fcce6e7265a04689f641
 
 ## golangci-lint v1.17.1
 installFromGithub golangci/golangci-lint 4ba2155996359eabd8800d1fbf3e3a9777c80490 cmd/golangci-lint

--- a/scripts/get_tools.sh
+++ b/scripts/get_tools.sh
@@ -58,8 +58,10 @@ installFromGithub square/certstrap 338204a88c4349b1c135eac1e8c14c693ad007da
 ## gox v1.0.1
 installFromGithub mitchellh/gox d8caaff5a9dc98f4cfa1fcce6e7265a04689f641
 
+## Trying to install golangci with Go 1.13 gives:
+## go: github.com/go-critic/go-critic@v0.0.0-20181204210945-1df300866540: invalid pseudo-version: does not match version-control timestamp (2019-05-26T07:48:19Z)
 ## golangci-lint v1.17.1
-installFromGithub golangci/golangci-lint 4ba2155996359eabd8800d1fbf3e3a9777c80490 cmd/golangci-lint
+# installFromGithub golangci/golangci-lint 4ba2155996359eabd8800d1fbf3e3a9777c80490 cmd/golangci-lint
 
 ## make test_with_deadlock
 ## XXX: https://github.com/tendermint/tendermint/issues/3242


### PR DESCRIPTION
Also 

- errcheck from v1.1.0 to v1.2.0
- certstrap to e27060a3643e814151e65b9807b6b06d169580a7
- golangci-lint from v0.13.2 to v1.17.1
- gox to v1.0.1

See full diff in
- https://github.com/gogo/protobuf/compare/v1.2.1...v1.3.0 (melekes: ✅)
- https://github.com/kisielk/errcheck/compare/v1.1.0...v1.2.0 (melekes: ✅)
- https://github.com/square/certstrap/compare/e27060a3643e814151e65b9807b6b06d169580a7...338204a88c4349b1c135eac1e8c14c693ad007da (melekes: ✅)
- https://github.com/golangci/golangci-lint/compare/v1.13.2...v1.17.1 (melekes: ✅)
- https://github.com/mitchellh/gox/compare/51ed453898ca5579fea9ad1f08dff6b121d9f2e8...d8caaff5a9dc98f4cfa1fcce6e7265a04689f641 (melekes: ✅)

Changelog:

Tested versions:

go 1.12.9
protoc 3.7.1
Improvements:

    plugin/stringer - Handle repeated and/or nullable types a bit better now.
    plugin/size - Remove the loop in sovXXX by using bit twiddling.
        Thanks: https://github.com/apelisse
    plugin/marshalto - Implemented a reverse marshal strategy which allows for faster marshalling. This now avoids a recursive (and repeated) call to Size().
        Thanks: https://github.com/apelisse
    plugin/compare - Added support for for oneof types.

Bug fixes:

    protoc-gen-gogo/generator - Fix assignment to entry in nil map.
        Thanks: https://github.com/tgulacsi
    protoc-gen-gogo/generator - Allows plugins to call RecordTypeUse without panicking.
        Thanks: https://github.com/fedenusy
    proto/extensions - Fixed set extension regression. We did not clear the extensions before setting.
    io/uint32 - fix uint32reader bug that causes ReadMsg to recreate buffer when lengths are the same.
        Thanks: https://github.com/SebiSujar
    proto/table_merge: Fix merge of non-nullable slices.
        Thanks: https://github.com/euroelessar

Upstream commits:

    merged in golang/protobuf commit 318d17de72747ed1c16502681db4b2bb709a92d0 - Add UnimplementedServer for server interface
    merged in golang/protobuf commit b85cd75de734650db18a99a943fe351d41387800 - protoc-gen-go/grpc: inline errUnimplemented function
    merged in golang/protobuf commit d3c38a4eb4970272b87a425ae00ccc4548e2f9bb - protoc-gen-go/grpc: use status and code packages only if needed
    merged in golang/protobuf commit e91709a02e0e8ff8b86b7aa913fdc9ae9498e825 - fix indentation in jsonpb with Any messages
    merged in golang/protobuf commit 8d0c54c1246661d9a51ca0ba455d22116d485eaa - protoc-gen-go: generate XXX_OneofWrappers instead of XXX_OneofFuncs

Misc:

    extensions.md - Markdown update.
        Thanks: https://github.com/TennyZhuang
    Readme.md - Added user.
    go/protoc update - Updated to go1.12.x and protoc 3.7.1
    Makefile update - fix go vet shadow tool reference
    test/mixbench - Update mixbench tool. Expose runnable benchmarks via flags.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
