### PR TITLE
rpc: remove godoc comments in favor of swagger docs

### DIFF
--- a/rpc/core/CONTRIBUTING.md
+++ b/rpc/core/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+## Swagger docs
+
+Do not forget to update ../swagger/swagger.yaml if making changes to any
+endpoint.

--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -8,54 +8,8 @@ import (
 	rpctypes "github.com/tendermint/tendermint/rpc/lib/types"
 )
 
-// Query the application for some information.
-//
-// ```shell
-// curl 'localhost:26657/abci_query?path=""&data="abcd"&prove=false'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// result, err := client.ABCIQuery("", "abcd", true)
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {
-// 		"response": {
-// 			"log": "exists",
-// 			"height": "0",
-// 			"proof": "010114FED0DAD959F36091AD761C922ABA3CBF1" +
-//  						 "D8349990101020103011406AA2262E2F448242D" +
-//							 "F2C2607C3CDC705313EE3B0001149D16177BC71" +
-//							 "E445476174622EA559715C293740C",
-// 			"value": "61626364",
-// 			"key": "61626364",
-// 			"index": "-1",
-// 			"code": "0"
-// 		}
-// 	},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
-//
-// ### Query Parameters
-//
-// | Parameter | Type   | Default | Required | Description                                    |
-// |-----------+--------+---------+----------+------------------------------------------------|
-// | path      | string | false   | false    | Path to the data ("/a/b/c")                    |
-// | data      | []byte | false   | true     | Data                                           |
-// | height    | int64  | 0       | false    | Height (0 means latest)                        |
-// | prove     | bool   | false   | false    | Includes proof if true                         |
+// ABCIQuery queries the application for some information.
+// More: https://tendermint.com/rpc/#/ABCI/abci_query
 func ABCIQuery(
 	ctx *rpctypes.Context,
 	path string,
@@ -76,36 +30,8 @@ func ABCIQuery(
 	return &ctypes.ResultABCIQuery{Response: *resQuery}, nil
 }
 
-// Get some info about the application.
-//
-// ```shell
-// curl 'localhost:26657/abci_info'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// info, err := client.ABCIInfo()
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {
-// 		"response": {
-// 			"data": "{\"size\":3}"
-// 		}
-// 	},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
+// ABCIInfo gets some info about the application.
+// More: https://tendermint.com/rpc/#/ABCI/abci_info
 func ABCIInfo(ctx *rpctypes.Context) (*ctypes.ResultABCIInfo, error) {
 	resInfo, err := proxyAppQuery.InfoSync(proxy.RequestInfo)
 	if err != nil {

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -10,65 +10,9 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-// Get block headers for minHeight <= height <= maxHeight.
+// BlockchainInfo gets block headers for minHeight <= height <= maxHeight.
 // Block headers are returned in descending order (highest first).
-//
-// ```shell
-// curl 'localhost:26657/blockchain?minHeight=10&maxHeight=10'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// info, err := client.BlockchainInfo(10, 10)
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {
-// 		"block_metas": [
-// 			{
-// 				"header": {
-// 					"app_hash": "",
-// 					"chain_id": "test-chain-6UTNIN",
-// 					"height": "10",
-// 					"time": "2017-05-29T15:05:53.877Z",
-// 					"num_txs": "0",
-// 					"last_block_id": {
-// 						"parts": {
-// 							"hash": "3C78F00658E06744A88F24FF97A0A5011139F34A",
-// 							"total": "1"
-// 						},
-// 						"hash": "F70588DAB36BDA5A953D548A16F7D48C6C2DFD78"
-// 					},
-// 					"last_commit_hash": "F31CC4282E50B3F2A58D763D233D76F26D26CABE",
-// 					"data_hash": "",
-// 					"validators_hash": "9365FC80F234C967BD233F5A3E2AB2F1E4B0E5AA"
-// 				},
-// 				"block_id": {
-// 					"parts": {
-// 						"hash": "277A4DBEF91483A18B85F2F5677ABF9694DFA40F",
-// 						"total": "1"
-// 					},
-// 					"hash": "96B1D2F2D201BA4BC383EB8224139DB1294944E5"
-// 				}
-// 			}
-// 		],
-// 		"last_height": "5493"
-// 	},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
-//
-// <aside class="notice">Returns at most 20 items.</aside>
+// More: https://tendermint.com/rpc/#/Info/blockchain
 func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error) {
 
 	// maximum 20 block metas
@@ -122,113 +66,9 @@ func filterMinMax(height, min, max, limit int64) (int64, int64, error) {
 	return min, max, nil
 }
 
-// Get block at a given height.
+// Block gets block at a given height.
 // If no height is provided, it will fetch the latest block.
-//
-// ```shell
-// curl 'localhost:26657/block?height=10'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// info, err := client.Block(10)
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-//   "error": "",
-//   "result": {
-//     "block": {
-//       "last_commit": {
-//         "precommits": [
-//           {
-//             "signature": {
-//               "data": "12C0D8893B8A38224488DC1DE6270DF76BB1A5E9DB" +
-//											 "1C68577706A6A97C6EC34FFD12339183D5CA8BC2F4" +
-//											 "6148773823DE905B7F6F5862FD564038BB7AE03BF50D",
-//               "type": "ed25519"
-//             },
-//             "block_id": {
-//               "parts": {
-//                 "hash": "3C78F00658E06744A88F24FF97A0A5011139F34A",
-//                 "total": "1"
-//               },
-//               "hash": "F70588DAB36BDA5A953D548A16F7D48C6C2DFD78"
-//             },
-//             "type": "2",
-//             "round": "0",
-//             "height": "9",
-//             "validator_index": "0",
-//             "validator_address": "E89A51D60F68385E09E716D353373B11F8FACD62"
-//           }
-//         ],
-//         "blockID": {
-//           "parts": {
-//             "hash": "3C78F00658E06744A88F24FF97A0A5011139F34A",
-//             "total": "1"
-//           },
-//           "hash": "F70588DAB36BDA5A953D548A16F7D48C6C2DFD78"
-//         }
-//       },
-//       "data": {
-//         "txs": []
-//       },
-//       "header": {
-//         "app_hash": "",
-//         "chain_id": "test-chain-6UTNIN",
-//         "height": "10",
-//         "time": "2017-05-29T15:05:53.877Z",
-//         "num_txs": "0",
-//         "last_block_id": {
-//           "parts": {
-//             "hash": "3C78F00658E06744A88F24FF97A0A5011139F34A",
-//             "total": "1"
-//           },
-//           "hash": "F70588DAB36BDA5A953D548A16F7D48C6C2DFD78"
-//         },
-//         "last_commit_hash": "F31CC4282E50B3F2A58D763D233D76F26D26CABE",
-//         "data_hash": "",
-//         "validators_hash": "9365FC80F234C967BD233F5A3E2AB2F1E4B0E5AA"
-//       }
-//     },
-//     "block_meta": {
-//       "header": {
-//         "app_hash": "",
-//         "chain_id": "test-chain-6UTNIN",
-//         "height": "10",
-//         "time": "2017-05-29T15:05:53.877Z",
-//         "num_txs": "0",
-//         "last_block_id": {
-//           "parts": {
-//             "hash": "3C78F00658E06744A88F24FF97A0A5011139F34A",
-//             "total": "1"
-//           },
-//           "hash": "F70588DAB36BDA5A953D548A16F7D48C6C2DFD78"
-//         },
-//         "last_commit_hash": "F31CC4282E50B3F2A58D763D233D76F26D26CABE",
-//         "data_hash": "",
-//         "validators_hash": "9365FC80F234C967BD233F5A3E2AB2F1E4B0E5AA"
-//       },
-//       "block_id": {
-//         "parts": {
-//           "hash": "277A4DBEF91483A18B85F2F5677ABF9694DFA40F",
-//           "total": "1"
-//         },
-//         "hash": "96B1D2F2D201BA4BC383EB8224139DB1294944E5"
-//       }
-//     }
-//   },
-//   "id": "",
-//   "jsonrpc": "2.0"
-// }
-// ```
+// More: https://tendermint.com/rpc/#/Info/block
 func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error) {
 	storeHeight := blockStore.Height()
 	height, err := getHeight(storeHeight, heightPtr)
@@ -241,83 +81,9 @@ func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error)
 	return &ctypes.ResultBlock{BlockMeta: blockMeta, Block: block}, nil
 }
 
-// Get block commit at a given height.
+// Commit gets block commit at a given height.
 // If no height is provided, it will fetch the commit for the latest block.
-//
-// ```shell
-// curl 'localhost:26657/commit?height=11'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// info, err := client.Commit(11)
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-//   "error": "",
-//   "result": {
-//     "canonical": true,
-//     "commit": {
-//       "precommits": [
-//         {
-//           "signature": {
-//             "data": "00970429FEC652E9E21D106A90AE8C5413759A74887" +
-//                     "75CEF4A3F44DC46C7F9D941070E4FBE9ED54DF247FA" +
-//                     "3983359A0C3A238D61DE55C75C9116D72ABC9CF50F",
-//             "type": "ed25519"
-//           },
-//           "block_id": {
-//             "parts": {
-//               "hash": "9E37CBF266BC044A779E09D81C456E653B89E006",
-//               "total": "1"
-//             },
-//             "hash": "CC6E861E31CA4334E9888381B4A9137D1458AB6A"
-//           },
-//           "type": "2",
-//           "round": "0",
-//           "height": "11",
-//           "validator_index": "0",
-//           "validator_address": "E89A51D60F68385E09E716D353373B11F8FACD62"
-//         }
-//       ],
-//       "blockID": {
-//         "parts": {
-//           "hash": "9E37CBF266BC044A779E09D81C456E653B89E006",
-//           "total": "1"
-//         },
-//         "hash": "CC6E861E31CA4334E9888381B4A9137D1458AB6A"
-//       }
-//     },
-//     "header": {
-//       "app_hash": "",
-//       "chain_id": "test-chain-6UTNIN",
-//       "height": "11",
-//       "time": "2017-05-29T15:05:54.893Z",
-//       "num_txs": "0",
-//       "last_block_id": {
-//         "parts": {
-//           "hash": "277A4DBEF91483A18B85F2F5677ABF9694DFA40F",
-//           "total": "1"
-//         },
-//         "hash": "96B1D2F2D201BA4BC383EB8224139DB1294944E5"
-//       },
-//       "last_commit_hash": "3CE0C9727CE524BA9CB7C91E28F08E2B94001087",
-//       "data_hash": "",
-//       "validators_hash": "9365FC80F234C967BD233F5A3E2AB2F1E4B0E5AA"
-//     }
-//   },
-//   "id": "",
-//   "jsonrpc": "2.0"
-// }
-// ```
+// More: https://tendermint.com/rpc/#/Info/commit
 func Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, error) {
 	storeHeight := blockStore.Height()
 	height, err := getHeight(storeHeight, heightPtr)
@@ -345,49 +111,7 @@ func Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, erro
 // Results are for the height of the block containing the txs.
 // Thus response.results.deliver_tx[5] is the results of executing
 // getBlock(h).Txs[5]
-//
-// ```shell
-// curl 'localhost:26657/block_results?height=10'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// info, err := client.BlockResults(10)
-// ```
-//
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-//   "jsonrpc": "2.0",
-//   "id": "",
-//   "result": {
-//     "height": "39",
-//     "results": {
-//       "deliver_tx": [
-//         {
-//           "tags": [
-//             {
-//               "key": "YXBwLmNyZWF0b3I=",
-//               "value": "Q29zbW9zaGkgTmV0b3dva28="
-//             }
-//           ]
-//         }
-//       ],
-//       "end_block": {
-//         "validator_updates": null
-//       },
-//       "begin_block": {}
-//     }
-//   }
-// }
-// ```
+// More: https://tendermint.com/rpc/#/Info/block_results
 func BlockResults(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlockResults, error) {
 	storeHeight := blockStore.Height()
 	height, err := getHeight(storeHeight, heightPtr)

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -8,48 +8,11 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-// Get the validator set at the given block height.
+// Validators gets the validator set at the given block height.
 // If no height is provided, it will fetch the current validator set.
 // Note the validators are sorted by their address - this is the canonical
 // order for the validators in the set as used in computing their Merkle root.
-//
-// ```shell
-// curl 'localhost:26657/validators'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// state, err := client.Validators()
-// ```
-//
-// The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {
-// 		"validators": [
-// 			{
-// 				"proposer_priority": "0",
-// 				"voting_power": "10",
-// 				"pub_key": {
-// 					"data": "68DFDA7E50F82946E7E8546BED37944A422CD1B831E70DF66BA3B8430593944D",
-// 					"type": "ed25519"
-// 				},
-// 				"address": "E89A51D60F68385E09E716D353373B11F8FACD62"
-// 			}
-// 		],
-// 		"block_height": "5241"
-// 	},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
+// More: https://tendermint.com/rpc/#/Info/validators
 func Validators(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultValidators, error) {
 	// The latest validator that we know is the
 	// NextValidator of the last block.
@@ -70,139 +33,7 @@ func Validators(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultValidato
 
 // DumpConsensusState dumps consensus state.
 // UNSTABLE
-//
-// ```shell
-// curl 'localhost:26657/dump_consensus_state'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// state, err := client.DumpConsensusState()
-// ```
-//
-// The above command returns JSON structured like this:
-//
-// ```json
-// {
-//   "jsonrpc": "2.0",
-//   "id": "",
-//   "result": {
-//     "round_state": {
-//       "height": "7185",
-//       "round": "0",
-//       "step": "1",
-//       "start_time": "2018-05-12T13:57:28.440293621-07:00",
-//       "commit_time": "2018-05-12T13:57:27.440293621-07:00",
-//       "validators": {
-//         "validators": [
-//           {
-//             "address": "B5B3D40BE53982AD294EF99FF5A34C0C3E5A3244",
-//             "pub_key": {
-//               "type": "tendermint/PubKeyEd25519",
-//               "value": "SBctdhRBcXtBgdI/8a/alTsUhGXqGs9k5ylV1u5iKHg="
-//             },
-//             "voting_power": "10",
-//             "proposer_priority": "0"
-//           }
-//         ],
-//         "proposer": {
-//           "address": "B5B3D40BE53982AD294EF99FF5A34C0C3E5A3244",
-//           "pub_key": {
-//             "type": "tendermint/PubKeyEd25519",
-//             "value": "SBctdhRBcXtBgdI/8a/alTsUhGXqGs9k5ylV1u5iKHg="
-//           },
-//           "voting_power": "10",
-//           "proposer_priority": "0"
-//         }
-//       },
-//       "proposal": null,
-//       "proposal_block": null,
-//       "proposal_block_parts": null,
-//       "locked_round": "0",
-//       "locked_block": null,
-//       "locked_block_parts": null,
-//       "valid_round": "0",
-//       "valid_block": null,
-//       "valid_block_parts": null,
-//       "votes": [
-//         {
-//           "round": "0",
-//           "prevotes": "_",
-//           "precommits": "_"
-//         }
-//       ],
-//       "commit_round": "-1",
-//       "last_commit": {
-//         "votes": [
-//           "Vote{0:B5B3D40BE539 7184/00/2(Precommit) 14F946FA7EF0 /702B1B1A602A.../ @ 2018-05-12T20:57:27.342Z}"
-//         ],
-//         "votes_bit_array": "x",
-//         "peer_maj_23s": {}
-//       },
-//       "last_validators": {
-//         "validators": [
-//           {
-//             "address": "B5B3D40BE53982AD294EF99FF5A34C0C3E5A3244",
-//             "pub_key": {
-//               "type": "tendermint/PubKeyEd25519",
-//               "value": "SBctdhRBcXtBgdI/8a/alTsUhGXqGs9k5ylV1u5iKHg="
-//             },
-//             "voting_power": "10",
-//             "proposer_priority": "0"
-//           }
-//         ],
-//         "proposer": {
-//           "address": "B5B3D40BE53982AD294EF99FF5A34C0C3E5A3244",
-//           "pub_key": {
-//             "type": "tendermint/PubKeyEd25519",
-//             "value": "SBctdhRBcXtBgdI/8a/alTsUhGXqGs9k5ylV1u5iKHg="
-//           },
-//           "voting_power": "10",
-//           "proposer_priority": "0"
-//         }
-//       }
-//     },
-//     "peers": [
-//       {
-//         "node_address": "30ad1854af22506383c3f0e57fb3c7f90984c5e8@172.16.63.221:26656",
-//         "peer_state": {
-//           "round_state": {
-//             "height": "7185",
-//             "round": "0",
-//             "step": "1",
-//             "start_time": "2018-05-12T13:57:27.438039872-07:00",
-//             "proposal": false,
-//             "proposal_block_parts_header": {
-//               "total": "0",
-//               "hash": ""
-//             },
-//             "proposal_block_parts": null,
-//             "proposal_pol_round": "-1",
-//             "proposal_pol": "_",
-//             "prevotes": "_",
-//             "precommits": "_",
-//             "last_commit_round": "0",
-//             "last_commit": "x",
-//             "catchup_commit_round": "-1",
-//             "catchup_commit": "_"
-//           },
-//           "stats": {
-//             "last_vote_height": "7184",
-//             "votes": "255",
-//             "last_block_part_height": "7184",
-//             "block_parts": "255"
-//           }
-//         }
-//       }
-//     ]
-//   }
-// }
-// ```
+// More: https://tendermint.com/rpc/#/Info/dump_consensus_state
 func DumpConsensusState(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState, error) {
 	// Get Peer consensus states.
 	peers := p2pPeers.Peers().List()
@@ -235,94 +66,16 @@ func DumpConsensusState(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState
 
 // ConsensusState returns a concise summary of the consensus state.
 // UNSTABLE
-//
-// ```shell
-// curl 'localhost:26657/consensus_state'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// state, err := client.ConsensusState()
-// ```
-//
-// The above command returns JSON structured like this:
-//
-// ```json
-//{
-//  "jsonrpc": "2.0",
-//  "id": "",
-//  "result": {
-//    "round_state": {
-//      "height/round/step": "9336/0/1",
-//      "start_time": "2018-05-14T10:25:45.72595357-04:00",
-//      "proposal_block_hash": "",
-//      "locked_block_hash": "",
-//      "valid_block_hash": "",
-//      "height_vote_set": [
-//        {
-//          "round": "0",
-//          "prevotes": [
-//            "nil-Vote"
-//          ],
-//          "prevotes_bit_array": "BA{1:_} 0/10 = 0.00",
-//          "precommits": [
-//            "nil-Vote"
-//          ],
-//          "precommits_bit_array": "BA{1:_} 0/10 = 0.00"
-//        }
-//      ]
-//    }
-//  }
-//}
-//```
+// More: https://tendermint.com/rpc/#/Info/consensus_state
 func ConsensusState(ctx *rpctypes.Context) (*ctypes.ResultConsensusState, error) {
 	// Get self round state.
 	bz, err := consensusState.GetRoundStateSimpleJSON()
 	return &ctypes.ResultConsensusState{RoundState: bz}, err
 }
 
-// Get the consensus parameters  at the given block height.
+// ConsensusParams gets the consensus parameters  at the given block height.
 // If no height is provided, it will fetch the current consensus params.
-//
-// ```shell
-// curl 'localhost:26657/consensus_params'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// state, err := client.ConsensusParams()
-// ```
-//
-// The above command returns JSON structured like this:
-//
-// ```json
-// {
-//   "jsonrpc": "2.0",
-//   "id": "",
-//   "result": {
-//     "block_height": "1",
-//     "consensus_params": {
-//       "block_size_params": {
-//         "max_txs_bytes": "22020096",
-//         "max_gas": "-1"
-//       },
-//       "evidence_params": {
-//         "max_age": "100000"
-//       }
-//     }
-//   }
-// }
-// ```
+// More: https://tendermint.com/rpc/#/Info/consensus_params
 func ConsensusParams(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultConsensusParams, error) {
 	height := consensusState.GetState().LastBlockHeight + 1
 	height, err := getHeight(height, heightPtr)

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -13,141 +13,7 @@ import (
 )
 
 // Subscribe for events via WebSocket.
-//
-// To tell which events you want, you need to provide a query. query is a
-// string, which has a form: "condition AND condition ..." (no OR at the
-// moment). condition has a form: "key operation operand". key is a string with
-// a restricted set of possible symbols ( \t\n\r\\()"'=>< are not allowed).
-// operation can be "=", "<", "<=", ">", ">=", "CONTAINS". operand can be a
-// string (escaped with single quotes), number, date or time.
-//
-// Examples:
-//		tm.event = 'NewBlock'               # new blocks
-//		tm.event = 'CompleteProposal'       # node got a complete proposal
-//		tm.event = 'Tx' AND tx.hash = 'XYZ' # single transaction
-//		tm.event = 'Tx' AND tx.height = 5   # all txs of the fifth block
-//		tx.height = 5                       # all txs of the fifth block
-//
-// Tendermint provides a few predefined keys: tm.event, tx.hash and tx.height.
-// Note for transactions, you can define additional keys by providing events with
-// DeliverTx response.
-//
-//  import (
-//	  abci "github.com/tendermint/tendermint/abci/types"
-// 	  "github.com/tendermint/tendermint/libs/pubsub/query"
-//  )
-//
-//  abci.ResponseDeliverTx{
-// 	Events: []abci.Event{
-// 		{
-// 			Type: "rewards.withdraw",
-// 			Attributes: cmn.KVPairs{
-// 				cmn.KVPair{Key: []byte("address"), Value: []byte("AddrA")},
-// 				cmn.KVPair{Key: []byte("source"), Value: []byte("SrcX")},
-// 				cmn.KVPair{Key: []byte("amount"), Value: []byte("...")},
-// 				cmn.KVPair{Key: []byte("balance"), Value: []byte("...")},
-// 			},
-// 		},
-// 		{
-// 			Type: "rewards.withdraw",
-// 			Attributes: cmn.KVPairs{
-// 				cmn.KVPair{Key: []byte("address"), Value: []byte("AddrB")},
-// 				cmn.KVPair{Key: []byte("source"), Value: []byte("SrcY")},
-// 				cmn.KVPair{Key: []byte("amount"), Value: []byte("...")},
-// 				cmn.KVPair{Key: []byte("balance"), Value: []byte("...")},
-// 			},
-// 		},
-// 		{
-// 			Type: "transfer",
-// 			Attributes: cmn.KVPairs{
-// 				cmn.KVPair{Key: []byte("sender"), Value: []byte("AddrC")},
-// 				cmn.KVPair{Key: []byte("recipient"), Value: []byte("AddrD")},
-// 				cmn.KVPair{Key: []byte("amount"), Value: []byte("...")},
-// 			},
-// 		},
-// 	},
-//  }
-//
-// All events are indexed by a composite key of the form {eventType}.{evenAttrKey}.
-// In the above examples, the following keys would be indexed:
-//     - rewards.withdraw.address
-//     - rewards.withdraw.source
-//     - rewards.withdraw.amount
-//     - rewards.withdraw.balance
-//     - transfer.sender
-//     - transfer.recipient
-//     - transfer.amount
-//
-// Multiple event types with duplicate keys are allowed and are meant to
-// categorize unique and distinct events. In the above example, all events
-// indexed under the key `rewards.withdraw.address` will have the following
-// values stored and queryable:
-//
-//     - AddrA
-//     - AddrB
-//
-// To create a query for txs where address AddrA withdrew rewards:
-//  query.MustParse("tm.event = 'Tx' AND rewards.withdraw.address = 'AddrA'")
-//
-// To create a query for txs where address AddrA withdrew rewards from source Y:
-//  query.MustParse("tm.event = 'Tx' AND rewards.withdraw.address = 'AddrA' AND rewards.withdraw.source = 'Y'")
-//
-// To create a query for txs where AddrA transferred funds:
-//  query.MustParse("tm.event = 'Tx' AND transfer.sender = 'AddrA'")
-//
-// The following queries would return no results:
-//  query.MustParse("tm.event = 'Tx' AND transfer.sender = 'AddrZ'")
-//  query.MustParse("tm.event = 'Tx' AND rewards.withdraw.address = 'AddrZ'")
-//  query.MustParse("tm.event = 'Tx' AND rewards.withdraw.source = 'W'")
-//
-// See list of all possible events here
-// https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants
-//
-// For complete query syntax, check out
-// https://godoc.org/github.com/tendermint/tendermint/libs/pubsub/query.
-//
-// ```go
-// import "github.com/tendermint/tendermint/types"
-//
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Second)
-// defer cancel()
-// query := "tm.event = 'Tx' AND tx.height = 3"
-// txs, err := client.Subscribe(ctx, "test-client", query)
-// if err != nil {
-//   // handle error
-// }
-//
-// go func() {
-//   for e := range txs {
-//     fmt.Println("got ", e.Data.(types.EventDataTx))
-//	 }
-// }()
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
-//
-// ### Query Parameters
-//
-// | Parameter | Type   | Default | Required | Description |
-// |-----------+--------+---------+----------+-------------|
-// | query     | string | ""      | true     | Query       |
-//
-// <aside class="notice">WebSocket only</aside>
+// More: https://tendermint.com/rpc/#/Websocket/subscribe
 func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, error) {
 	addr := ctx.RemoteAddr()
 
@@ -206,39 +72,7 @@ func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, er
 }
 
 // Unsubscribe from events via WebSocket.
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// query := "tm.event = 'Tx' AND tx.height = 3"
-// err = client.Unsubscribe(context.Background(), "test-client", query)
-// if err != nil {
-//   // handle error
-// }
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
-//
-// ### Query Parameters
-//
-// | Parameter | Type   | Default | Required | Description |
-// |-----------+--------+---------+----------+-------------|
-// | query     | string | ""      | true     | Query       |
-//
-// <aside class="notice">WebSocket only</aside>
+// More: https://tendermint.com/rpc/#/Websocket/unsubscribe
 func Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe, error) {
 	addr := ctx.RemoteAddr()
 	logger.Info("Unsubscribe from query", "remote", addr, "query", query)
@@ -253,33 +87,8 @@ func Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe
 	return &ctypes.ResultUnsubscribe{}, nil
 }
 
-// Unsubscribe from all events via WebSocket.
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// err = client.UnsubscribeAll(context.Background(), "test-client")
-// if err != nil {
-//   // handle error
-// }
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
-//
-// <aside class="notice">WebSocket only</aside>
+// UnsubscribeAll from all events via WebSocket.
+// More: https://tendermint.com/rpc/#/Websocket/unsubscribe_all
 func UnsubscribeAll(ctx *rpctypes.Context) (*ctypes.ResultUnsubscribe, error) {
 	addr := ctx.RemoteAddr()
 	logger.Info("Unsubscribe from all", "remote", addr)

--- a/rpc/core/evidence.go
+++ b/rpc/core/evidence.go
@@ -6,32 +6,8 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-// Broadcast evidence of the misbehavior.
-//
-// ```shell
-// curl 'localhost:26657/broadcast_evidence?evidence={amino-encoded DuplicateVoteEvidence}'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// res, err := client.BroadcastEvidence(
-//	  &types.DuplicateVoteEvidence{PubKey: ev.PubKey, VoteA: ev.VoteA, VoteB: ev.VoteB},
-// )
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// ```
-//
-// | Parameter | Type           | Default | Required | Description                 |
-// |-----------+----------------+---------+----------+-----------------------------|
-// | evidence  | types.Evidence | nil     | true     | Amino-encoded JSON evidence |
+// BroadcastEvidence broadcasts evidence of the misbehavior.
+// More: https://tendermint.com/rpc/#/Info/broadcast_evidence
 func BroadcastEvidence(ctx *rpctypes.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
 	err := evidencePool.AddEvidence(ev)
 	if err != nil {

--- a/rpc/core/health.go
+++ b/rpc/core/health.go
@@ -5,33 +5,9 @@ import (
 	rpctypes "github.com/tendermint/tendermint/rpc/lib/types"
 )
 
-// Get node health. Returns empty result (200 OK) on success, no response - in
-// case of an error.
-//
-// ```shell
-// curl 'localhost:26657/health'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// result, err := client.Health()
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
+// Health gets node health. Returns empty result (200 OK) on success, no
+// response - in case of an error.
+// More: https://tendermint.com/rpc/#/Info/health
 func Health(ctx *rpctypes.Context) (*ctypes.ResultHealth, error) {
 	return &ctypes.ResultHealth{}, nil
 }

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -17,62 +17,9 @@ import (
 //-----------------------------------------------------------------------------
 // NOTE: tx should be signed, but this is only checked at the app level (not by Tendermint!)
 
-// Returns right away, with no response. Does not wait for CheckTx nor
-// DeliverTx results.
-//
-// If you want to be sure that the transaction is included in a block, you can
-// subscribe for the result using JSONRPC via a websocket. See
-// https://tendermint.com/docs/app-dev/subscribing-to-events-via-websocket.html
-// If you haven't received anything after a couple of blocks, resend it. If the
-// same happens again, send it to some other node. A few reasons why it could
-// happen:
-//
-// 1. malicious node can drop or pretend it had committed your tx
-// 2. malicious proposer (not necessary the one you're communicating with) can
-// drop transactions, which might become valid in the future
-// (https://github.com/tendermint/tendermint/issues/3322)
-// 3. node can be offline
-//
-// Please refer to
-// https://tendermint.com/docs/tendermint-core/using-tendermint.html#formatting
-// for formatting/encoding rules.
-//
-//
-// ```shell
-// curl 'localhost:26657/broadcast_tx_async?tx="123"'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// result, err := client.BroadcastTxAsync("123")
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {
-// 		"hash": "E39AAB7A537ABAA237831742DCE1117F187C3C52",
-// 		"log": "",
-// 		"data": "",
-// 		"code": "0"
-// 	},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
-//
-// ### Query Parameters
-//
-// | Parameter | Type | Default | Required | Description     |
-// |-----------+------+---------+----------+-----------------|
-// | tx        | Tx   | nil     | true     | The transaction |
+// BroadcastTxAsync returns right away, with no response. Does not wait for
+// CheckTx nor DeliverTx results.
+// More: https://tendermint.com/rpc/#/Tx/broadcast_tx_async
 func BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 	err := mempool.CheckTx(tx, nil, mempl.TxInfo{})
 
@@ -82,59 +29,9 @@ func BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadca
 	return &ctypes.ResultBroadcastTx{Hash: tx.Hash()}, nil
 }
 
-// Returns with the response from CheckTx. Does not wait for DeliverTx result.
-//
-// If you want to be sure that the transaction is included in a block, you can
-// subscribe for the result using JSONRPC via a websocket. See
-// https://tendermint.com/docs/app-dev/subscribing-to-events-via-websocket.html
-// If you haven't received anything after a couple of blocks, resend it. If the
-// same happens again, send it to some other node. A few reasons why it could
-// happen:
-//
-// 1. malicious node can drop or pretend it had committed your tx
-// 2. malicious proposer (not necessary the one you're communicating with) can
-// drop transactions, which might become valid in the future
-// (https://github.com/tendermint/tendermint/issues/3322)
-//
-// Please refer to
-// https://tendermint.com/docs/tendermint-core/using-tendermint.html#formatting
-// for formatting/encoding rules.
-//
-// ```shell
-// curl 'localhost:26657/broadcast_tx_sync?tx="456"'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// result, err := client.BroadcastTxSync("456")
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"jsonrpc": "2.0",
-// 	"id": "",
-// 	"result": {
-// 		"code": "0",
-// 		"data": "",
-// 		"log": "",
-// 		"hash": "0D33F2F03A5234F38706E43004489E061AC40A2E"
-// 	},
-// 	"error": ""
-// }
-// ```
-//
-// ### Query Parameters
-//
-// | Parameter | Type | Default | Required | Description     |
-// |-----------+------+---------+----------+-----------------|
-// | tx        | Tx   | nil     | true     | The transaction |
+// BroadcastTxSync returns with the response from CheckTx. Does not wait for
+// DeliverTx result.
+// More: https://tendermint.com/rpc/#/Tx/broadcast_tx_sync
 func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 	resCh := make(chan *abci.Response, 1)
 	err := mempool.CheckTx(tx, func(res *abci.Response) {
@@ -153,67 +50,8 @@ func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcas
 	}, nil
 }
 
-// Returns with the responses from CheckTx and DeliverTx.
-//
-// IMPORTANT: use only for testing and development. In production, use
-// BroadcastTxSync or BroadcastTxAsync. You can subscribe for the transaction
-// result using JSONRPC via a websocket. See
-// https://tendermint.com/docs/app-dev/subscribing-to-events-via-websocket.html
-//
-// CONTRACT: only returns error if mempool.CheckTx() errs or if we timeout
-// waiting for tx to commit.
-//
-// If CheckTx or DeliverTx fail, no error will be returned, but the returned result
-// will contain a non-OK ABCI code.
-//
-// Please refer to
-// https://tendermint.com/docs/tendermint-core/using-tendermint.html#formatting
-// for formatting/encoding rules.
-//
-//
-// ```shell
-// curl 'localhost:26657/broadcast_tx_commit?tx="789"'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// result, err := client.BroadcastTxCommit("789")
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {
-// 		"height": "26682",
-// 		"hash": "75CA0F856A4DA078FC4911580360E70CEFB2EBEE",
-// 		"deliver_tx": {
-// 			"log": "",
-// 			"data": "",
-// 			"code": "0"
-// 		},
-// 		"check_tx": {
-// 			"log": "",
-// 			"data": "",
-// 			"code": "0"
-// 		}
-// 	},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
-//
-// ### Query Parameters
-//
-// | Parameter | Type | Default | Required | Description     |
-// |-----------+------+---------+----------+-----------------|
-// | tx        | Tx   | nil     | true     | The transaction |
+// BroadcastTxCommit returns with the responses from CheckTx and DeliverTx.
+// More: https://tendermint.com/rpc/#/Tx/broadcast_tx_commit
 func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
 	subscriber := ctx.RemoteAddr()
 
@@ -289,43 +127,9 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadc
 	}
 }
 
-// Get unconfirmed transactions (maximum ?limit entries) including their number.
-//
-// ```shell
-// curl 'localhost:26657/unconfirmed_txs'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// result, err := client.UnconfirmedTxs()
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-//   "result" : {
-//       "txs" : [],
-//       "total_bytes" : "0",
-//       "n_txs" : "0",
-//       "total" : "0"
-//     },
-//     "jsonrpc" : "2.0",
-//     "id" : ""
-//   }
-// ```
-//
-// ### Query Parameters
-//
-// | Parameter | Type | Default | Required | Description                          |
-// |-----------+------+---------+----------+--------------------------------------|
-// | limit     | int  | 30      | false    | Maximum number of entries (max: 100) |
-// ```
+// UnconfirmedTxs gets unconfirmed transactions (maximum ?limit entries)
+// including their number.
+// More: https://tendermint.com/rpc/#/Info/unconfirmed_txs
 func UnconfirmedTxs(ctx *rpctypes.Context, limit int) (*ctypes.ResultUnconfirmedTxs, error) {
 	// reuse per_page validator
 	limit = validatePerPage(limit)
@@ -338,36 +142,8 @@ func UnconfirmedTxs(ctx *rpctypes.Context, limit int) (*ctypes.ResultUnconfirmed
 		Txs:        txs}, nil
 }
 
-// Get number of unconfirmed transactions.
-//
-// ```shell
-// curl 'localhost:26657/num_unconfirmed_txs'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-// // handle error
-// }
-// defer client.Stop()
-// result, err := client.UnconfirmedTxs()
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-//   "jsonrpc" : "2.0",
-//   "id" : "",
-//   "result" : {
-//     "n_txs" : "0",
-//     "total_bytes" : "0",
-//     "total" : "0"
-//     "txs" : null,
-//   }
-// }
-// ```
+// NumUnconfirmedTxs gets number of unconfirmed transactions.
+// More: https://tendermint.com/rpc/#/Info/num_unconfirmed_txs
 func NumUnconfirmedTxs(ctx *rpctypes.Context) (*ctypes.ResultUnconfirmedTxs, error) {
 	return &ctypes.ResultUnconfirmedTxs{
 		Count:      mempool.Size(),

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -10,150 +10,8 @@ import (
 	rpctypes "github.com/tendermint/tendermint/rpc/lib/types"
 )
 
-// Get network info.
-//
-// ```shell
-// curl 'localhost:26657/net_info'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// info, err := client.NetInfo()
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-//   "jsonrpc": "2.0",
-//   "id": "",
-//   "result": {
-//   	"listening": true,
-//   	"listeners": [
-//   		"Listener(@)"
-//   	],
-//   	"n_peers": "3",
-//   	"peers": [
-//   		{
-//   			"node_info": {
-//   				"protocol_version": {
-//   					"p2p": "7",
-//   					"block": "8",
-//   					"app": "1"
-//   				},
-//   				"id": "93529da3435c090d02251a050342b6a488d4ab56",
-//   				"listen_addr": "tcp://0.0.0.0:26656",
-//   				"network": "chain-RFo6qC",
-//   				"version": "0.30.0",
-//   				"channels": "4020212223303800",
-//   				"moniker": "fc89e4ed23f2",
-//   				"other": {
-//   					"tx_index": "on",
-//   					"rpc_address": "tcp://0.0.0.0:26657"
-//   				}
-//   			},
-//   			"is_outbound": true,
-//   			"connection_status": {
-//   				"Duration": "3475230558",
-//   				"SendMonitor": {
-//   					"Active": true,
-//   					"Start": "2019-02-14T12:40:47.52Z",
-//   					"Duration": "3480000000",
-//   					"Idle": "240000000",
-//   					"Bytes": "4512",
-//   					"Samples": "9",
-//   					"InstRate": "1338",
-//   					"CurRate": "2046",
-//   					"AvgRate": "1297",
-//   					"PeakRate": "6570",
-//   					"BytesRem": "0",
-//   					"TimeRem": "0",
-//   					"Progress": 0
-//   				},
-//   				"RecvMonitor": {
-//   					"Active": true,
-//   					"Start": "2019-02-14T12:40:47.52Z",
-//   					"Duration": "3480000000",
-//   					"Idle": "280000000",
-//   					"Bytes": "4489",
-//   					"Samples": "10",
-//   					"InstRate": "1821",
-//   					"CurRate": "1663",
-//   					"AvgRate": "1290",
-//   					"PeakRate": "5512",
-//   					"BytesRem": "0",
-//   					"TimeRem": "0",
-//   					"Progress": 0
-//   				},
-//   				"Channels": [
-//   					{
-//   						"ID": 48,
-//   						"SendQueueCapacity": "1",
-//   						"SendQueueSize": "0",
-//   						"Priority": "5",
-//   						"RecentlySent": "0"
-//   					},
-//   					{
-//   						"ID": 64,
-//   						"SendQueueCapacity": "1000",
-//   						"SendQueueSize": "0",
-//   						"Priority": "10",
-//   						"RecentlySent": "14"
-//   					},
-//   					{
-//   						"ID": 32,
-//   						"SendQueueCapacity": "100",
-//   						"SendQueueSize": "0",
-//   						"Priority": "5",
-//   						"RecentlySent": "619"
-//   					},
-//   					{
-//   						"ID": 33,
-//   						"SendQueueCapacity": "100",
-//   						"SendQueueSize": "0",
-//   						"Priority": "10",
-//   						"RecentlySent": "1363"
-//   					},
-//   					{
-//   						"ID": 34,
-//   						"SendQueueCapacity": "100",
-//   						"SendQueueSize": "0",
-//   						"Priority": "5",
-//   						"RecentlySent": "2145"
-//   					},
-//   					{
-//   						"ID": 35,
-//   						"SendQueueCapacity": "2",
-//   						"SendQueueSize": "0",
-//   						"Priority": "1",
-//   						"RecentlySent": "0"
-//   					},
-//   					{
-//   						"ID": 56,
-//   						"SendQueueCapacity": "1",
-//   						"SendQueueSize": "0",
-//   						"Priority": "5",
-//   						"RecentlySent": "0"
-//   					},
-//   					{
-//   						"ID": 0,
-//   						"SendQueueCapacity": "10",
-//   						"SendQueueSize": "0",
-//   						"Priority": "1",
-//   						"RecentlySent": "10"
-//   					}
-//   				]
-//   			},
-//   			"remote_ip": "192.167.10.3"
-//   		},
-//      ...
-//   }
-// ```
+// NetInfo returns network info.
+// More: https://tendermint.com/rpc/#/Info/net_info
 func NetInfo(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error) {
 	out, in, _ := p2pPeers.NumPeers()
 	peers := make([]ctypes.Peer, 0, out+in)
@@ -180,6 +38,7 @@ func NetInfo(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error) {
 	}, nil
 }
 
+// UnsafeDialSeeds dials the given seeds (comma-separated id@IP:PORT).
 func UnsafeDialSeeds(ctx *rpctypes.Context, seeds []string) (*ctypes.ResultDialSeeds, error) {
 	if len(seeds) == 0 {
 		return &ctypes.ResultDialSeeds{}, errors.New("No seeds provided")
@@ -191,6 +50,8 @@ func UnsafeDialSeeds(ctx *rpctypes.Context, seeds []string) (*ctypes.ResultDialS
 	return &ctypes.ResultDialSeeds{Log: "Dialing seeds in progress. See /net_info for details"}, nil
 }
 
+// UnsafeDialPeers dials the given peers (comma-separated id@IP:PORT),
+// optionally making them persistent.
 func UnsafeDialPeers(ctx *rpctypes.Context, peers []string, persistent bool) (*ctypes.ResultDialPeers, error) {
 	if len(peers) == 0 {
 		return &ctypes.ResultDialPeers{}, errors.New("No peers provided")
@@ -207,48 +68,8 @@ func UnsafeDialPeers(ctx *rpctypes.Context, peers []string, persistent bool) (*c
 	return &ctypes.ResultDialPeers{Log: "Dialing peers in progress. See /net_info for details"}, nil
 }
 
-// Get genesis file.
-//
-// ```shell
-// curl 'localhost:26657/genesis'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// genesis, err := client.Genesis()
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {
-// 		"genesis": {
-// 			"app_hash": "",
-// 			"validators": [
-// 				{
-// 					"name": "",
-// 					"power": "10",
-// 					"pub_key": {
-// 						"data": "68DFDA7E50F82946E7E8546BED37944A422CD1B831E70DF66BA3B8430593944D",
-// 						"type": "ed25519"
-// 					}
-// 				}
-// 			],
-// 			"chain_id": "test-chain-6UTNIN",
-// 			"genesis_time": "2017-05-29T15:05:41.671Z"
-// 		}
-// 	},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
+// Genesis returns genesis file.
+// More: https://tendermint.com/rpc/#/Info/genesis
 func Genesis(ctx *rpctypes.Context) (*ctypes.ResultGenesis, error) {
 	return &ctypes.ResultGenesis{Genesis: genDoc}, nil
 }

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -12,65 +12,9 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-// Get Tendermint status including node info, pubkey, latest block
+// Status returns Tendermint status including node info, pubkey, latest block
 // hash, app hash, block height and time.
-//
-// ```shell
-// curl 'localhost:26657/status'
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// result, err := client.Status()
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// "jsonrpc": "2.0",
-// "id": "",
-// "result": {
-//   "node_info": {
-//   		"protocol_version": {
-//   			"p2p": "4",
-//   			"block": "7",
-//   			"app": "0"
-//   		},
-//   		"id": "53729852020041b956e86685e24394e0bee4373f",
-//   		"listen_addr": "10.0.2.15:26656",
-//   		"network": "test-chain-Y1OHx6",
-//   		"version": "0.24.0-2ce1abc2",
-//   		"channels": "4020212223303800",
-//   		"moniker": "ubuntu-xenial",
-//   		"other": {
-//   			"tx_index": "on",
-//   			"rpc_addr": "tcp://0.0.0.0:26657"
-//   		}
-//   	},
-//   	"sync_info": {
-//   		"latest_block_hash": "F51538DA498299F4C57AC8162AAFA0254CE08286",
-//   		"latest_app_hash": "0000000000000000",
-//   		"latest_block_height": "18",
-//   		"latest_block_time": "2018-09-17T11:42:19.149920551Z",
-//   		"catching_up": false
-//   	},
-//   	"validator_info": {
-//   		"address": "D9F56456D7C5793815D0E9AF07C3A355D0FC64FD",
-//   		"pub_key": {
-//   			"type": "tendermint/PubKeyEd25519",
-//   			"value": "wVxKNtEsJmR4vvh651LrVoRguPs+6yJJ9Bz174gw9DM="
-//   		},
-//   		"voting_power": "10"
-//   	}
-//   }
-// }
-// ```
+// More: https://tendermint.com/rpc/#/Info/status
 func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 	var latestHeight int64
 	if consensusReactor.FastSync() {

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -15,69 +15,7 @@ import (
 // Tx allows you to query the transaction results. `nil` could mean the
 // transaction is in the mempool, invalidated, or was not sent in the first
 // place.
-//
-// ```shell
-// curl "localhost:26657/tx?hash=0xF87370F68C82D9AC7201248ECA48CEC5F16FFEC99C461C1B2961341A2FE9C1C8"
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// hashBytes, err := hex.DecodeString("F87370F68C82D9AC7201248ECA48CEC5F16FFEC99C461C1B2961341A2FE9C1C8")
-// tx, err := client.Tx(hashBytes, true)
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-// 	"error": "",
-// 	"result": {
-// 		"proof": {
-// 			"Proof": {
-// 				"aunts": []
-// 			},
-// 			"Data": "YWJjZA==",
-// 			"RootHash": "2B8EC32BA2579B3B8606E42C06DE2F7AFA2556EF",
-// 			"Total": "1",
-// 			"Index": "0"
-// 		},
-// 		"tx": "YWJjZA==",
-// 		"tx_result": {
-// 			"log": "",
-// 			"data": "",
-// 			"code": "0"
-// 		},
-// 		"index": "0",
-// 		"height": "52",
-//		"hash": "2B8EC32BA2579B3B8606E42C06DE2F7AFA2556EF"
-// 	},
-// 	"id": "",
-// 	"jsonrpc": "2.0"
-// }
-// ```
-//
-// Returns a transaction matching the given transaction hash.
-//
-// ### Query Parameters
-//
-// | Parameter | Type   | Default | Required | Description                                               |
-// |-----------+--------+---------+----------+-----------------------------------------------------------|
-// | hash      | []byte | nil     | true     | The transaction hash                                      |
-// | prove     | bool   | false   | false    | Include a proof of the transaction inclusion in the block |
-//
-// ### Returns
-//
-// - `proof`: the `types.TxProof` object
-// - `tx`: `[]byte` - the transaction
-// - `tx_result`: the `abci.Result` object
-// - `index`: `int` - index of the transaction
-// - `height`: `int` - height of the block where this transaction was in
-// - `hash`: `[]byte` - hash of the transaction
+// More: https://tendermint.com/rpc/#/Info/tx
 func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error) {
 
 	// if index is disabled, return error
@@ -115,75 +53,7 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 
 // TxSearch allows you to query for multiple transactions results. It returns a
 // list of transactions (maximum ?per_page entries) and the total count.
-//
-// ```shell
-// curl "localhost:26657/tx_search?query=\"account.owner='Ivan'\"&prove=true"
-// ```
-//
-// ```go
-// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
-// err := client.Start()
-// if err != nil {
-//   // handle error
-// }
-// defer client.Stop()
-// q, err := tmquery.New("account.owner='Ivan'")
-// tx, err := client.TxSearch(q, true)
-// ```
-//
-// > The above command returns JSON structured like this:
-//
-// ```json
-// {
-//   "jsonrpc": "2.0",
-//   "id": "",
-//   "result": {
-// 	   "txs": [
-//       {
-//         "proof": {
-//           "Proof": {
-//             "aunts": [
-//               "J3LHbizt806uKnABNLwG4l7gXCA=",
-//               "iblMO/M1TnNtlAefJyNCeVhjAb0=",
-//               "iVk3ryurVaEEhdeS0ohAJZ3wtB8=",
-//               "5hqMkTeGqpct51ohX0lZLIdsn7Q=",
-//               "afhsNxFnLlZgFDoyPpdQSe0bR8g="
-//             ]
-//           },
-//           "Data": "mvZHHa7HhZ4aRT0xMDA=",
-//           "RootHash": "F6541223AA46E428CB1070E9840D2C3DF3B6D776",
-//           "Total": "32",
-//           "Index": "31"
-//         },
-//         "tx": "mvZHHa7HhZ4aRT0xMDA=",
-//         "tx_result": {},
-//         "index": "31",
-//         "height": "12",
-//         "hash": "2B8EC32BA2579B3B8606E42C06DE2F7AFA2556EF"
-//       }
-//     ],
-//     "total_count": "1"
-//   }
-// }
-// ```
-//
-// ### Query Parameters
-//
-// | Parameter | Type   | Default | Required | Description                                               |
-// |-----------+--------+---------+----------+-----------------------------------------------------------|
-// | query     | string | ""      | true     | Query                                                     |
-// | prove     | bool   | false   | false    | Include proofs of the transactions inclusion in the block |
-// | page      | int    | 1       | false    | Page number (1-based)                                     |
-// | per_page  | int    | 30      | false    | Number of entries per page (max: 100)                     |
-//
-// ### Returns
-//
-// - `proof`: the `types.TxProof` object
-// - `tx`: `[]byte` - the transaction
-// - `tx_result`: the `abci.Result` object
-// - `index`: `int` - index of the transaction
-// - `height`: `int` - height of the block where this transaction was in
-// - `hash`: `[]byte` - hash of the transaction
+// More: https://tendermint.com/rpc/#/Info/tx_search
 func TxSearch(ctx *rpctypes.Context, query string, prove bool, page, perPage int) (*ctypes.ResultTxSearch, error) {
 	// if index is disabled, return error
 	if _, ok := txIndexer.(*null.TxIndex); ok {


### PR DESCRIPTION
No need to duplicate information in this case. It a) requires extra
efforts to keep both in sync b) nobody reads godoc documentation
anyways.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] ~~Referenced an issue explaining the need for the change~~
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] ~~Wrote tests~~
* [ ] ~~Updated CHANGELOG_PENDING.md~~
