### PR TITLE
Update docs and scripts to golang/1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Or [Blockchain](<https://en.wikipedia.org/wiki/Blockchain_(database)>), for shor
 
 [![version](https://img.shields.io/github/tag/tendermint/tendermint.svg)](https://github.com/tendermint/tendermint/releases/latest)
 [![API Reference](https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667)](https://godoc.org/github.com/tendermint/tendermint)
-[![Go version](https://img.shields.io/badge/go-1.12.0-blue.svg)](https://github.com/moovweb/gvm)
+[![Go version](https://img.shields.io/badge/go-1.13-blue.svg)](https://github.com/moovweb/gvm)
 [![riot.im](https://img.shields.io/badge/riot.im-JOIN%20CHAT-green.svg)](https://riot.im/app/#/room/#tendermint:matrix.org)
 [![license](https://img.shields.io/github/license/tendermint/tendermint.svg)](https://github.com/tendermint/tendermint/blob/master/LICENSE)
 [![](https://tokei.rs/b1/github/tendermint/tendermint?category=lines)](https://github.com/tendermint/tendermint)
@@ -49,7 +49,7 @@ For examples of the kinds of bugs we're looking for, see [SECURITY.md](SECURITY.
 
 | Requirement | Notes              |
 | ----------- | ------------------ |
-| Go version  | Go1.11.4 or higher |
+| Go version  | Go1.13 or higher   |
 
 ## Documentation
 

--- a/docs/guides/go-built-in.md
+++ b/docs/guides/go-built-in.md
@@ -40,7 +40,7 @@ Verify that you have the latest version of Go installed:
 
 ```sh
 $ go version
-go version go1.12.7 darwin/amd64
+go version go1.13 darwin/amd64
 ```
 
 Make sure you have `$GOPATH` environment variable set:

--- a/docs/guides/go.md
+++ b/docs/guides/go.md
@@ -43,7 +43,7 @@ Verify that you have the latest version of Go installed:
 
 ```sh
 $ go version
-go version go1.12.7 darwin/amd64
+go version go1.13 darwin/amd64
 ```
 
 Make sure you have `$GOPATH` environment variable set:

--- a/networks/remote/integration.sh
+++ b/networks/remote/integration.sh
@@ -10,8 +10,8 @@ sudo apt-get upgrade -y
 sudo apt-get install -y jq unzip python-pip software-properties-common make
 
 # get and unpack golang
-curl -O https://storage.googleapis.com/golang/go1.12.linux-amd64.tar.gz
-tar -xvf go1.12.linux-amd64.tar.gz
+curl -O https://storage.googleapis.com/golang/go1.13.linux-amd64.tar.gz
+tar -xvf go1.13.linux-amd64.tar.gz
 
 ## move binary and add to path
 mv go /usr/local

--- a/scripts/install/install_tendermint_arm.sh
+++ b/scripts/install/install_tendermint_arm.sh
@@ -5,7 +5,7 @@ REPO=github.com/tendermint/tendermint
 # change this to a specific release or branch
 BRANCH=master
 
-GO_VERSION=1.12
+GO_VERSION=1.13
 
 sudo apt-get update -y
 

--- a/scripts/install/install_tendermint_bsd.sh
+++ b/scripts/install/install_tendermint_bsd.sh
@@ -16,7 +16,7 @@
 set BRANCH=master
 set REPO=github.com/tendermint/tendermint
 
-set GO_VERSION=1.12
+set GO_VERSION=1.13
 
 sudo pkg update
 

--- a/scripts/install/install_tendermint_ubuntu.sh
+++ b/scripts/install/install_tendermint_ubuntu.sh
@@ -13,7 +13,7 @@ REPO=github.com/tendermint/tendermint
 # change this to a specific release or branch
 BRANCH=master
 
-GO_VERSION=1.12
+GO_VERSION=1.13
 
 sudo apt-get update -y
 sudo apt-get install -y make

--- a/tools/build/Makefile
+++ b/tools/build/Makefile
@@ -4,7 +4,7 @@
 
 requirements_check = true
 gpg_check = false
-go_min_version = 1.12.0
+go_min_version = 1.13
 gpg_key = 2122CBE9
 
 ifeq ($(requirements_check),true)


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

`github.com/ChainSafe/go-schnorrkel v0.0.0-20191204112926-74e22bf42a85` is required from https://github.com/tendermint/tendermint/pull/4190, but it dependencies `go 1.13`, so we need to update minimum requirements of go version to 1.13

```
# github.com/ChainSafe/go-schnorrkel
../../go/pkg/mod/github.com/!chain!safe/go-schnorrkel@v0.0.0-20191204112926-74e22bf42a85/helpers.go:14:18: syntax error: unexpected b00000111 at end of statement
note: module requires Go 1.13
make: *** [build] Error 2
```

- update README.md (Minimum requirements of Go version and svg badge)
- update relevant docs and install, make scripts

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
