### PR TITLE
RPC:tx_search show txs in the latest-first order

### DIFF
--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -212,7 +212,8 @@ func TxSearch(ctx *rpctypes.Context, query string, prove bool, page, perPage int
 	var proof types.TxProof
 	// if there's no tx in the results array, we don't need to loop through the apiResults array
 	for i := 0; i < len(apiResults); i++ {
-		r := results[skipCount+i]
+		// show transactions in the latest-first order
+		r := results[totalCount-1-skipCount-i]
 		height := r.Height
 		index := r.Index
 


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->
This PR is to solve the  TxSearch problem #3333 .In most cases, we need to show transactions in the latest-first order.
* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
