### PR TITLE
Simple Patch for `atomic`'s Bug on 32-bit Machine

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,4 +23,4 @@ program](https://hackerone.com/tendermint).
 
 ### BUG FIXES:
 
-- [mempool] \#3968 `mempool` Memory Loading Error on 32-bit Ubuntu 16.04 Machine.
+- [mempool] \#3968 Fix memory loading error on 32-bit machines (@jon-certik)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,3 +22,5 @@ program](https://hackerone.com/tendermint).
 - [rpc] \#2010 Add NewHTTPWithClient and NewJSONRPCClientWithHTTPClient (note these and NewHTTP, NewJSONRPCClient functions panic if remote is invalid) (@gracenoah)
 
 ### BUG FIXES:
+
+- [mempool] \#3968 `mempool` Memory Loading Error on 32-bit Ubuntu 16.04 Machine.

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -53,8 +53,8 @@ type CListMempool struct {
 
 	// Atomic integers
 	height     int64 // the last block Update()'d to
-	rechecking int32 // for re-checking filtered txs on Update()
 	txsBytes   int64 // total size of mempool, in bytes
+	rechecking int32 // for re-checking filtered txs on Update()
 
 	// Keep a cache of already-seen txs.
 	// This reduces the pressure on the proxyApp.


### PR DESCRIPTION
## What For

The bug of `atomic` results in `go test` error in the `mempool` module. See #3968 for details.

## Bug Cause

This is related to `atomic` library's bug: [atomic](https://golang.org/pkg/sync/atomic/#pkg-note-BUG)

> On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.

## Solution

In `clist_mempool.go`, the following variables are to be loaded by `atomic`'s `LoadInt64`:

```
// Atomic integers
height     int64 // the last block Update()'d to
rechecking int32 // for re-checking filtered txs on Update()
txsBytes   int64 // total size of mempool, in bytes
```

On 32-bit architecture, the memory alignment guarantee of type `int64` is 32-bit. However `atomic.LoadInt64` requires "64-bit alignment of 64-bit words".

The current alignment for `txsBytes` is not 64-bit aligned and thus would result in error upon being read by `atomic.LoadInt64` on 32-bit architecture.

Switching the `rechecking` and `txsBytes` fields of `CListMempool` makes the `txsBytes` to be 64-bit aligned and passed all the tests (`go test`).

## Result

All tests in `mempool` passed after the patch:

```bash
PASS
ok  	github.com/tendermint/tendermint/mempool	26.860s
```

## Checklist

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests: Already covered by the original tests.
* [x] Updated CHANGELOG_PENDING.md
