### PR TITLE
Improve building instructions for docs

### DIFF
--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -64,29 +64,11 @@ To build and serve the documentation locally, run:
 
 ```
 # from this directory
-npm install -g vuepress
-```
-
-NOTE: the command may require `sudo`.
-
-then change the following line in the `.vuepress/config.js`:
-
-```
-base: "/docs/",
-```
-
-to:
-
-```
-base: "/",
-```
-
-Finally, go up one directory to the root of the repo and run:
-
-```
-# from root of repo
-vuepress build docs
-cd dist/docs
+npm install -g vuepress # this command may require `sudo`
+npm install
+export VUEPRESS_BASE="/"
+vuepress build
+cd .vuepress/dist
 python -m SimpleHTTPServer 8080
 ```
 


### PR DESCRIPTION
Hi, I've been trying to build the documentation site and I've run into some issues, posting this as a PR instead of an issue because I've already done some work and it's easier to provide the diff this way than to just embed a diff into the issue. If you want me to open an issue instead feel free to close this.

Some problems I've found:
- Currently the instructions don't point to the installation of vuepress-theme-cosmos, leading to the failure of the install
- After installing it with `npm install`, running `vuepress build docs` fails because the node_modules is not part of the path anymore, the solution to that is to run `vuepress build` while being inside the docs folder, I've also fixed some other outdated stuff in the docs.
- running `vuepress build` fails with the following error:
```
Rendering page: /DEV_SESSIONS.html[Vue warn]: Error in render: "TypeError: _vm.md is not a function"

found in

---> <TmHelpSupport>
       <TmFooter>
         <TmLayout>
           <Anonymous>
             <Anonymous>
               <Root>
error Error rendering /DEV_SESSIONS.html: false
```
weirdly, running `vuepress dev` succeeds. I've managed to track this error to [this issue](https://github.com/vuejs/vuepress/issues/1688), which seems to be about the same problem.
- Even when the system is built with `vuepress dev` it results in the following interface, which is different from the current page at tendermint.com/docs. I have no clue why this happens.
![Screenshot from 2019-11-10 01-22-30](https://user-images.githubusercontent.com/32309574/68532752-2de3cd80-035c-11ea-9dfe-b3a0a67b3257.png)

Note: I've also tried to update the theme to it's last version and building it there results in the following interface, which has a broken sidebar:
![Screenshot from 2019-11-10 01-20-06](https://user-images.githubusercontent.com/32309574/68532758-350adb80-035c-11ea-8afe-5b579a4be7ac.png)

2nd note: while going through all this I've also noticed that the "fix this page" links in the documentation point to the develop branch of this repo and therefore bring up a 404, they should be redirected to point to master.

3rd note: What use is the package-lock.json file in the repository root?