### PR TITLE
Fixing broken links: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,7 +451,7 @@ Special thanks to external contributors on this release:
 - [libs/db] [\#3611](https://github.com/tendermint/tendermint/issues/3611) Conditional compilation
   * Use `cleveldb` tag instead of `gcc` to compile Tendermint with CLevelDB or
     use `make build_c` / `make install_c` (full instructions can be found at
-    https://tendermint.com/docs/introduction/install.html#compile-with-cleveldb-support)
+    https://docs.tendermint.com/master/introduction/install.html#compile-with-cleveldb-support)
   * Use `boltdb` tag to compile Tendermint with bolt db
 - [node] [\#3362](https://github.com/tendermint/tendermint/issues/3362) Return an error if `persistent_peers` list is invalid (except
   when IP lookup fails)

--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -20,9 +20,9 @@ Respective versioned files can be found https://raw.githubusercontent.com/tender
 
 Tendermint Core is Byzantine Fault Tolerant (BFT) middleware that takes a state transition machine, written in any programming language, and securely replicates it on many machines.
 
-For more background, see the [the docs](https://tendermint.com/docs/introduction/#quick-start).
+For more background, see the [the docs](https://docs.tendermint.com/master/introduction/#quick-start).
 
-To get started developing applications, see the [application developers guide](https://tendermint.com/docs/introduction/quick-start.html).
+To get started developing applications, see the [application developers guide](https://docs.tendermint.com/master/introduction/quick-start.html).
 
 ## How to use this image
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For examples of the kinds of bugs we're looking for, see [SECURITY.md](SECURITY.
 
 ## Documentation
 
-Complete documentation can be found on the [website](https://tendermint.com/docs/).
+Complete documentation can be found on the [website](https://docs.tendermint.com/master/).
 
 ### Install
 
@@ -132,7 +132,7 @@ For details about the blockchain data structures and the p2p protocols, see the
 [Tendermint specification](/docs/spec).
 
 For details on using the software, see the [documentation](/docs/) which is also
-hosted at: https://tendermint.com/docs/
+hosted at: https://docs.tendermint.com/master/
 
 ### Tools
 

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -2,7 +2,7 @@
 
 The documentation for Tendermint Core is hosted at:
 
-- https://tendermint.com/docs/ and
+- https://docs.tendermint.com/master/ and
 - https://tendermint-staging.interblock.io/docs/
 
 built from the files in this (`/docs`) directory for

--- a/docs/guides/go-built-in.md
+++ b/docs/guides/go-built-in.md
@@ -200,7 +200,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://tendermint.com/docs/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -319,7 +319,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 ```
 
 The complete specification can be found
-[here](https://tendermint.com/docs/spec/abci/).
+[here](https://docs.tendermint.com/master/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instance in the same process
 
@@ -647,4 +647,4 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://tendermint.com/docs/).
+deeper, read [the docs](https://docs.tendermint.com/master/).

--- a/docs/guides/go.md
+++ b/docs/guides/go.md
@@ -203,7 +203,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://tendermint.com/docs/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -322,7 +322,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 ```
 
 The complete specification can be found
-[here](https://tendermint.com/docs/spec/abci/).
+[here](https://docs.tendermint.com/master/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -448,7 +448,7 @@ I[2019-07-16|18:20:36.482] Generated genesis file                       module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://tendermint.com/docs/tendermint-core/configuration.html).
+[here](https://docs.tendermint.com/master/tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -531,4 +531,4 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://tendermint.com/docs/).
+deeper, read [the docs](https://docs.tendermint.com/master/).

--- a/docs/guides/java.md
+++ b/docs/guides/java.md
@@ -311,7 +311,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://tendermint.com/docs/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [JetBrains Xodus](https://github.com/JetBrains/xodus), which is a transactional schema-less embedded high-performance database written in Java.
@@ -455,7 +455,7 @@ public void query(RequestQuery req, StreamObserver<ResponseQuery> responseObserv
 ```
 
 The complete specification can be found
-[here](https://tendermint.com/docs/spec/abci/).
+[here](https://docs.tendermint.com/master/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -547,7 +547,7 @@ I[2019-07-16|18:20:36.482] Generated genesis file                       module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://tendermint.com/docs/tendermint-core/configuration.html).
+[here](https://docs.tendermint.com/master/tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -613,6 +613,6 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://tendermint.com/docs/).
+deeper, read [the docs](https://docs.tendermint.com/master/).
 
 The full source code of this example project can be found [here](https://github.com/climber73/tendermint-abci-grpc-java).

--- a/docs/guides/kotlin.md
+++ b/docs/guides/kotlin.md
@@ -301,7 +301,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://tendermint.com/docs/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [JetBrains Xodus](https://github.com/JetBrains/xodus), which is a transactional schema-less embedded high-performance database written in Java.
@@ -433,7 +433,7 @@ override fun query(req: RequestQuery, responseObserver: StreamObserver<ResponseQ
 ```
 
 The complete specification can be found
-[here](https://tendermint.com/docs/spec/abci/).
+[here](https://docs.tendermint.com/master/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -520,7 +520,7 @@ I[2019-07-16|18:20:36.482] Generated genesis file                       module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://tendermint.com/docs/tendermint-core/configuration.html).
+[here](https://docs.tendermint.com/master/tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -586,6 +586,6 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://tendermint.com/docs/).
+deeper, read [the docs](https://docs.tendermint.com/master/).
 
 The full source code of this example project can be found [here](https://github.com/climber73/tendermint-abci-grpc-kotlin).

--- a/networks/remote/README.md
+++ b/networks/remote/README.md
@@ -1,3 +1,3 @@
 # Remote Cluster with Terraform and Ansible
 
-See the [docs](https://tendermint.com/docs/networks/terraform-and-ansible.html).
+See the [docs](https://docs.tendermint.com/master/networks/terraform-and-ansible.html).

--- a/rpc/swagger/swagger.yaml
+++ b/rpc/swagger/swagger.yaml
@@ -33,7 +33,7 @@ paths:
       description: |
         If you want to be sure that the transaction is included in a block, you can
         subscribe for the result using JSONRPC via a websocket. See
-        https://tendermint.com/docs/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/master/app-dev/subscribing-to-events-via-websocket.html
         If you haven't received anything after a couple of blocks, resend it. If the
         same happens again, send it to some other node. A few reasons why it could
         happen:
@@ -45,7 +45,7 @@ paths:
 
 
         Please refer to
-        https://tendermint.com/docs/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -74,7 +74,7 @@ paths:
       description: |
         If you want to be sure that the transaction is included in a block, you can
         subscribe for the result using JSONRPC via a websocket. See
-        https://tendermint.com/docs/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/master/app-dev/subscribing-to-events-via-websocket.html
         If you haven't received anything after a couple of blocks, resend it. If the
         same happens again, send it to some other node. A few reasons why it could
         happen:
@@ -86,7 +86,7 @@ paths:
         3. node can be offline
 
         Please refer to
-        https://tendermint.com/docs/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -116,7 +116,7 @@ paths:
         IMPORTANT: use only for testing and development. In production, use
         BroadcastTxSync or BroadcastTxAsync. You can subscribe for the transaction
         result using JSONRPC via a websocket. See
-        https://tendermint.com/docs/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/master/app-dev/subscribing-to-events-via-websocket.html
 
         CONTRACT: only returns error if mempool.CheckTx() errs or if we timeout
         waiting for tx to commit.
@@ -125,7 +125,7 @@ paths:
         will contain a non-OK ABCI code.
 
         Please refer to
-        https://tendermint.com/docs/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,4 +2,4 @@
 
 Tools for working with Tendermint and associated technologies. Documentation for
 these tools can be found online in the [Tendermint tools
-documentation](https://tendermint.com/docs/tools/).
+documentation](https://docs.tendermint.com/master/tools/).


### PR DESCRIPTION
_Issue_:
The Tendermint documentation domain was updated from 
"https://tendermint.com/docs"  to "https://docs.tendermint.com/master"

Which most of the old links will give the following error message:

> 404
> There's nothing here.
> Take me home.

For example: "https://tendermint.com/docs/introduction" 
_____________________________________________________________________________
_Solution_:
- Updated 34 links in this repository. 

