### PR TITLE
docs: Fix broken rpc link

### DIFF
--- a/docs/tendermint-core/rpc.md
+++ b/docs/tendermint-core/rpc.md
@@ -6,6 +6,6 @@ order: 4
 
 The RPC documentation is hosted here:
 
-- [https://tendermint.com/rpc/](https://tendermint.com/rpc/)
+- [https://docs.tendermint.com/master/rpc/](https://docs.tendermint.com/master/rpc/)
 
 To update the documentation, edit the relevant `godoc` comments in the [rpc/core directory](https://github.com/tendermint/tendermint/tree/master/rpc/core).


### PR DESCRIPTION
- chane rpc link to master branch rpc docs, current link leads to 404
- closes #4199

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
