### PR TITLE
docs: remove "0 means latest" from swagger docs

### DIFF
--- a/rpc/swagger/swagger.yaml
+++ b/rpc/swagger/swagger.yaml
@@ -94,7 +94,7 @@ paths:
         - in: query
           name: tx
           required: true
-          schema: 
+          schema:
             type: string
             example: "123"
           description: The transaction
@@ -532,7 +532,7 @@ paths:
             type: number
             default: 0
             example: 1
-          description: height to return. If no height is provided, it will fetch the latest block. 0 means latest
+          description: height to return. If no height is provided, it will fetch the latest block.
       tags:
         - Info
       description: |
@@ -557,7 +557,7 @@ paths:
       parameters:
         - in: query
           name: height
-          description: height to return. If no height is provided, it will fetch informations regarding the latest block. 0 means latest
+          description: height to return. If no height is provided, it will fetch informations regarding the latest block.
           schema:
             type: number
             default: 0
@@ -586,8 +586,8 @@ paths:
       parameters:
         - in: query
           name: height
-          description: height to return. If no height is provided, it will fetch commit informations regarding the latest block. 0 means latest
-          schema:  
+          description: height to return. If no height is provided, it will fetch commit informations regarding the latest block.
+          schema:
             type: number
             default: 0
             example: 1
@@ -615,7 +615,7 @@ paths:
       parameters:
         - in: query
           name: height
-          description: height to return. If no height is provided, it will fetch validato set at the latest block. 0 means latest
+          description: height to return. If no height is provided, it will fetch validator set which corresponds to the latest block.
           schema:
             type: number
             default: 0
@@ -723,7 +723,7 @@ paths:
       parameters:
         - in: query
           name: height
-          description: height to return. If no height is provided, it will fetch commit informations regarding the latest block. 0 means latest
+          description: height to return. If no height is provided, it will fetch commit informations regarding the latest block.
           schema:
             type: number
             default: 0


### PR DESCRIPTION
Fixes #4014

The reason being when you call any endpoint supporting optional height
and use `height=0`, it will return an error. For example:

```
$ curl localhost:2667/consensus_params?height=0
{
  "jsonrpc": "2.0",
  "id": -1,
  "error": {
    "code": -32603,
    "message": "Internal error",
    "data": "height must be greater than 0"
  }
}
```

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [ ] ~~Updated all code comments where relevant~~
* [ ] ~~Wrote tests~~
* [ ] ~~Updated CHANGELOG_PENDING.md~~
