### PR TITLE
Fix linter errors thrown by `unconvert`, `goconst`, and `nakedret`

### DIFF
--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -18,6 +18,11 @@ import (
 	"github.com/tendermint/tendermint/abci/types"
 )
 
+const (
+	testKey   = "abc"
+	testValue = "def"
+)
+
 func testKVStore(t *testing.T, app types.Application, tx []byte, key, value string) {
 	req := types.RequestDeliverTx{Tx: tx}
 	ar := app.DeliverTx(req)
@@ -46,12 +51,12 @@ func testKVStore(t *testing.T, app types.Application, tx []byte, key, value stri
 
 func TestKVStoreKV(t *testing.T) {
 	kvstore := NewKVStoreApplication()
-	key := "abc"
+	key := testKey
 	value := key
 	tx := []byte(key)
 	testKVStore(t, kvstore, tx, key, value)
 
-	value = "def"
+	value = testValue
 	tx = []byte(key + "=" + value)
 	testKVStore(t, kvstore, tx, key, value)
 }
@@ -62,12 +67,12 @@ func TestPersistentKVStoreKV(t *testing.T) {
 		t.Fatal(err)
 	}
 	kvstore := NewPersistentKVStoreApplication(dir)
-	key := "abc"
+	key := testKey
 	value := key
 	tx := []byte(key)
 	testKVStore(t, kvstore, tx, key, value)
 
-	value = "def"
+	value = testValue
 	tx = []byte(key + "=" + value)
 	testKVStore(t, kvstore, tx, key, value)
 }
@@ -272,12 +277,12 @@ func TestClientServer(t *testing.T) {
 
 func runClientTests(t *testing.T, client abcicli.Client) {
 	// run some tests....
-	key := "abc"
+	key := testKey
 	value := key
 	tx := []byte(key)
 	testClient(t, client, tx, key, value)
 
-	value = "def"
+	value = testValue
 	tx = []byte(key + "=" + value)
 	testClient(t, client, tx, key, value)
 }

--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -90,7 +90,7 @@ func TestPersistentKVStoreInfo(t *testing.T) {
 	height = int64(1)
 	hash := []byte("foo")
 	header := types.Header{
-		Height: int64(height),
+		Height: height,
 	}
 	kvstore.BeginBlock(types.RequestBeginBlock{Hash: hash, Header: header})
 	kvstore.EndBlock(types.RequestEndBlock{Height: header.Height})

--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -198,7 +198,7 @@ func (app *PersistentKVStoreApplication) execValidatorTx(tx []byte) types.Respon
 	}
 
 	// update
-	return app.updateValidator(types.Ed25519ValidatorUpdate(pubkey, int64(power)))
+	return app.updateValidator(types.Ed25519ValidatorUpdate(pubkey, power))
 }
 
 // add, update, or remove a validator

--- a/blockchain/v1/pool.go
+++ b/blockchain/v1/pool.go
@@ -191,7 +191,7 @@ func (pool *BlockPool) makeRequestBatch(maxNumRequests int) []int {
 	// - FSM timed out on waiting to advance the block execution due to missing blocks at h or h+1
 	// Determine the number of requests needed by subtracting the number of requests already made from the maximum
 	// allowed
-	numNeeded := int(maxNumRequests) - len(pool.blocks)
+	numNeeded := maxNumRequests - len(pool.blocks)
 	for len(pool.plannedRequests) < numNeeded {
 		if pool.nextRequestHeight > pool.MaxPeerHeight {
 			break

--- a/blockchain/v1/pool_test.go
+++ b/blockchain/v1/pool_test.go
@@ -77,10 +77,10 @@ func makeBlockPool(bcr *testBcR, height int64, peers []BpPeer, blocks map[int64]
 	bPool.MaxPeerHeight = maxH
 	for h, p := range blocks {
 		bPool.blocks[h] = p.id
-		bPool.peers[p.id].RequestSent(int64(h))
+		bPool.peers[p.id].RequestSent(h)
 		if p.create {
 			// simulate that a block at height h has been received
-			_ = bPool.peers[p.id].AddBlock(types.MakeBlock(int64(h), txs, nil, nil), 100)
+			_ = bPool.peers[p.id].AddBlock(types.MakeBlock(h, txs, nil, nil), 100)
 		}
 	}
 	return bPool

--- a/blockchain/v1/reactor_fsm_test.go
+++ b/blockchain/v1/reactor_fsm_test.go
@@ -140,7 +140,7 @@ func sBlockRespEv(current, expected string, peerID p2p.ID, height int64, prevBlo
 		data: bReactorEventData{
 			peerID: peerID,
 			height: height,
-			block:  types.MakeBlock(int64(height), txs, nil, nil),
+			block:  types.MakeBlock(height, txs, nil, nil),
 			length: 100},
 		wantState:     expected,
 		wantNewBlocks: append(prevBlocks, height),
@@ -157,7 +157,7 @@ func sBlockRespEvErrored(current, expected string,
 		data: bReactorEventData{
 			peerID: peerID,
 			height: height,
-			block:  types.MakeBlock(int64(height), txs, nil, nil),
+			block:  types.MakeBlock(height, txs, nil, nil),
 			length: 100},
 		wantState:        expected,
 		wantErr:          wantErr,
@@ -769,7 +769,7 @@ forLoop:
 	for i := 0; i < int(numBlocks); i++ {
 
 		// Add the makeRequestEv step periodically.
-		if i%int(maxRequestsPerPeer) == 0 {
+		if maxRequestsPerPeer == 0 {
 			testSteps = append(
 				testSteps,
 				sMakeRequestsEv("waitForBlock", "waitForBlock", maxNumRequests),
@@ -786,7 +786,7 @@ forLoop:
 		numBlocksReceived++
 
 		// Add the processedBlockEv step periodically.
-		if numBlocksReceived >= int(maxRequestsPerPeer) || height >= numBlocks {
+		if numBlocksReceived >= maxRequestsPerPeer || height >= numBlocks {
 			for j := int(height) - numBlocksReceived; j < int(height); j++ {
 				if j >= int(numBlocks) {
 					// This is the last block that is processed, we should be in "finished" state.
@@ -829,7 +829,7 @@ func makeCorrectTransitionSequenceWithRandomParameters() testFields {
 	maxRequestsPerPeer := cmn.RandIntn(maxRequestsPerPeerTest) + 1
 
 	// Generate the maximum number of total pending requests, >= maxRequestsPerPeer.
-	maxPendingRequests := cmn.RandIntn(maxTotalPendingRequestsTest-int(maxRequestsPerPeer)) + maxRequestsPerPeer
+	maxPendingRequests := cmn.RandIntn(maxTotalPendingRequestsTest-maxRequestsPerPeer) + maxRequestsPerPeer
 
 	// Generate the number of blocks to be synced.
 	numBlocks := int64(cmn.RandIntn(maxNumBlocksInChainTest)) + startingHeight

--- a/blockchain/v1/reactor_fsm_test.go
+++ b/blockchain/v1/reactor_fsm_test.go
@@ -769,7 +769,7 @@ forLoop:
 	for i := 0; i < int(numBlocks); i++ {
 
 		// Add the makeRequestEv step periodically.
-		if maxRequestsPerPeer == 0 {
+		if i%maxRequestsPerPeer == 0 {
 			testSteps = append(
 				testSteps,
 				sMakeRequestsEv("waitForBlock", "waitForBlock", maxNumRequests),

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -246,7 +246,7 @@ func (h *Handshaker) Handshake(proxyApp proxy.AppConns) error {
 		return fmt.Errorf("Error calling Info: %v", err)
 	}
 
-	blockHeight := int64(res.LastBlockHeight)
+	blockHeight := res.LastBlockHeight
 	if blockHeight < 0 {
 		return fmt.Errorf("Got a negative last block height (%d) from the app", blockHeight)
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1675,7 +1675,7 @@ func (cs *ConsensusState) addVote(vote *types.Vote, peerID p2p.ID) (added bool, 
 		panic(fmt.Sprintf("Unexpected vote type %X", vote.Type)) // go-amino should prevent this.
 	}
 
-	return
+	return added, err
 }
 
 func (cs *ConsensusState) signVote(type_ types.SignedMsgType, hash []byte, header types.PartSetHeader) (*types.Vote, error) {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1458,7 +1458,7 @@ func (cs *ConsensusState) addProposalBlockPart(msg *BlockPartMessage, peerID p2p
 		_, err = cdc.UnmarshalBinaryLengthPrefixedReader(
 			cs.ProposalBlockParts.GetReader(),
 			&cs.ProposalBlock,
-			int64(cs.state.ConsensusParams.Block.MaxBytes),
+			cs.state.ConsensusParams.Block.MaxBytes,
 		)
 		if err != nil {
 			return added, err

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -189,7 +189,7 @@ func TestStateBadProposal(t *testing.T) {
 	if len(stateHash) == 0 {
 		stateHash = make([]byte, 32)
 	}
-	stateHash[0] = byte((stateHash[0] + 1) % 255)
+	stateHash[0] = (stateHash[0] + 1) % 255
 	propBlock.AppHash = stateHash
 	propBlockParts := propBlock.MakePartSet(partSize)
 	blockID := types.BlockID{Hash: propBlock.Hash(), PartsHeader: propBlockParts.Header()}
@@ -364,7 +364,7 @@ func TestStateLockNoPOL(t *testing.T) {
 	// lets add one for a different block
 	hash := make([]byte, len(theBlockHash))
 	copy(hash, theBlockHash)
-	hash[0] = byte((hash[0] + 1) % 255)
+	hash[0] = (hash[0] + 1) % 255
 	signAddVotes(cs1, types.PrecommitType, hash, thePartSetHeader, vs2)
 	ensurePrecommit(voteCh, height, round) // precommit
 

--- a/crypto/merkle/proof_simple_value.go
+++ b/crypto/merkle/proof_simple_value.go
@@ -74,8 +74,8 @@ func (op SimpleValueOp) Run(args [][]byte) ([][]byte, error) {
 
 	bz := new(bytes.Buffer)
 	// Wrap <op.Key, vhash> to hash the KVPair.
-	encodeByteSlice(bz, []byte(op.key)) // does not error
-	encodeByteSlice(bz, []byte(vhash))  // does not error
+	encodeByteSlice(bz, op.key) // does not error
+	encodeByteSlice(bz, vhash)  // does not error
 	kvhash := leafHash(bz.Bytes())
 
 	if !bytes.Equal(kvhash, op.Proof.LeafHash) {

--- a/crypto/multisig/bitarray/compact_bit_array_test.go
+++ b/crypto/multisig/bitarray/compact_bit_array_test.go
@@ -21,7 +21,7 @@ func randCompactBitArray(bits int) (*CompactBitArray, []byte) {
 		}
 	}
 	// Set remaining bits
-	for i := uint8(0); i < 8-uint8(bA.ExtraBitsStored); i++ {
+	for i := uint8(0); i < 8-bA.ExtraBitsStored; i++ {
 		bA.SetIndex(numBytes*8+int(i), src[numBytes-1]&(uint8(1)<<(8-i)) > 0)
 	}
 	return bA, src

--- a/lite/dynamic_verifier_test.go
+++ b/lite/dynamic_verifier_test.go
@@ -13,6 +13,8 @@ import (
 	dbm "github.com/tendermint/tm-db"
 )
 
+const testChainID = "inquiry-test"
+
 func TestInquirerValidPath(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 	trust := NewDBProvider("trust", dbm.NewMemDB())
@@ -24,7 +26,7 @@ func TestInquirerValidPath(t *testing.T) {
 	nkeys := keys.Extend(1)
 
 	// Construct a bunch of commits, each with one more height than the last.
-	chainID := "inquiry-test"
+	chainID := testChainID
 	consHash := []byte("params")
 	resHash := []byte("results")
 	count := 50
@@ -146,7 +148,7 @@ func TestInquirerVerifyHistorical(t *testing.T) {
 	nkeys := keys.Extend(1)
 
 	// Construct a bunch of commits, each with one more height than the last.
-	chainID := "inquiry-test"
+	chainID := testChainID
 	count := 10
 	consHash := []byte("special-params")
 	fcz := make([]FullCommit, count)
@@ -229,7 +231,7 @@ func TestConcurrencyInquirerVerify(t *testing.T) {
 	nkeys := keys.Extend(1)
 
 	// Construct a bunch of commits, each with one more height than the last.
-	chainID := "inquiry-test"
+	chainID := testChainID
 	count := 10
 	consHash := []byte("special-params")
 	fcz := make([]FullCommit, count)

--- a/lite/proxy/query.go
+++ b/lite/proxy/query.go
@@ -29,7 +29,7 @@ func GetWithProof(prt *merkle.ProofRuntime, key []byte, reqHeight int64, node rp
 	}
 
 	res, err := GetWithProofOptions(prt, "/key", key,
-		rpcclient.ABCIQueryOptions{Height: int64(reqHeight), Prove: true},
+		rpcclient.ABCIQueryOptions{Height: reqHeight, Prove: true},
 		node, cert)
 	if err != nil {
 		return

--- a/lite/proxy/wrapper.go
+++ b/lite/proxy/wrapper.go
@@ -58,7 +58,7 @@ func (w Wrapper) Tx(hash []byte, prove bool) (*ctypes.ResultTx, error) {
 	if !prove || err != nil {
 		return res, err
 	}
-	h := int64(res.Height)
+	h := res.Height
 	sh, err := GetCertifiedCommit(h, w.Client, w.cert)
 	if err != nil {
 		return res, err

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -564,7 +564,7 @@ func TestMempoolRemoteAppConcurrency(t *testing.T) {
 	for i := 0; i < N; i++ {
 		peerID := mrand.Intn(maxPeers)
 		txNum := mrand.Intn(nTxs)
-		tx := txs[int(txNum)]
+		tx := txs[txNum]
 
 		// this will err with ErrTxInCache many times ...
 		mempool.CheckTxWithInfo(tx, nil, TxInfo{SenderID: uint16(peerID)})

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -803,7 +803,7 @@ func (ch *Channel) isSendPending() bool {
 // Not goroutine-safe
 func (ch *Channel) nextPacketMsg() PacketMsg {
 	packet := PacketMsg{}
-	packet.ChannelID = byte(ch.desc.ID)
+	packet.ChannelID = ch.desc.ID
 	maxSize := ch.maxPacketMsgPayloadSize
 	packet.Bytes = ch.sending[:cmn.MinInt(maxSize, len(ch.sending))]
 	if len(ch.sending) <= maxSize {

--- a/p2p/conn/connection_test.go
+++ b/p2p/conn/connection_test.go
@@ -133,7 +133,7 @@ func TestMConnectionReceive(t *testing.T) {
 
 	select {
 	case receivedBytes := <-receivedCh:
-		assert.Equal(t, []byte(msg), receivedBytes)
+		assert.Equal(t, msg, receivedBytes)
 	case err := <-errorsCh:
 		t.Fatalf("Expected %s, got %+v", msg, err)
 	case <-time.After(500 * time.Millisecond):

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -188,7 +188,7 @@ func (sc *SecretConnection) Write(data []byte) (n int, err error) {
 			return n, err
 		}
 	}
-	return
+	return n, err
 }
 
 // CONTRACT: data smaller than dataMaxSize is read atomically.
@@ -234,7 +234,7 @@ func (sc *SecretConnection) Read(data []byte) (n int, err error) {
 		sc.recvBuffer = make([]byte, len(chunk)-n)
 		copy(sc.recvBuffer, chunk[n:])
 	}
-	return
+	return n, err
 }
 
 // Implements net.Conn

--- a/p2p/conn/secret_connection_test.go
+++ b/p2p/conn/secret_connection_test.go
@@ -87,7 +87,7 @@ func makeSecretConnPair(tb testing.TB) (fooSecConn, barSecConn *SecretConnection
 	require.Nil(tb, trs.FirstError())
 	require.True(tb, ok, "Unexpected task abortion")
 
-	return
+	return fooSecConn, barSecConn
 }
 
 func TestSecretConnectionHandshake(t *testing.T) {

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -784,12 +784,12 @@ func (a *addrBook) groupKey(na *p2p.NetAddress) string {
 	}
 	if na.RFC6145() || na.RFC6052() {
 		// last four bytes are the ip address
-		ip := net.IP(na.IP[12:16])
+		ip := na.IP[12:16]
 		return (&net.IPNet{IP: ip, Mask: net.CIDRMask(16, 32)}).String()
 	}
 
 	if na.RFC3964() {
-		ip := net.IP(na.IP[2:7])
+		ip := na.IP[2:7]
 		return (&net.IPNet{IP: ip, Mask: net.CIDRMask(16, 32)}).String()
 
 	}

--- a/p2p/upnp/probe.go
+++ b/p2p/upnp/probe.go
@@ -78,7 +78,7 @@ func testHairpin(listener net.Listener, extAddr string, logger log.Logger) (supp
 
 	// Wait for data receipt
 	time.Sleep(1 * time.Second)
-	return
+	return supportsHairpin
 }
 
 func Probe(logger log.Logger) (caps UPNPCapabilities, err error) {

--- a/p2p/upnp/upnp.go
+++ b/p2p/upnp/upnp.go
@@ -105,7 +105,7 @@ func Discover() (nat NAT, err error) {
 		}
 	}
 	err = errors.New("UPnP port discovery failed")
-	return
+	return nat, err
 }
 
 type Envelope struct {
@@ -241,7 +241,7 @@ func getServiceURL(rootURL string) (url, urnDomain string, err error) {
 	// Extract the domain name, which isn't always 'schemas-upnp-org'
 	urnDomain = strings.Split(d.ServiceType, ":")[1]
 	url = combineURL(rootURL, d.ControlURL)
-	return
+	return url, urnDomain, err
 }
 
 func combineURL(rootURL, subURL string) string {
@@ -285,7 +285,7 @@ func soapRequest(url, function, message, domain string) (r *http.Response, err e
 		r = nil
 		return
 	}
-	return
+	return r, err
 }
 
 type statusInfo struct {
@@ -322,7 +322,7 @@ func (n *upnpNAT) getExternalIPAddress() (info statusInfo, err error) {
 		return
 	}
 
-	return
+	return info, err
 }
 
 // GetExternalAddress returns an external IP. If GetExternalIPAddress action

--- a/proxy/app_conn_test.go
+++ b/proxy/app_conn_test.go
@@ -147,7 +147,7 @@ func TestInfo(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if string(resInfo.Data) != "{\"size\":0}" {
+	if resInfo.Data != "{\"size\":0}" {
 		t.Error("Expected ResponseInfo with one element '{\"size\":0}' but got something else")
 	}
 }

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -559,7 +559,7 @@ func makeEvidences(t *testing.T, val *privval.FilePV, chainID string) (ev types.
 	// exactly same vote
 	vote2 = deepcpVote(vote)
 	fakes[41] = newEvidence(t, val, vote, vote2, chainID)
-	return
+	return ev, fakes
 }
 
 func TestBroadcastEvidenceDuplicateVote(t *testing.T) {

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -106,7 +106,7 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 	return &ctypes.ResultTx{
 		Hash:     hash,
 		Height:   height,
-		Index:    uint32(index),
+		Index:    index,
 		TxResult: r.Result,
 		Tx:       r.Tx,
 		Proof:    proof,

--- a/rpc/lib/rpc_test.go
+++ b/rpc/lib/rpc_test.go
@@ -33,6 +33,8 @@ const (
 	unixAddr   = "unix://" + unixSocket
 
 	websocketEndpoint = "/websocket/endpoint"
+
+	testVal = "acbd"
 )
 
 type ResultEcho struct {
@@ -189,7 +191,7 @@ func echoDataBytesViaHTTP(cl client.HTTPClient, bytes cmn.HexBytes) (cmn.HexByte
 }
 
 func testWithHTTPClient(t *testing.T, cl client.HTTPClient) {
-	val := "acbd"
+	val := testVal
 	got, err := echoViaHTTP(cl, val)
 	require.Nil(t, err)
 	assert.Equal(t, got, val)
@@ -255,7 +257,7 @@ func echoBytesViaWS(cl *client.WSClient, bytes []byte) ([]byte, error) {
 }
 
 func testWithWSClient(t *testing.T, cl *client.WSClient) {
-	val := "acbd"
+	val := testVal
 	got, err := echoViaWS(cl, val)
 	require.Nil(t, err)
 	assert.Equal(t, got, val)
@@ -314,7 +316,7 @@ func TestWSNewWSRPCFunc(t *testing.T) {
 	require.Nil(t, err)
 	defer cl.Stop()
 
-	val := "acbd"
+	val := testVal
 	params := map[string]interface{}{
 		"arg": val,
 	}
@@ -339,7 +341,7 @@ func TestWSHandlesArrayParams(t *testing.T) {
 	require.Nil(t, err)
 	defer cl.Stop()
 
-	val := "acbd"
+	val := testVal
 	params := []interface{}{val}
 	err = cl.CallWithArrayParams(context.Background(), "echo_ws", params)
 	require.Nil(t, err)

--- a/rpc/lib/server/handlers.go
+++ b/rpc/lib/server/handlers.go
@@ -376,9 +376,9 @@ func _nonJSONStringToArg(cdc *amino.Codec, rt reflect.Type, arg string) (reflect
 		rv, err := jsonStringToArg(cdc, rt, qarg)
 		if err != nil {
 			return rv, err, false
-		} else {
-			return rv, nil, true
 		}
+
+		return rv, nil, true
 	}
 
 	if isHexString {
@@ -396,7 +396,7 @@ func _nonJSONStringToArg(cdc *amino.Codec, rt reflect.Type, arg string) (reflect
 		if rt.Kind() == reflect.String {
 			return reflect.ValueOf(string(value)), nil, true
 		}
-		return reflect.ValueOf([]byte(value)), nil, true
+		return reflect.ValueOf(value), nil, true
 	}
 
 	if isQuotedString && expectingByteSlice {

--- a/rpc/lib/types/types_test.go
+++ b/rpc/lib/types/types_test.go
@@ -39,17 +39,17 @@ func TestResponses(t *testing.T) {
 		a := NewRPCSuccessResponse(cdc, jsonid, &SampleResult{"hello"})
 		b, _ := json.Marshal(a)
 		s := fmt.Sprintf(`{"jsonrpc":"2.0","id":%v,"result":{"Value":"hello"}}`, tt.expected)
-		assert.Equal(string(s), string(b))
+		assert.Equal(s, string(b))
 
 		d := RPCParseError(jsonid, errors.New("Hello world"))
 		e, _ := json.Marshal(d)
 		f := fmt.Sprintf(`{"jsonrpc":"2.0","id":%v,"error":{"code":-32700,"message":"Parse error. Invalid JSON","data":"Hello world"}}`, tt.expected)
-		assert.Equal(string(f), string(e))
+		assert.Equal(f, string(e))
 
 		g := RPCMethodNotFoundError(jsonid)
 		h, _ := json.Marshal(g)
 		i := fmt.Sprintf(`{"jsonrpc":"2.0","id":%v,"error":{"code":-32601,"message":"Method not found"}}`, tt.expected)
-		assert.Equal(string(h), string(i))
+		assert.Equal(string(h), i)
 	}
 }
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -645,7 +645,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 	tearDown, _, state := setupTestCase(t)
 	defer tearDown(t)
 
-	genesisVotingPower := int64(types.MaxTotalVotingPower / 1000)
+	genesisVotingPower := types.MaxTotalVotingPower / 1000
 	genesisPubKey := ed25519.GenPrivKey().PubKey()
 	// fmt.Println("genesis addr: ", genesisPubKey.Address())
 	genesisVal := &types.Validator{Address: genesisPubKey.Address(), PubKey: genesisPubKey, VotingPower: genesisVotingPower}

--- a/tools/tm-monitor/monitor/network.go
+++ b/tools/tm-monitor/monitor/network.go
@@ -85,7 +85,7 @@ func (n *Network) NewBlock(b tmtypes.Header) {
 	} else {
 		n.AvgBlockTime = 0.0
 	}
-	n.txThroughputMeter.Mark(int64(b.NumTxs))
+	n.txThroughputMeter.Mark(b.NumTxs)
 	n.AvgTxThroughput = n.txThroughputMeter.Rate1()
 }
 

--- a/types/tx.go
+++ b/types/tx.go
@@ -133,6 +133,6 @@ type TxResult struct {
 // fieldNum is also 1 (see BinFieldNum in amino.MarshalBinaryBare).
 func ComputeAminoOverhead(tx Tx, fieldNum int) int64 {
 	fnum := uint64(fieldNum)
-	typ3AndFieldNum := (uint64(fnum) << 3) | uint64(amino.Typ3_ByteLength)
+	typ3AndFieldNum := (fnum << 3) | uint64(amino.Typ3_ByteLength)
 	return int64(amino.UvarintSize(typ3AndFieldNum)) + int64(amino.UvarintSize(uint64(len(tx))))
 }

--- a/types/vote.go
+++ b/types/vote.go
@@ -13,6 +13,7 @@ import (
 const (
 	// MaxVoteBytes is a maximum vote size (including amino overhead).
 	MaxVoteBytes int64 = 223
+	nilVoteStr         = "nil-Vote"
 )
 
 var (
@@ -84,7 +85,7 @@ func (vote *Vote) Copy() *Vote {
 
 func (vote *Vote) String() string {
 	if vote == nil {
-		return "nil-Vote"
+		return nilVoteStr
 	}
 	var typeString string
 	switch vote.Type {


### PR DESCRIPTION
* [x] Referenced an issue explaining the need for the change

This PR repairs linter errors seen when running the following commands:
`golangci-lint run --no-config --disable-all=true --enable=unconvert`
`golangci-lint run --no-config --disable-all=true --enable=goconst`
`golangci-lint run --no-config --disable-all=true --enable=nakedret`

Contributes to #3262