### PR TITLE
rpc: Added highest block in status RPC method

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -112,6 +112,7 @@ program](https://hackerone.com/tendermint).
 - [cli] \#4234 Add `--db_backend and --db_dir` flags (@princesinha19)
 - [cli] \#4113 Add optional `--genesis_hash` flag to check genesis hash upon startup
 - [config] \#3831 Add support for [RocksDB](https://rocksdb.org/) (@Stumble)
+- [rpc] [\#3983](https://github.com/tendermint/tendermint/pull/4251) Added `highest_block_height` in `status` RPC method (@princesinha19)
 
 ### IMPROVEMENTS:
 

--- a/lite/client/provider.go
+++ b/lite/client/provider.go
@@ -79,15 +79,15 @@ func (p *provider) fetchLatestCommit(minHeight int64, maxHeight int64) (*ctypes.
 	if err != nil {
 		return nil, err
 	}
-	if status.SyncInfo.LatestBlockHeight < minHeight {
+	if status.SyncInfo.CurrentBlockHeight < minHeight {
 		err = fmt.Errorf("provider is at %v but require minHeight=%v",
-			status.SyncInfo.LatestBlockHeight, minHeight)
+			status.SyncInfo.CurrentBlockHeight, minHeight)
 		return nil, err
 	}
 	if maxHeight == 0 {
-		maxHeight = status.SyncInfo.LatestBlockHeight
-	} else if status.SyncInfo.LatestBlockHeight < maxHeight {
-		maxHeight = status.SyncInfo.LatestBlockHeight
+		maxHeight = status.SyncInfo.CurrentBlockHeight
+	} else if status.SyncInfo.CurrentBlockHeight < maxHeight {
+		maxHeight = status.SyncInfo.CurrentBlockHeight
 	}
 	return p.client.Commit(&maxHeight)
 }

--- a/lite/proxy/wrapper.go
+++ b/lite/proxy/wrapper.go
@@ -130,7 +130,7 @@ func (w Wrapper) Commit(height *int64) (*ctypes.ResultCommit, error) {
 		// have here, but we may have to address this at some
 		// point.
 		height = new(int64)
-		*height = resStatus.SyncInfo.LatestBlockHeight
+		*height = resStatus.SyncInfo.CurrentBlockHeight
 	}
 	rpcclient.WaitForHeight(w.Client, *height, nil)
 	res, err := w.Client.Commit(height)

--- a/rpc/client/helpers.go
+++ b/rpc/client/helpers.go
@@ -41,7 +41,7 @@ func WaitForHeight(c StatusClient, h int64, waiter Waiter) error {
 		if err != nil {
 			return err
 		}
-		delta = h - s.SyncInfo.LatestBlockHeight
+		delta = h - s.SyncInfo.CurrentBlockHeight
 		// wait for the time, or abort early
 		if err := waiter(delta); err != nil {
 			return err

--- a/rpc/client/helpers_test.go
+++ b/rpc/client/helpers_test.go
@@ -32,7 +32,7 @@ func TestWaitForHeight(t *testing.T) {
 
 	// now set current block height to 10
 	m.Call = mock.Call{
-		Response: &ctypes.ResultStatus{SyncInfo: ctypes.SyncInfo{LatestBlockHeight: 10}},
+		Response: &ctypes.ResultStatus{SyncInfo: ctypes.SyncInfo{CurrentBlockHeight: 10}},
 	}
 
 	// we will not wait for more than 10 blocks
@@ -52,7 +52,7 @@ func TestWaitForHeight(t *testing.T) {
 	// we use the callback to update the status height
 	myWaiter := func(delta int64) error {
 		// update the height for the next call
-		m.Call.Response = &ctypes.ResultStatus{SyncInfo: ctypes.SyncInfo{LatestBlockHeight: 15}}
+		m.Call.Response = &ctypes.ResultStatus{SyncInfo: ctypes.SyncInfo{CurrentBlockHeight: 15}}
 		return client.DefaultWaitStrategy(delta)
 	}
 
@@ -66,11 +66,11 @@ func TestWaitForHeight(t *testing.T) {
 	require.Nil(pre.Error)
 	prer, ok := pre.Response.(*ctypes.ResultStatus)
 	require.True(ok)
-	assert.Equal(int64(10), prer.SyncInfo.LatestBlockHeight)
+	assert.Equal(int64(10), prer.SyncInfo.CurrentBlockHeight)
 
 	post := r.Calls[4]
 	require.Nil(post.Error)
 	postr, ok := post.Response.(*ctypes.ResultStatus)
 	require.True(ok)
-	assert.Equal(int64(15), postr.SyncInfo.LatestBlockHeight)
+	assert.Equal(int64(15), postr.SyncInfo.CurrentBlockHeight)
 }

--- a/rpc/client/mock/status_test.go
+++ b/rpc/client/mock/status_test.go
@@ -18,9 +18,9 @@ func TestStatus(t *testing.T) {
 		Call: mock.Call{
 			Response: &ctypes.ResultStatus{
 				SyncInfo: ctypes.SyncInfo{
-					LatestBlockHash:   bytes.HexBytes("block"),
-					LatestAppHash:     bytes.HexBytes("app"),
-					LatestBlockHeight: 10,
+					LatestBlockHash:    bytes.HexBytes("block"),
+					LatestAppHash:      bytes.HexBytes("app"),
+					CurrentBlockHeight: 10,
 				},
 			}},
 	}
@@ -32,7 +32,7 @@ func TestStatus(t *testing.T) {
 	status, err := r.Status()
 	require.Nil(err, "%+v", err)
 	assert.EqualValues("block", status.SyncInfo.LatestBlockHash)
-	assert.EqualValues(10, status.SyncInfo.LatestBlockHeight)
+	assert.EqualValues(10, status.SyncInfo.CurrentBlockHeight)
 
 	// make sure recorder works properly
 	require.Equal(1, len(r.Calls))
@@ -44,5 +44,5 @@ func TestStatus(t *testing.T) {
 	st, ok := rs.Response.(*ctypes.ResultStatus)
 	require.True(ok)
 	assert.EqualValues("block", st.SyncInfo.LatestBlockHash)
-	assert.EqualValues(10, st.SyncInfo.LatestBlockHeight)
+	assert.EqualValues(10, st.SyncInfo.CurrentBlockHeight)
 }

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -96,7 +96,7 @@ func TestInfo(t *testing.T) {
 		info, err := c.ABCIInfo()
 		require.Nil(t, err, "%d: %+v", i, err)
 		// TODO: this is not correct - fix merkleeyes!
-		// assert.EqualValues(t, status.SyncInfo.LatestBlockHeight, info.Response.LastBlockHeight)
+		// assert.EqualValues(t, status.SyncInfo.CurrentBlockHeight, info.Response.LastBlockHeight)
 		assert.True(t, strings.Contains(info.Response.Data, "size"))
 	}
 }
@@ -193,7 +193,7 @@ func TestAppCalls(t *testing.T) {
 		s, err := c.Status()
 		require.Nil(err, "%d: %+v", i, err)
 		// sh is start height or status height
-		sh := s.SyncInfo.LatestBlockHeight
+		sh := s.SyncInfo.CurrentBlockHeight
 
 		// look for the future
 		h := sh + 2
@@ -592,7 +592,7 @@ func TestBroadcastEvidenceDuplicateVote(t *testing.T) {
 
 		status, err := c.Status()
 		require.NoError(t, err)
-		client.WaitForHeight(c, status.SyncInfo.LatestBlockHeight+2, nil)
+		client.WaitForHeight(c, status.SyncInfo.CurrentBlockHeight+2, nil)
 
 		ed25519pub := ev.PubKey.(ed25519.PubKeyEd25519)
 		rawpub := ed25519pub[:]

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -45,11 +45,12 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 	result := &ctypes.ResultStatus{
 		NodeInfo: p2pTransport.NodeInfo().(p2p.DefaultNodeInfo),
 		SyncInfo: ctypes.SyncInfo{
-			LatestBlockHash:   latestBlockHash,
-			LatestAppHash:     latestAppHash,
-			LatestBlockHeight: latestHeight,
-			LatestBlockTime:   latestBlockTime,
-			CatchingUp:        consensusReactor.FastSync(),
+			LatestBlockHash:    latestBlockHash,
+			LatestAppHash:      latestAppHash,
+			CurrentBlockHeight: blockStore.Height(),
+			HighestBlockHeight: consensusState.GetLastHeight(),
+			LatestBlockTime:    latestBlockTime,
+			CatchingUp:         consensusReactor.FastSync(),
 		},
 		ValidatorInfo: ctypes.ValidatorInfo{
 			Address:     pubKey.Address(),

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -61,11 +61,12 @@ func NewResultCommit(header *types.Header, commit *types.Commit,
 
 // Info about the node's syncing state
 type SyncInfo struct {
-	LatestBlockHash   bytes.HexBytes `json:"latest_block_hash"`
-	LatestAppHash     bytes.HexBytes `json:"latest_app_hash"`
-	LatestBlockHeight int64          `json:"latest_block_height"`
-	LatestBlockTime   time.Time      `json:"latest_block_time"`
-	CatchingUp        bool           `json:"catching_up"`
+	LatestBlockHash    bytes.HexBytes `json:"latest_block_hash"`
+	LatestAppHash      bytes.HexBytes `json:"latest_app_hash"`
+	CurrentBlockHeight int64          `json:"current_block_height"`
+	HighestBlockHeight int64          `json:"highest_block_height"`
+	LatestBlockTime    time.Time      `json:"latest_block_time"`
+	CatchingUp         bool           `json:"catching_up"`
 }
 
 // Info about the node's validator


### PR DESCRIPTION
I have added `highest_block` in `status` RPC method

Fixes (Feature): #3983 (partially)
