### PR TITLE
Override Go's GOPROXY default value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,17 @@ GOTOOLS = \
 GOBIN?=${GOPATH}/bin
 PACKAGES=$(shell go list ./...)
 OUTPUT?=build/tendermint
+GOPROXY ?= direct
+goproxy := $(GOPROXY)
 
 export GO111MODULE = on
+export GOPROXY = $(goproxy)
 
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gogo/protobuf/protobuf
 BUILD_TAGS?='tendermint'
 LD_FLAGS = -X github.com/tendermint/tendermint/version.GitCommit=`git rev-parse --short=8 HEAD` -s -w
 BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
+
 
 all: check build test install
 


### PR DESCRIPTION
Go 1.13 uses http://proxy.golang.org as GOPROXY's default
value if the environment variable is unset or blank. This
patch makes tendermint's buildsystem override Go env's
default and fallback to 'direct' if and only if GOPROXY is
unset in the user's environment; else it honours users'
settings.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
