### PR TITLE
Improved tm-monitor formatting

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,7 @@
 \*\*
 
 Special thanks to external contributors on this release:
+@erikgrinaker
 
 Friendly reminder, we have a [bug bounty
 program](https://hackerone.com/tendermint).
@@ -19,4 +20,8 @@ program](https://hackerone.com/tendermint).
 
 ### IMPROVEMENTS:
 
+- [tools] Improved `tm-monitor` formatting of start time and avg tx throughput
+
 ### BUG FIXES:
+
+- [tools] Refresh `tm-monitor` health when validator set is updated

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,8 +20,8 @@ program](https://hackerone.com/tendermint).
 
 ### IMPROVEMENTS:
 
-- [tools] Improved `tm-monitor` formatting of start time and avg tx throughput
+- [tools] [\#4023](https://github.com/tendermint/tendermint/issues/4023) Improved `tm-monitor` formatting of start time and avg tx throughput
 
 ### BUG FIXES:
 
-- [tools] Refresh `tm-monitor` health when validator set is updated
+- [tools] [\#4023](https://github.com/tendermint/tendermint/issues/4023) Refresh `tm-monitor` health when validator count is updated

--- a/tools/tm-monitor/monitor/network.go
+++ b/tools/tm-monitor/monitor/network.go
@@ -180,6 +180,7 @@ func (n *Network) UpdateNumValidatorsForHeight(num int, height int64) {
 	if n.Height <= height {
 		n.NumValidators = num
 	}
+	n.updateHealth()
 }
 
 func (n *Network) GetHealthString() string {

--- a/tools/tm-monitor/ton.go
+++ b/tools/tm-monitor/ton.go
@@ -61,11 +61,11 @@ func (o *Ton) Stop() {
 
 func (o *Ton) printHeader() {
 	n := o.monitor.Network
-	fmt.Fprintf(o.Output, "%v up %.2f%%\n", n.StartTime(), n.Uptime())
+	fmt.Fprintf(o.Output, "%v up %.2f%%\n", n.StartTime().Format(time.RFC1123Z), n.Uptime())
 	fmt.Println()
 	fmt.Fprintf(o.Output, "Height: %d\n", n.Height)
 	fmt.Fprintf(o.Output, "Avg block time: %.3f ms\n", n.AvgBlockTime)
-	fmt.Fprintf(o.Output, "Avg tx throughput: %.0f per sec\n", n.AvgTxThroughput)
+	fmt.Fprintf(o.Output, "Avg tx throughput: %.3f per sec\n", n.AvgTxThroughput)
 	fmt.Fprintf(o.Output, "Avg block latency: %.3f ms\n", n.AvgBlockLatency)
 	fmt.Fprintf(o.Output, "Active nodes: %d/%d (health: %s) Validators: %d\n", n.NumNodesMonitoredOnline, n.NumNodesMonitored, n.GetHealthString(), n.NumValidators)
 }


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] ~Referenced an issue explaining the need for the change~
* [ ] ~Updated all relevant documentation in docs~
* [ ] ~Updated all code comments where relevant~
* [ ] Wrote tests
* [x] Updated CHANGELOG_PENDING.md

Improves `tm-monitor` formatting of start time (RFC1123 without unnecessary precision) and avg tx throughput (three decimal places). The old tx throughput display was confusing during local testing where the tx rate is low and displayed as 0.

Also updates the monitor health whenever the validator number changes. It otherwise starts with moderate health and fails to update this once it discovers the validators, leading to incorrect health reporting and invalid uptime statistics. Let me know if you would like me to submit this as a separate PR.

### Before:

```
2019-09-29 20:40:00.992834 +0200 CEST m=+0.024057059 up -92030989600.42%

Height: 2518
Avg block time: 1275.496 ms
Avg tx throughput: 0 per sec
Avg block latency: 2.464 ms
Active nodes: 4/4 (health: moderate) Validators: 4

NAME                HEIGHT     BLOCK LATENCY     ONLINE     VALIDATOR     
localhost:26657     2518       0.935 ms          true       true          
localhost:26660     2518       0.710 ms          true       true          
localhost:26662     2518       0.708 ms          true       true          
localhost:26664     2518       0.717 ms          true       true          
```

### After:

```
Sun, 29 Sep 2019 20:21:59 +0200 up 100.00%

Height: 2480
Avg block time: 1361.445 ms
Avg tx throughput: 0.735 per sec
Avg block latency: 4.232 ms
Active nodes: 4/4 (health: full) Validators: 4

NAME                HEIGHT     BLOCK LATENCY     ONLINE     VALIDATOR     
localhost:26657     2480       1.174 ms          true       true          
localhost:26660     2480       1.037 ms          true       true          
localhost:26662     2480       0.981 ms          true       true          
localhost:26664     2480       0.995 ms          true       true          
```