### PR TITLE
Added make command to install the tendermint binary

### DIFF
--- a/docs/app-dev/getting-started.md
+++ b/docs/app-dev/getting-started.md
@@ -33,6 +33,7 @@ go get github.com/tendermint/tendermint
 cd $GOPATH/src/github.com/tendermint/tendermint
 make tools
 make install_abci
+make install
 ```
 
 Now you should have the `abci-cli` installed; you'll see a couple of


### PR DESCRIPTION
I noticed that the Getting Started doc was missing the step to install the tendermint binary
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
