### PR TITLE
consensus: stricter on LastCommitRound check

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -143,3 +143,4 @@ program](https://hackerone.com/tendermint).
 - [p2p] \#4140 `SecretConnection`: use the transcript solely for authentication (i.e. MAC)
 - [consensus/types] \#4243 fix BenchmarkRoundStateDeepCopy panics (@cuonglm)
 - [rpc] \#4256 Pass `outCapacity` to `eventBus#Subscribe` when subscribing using a local client
+- [consensus] \#2737 Stricter on LastCommitRound check (@cuonglm)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1435,7 +1435,7 @@ func (m *NewRoundStepMessage) ValidateBasic() error {
 	// NOTE: SecondsSinceStartTime may be negative
 
 	if (m.Height == 1 && m.LastCommitRound != -1) ||
-		(m.Height > 1 && m.LastCommitRound < -1) { // TODO: #2737 LastCommitRound should always be >= 0 for heights > 1
+		(m.Height > 1 && m.LastCommitRound < 0) {
 		return errors.New("invalid LastCommitRound (for 1st block: -1, for others: >= 0)")
 	}
 	return nil

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -676,12 +676,12 @@ func TestNewRoundStepMessageValidateBasic(t *testing.T) {
 		testName               string
 		messageStep            cstypes.RoundStepType
 	}{
-		{false, 0, 0, 0, "Valid Message", 0x01},
-		{true, -1, 0, 0, "Invalid Message", 0x01},
-		{true, 0, 0, -1, "Invalid Message", 0x01},
-		{true, 0, 0, 1, "Invalid Message", 0x00},
-		{true, 0, 0, 1, "Invalid Message", 0x00},
-		{true, 0, -2, 2, "Invalid Message", 0x01},
+		{false, 0, 0, 0, "Valid Message", cstypes.RoundStepNewHeight},
+		{true, -1, 0, 0, "Negative round", cstypes.RoundStepNewHeight},
+		{true, 0, 0, -1, "Negative height", cstypes.RoundStepNewHeight},
+		{true, 0, 0, 0, "Invalid Step", cstypes.RoundStepCommit + 1},
+		{true, 0, 0, 1, "H == 1 but LCR != -1 ", cstypes.RoundStepNewHeight},
+		{true, 0, -1, 2, "H > 1 but LCR < 0", cstypes.RoundStepNewHeight},
 	}
 
 	for _, tc := range testCases {

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -687,6 +687,7 @@ func TestNewRoundStepMessageValidateBasic(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
 			message := NewRoundStepMessage{
 				Height:          tc.messageHeight,
 				Round:           tc.messageRound,
@@ -724,6 +725,7 @@ func TestNewValidBlockMessageValidateBasic(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			t.Parallel()
 			msg := &NewValidBlockMessage{
 				Height: 1,
 				Round:  0,
@@ -758,6 +760,7 @@ func TestProposalPOLMessageValidateBasic(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			t.Parallel()
 			msg := &ProposalPOLMessage{
 				Height:           1,
 				ProposalPOLRound: 1,
@@ -791,6 +794,7 @@ func TestBlockPartMessageValidateBasic(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
 			message := BlockPartMessage{
 				Height: tc.messageHeight,
 				Round:  tc.messageRound,
@@ -831,6 +835,7 @@ func TestHasVoteMessageValidateBasic(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
 			message := HasVoteMessage{
 				Height: tc.messageHeight,
 				Round:  tc.messageRound,
@@ -876,6 +881,7 @@ func TestVoteSetMaj23MessageValidateBasic(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
 			message := VoteSetMaj23Message{
 				Height:  tc.messageHeight,
 				Round:   tc.messageRound,
@@ -913,6 +919,7 @@ func TestVoteSetBitsMessageValidateBasic(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			t.Parallel()
 			msg := &VoteSetBitsMessage{
 				Height:  1,
 				Round:   0,

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -529,12 +529,11 @@ func (cs *State) updateToState(state sm.State) {
 
 	// Reset fields based on state.
 	validators := state.Validators
-	lastPrecommits := (*types.VoteSet)(nil)
 	if cs.CommitRound > -1 && cs.Votes != nil {
 		if !cs.Votes.Precommits(cs.CommitRound).HasTwoThirdsMajority() {
 			panic("updateToState(state) called but last Precommit round didn't have +2/3")
 		}
-		lastPrecommits = cs.Votes.Precommits(cs.CommitRound)
+		cs.LastCommit = cs.Votes.Precommits(cs.CommitRound)
 	}
 
 	// Next desired block height
@@ -566,7 +565,6 @@ func (cs *State) updateToState(state sm.State) {
 	cs.ValidBlockParts = nil
 	cs.Votes = cstypes.NewHeightVoteSet(state.ChainID, height, validators)
 	cs.CommitRound = -1
-	cs.LastCommit = lastPrecommits
 	cs.LastValidators = state.LastValidators
 	cs.TriggeredTimeoutPrecommit = false
 

--- a/consensus/types/round_state.go
+++ b/consensus/types/round_state.go
@@ -84,7 +84,7 @@ type RoundState struct {
 	ValidRound int          `json:"valid_round"`
 	ValidBlock *types.Block `json:"valid_block"` // Last known block of POL mentioned above.
 
-	// Last known block parts of POL metnioned above.
+	// Last known block parts of POL mentioned above.
 	ValidBlockParts           *types.PartSet      `json:"valid_block_parts"`
 	Votes                     *HeightVoteSet      `json:"votes"`
 	CommitRound               int                 `json:"commit_round"` //


### PR DESCRIPTION
LastCommitRound should always be >= 0 for heights > 1.

In State.updateToState, last precommit is computed  only when round
greater than -1 and has votes. But "LastCommit" is always updated
regardless of the condition. If there's no last precommit, "LastCommit"
is set to (*types.VoteSet)(nil). That's why "LastCommit" can be -1 for
heights > 1.

To fix it, only update State.RoundState.LastCommit when there is last
precommit.

Fixes #2737

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
