### PR TITLE
Update signer_dialer_endpoint.go

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,6 +27,7 @@ program](https://hackerone.com/tendermint).
 - [libs/pubsub] [\#4070](https://github.com/tendermint/tendermint/pull/4070) No longer panic in `Query#(Matches|Conditions)` preferring to return an error instead.
 - [libs/pubsub] [\#4070](https://github.com/tendermint/tendermint/pull/4070) Strip out non-numeric characters when attempting to match numeric values.
 - [p2p] [\#3991](https://github.com/tendermint/tendermint/issues/3991) Log "has been established or dialed" as debug log instead of Error for connected peers (@whunmr)
+- [privval] Add `SignerDialerEndpointRetryWaitInterval` option (@cosmostuba)
 
 ### BUG FIXES:
 

--- a/privval/signer_dialer_endpoint.go
+++ b/privval/signer_dialer_endpoint.go
@@ -28,7 +28,7 @@ func SignerDialerEndpointConnRetries(retries int) SignerServiceEndpointOption {
 
 // SignerDialerEndpointRetryWaitInterval sets the retry wait interval to a custom value
 func SignerDialerEndpointRetryWaitInterval(retryWaitInterval time.Duration) SignerServiceEndpointOption {
-	return func(ss *SignerDialerEndpoint) { ss.retryWait = retryWaitInterval }
+	return func(ss *SignerDialerEndpoint) { ss.retryWait = interval }
 }
 
 // SignerDialerEndpoint dials using its dialer and responds to any

--- a/privval/signer_dialer_endpoint.go
+++ b/privval/signer_dialer_endpoint.go
@@ -27,7 +27,7 @@ func SignerDialerEndpointConnRetries(retries int) SignerServiceEndpointOption {
 }
 
 // SignerDialerEndpointRetryWaitInterval sets the retry wait interval to a custom value
-func SignerDialerEndpointRetryWaitInterval(retryWaitInterval time.Duration) SignerServiceEndpointOption {
+func SignerDialerEndpointRetryWaitInterval(interval time.Duration) SignerServiceEndpointOption {
 	return func(ss *SignerDialerEndpoint) { ss.retryWait = interval }
 }
 

--- a/privval/signer_dialer_endpoint.go
+++ b/privval/signer_dialer_endpoint.go
@@ -26,6 +26,11 @@ func SignerDialerEndpointConnRetries(retries int) SignerServiceEndpointOption {
 	return func(ss *SignerDialerEndpoint) { ss.maxConnRetries = retries }
 }
 
+// SignerDialerEndpointRetryWaitInterval sets the retry wait interval to a custom value
+func SignerDialerEndpointRetryWaitInterval(retryWaitInterval time.Duration) SignerServiceEndpointOption {
+	return func(ss *SignerDialerEndpoint) { ss.retryWait = retryWaitInterval }
+}
+
 // SignerDialerEndpoint dials using its dialer and responds to any
 // signature requests using its privVal.
 type SignerDialerEndpoint struct {


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md

Added a small function to be able to change the default retry interval for the privval. The default is 100ms, this function allows to change to any time.Duration. 

