### PR TITLE
[behaviour] Fix mock reporter interface

### DIFF
--- a/behaviour/reporter.go
+++ b/behaviour/reporter.go
@@ -63,10 +63,12 @@ func NewMockReporter() *MockReporter {
 }
 
 // Report stores the PeerBehaviour produced by the peer identified by peerID.
-func (mpbr *MockReporter) Report(behaviour PeerBehaviour) {
+func (mpbr *MockReporter) Report(behaviour PeerBehaviour) error {
 	mpbr.mtx.Lock()
 	defer mpbr.mtx.Unlock()
 	mpbr.pb[behaviour.peerID] = append(mpbr.pb[behaviour.peerID], behaviour)
+
+	return nil
 }
 
 // GetBehaviours returns all behaviours reported on the peer identified by peerID.


### PR DESCRIPTION
 MockReporeter.Report should return an error to adhere to the `behaviour.Reporter` interface

* [ ] ~~Referenced an issue explaining the need for the change~~
* [ ] ~~Updated all relevant documentation in docs~~
* [ ] ~~Updated all code comments where relevant~~
* [ ] ~~Wrote tests~~
* [ ] Updated CHANGELOG_PENDING.md
