### PR TITLE
Add unsafe routes to swagger

### DIFF
--- a/rpc/swagger/swagger.yaml
+++ b/rpc/swagger/swagger.yaml
@@ -431,11 +431,8 @@ paths:
       responses:
         200:
           description: Dialing seeds in progress. See /net_info for details
-          type: object
-          properties:
-            Log:
-              type: string
-              x-example: "Dialing seeds in progress. See /net_info for details"
+          schema:
+            $ref: "#/definitions/dialResp"
         500:
           description: empty error
           schema:
@@ -456,17 +453,14 @@ paths:
           name: Array of peers to connect to & if they should be persistent
           required: true
           schema:
-            $ref: "#definitions/dialPeersPost"
+            $ref: "#/definitions/dialPeersPost"
       produces:
         - application/json
       responses:
         200:
           description: Dialing seeds in progress. See /net_info for details
-          type: object
-          properties:
-            Log:
-              type: string
-              x-example: "Dialing seeds in progress. See /net_info for details"
+          schema:
+            $ref: "#/definitions/dialResp"
         500:
           description: empty error
           schema:
@@ -2741,10 +2735,10 @@ definitions:
     type: object
     properties:
       Persistent:
-        type: bool
+        type: boolean
         example: false
       Peers:
-        type: Array
+        type: array
         items:
           type: "string"
         example: ["6f172048b821e3b1ab98ffb0973ba737966eecf8@192.168.1.2:26656"]
@@ -2752,7 +2746,13 @@ definitions:
     type: object
     properties:
       Peers:
-        type: Array
+        type: array
         items:
           type: "string"
         example: ["6f172048b821e3b1ab98ffb0973ba737966eecf8@192.168.1.2:26656"]
+  dialResp:
+    type: object
+    properties:
+      Log:
+        type: string
+        x-example: "Dialing seeds in progress. See /net_info for details"

--- a/rpc/swagger/swagger.yaml
+++ b/rpc/swagger/swagger.yaml
@@ -409,6 +409,68 @@ paths:
           description: empty error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /dial_seeds:
+    post:
+      summary: Dial Seeds (Unsafe)
+      operationId: dial_seeds
+      tags:
+        - unsafe
+      description: |
+        Dial a peer, this route in under unsafe, and has to manually enabled to use
+      consumes:
+        - application/json
+      parameters:
+        - description: string of possible peers
+          in: body
+          name: Array of peers to connect to
+          required: true
+          schema:
+            $ref: "#/definitions/dialSeedsPost"
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Dialing seeds in progress. See /net_info for details
+          type: object
+          properties:
+            Log:
+              type: string
+              x-example: "Dialing seeds in progress. See /net_info for details"
+        500:
+          description: empty error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+  /dial_peers:
+    post:
+      summary: Add Peers/Persistent Peers (unsafe)
+      operationId: dial_peers
+      tags:
+        - unsafe
+      description: |
+        Set a persistent peer, this route in under unsafe, and has to manually enabled to use
+      consumes:
+        - application/json
+      parameters:
+        - description: string of possible peers, can be added as persistent peers
+          in: body
+          name: Array of peers to connect to & if they should be persistent
+          required: true
+          schema:
+            $ref: "#definitions/dialPeersPost"
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Dialing seeds in progress. See /net_info for details
+          type: object
+          properties:
+            Log:
+              type: string
+              x-example: "Dialing seeds in progress. See /net_info for details"
+        500:
+          description: empty error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /blockchain:
     get:
       summary: Get block headers for minHeight <= height <= maxHeight.
@@ -2675,3 +2737,22 @@ definitions:
       error:
         type: "string"
         example: ""
+  dialPeersPost:
+    type: object
+    properties:
+      Persistent:
+        type: bool
+        example: false
+      Peers:
+        type: Array
+        items:
+          type: "string"
+        example: ["peer:id"]
+  dialSeedsPost:
+    type: object
+    properties:
+      Peers:
+        type: Array
+        items:
+          type: "string"
+        example: ["peer:id"]

--- a/rpc/swagger/swagger.yaml
+++ b/rpc/swagger/swagger.yaml
@@ -451,7 +451,7 @@ paths:
       consumes:
         - application/json
       parameters:
-        - description: string of possible peers, can be added as persistent peers
+        - description: string of possible peers, bool arguement if they should be added as persistent
           in: body
           name: Array of peers to connect to & if they should be persistent
           required: true
@@ -2747,7 +2747,7 @@ definitions:
         type: Array
         items:
           type: "string"
-        example: ["peer:id"]
+        example: ["deadbeefdeadbeef@192.168.1.2:26656"]
   dialSeedsPost:
     type: object
     properties:
@@ -2755,4 +2755,4 @@ definitions:
         type: Array
         items:
           type: "string"
-        example: ["peer:id"]
+        example: ["deadbeefdeadbeefdeadbeef@192.168.1.2:26656"]

--- a/rpc/swagger/swagger.yaml
+++ b/rpc/swagger/swagger.yaml
@@ -451,7 +451,7 @@ paths:
       consumes:
         - application/json
       parameters:
-        - description: string of possible peers, bool arguement if they should be added as persistent
+        - description: string of possible peers, bool argument if they should be added as persistent
           in: body
           name: Array of peers to connect to & if they should be persistent
           required: true
@@ -2747,7 +2747,7 @@ definitions:
         type: Array
         items:
           type: "string"
-        example: ["deadbeefdeadbeef@192.168.1.2:26656"]
+        example: ["6f172048b821e3b1ab98ffb0973ba737966eecf8@192.168.1.2:26656"]
   dialSeedsPost:
     type: object
     properties:
@@ -2755,4 +2755,4 @@ definitions:
         type: Array
         items:
           type: "string"
-        example: ["deadbeefdeadbeefdeadbeef@192.168.1.2:26656"]
+        example: ["6f172048b821e3b1ab98ffb0973ba737966eecf8@192.168.1.2:26656"]


### PR DESCRIPTION
- added `/dial_peers` & `dial_seeds` to swagger docs under unsafe tag

closes #4047

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
