### PR TITLE
[R4R]txindex/kv: Fsync data to disk immediately after receiving it 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -30,4 +30,4 @@ program](https://hackerone.com/tendermint).
 ### BUG FIXES:
 
 - [tools] [\#4023](https://github.com/tendermint/tendermint/issues/4023) Refresh `tm-monitor` health when validator count is updated (@erikgrinaker)
-- [index] [\#4104](https://github.com/tendermint/tendermint/pull/4104) Fix tx index lag too much 
+- [state] [\#4104](https://github.com/tendermint/tendermint/pull/4104) txindex/kv: Fsync data to disk immediately after receiving it (@guagualvcha)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -30,3 +30,4 @@ program](https://hackerone.com/tendermint).
 ### BUG FIXES:
 
 - [tools] [\#4023](https://github.com/tendermint/tendermint/issues/4023) Refresh `tm-monitor` health when validator count is updated (@erikgrinaker)
+- [index] [\#4104](https://github.com/tendermint/tendermint/pull/4104) Fix tx index lag too much 

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -103,7 +103,7 @@ func (txi *TxIndex) AddBatch(b *txindex.Batch) error {
 		storeBatch.Set(hash, rawBytes)
 	}
 
-	storeBatch.Write()
+	storeBatch.WriteSync()
 	return nil
 }
 
@@ -132,7 +132,7 @@ func (txi *TxIndex) Index(result *types.TxResult) error {
 	}
 
 	b.Set(hash, rawBytes)
-	b.Write()
+	b.WriteSync()
 
 	return nil
 }


### PR DESCRIPTION
Why this pr:
When restarting chain node, sometimes we lost tx index about recent(around 80)blocks, and some client complains that they can't find the tx by RPC call(tx_search) when the tx do exist in the block.

I try to partially fix this issue in a simple way by writing the index data in a sync way. 
There is no performance difference under 1K TPS according to our test.

It is still possible that lost index data after restarting the node, but only 2 block data will lost at most.
I try to totally fix this in https://github.com/tendermint/tendermint/pull/3847/files, but this one is simple and can solve most part of the issue. Please review first, thks.