### PR TITLE
Relax Tx Querying

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,8 @@ program](https://hackerone.com/tendermint).
 
 - [mempool] [\#4057](https://github.com/tendermint/tendermint/issues/4057) Include peer ID when logging rejected txns (@erikgrinaker)
 - [tools] [\#4023](https://github.com/tendermint/tendermint/issues/4023) Improved `tm-monitor` formatting of start time and avg tx throughput (@erikgrinaker)
+- [libs/pubsub] [\#4070](https://github.com/tendermint/tendermint/pull/4070) No longer panic in `Query#Matches` preferring a log instead.
+- [libs/pubsub] [\#4070](https://github.com/tendermint/tendermint/pull/4070) Strip out non-numeric characters when attempting to match numeric values.
 
 ### BUG FIXES:
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,7 @@ program](https://hackerone.com/tendermint).
 - Apps
 
 - Go API
+  - [libs/pubsub] [\#4070](https://github.com/tendermint/tendermint/pull/4070) `Query#(Matches|Conditions)` returns an error.
 
 ### FEATURES:
 
@@ -22,7 +23,7 @@ program](https://hackerone.com/tendermint).
 
 - [mempool] [\#4057](https://github.com/tendermint/tendermint/issues/4057) Include peer ID when logging rejected txns (@erikgrinaker)
 - [tools] [\#4023](https://github.com/tendermint/tendermint/issues/4023) Improved `tm-monitor` formatting of start time and avg tx throughput (@erikgrinaker)
-- [libs/pubsub] [\#4070](https://github.com/tendermint/tendermint/pull/4070) No longer panic in `Query#Matches` preferring a log instead.
+- [libs/pubsub] [\#4070](https://github.com/tendermint/tendermint/pull/4070) No longer panic in `Query#(Matches|Conditions)` preferring to return an error instead.
 - [libs/pubsub] [\#4070](https://github.com/tendermint/tendermint/pull/4070) Strip out non-numeric characters when attempting to match numeric values.
 
 ### BUG FIXES:

--- a/docs/spec/consensus/fork-accountability.md
+++ b/docs/spec/consensus/fork-accountability.md
@@ -187,7 +187,7 @@ Validators:
 Execution:
 * for the main chain F behaves nicely
 * F coordinates to sign a block B that is different from the one on the main chain.
-* the lite clients obtains B and trusts at as it is signed by more and 2/3 of the voting power.
+* the lite clients obtains B and trusts at as it is signed by more than 2/3 of the voting power.
 
 Consequences:
 
@@ -251,11 +251,11 @@ Consequences:
 Only in case they signed something which conflicts with the application this can be used against them. Otherwise they do not do anything incorrect.
 * This case is not covered by the report https://docs.google.com/document/d/11ZhMsCj3y7zIZz4udO9l25xqb0kl7gmWqNpGVRzOeyY/edit?usp=sharing as it only assumes at most 2/3 of faulty validators.
 
-**Q:** do we need to define a special kind of attack for the case where a validator sign arbitrarily state? It seems that detecting such attack requires different mechanism that would require as an evidence a sequence of blocks that lead to that state. This might be very tricky to implement.
+**Q:** do we need to define a special kind of attack for the case where a validator sign arbitrarily state? It seems that detecting such attack requires a different mechanism that would require as an evidence a sequence of blocks that led to that state. This might be very tricky to implement.
 
 ### Back to the past
 
-In this kind of attacks faulty validators take advantage of the fact that they did not sign messages in some of the past rounds. Due to the asynchronous network in which Tendermint operates, we cannot easily differentiate between such an attack and delayed message. This kind of attack can be used at both full nodes and lite clients.
+In this kind of attack, faulty validators take advantage of the fact that they did not sign messages in some of the past rounds. Due to the asynchronous network in which Tendermint operates, we cannot easily differentiate between such an attack and delayed message. This kind of attack can be used at both full nodes and lite clients.
 
 #### Scenario 5:
 
@@ -271,7 +271,7 @@ Validators:
 Execution:
 
 * in a round *r* of height *h* we have C1 precommitting a value A,
-* C2  precommits nil,
+* C2 precommits nil,
 * F does not send any message
 * *q* precommits nil.
 * In some round *r' > r*, F and *q* and C2 commit some other value B different from A.
@@ -283,7 +283,7 @@ Consequences:
 
 * Only a single faulty validator that previously precommited nil did equivocation, while the other 1/3 of faulty validators actually executed an attack that has exactly the same sequence of messages as part of amnesia attack. Detecting this kind of attack boil down to mechanisms for equivocation and amnesia.
 
-**Q:** should we keep this as a separate kind of attack? It seems that equivocation, amnesia and phantom validators are the only kind of attack we need to support and this gives us security also in other cases. This would not be surprising as equivocation and amnesia are attacks that followed from the protocol and phantom attack is not really an attack to Tendermint but more to the Proof of stake module.
+**Q:** should we keep this as a separate kind of attack? It seems that equivocation, amnesia and phantom validators are the only kind of attack we need to support and this gives us security also in other cases. This would not be surprising as equivocation and amnesia are attacks that followed from the protocol and phantom attack is not really an attack to Tendermint but more to the Proof of Stake module.
 
 ### Phantom validators
 
@@ -296,19 +296,19 @@ Validators:
 
 Execution:
 
-* There is a fork, and there exists two different headers for height *h + k*, with different validator sets:
+* There is a fork, and there exist two different headers for height *h + k*, with different validator sets:
   - VS2 on the main chain
   - forged header VS2', signed by F (and others)
 
 * a lite client has a trust in a header for height *h* (and the corresponding validator set VS1).
-* As part of bisection header verification, it verifies header at height *h + k* with new validator set VS2'.
+* As part of bisection header verification, it verifies the header at height *h + k* with new validator set VS2'.
 
 Consequences:
 
 * To detect this, a node needs to see both, the forged header and the canonical header from the chain.
 * If this is the case, detecting these kind of attacks is easy as it just requires verifying if processes are signing messages in heights in which they are not part of the validator set.  
 
-**Remark.** We can have phantom-validator-based attacks as a follow up of equivocation or amnesia based attack where forked state contains validators that are not part of the validator set at the main chain. In this case, they keep signing messages contributed to a forked chain (the wrong branch) although they are not part of the validator set on the main chain. This attack can also be used to attack full node during a period of time he is eclipsed.
+**Remark.** We can have phantom-validator-based attacks as a follow up of equivocation or amnesia based attack where forked state contains validators that are not part of the validator set at the main chain. In this case, they keep signing messages contributed to a forked chain (the wrong branch) although they are not part of the validator set on the main chain. This attack can also be used to attack full node during a period of time it is eclipsed.
 
 ### Lunatic validator
 
@@ -316,4 +316,4 @@ Lunatic validator agrees to sign commit messages for arbitrary application state
 Note that detecting this behavior require application knowledge. Detecting this behavior can probably be done by
 referring to the block before the one in which height happen.  
 
-**Q:** can we say that in this case a validator ignore to check if proposed value is valid before voting for it?
+**Q:** can we say that in this case a validator declines to check if a proposed value is valid before voting for it?

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -410,7 +410,7 @@ func (state *state) send(msg interface{}, events map[string][]string) error {
 
 		match, err := q.Matches(events)
 		if err != nil {
-			return fmt.Errorf("failed to match against query %s: %w", q.String(), err)
+			return errors.Wrapf(err, "failed to match against query %s", q.String())
 		}
 
 		if match {

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -36,10 +36,9 @@ package pubsub
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"sync"
 
+	"github.com/pkg/errors"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
 

--- a/libs/pubsub/query/empty.go
+++ b/libs/pubsub/query/empty.go
@@ -5,8 +5,8 @@ type Empty struct {
 }
 
 // Matches always returns true.
-func (Empty) Matches(tags map[string][]string) bool {
-	return true
+func (Empty) Matches(tags map[string][]string) (bool, error) {
+	return true, nil
 }
 
 func (Empty) String() string {

--- a/libs/pubsub/query/empty_test.go
+++ b/libs/pubsub/query/empty_test.go
@@ -10,8 +10,19 @@ import (
 
 func TestEmptyQueryMatchesAnything(t *testing.T) {
 	q := query.Empty{}
-	assert.True(t, q.Matches(map[string][]string{}))
-	assert.True(t, q.Matches(map[string][]string{"Asher": {"Roth"}}))
-	assert.True(t, q.Matches(map[string][]string{"Route": {"66"}}))
-	assert.True(t, q.Matches(map[string][]string{"Route": {"66"}, "Billy": {"Blue"}}))
+
+	testCases := []struct {
+		query map[string][]string
+	}{
+		{map[string][]string{}},
+		{map[string][]string{"Asher": {"Roth"}}},
+		{map[string][]string{"Route": {"66"}}},
+		{map[string][]string{"Route": {"66"}, "Billy": {"Blue"}}},
+	}
+
+	for _, tc := range testCases {
+		match, err := q.Matches(tc.query)
+		assert.Nil(t, err)
+		assert.True(t, match)
+	}
 }

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -129,26 +129,24 @@ func (q *Query) Conditions() []Condition {
 			if strings.ContainsAny(number, ".") { // if it looks like a floating-point number
 				value, err := strconv.ParseFloat(number, 64)
 				if err != nil {
-					fmt.Printf(
-						"got %v while trying to parse %s as float64 (should never happen if the grammar is correct)\n",
-						err,
-						number,
+					panic(
+						fmt.Sprintf(
+							"got %v while trying to parse %s as float64 (should never happen if the grammar is correct)",
+							err, number,
+						),
 					)
-
-					return []Condition{}
 				}
 
 				conditions = append(conditions, Condition{eventAttr, op, value})
 			} else {
 				value, err := strconv.ParseInt(number, 10, 64)
 				if err != nil {
-					fmt.Printf(
-						"got %v while trying to parse %s as int64 (should never happen if the grammar is correct)\n",
-						err,
-						number,
+					panic(
+						fmt.Sprintf(
+							"got %v while trying to parse %s as int64 (should never happen if the grammar is correct)",
+							err, number,
+						),
 					)
-
-					return []Condition{}
 				}
 
 				conditions = append(conditions, Condition{eventAttr, op, value})
@@ -157,13 +155,12 @@ func (q *Query) Conditions() []Condition {
 		case ruletime:
 			value, err := time.Parse(TimeLayout, buffer[begin:end])
 			if err != nil {
-				fmt.Printf(
-					"got %v while trying to parse %s as time.Time / RFC3339 (should never happen if the grammar is correct)\n",
-					err,
-					buffer[begin:end],
+				panic(
+					fmt.Sprintf(
+						"got %v while trying to parse %s as time.Time / RFC3339 (should never happen if the grammar is correct)",
+						err, buffer[begin:end],
+					),
 				)
-
-				return []Condition{}
 			}
 
 			conditions = append(conditions, Condition{eventAttr, op, value})
@@ -171,13 +168,12 @@ func (q *Query) Conditions() []Condition {
 		case ruledate:
 			value, err := time.Parse("2006-01-02", buffer[begin:end])
 			if err != nil {
-				fmt.Printf(
-					"got %v while trying to parse %s as time.Time / '2006-01-02' (should never happen if the grammar is correct)\n",
-					err,
-					buffer[begin:end],
+				panic(
+					fmt.Sprintf(
+						"got %v while trying to parse %s as time.Time / '2006-01-02' (should never happen if the grammar is correct)",
+						err, buffer[begin:end],
+					),
 				)
-
-				return []Condition{}
 			}
 
 			conditions = append(conditions, Condition{eventAttr, op, value})

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -247,7 +247,11 @@ func (q *Query) Matches(events map[string][]string) (bool, error) {
 			if strings.ContainsAny(number, ".") { // if it looks like a floating-point number
 				value, err := strconv.ParseFloat(number, 64)
 				if err != nil {
-					return false, fmt.Errorf("got %v while trying to parse %s as float64 (should never happen if the grammar is correct)", err, number)
+					err = fmt.Errorf(
+						"got %v while trying to parse %s as float64 (should never happen if the grammar is correct)",
+						err, number,
+					)
+					return false, err
 				}
 
 				match, err := match(eventAttr, op, reflect.ValueOf(value), events)
@@ -261,7 +265,11 @@ func (q *Query) Matches(events map[string][]string) (bool, error) {
 			} else {
 				value, err := strconv.ParseInt(number, 10, 64)
 				if err != nil {
-					return false, fmt.Errorf("got %v while trying to parse %s as int64 (should never happen if the grammar is correct)", err, number)
+					err = fmt.Errorf(
+						"got %v while trying to parse %s as int64 (should never happen if the grammar is correct)",
+						err, number,
+					)
+					return false, err
 				}
 
 				match, err := match(eventAttr, op, reflect.ValueOf(value), events)
@@ -277,7 +285,11 @@ func (q *Query) Matches(events map[string][]string) (bool, error) {
 		case ruletime:
 			value, err := time.Parse(TimeLayout, buffer[begin:end])
 			if err != nil {
-				return false, fmt.Errorf("got %v while trying to parse %s as time.Time / RFC3339 (should never happen if the grammar is correct)", err, buffer[begin:end])
+				err = fmt.Errorf(
+					"got %v while trying to parse %s as time.Time / RFC3339 (should never happen if the grammar is correct)",
+					err, buffer[begin:end],
+				)
+				return false, err
 			}
 
 			match, err := match(eventAttr, op, reflect.ValueOf(value), events)
@@ -292,7 +304,11 @@ func (q *Query) Matches(events map[string][]string) (bool, error) {
 		case ruledate:
 			value, err := time.Parse("2006-01-02", buffer[begin:end])
 			if err != nil {
-				return false, fmt.Errorf("got %v while trying to parse %s as time.Time / '2006-01-02' (should never happen if the grammar is correct)", err, buffer[begin:end])
+				err = fmt.Errorf(
+					"got %v while trying to parse %s as time.Time / '2006-01-02' (should never happen if the grammar is correct)",
+					err, buffer[begin:end],
+				)
+				return false, err
 			}
 
 			match, err := match(eventAttr, op, reflect.ValueOf(value), events)

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -372,7 +372,7 @@ func matchValue(value string, op Operator, operand reflect.Value) bool {
 		var v float64
 
 		operandFloat64 := operand.Interface().(float64)
-		matchedValue := numRegex.FindString(value)
+		filteredValue := numRegex.FindString(value)
 
 		// try our best to convert value from tags to float64
 		v, err := strconv.ParseFloat(matchedValue, 64)

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -435,7 +435,7 @@ func matchValue(value string, op Operator, operand reflect.Value) (bool, error) 
 			// try our best to convert value from tags to int64
 			v, err = strconv.ParseInt(filteredValue, 10, 64)
 			if err != nil {
-				return false, fmt.Errorf("failed to convert value %v from event attribute to int64: %w", filteredValue, err)
+				return false, errors.Wrapf(err, "failed to convert value %v from event attribute to int64", filteredValue)
 			}
 		}
 

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -375,7 +375,7 @@ func matchValue(value string, op Operator, operand reflect.Value) (bool, error) 
 			v, err = time.Parse(DateLayout, value)
 		}
 		if err != nil {
-			return false, fmt.Errorf("failed to convert value %v from event attribute to time.Time: %w", value, err)
+			return false, errors.Wrapf(err, "failed to convert value %v from event attribute to time.Time", value)
 		}
 
 		switch op {

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -461,7 +461,7 @@ func matchValue(value string, op Operator, operand reflect.Value) (bool, error) 
 		}
 
 	default:
-		return false, fmt.Errorf("unknown kind of operand %v\n", operand.Kind())
+		return false, fmt.Errorf("unknown kind of operand %v", operand.Kind())
 	}
 
 	return false, nil

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -426,7 +426,7 @@ func matchValue(value string, op Operator, operand reflect.Value) (bool, error) 
 		if strings.ContainsAny(filteredValue, ".") {
 			v1, err := strconv.ParseFloat(filteredValue, 64)
 			if err != nil {
-				return false, fmt.Errorf("failed to convert value %v from event attribute to float64: %w", filteredValue, err)
+				return false, errors.Wrapf(err, "failed to convert value %v from event attribute to float64", filteredValue)
 			}
 
 			v = int64(v1)

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -400,7 +400,7 @@ func matchValue(value string, op Operator, operand reflect.Value) (bool, error) 
 		// try our best to convert value from tags to float64
 		v, err := strconv.ParseFloat(filteredValue, 64)
 		if err != nil {
-			return false, fmt.Errorf("failed to convert value %v from event attribute to float64: %w", filteredValue, err)
+			return false, errors.Wrapf(err, "failed to convert value %v from event attribute to float64", filteredValue)
 		}
 
 		switch op {

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -129,24 +129,20 @@ func (q *Query) Conditions() []Condition {
 			if strings.ContainsAny(number, ".") { // if it looks like a floating-point number
 				value, err := strconv.ParseFloat(number, 64)
 				if err != nil {
-					panic(
-						fmt.Sprintf(
-							"got %v while trying to parse %s as float64 (should never happen if the grammar is correct)",
-							err, number,
-						),
-					)
+					panic(fmt.Sprintf(
+						"got %v while trying to parse %s as float64 (should never happen if the grammar is correct)",
+						err, number,
+					))
 				}
 
 				conditions = append(conditions, Condition{eventAttr, op, value})
 			} else {
 				value, err := strconv.ParseInt(number, 10, 64)
 				if err != nil {
-					panic(
-						fmt.Sprintf(
-							"got %v while trying to parse %s as int64 (should never happen if the grammar is correct)",
-							err, number,
-						),
-					)
+					panic(fmt.Sprintf(
+						"got %v while trying to parse %s as int64 (should never happen if the grammar is correct)",
+						err, number,
+					))
 				}
 
 				conditions = append(conditions, Condition{eventAttr, op, value})
@@ -155,12 +151,10 @@ func (q *Query) Conditions() []Condition {
 		case ruletime:
 			value, err := time.Parse(TimeLayout, buffer[begin:end])
 			if err != nil {
-				panic(
-					fmt.Sprintf(
-						"got %v while trying to parse %s as time.Time / RFC3339 (should never happen if the grammar is correct)",
-						err, buffer[begin:end],
-					),
-				)
+				panic(fmt.Sprintf(
+					"got %v while trying to parse %s as time.Time / RFC3339 (should never happen if the grammar is correct)",
+					err, buffer[begin:end],
+				))
 			}
 
 			conditions = append(conditions, Condition{eventAttr, op, value})
@@ -168,12 +162,10 @@ func (q *Query) Conditions() []Condition {
 		case ruledate:
 			value, err := time.Parse("2006-01-02", buffer[begin:end])
 			if err != nil {
-				panic(
-					fmt.Sprintf(
-						"got %v while trying to parse %s as time.Time / '2006-01-02' (should never happen if the grammar is correct)",
-						err, buffer[begin:end],
-					),
-				)
+				panic(fmt.Sprintf(
+					"got %v while trying to parse %s as time.Time / '2006-01-02' (should never happen if the grammar is correct)",
+					err, buffer[begin:end],
+				))
 			}
 
 			conditions = append(conditions, Condition{eventAttr, op, value})

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -358,7 +358,8 @@ func matchValue(value string, op Operator, operand reflect.Value) bool {
 			v, err = time.Parse(DateLayout, value)
 		}
 		if err != nil {
-			panic(fmt.Sprintf("failed to convert value %v from tag to time.Time: %v", value, err))
+			fmt.Printf("failed to convert value %v from tag to time.Time: %v\n", value, err)
+			return false
 		}
 
 		switch op {
@@ -381,7 +382,8 @@ func matchValue(value string, op Operator, operand reflect.Value) bool {
 		// try our best to convert value from tags to float64
 		v, err := strconv.ParseFloat(value, 64)
 		if err != nil {
-			panic(fmt.Sprintf("failed to convert value %v from tag to float64: %v", value, err))
+			fmt.Printf("failed to convert value %v from tag to float64: %v\n", value, err)
+			return false
 		}
 
 		switch op {
@@ -404,17 +406,21 @@ func matchValue(value string, op Operator, operand reflect.Value) bool {
 		if strings.ContainsAny(value, ".") {
 			v1, err := strconv.ParseFloat(value, 64)
 			if err != nil {
-				panic(fmt.Sprintf("failed to convert value %v from tag to float64: %v", value, err))
+				fmt.Printf("failed to convert value %v from tag to float64: %v\n", value, err)
+				return false
 			}
+
 			v = int64(v1)
 		} else {
 			var err error
 			// try our best to convert value from tags to int64
 			v, err = strconv.ParseInt(value, 10, 64)
 			if err != nil {
-				panic(fmt.Sprintf("failed to convert value %v from tag to int64: %v", value, err))
+				fmt.Printf("failed to convert value %v from tag to int64: %v\n", value, err)
+				return false
 			}
 		}
+
 		switch op {
 		case OpLessEqual:
 			return v <= operandInt
@@ -437,7 +443,8 @@ func matchValue(value string, op Operator, operand reflect.Value) bool {
 		}
 
 	default:
-		panic(fmt.Sprintf("unknown kind of operand %v", operand.Kind()))
+		fmt.Printf("unknown kind of operand %v\n", operand.Kind())
+		return false
 	}
 
 	return false

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -375,9 +375,9 @@ func matchValue(value string, op Operator, operand reflect.Value) bool {
 		filteredValue := numRegex.FindString(value)
 
 		// try our best to convert value from tags to float64
-		v, err := strconv.ParseFloat(matchedValue, 64)
+		v, err := strconv.ParseFloat(filteredValue, 64)
 		if err != nil {
-			fmt.Printf("failed to convert value %v from event attribute to float64: %v\n", matchedValue, err)
+			fmt.Printf("failed to convert value %v from event attribute to float64: %v\n", filteredValue, err)
 			return false
 		}
 
@@ -398,13 +398,13 @@ func matchValue(value string, op Operator, operand reflect.Value) bool {
 		var v int64
 
 		operandInt := operand.Interface().(int64)
-		matchedValue := numRegex.FindString(value)
+		filteredValue := numRegex.FindString(value)
 
 		// if value looks like float, we try to parse it as float
-		if strings.ContainsAny(matchedValue, ".") {
-			v1, err := strconv.ParseFloat(matchedValue, 64)
+		if strings.ContainsAny(filteredValue, ".") {
+			v1, err := strconv.ParseFloat(filteredValue, 64)
 			if err != nil {
-				fmt.Printf("failed to convert value %v from event attribute to float64: %v\n", matchedValue, err)
+				fmt.Printf("failed to convert value %v from event attribute to float64: %v\n", filteredValue, err)
 				return false
 			}
 
@@ -412,9 +412,9 @@ func matchValue(value string, op Operator, operand reflect.Value) bool {
 		} else {
 			var err error
 			// try our best to convert value from tags to int64
-			v, err = strconv.ParseInt(matchedValue, 10, 64)
+			v, err = strconv.ParseInt(filteredValue, 10, 64)
 			if err != nil {
-				fmt.Printf("failed to convert value %v from event attribute to int64: %v\n", matchedValue, err)
+				fmt.Printf("failed to convert value %v from event attribute to int64: %v\n", filteredValue, err)
 				return false
 			}
 		}

--- a/libs/pubsub/query/query_test.go
+++ b/libs/pubsub/query/query_test.go
@@ -172,6 +172,8 @@ func TestConditions(t *testing.T) {
 		q, err := query.New(tc.s)
 		require.Nil(t, err)
 
-		assert.Equal(t, tc.conditions, q.Conditions())
+		c, err := q.Conditions()
+		require.NoError(t, err)
+		assert.Equal(t, tc.conditions, c)
 	}
 }

--- a/libs/pubsub/query/query_test.go
+++ b/libs/pubsub/query/query_test.go
@@ -24,8 +24,11 @@ func TestMatches(t *testing.T) {
 		matches bool
 	}{
 		{"tm.events.type='NewBlock'", map[string][]string{"tm.events.type": {"NewBlock"}}, false, true},
-
 		{"tx.gas > 7", map[string][]string{"tx.gas": {"8"}}, false, true},
+		{"transfer.amount > 7", map[string][]string{"transfer.amount": {"8stake"}}, false, true},
+		{"transfer.amount > 7", map[string][]string{"transfer.amount": {"8.045stake"}}, false, true},
+		{"transfer.amount > 7.043", map[string][]string{"transfer.amount": {"8.045stake"}}, false, true},
+		{"transfer.amount > 8.045", map[string][]string{"transfer.amount": {"8.045stake"}}, false, false},
 		{"tx.gas > 7 AND tx.gas < 9", map[string][]string{"tx.gas": {"8"}}, false, true},
 		{"body.weight >= 3.5", map[string][]string{"body.weight": {"3.5"}}, false, true},
 		{"account.balance < 1000.0", map[string][]string{"account.balance": {"900"}}, false, true},
@@ -47,7 +50,6 @@ func TestMatches(t *testing.T) {
 		},
 		{"tx.date = DATE 2017-01-01", map[string][]string{"tx.date": {txDate}}, false, true},
 		{"tx.date = DATE 2018-01-01", map[string][]string{"tx.date": {txDate}}, false, false},
-
 		{
 			"tx.time >= TIME 2013-05-03T14:45:00Z",
 			map[string][]string{"tx.time": {time.Now().Format(query.TimeLayout)}},
@@ -55,7 +57,6 @@ func TestMatches(t *testing.T) {
 			true,
 		},
 		{"tx.time = TIME 2013-05-03T14:45:00Z", map[string][]string{"tx.time": {txTime}}, false, false},
-
 		{"abci.owner.name CONTAINS 'Igor'", map[string][]string{"abci.owner.name": {"Igor,Ivan"}}, false, true},
 		{"abci.owner.name CONTAINS 'Igor'", map[string][]string{"abci.owner.name": {"Pavel,Ivan"}}, false, false},
 

--- a/libs/pubsub/query/query_test.go
+++ b/libs/pubsub/query/query_test.go
@@ -18,64 +18,69 @@ func TestMatches(t *testing.T) {
 	)
 
 	testCases := []struct {
-		s       string
-		events  map[string][]string
-		err     bool
-		matches bool
+		s        string
+		events   map[string][]string
+		err      bool
+		matches  bool
+		matchErr bool
 	}{
-		{"tm.events.type='NewBlock'", map[string][]string{"tm.events.type": {"NewBlock"}}, false, true},
-		{"tx.gas > 7", map[string][]string{"tx.gas": {"8"}}, false, true},
-		{"transfer.amount > 7", map[string][]string{"transfer.amount": {"8stake"}}, false, true},
-		{"transfer.amount > 7", map[string][]string{"transfer.amount": {"8.045stake"}}, false, true},
-		{"transfer.amount > 7.043", map[string][]string{"transfer.amount": {"8.045stake"}}, false, true},
-		{"transfer.amount > 8.045", map[string][]string{"transfer.amount": {"8.045stake"}}, false, false},
-		{"tx.gas > 7 AND tx.gas < 9", map[string][]string{"tx.gas": {"8"}}, false, true},
-		{"body.weight >= 3.5", map[string][]string{"body.weight": {"3.5"}}, false, true},
-		{"account.balance < 1000.0", map[string][]string{"account.balance": {"900"}}, false, true},
-		{"apples.kg <= 4", map[string][]string{"apples.kg": {"4.0"}}, false, true},
-		{"body.weight >= 4.5", map[string][]string{"body.weight": {fmt.Sprintf("%v", float32(4.5))}}, false, true},
+		{"tm.events.type='NewBlock'", map[string][]string{"tm.events.type": {"NewBlock"}}, false, true, false},
+		{"tx.gas > 7", map[string][]string{"tx.gas": {"8"}}, false, true, false},
+		{"transfer.amount > 7", map[string][]string{"transfer.amount": {"8stake"}}, false, true, false},
+		{"transfer.amount > 7", map[string][]string{"transfer.amount": {"8.045stake"}}, false, true, false},
+		{"transfer.amount > 7.043", map[string][]string{"transfer.amount": {"8.045stake"}}, false, true, false},
+		{"transfer.amount > 8.045", map[string][]string{"transfer.amount": {"8.045stake"}}, false, false, false},
+		{"tx.gas > 7 AND tx.gas < 9", map[string][]string{"tx.gas": {"8"}}, false, true, false},
+		{"body.weight >= 3.5", map[string][]string{"body.weight": {"3.5"}}, false, true, false},
+		{"account.balance < 1000.0", map[string][]string{"account.balance": {"900"}}, false, true, false},
+		{"apples.kg <= 4", map[string][]string{"apples.kg": {"4.0"}}, false, true, false},
+		{"body.weight >= 4.5", map[string][]string{"body.weight": {fmt.Sprintf("%v", float32(4.5))}}, false, true, false},
 		{
 			"oranges.kg < 4 AND watermellons.kg > 10",
 			map[string][]string{"oranges.kg": {"3"}, "watermellons.kg": {"12"}},
 			false,
 			true,
+			false,
 		},
-		{"peaches.kg < 4", map[string][]string{"peaches.kg": {"5"}}, false, false},
-
+		{"peaches.kg < 4", map[string][]string{"peaches.kg": {"5"}}, false, false, false},
 		{
 			"tx.date > DATE 2017-01-01",
 			map[string][]string{"tx.date": {time.Now().Format(query.DateLayout)}},
 			false,
 			true,
+			false,
 		},
-		{"tx.date = DATE 2017-01-01", map[string][]string{"tx.date": {txDate}}, false, true},
-		{"tx.date = DATE 2018-01-01", map[string][]string{"tx.date": {txDate}}, false, false},
+		{"tx.date = DATE 2017-01-01", map[string][]string{"tx.date": {txDate}}, false, true, false},
+		{"tx.date = DATE 2018-01-01", map[string][]string{"tx.date": {txDate}}, false, false, false},
 		{
 			"tx.time >= TIME 2013-05-03T14:45:00Z",
 			map[string][]string{"tx.time": {time.Now().Format(query.TimeLayout)}},
 			false,
 			true,
+			false,
 		},
-		{"tx.time = TIME 2013-05-03T14:45:00Z", map[string][]string{"tx.time": {txTime}}, false, false},
-		{"abci.owner.name CONTAINS 'Igor'", map[string][]string{"abci.owner.name": {"Igor,Ivan"}}, false, true},
-		{"abci.owner.name CONTAINS 'Igor'", map[string][]string{"abci.owner.name": {"Pavel,Ivan"}}, false, false},
-
-		{"abci.owner.name = 'Igor'", map[string][]string{"abci.owner.name": {"Igor", "Ivan"}}, false, true},
+		{"tx.time = TIME 2013-05-03T14:45:00Z", map[string][]string{"tx.time": {txTime}}, false, false, false},
+		{"abci.owner.name CONTAINS 'Igor'", map[string][]string{"abci.owner.name": {"Igor,Ivan"}}, false, true, false},
+		{"abci.owner.name CONTAINS 'Igor'", map[string][]string{"abci.owner.name": {"Pavel,Ivan"}}, false, false, false},
+		{"abci.owner.name = 'Igor'", map[string][]string{"abci.owner.name": {"Igor", "Ivan"}}, false, true, false},
 		{
 			"abci.owner.name = 'Ivan'",
 			map[string][]string{"abci.owner.name": {"Igor", "Ivan"}},
 			false,
 			true,
+			false,
 		},
 		{
 			"abci.owner.name = 'Ivan' AND abci.owner.name = 'Igor'",
 			map[string][]string{"abci.owner.name": {"Igor", "Ivan"}},
 			false,
 			true,
+			false,
 		},
 		{
 			"abci.owner.name = 'Ivan' AND abci.owner.name = 'John'",
 			map[string][]string{"abci.owner.name": {"Igor", "Ivan"}},
+			false,
 			false,
 			false,
 		},
@@ -84,17 +89,26 @@ func TestMatches(t *testing.T) {
 			map[string][]string{"tm.events.type": {"NewBlock"}, "app.name": {"fuzzed"}},
 			false,
 			true,
+			false,
 		},
-		{"app.name = 'fuzzed'", map[string][]string{"tm.events.type": {"NewBlock"}, "app.name": {"fuzzed"}}, false, true},
+		{
+			"app.name = 'fuzzed'",
+			map[string][]string{"tm.events.type": {"NewBlock"}, "app.name": {"fuzzed"}},
+			false,
+			true,
+			false,
+		},
 		{
 			"tm.events.type='NewBlock' AND app.name = 'fuzzed'",
 			map[string][]string{"tm.events.type": {"NewBlock"}, "app.name": {"fuzzed"}},
 			false,
 			true,
+			false,
 		},
 		{
 			"tm.events.type='NewHeader' AND app.name = 'fuzzed'",
 			map[string][]string{"tm.events.type": {"NewBlock"}, "app.name": {"fuzzed"}},
+			false,
 			false,
 			false,
 		},
@@ -109,9 +123,13 @@ func TestMatches(t *testing.T) {
 		require.NotNil(t, q, "Query '%s' should not be nil", tc.s)
 
 		if tc.matches {
-			assert.True(t, q.Matches(tc.events), "Query '%s' should match %v", tc.s, tc.events)
+			match, err := q.Matches(tc.events)
+			assert.Nil(t, err, "Query '%s' should not error on match %v", tc.s, tc.events)
+			assert.True(t, match, "Query '%s' should match %v", tc.s, tc.events)
 		} else {
-			assert.False(t, q.Matches(tc.events), "Query '%s' should not match %v", tc.s, tc.events)
+			match, err := q.Matches(tc.events)
+			assert.Equal(t, tc.matchErr, err != nil, "Unexpected error for query '%s' match %v", tc.s, tc.events)
+			assert.False(t, match, "Query '%s' should not match %v", tc.s, tc.events)
 		}
 	}
 }

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -168,7 +168,10 @@ func (txi *TxIndex) Search(q *query.Query) ([]*types.TxResult, error) {
 	filteredHashes := make(map[string][]byte)
 
 	// get a list of conditions (like "tx.height > 5")
-	conditions := q.Conditions()
+	conditions, err := q.Conditions()
+	if err != nil {
+		return nil, errors.Wrap(err, "error during parsing conditions from query")
+	}
 
 	// if there is a hash condition, return the result immediately
 	hash, err, ok := lookForHash(conditions)


### PR DESCRIPTION
- Some linting/cleanup missed from the initial events refactor
- Don't panic; instead, return `false, error` when matching breaks unexpectedly 
- Strip non-numeric chars from values when attempting to match against query values
- Have the server log during `send` upon error 

----

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
