### PR TITLE
Fix build instructions

### DIFF
--- a/docs/app-dev/getting-started.md
+++ b/docs/app-dev/getting-started.md
@@ -21,10 +21,13 @@ using Tendermint.
 ### Install
 
 The first apps we will work with are written in Go. To install them, you
-need to [install Go](https://golang.org/doc/install) and put
-`$GOPATH/bin` in your `$PATH`; see
-[here](https://github.com/tendermint/tendermint/wiki/Setting-GOPATH) for
-more info.
+need to [install Go](https://golang.org/doc/install), put
+`$GOPATH/bin` in your `$PATH` and enable go modules with these instructions:
+```bash
+echo export GOPATH=\"\$HOME/go\" >> ~/.bash_profile
+echo export PATH=\"\$PATH:\$GOPATH/bin\" >> ~/.bash_profile
+echo export GO111MODULE=on >> ~/.bash_profile
+```
 
 Then run
 

--- a/docs/introduction/install.md
+++ b/docs/introduction/install.md
@@ -18,7 +18,12 @@ To download pre-built binaries, see the [releases page](https://github.com/tende
 ## From Source
 
 You'll need `go` [installed](https://golang.org/doc/install) and the required
-[environment variables set](https://github.com/tendermint/tendermint/wiki/Setting-GOPATH)
+environment variables set, which can be done with the following commands:
+```bash
+echo export GOPATH=\"\$HOME/go\" >> ~/.bash_profile
+echo export PATH=\"\$PATH:\$GOPATH/bin\" >> ~/.bash_profile
+echo export GO111MODULE=on >> ~/.bash_profile
+```
 
 ### Get Source Code
 


### PR DESCRIPTION
Currently the documentation on installing tendermint from source references the now-gone repository wiki, which leads to those links being broken. This PR fixes that by just inlining the content that was in the wiki.

Furthermore, building tendermint with just the instructions provided results in the following error:
```
Get Certstrap
go get: warning: modules disabled by GO111MODULE=auto in GOPATH/src;
	ignoring go.mod;
	see 'go help modules'
go: cannot use path@version syntax in GOPATH mode
make: *** [tools.mk:62: /home/corollari/go/bin/certstrap] Error 1
```
This PR fixes that by also setting the `GO111MODULE` environment variable.
