### PR TITLE
refactor(rpc): return an error on invalid remote (#3953)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -65,6 +65,7 @@ program](https://hackerone.com/tendermint).
 
 - Go API
 
+  - [rpc] \#3953 Modify NewHTTP, NewXXXClient functions to return an error on invalid remote instead of panicking (@mrekucci)
   - [rpc/client] \#3471 `Validators` now requires two more args: `page` and `perPage`
   - [libs/common] \#3262 Make error the last parameter of `Task` (@PSalant726)
   - [cs/types] \#3262 Rename `GotVoteFromUnwantedRoundError` to `ErrGotVoteFromUnwantedRound` (@PSalant726)

--- a/cmd/tendermint/commands/debug/dump.go
+++ b/cmd/tendermint/commands/debug/dump.go
@@ -58,7 +58,10 @@ func dumpCmdHandler(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	rpc := rpcclient.NewHTTP(nodeRPCAddr, "/websocket")
+	rpc, err := rpcclient.NewHTTP(nodeRPCAddr, "/websocket")
+	if err != nil {
+		return errors.Wrap(err, "failed to create new http client")
+	}
 
 	home := viper.GetString(cli.HomeFlag)
 	conf := cfg.DefaultConfig()

--- a/cmd/tendermint/commands/debug/kill.go
+++ b/cmd/tendermint/commands/debug/kill.go
@@ -44,7 +44,10 @@ func killCmdHandler(cmd *cobra.Command, args []string) error {
 		return errors.New("invalid output file")
 	}
 
-	rpc := rpcclient.NewHTTP(nodeRPCAddr, "/websocket")
+	rpc, err := rpcclient.NewHTTP(nodeRPCAddr, "/websocket")
+	if err != nil {
+		return errors.Wrap(err, "failed to create new http client")
+	}
 
 	home := viper.GetString(cli.HomeFlag)
 	conf := cfg.DefaultConfig()

--- a/cmd/tendermint/commands/lite.go
+++ b/cmd/tendermint/commands/lite.go
@@ -80,7 +80,10 @@ func runProxy(cmd *cobra.Command, args []string) error {
 
 	// First, connect a client
 	logger.Info("Connecting to source HTTP client...")
-	node := rpcclient.NewHTTP(nodeAddr, "/websocket")
+	node, err := rpcclient.NewHTTP(nodeAddr, "/websocket")
+	if err != nil {
+		return errors.Wrap(err, "new HTTP client")
+	}
 
 	logger.Info("Constructing Verifier...")
 	cert, err := proxy.NewVerifier(chainID, home, node, logger, cacheSize)

--- a/lite/client/provider.go
+++ b/lite/client/provider.go
@@ -39,8 +39,12 @@ func NewProvider(chainID string, client SignStatusClient) lite.Provider {
 
 // NewHTTPProvider can connect to a tendermint json-rpc endpoint
 // at the given url, and uses that as a read-only provider.
-func NewHTTPProvider(chainID, remote string) lite.Provider {
-	return NewProvider(chainID, rpcclient.NewHTTP(remote, "/websocket"))
+func NewHTTPProvider(chainID, remote string) (lite.Provider, error) {
+	httpClient, err := rpcclient.NewHTTP(remote, "/websocket")
+	if err != nil {
+		return nil, err
+	}
+	return NewProvider(chainID, httpClient), nil
 }
 
 // Implements Provider.

--- a/lite/client/provider_test.go
+++ b/lite/client/provider_test.go
@@ -35,8 +35,9 @@ func TestProvider(t *testing.T) {
 	}
 	chainID := genDoc.ChainID
 	t.Log("chainID:", chainID)
-	p := NewHTTPProvider(chainID, rpcAddr)
-	require.NotNil(t, p)
+	p, err := NewHTTPProvider(chainID, rpcAddr)
+	require.Nil(err)
+	require.NotNil(p)
 
 	// let it produce some blocks
 	err = rpcclient.WaitForHeight(p.(*provider).client, 6, nil)

--- a/lite2/provider/http/http.go
+++ b/lite2/provider/http/http.go
@@ -23,8 +23,12 @@ type http struct {
 
 // New creates a HTTP provider, which is using the rpcclient.HTTP
 // client under the hood.
-func New(chainID, remote string) provider.Provider {
-	return NewWithClient(chainID, rpcclient.NewHTTP(remote, "/websocket"))
+func New(chainID, remote string) (provider.Provider, error) {
+	httpClient, err := rpcclient.NewHTTP(remote, "/websocket")
+	if err != nil {
+		return nil, err
+	}
+	return NewWithClient(chainID, httpClient), nil
 }
 
 // NewWithClient allows you to provide custom SignStatusClient.

--- a/lite2/provider/http/http_test.go
+++ b/lite2/provider/http/http_test.go
@@ -33,7 +33,8 @@ func TestProvider(t *testing.T) {
 	}
 	chainID := genDoc.ChainID
 	t.Log("chainID:", chainID)
-	p := New(chainID, rpcAddr)
+	p, err := New(chainID, rpcAddr)
+	require.Nil(t, err)
 	require.NotNil(t, p)
 
 	// let it produce some blocks

--- a/rpc/client/examples_test.go
+++ b/rpc/client/examples_test.go
@@ -18,7 +18,10 @@ func ExampleHTTP_simple() {
 
 	// Create our RPC client
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c := client.NewHTTP(rpcAddr, "/websocket")
+	c, err := client.NewHTTP(rpcAddr, "/websocket")
+	if err != nil {
+		panic(err)
+	}
 
 	// Create a transaction
 	k := []byte("name")
@@ -68,7 +71,10 @@ func ExampleHTTP_batching() {
 
 	// Create our RPC client
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c := client.NewHTTP(rpcAddr, "/websocket")
+	c, err := client.NewHTTP(rpcAddr, "/websocket")
+	if err != nil {
+		panic(err)
+	}
 
 	// Create our two transactions
 	k1 := []byte("firstName")

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -29,7 +29,10 @@ import (
 
 func getHTTPClient() *client.HTTP {
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c := client.NewHTTP(rpcAddr, "/websocket")
+	c, err := client.NewHTTP(rpcAddr, "/websocket")
+	if err != nil {
+		panic(err)
+	}
 	c.SetLogger(log.TestingLogger())
 	return c
 }
@@ -48,16 +51,17 @@ func GetClients() []client.Client {
 
 func TestNilCustomHTTPClient(t *testing.T) {
 	require.Panics(t, func() {
-		client.NewHTTPWithClient("http://example.com", "/websocket", nil)
+		_, _ = client.NewHTTPWithClient("http://example.com", "/websocket", nil)
 	})
 	require.Panics(t, func() {
-		rpcclient.NewJSONRPCClientWithHTTPClient("http://example.com", nil)
+		_, _ = rpcclient.NewJSONRPCClientWithHTTPClient("http://example.com", nil)
 	})
 }
 
 func TestCustomHTTPClient(t *testing.T) {
 	remote := rpctest.GetConfig().RPC.ListenAddress
-	c := client.NewHTTPWithClient(remote, "/websocket", http.DefaultClient)
+	c, err := client.NewHTTPWithClient(remote, "/websocket", http.DefaultClient)
+	require.Nil(t, err)
 	status, err := c.Status()
 	require.NoError(t, err)
 	require.NotNil(t, status)

--- a/rpc/lib/client/http_json_client_test.go
+++ b/rpc/lib/client/http_json_client_test.go
@@ -12,7 +12,8 @@ func TestHTTPClientMakeHTTPDialer(t *testing.T) {
 	for _, f := range remote {
 		protocol, address, err := parseRemoteAddr(f)
 		require.NoError(t, err)
-		dialFn := makeHTTPDialer(f)
+		dialFn, err := makeHTTPDialer(f)
+		require.Nil(t, err)
 
 		addr, err := dialFn(protocol, address)
 		require.NoError(t, err)

--- a/rpc/lib/client/http_uri_client.go
+++ b/rpc/lib/client/http_uri_client.go
@@ -1,7 +1,6 @@
 package rpcclient
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -33,17 +32,26 @@ type URIClient struct {
 var _ HTTPClient = (*URIClient)(nil)
 
 // NewURIClient returns a new client.
-// The function panics if the provided remote is invalid.
-func NewURIClient(remote string) *URIClient {
+// An error is returned on invalid remote.
+// The function panics when remote is nil.
+func NewURIClient(remote string) (*URIClient, error) {
 	clientAddress, err := toClientAddress(remote)
 	if err != nil {
-		panic(fmt.Sprintf("invalid remote %s: %s", remote, err))
+		return nil, err
 	}
-	return &URIClient{
+
+	httpClient, err := DefaultHTTPClient(remote)
+	if err != nil {
+		return nil, err
+	}
+
+	uriClient := &URIClient{
 		address: clientAddress,
-		client:  DefaultHTTPClient(remote),
+		client:  httpClient,
 		cdc:     amino.NewCodec(),
 	}
+
+	return uriClient, nil
 }
 
 // Call issues a POST form HTTP request.

--- a/rpc/lib/client/integration_test.go
+++ b/rpc/lib/client/integration_test.go
@@ -28,7 +28,8 @@ func TestWSClientReconnectWithJitter(t *testing.T) {
 	buf := new(bytes.Buffer)
 	logger := log.NewTMLogger(buf)
 	for i := 0; i < n; i++ {
-		c := NewWSClient("tcp://foo", "/websocket")
+		c, err := NewWSClient("tcp://foo", "/websocket")
+		require.Nil(t, err)
 		c.Dialer = func(string, string) (net.Conn, error) {
 			return nil, errNotConnected
 		}

--- a/rpc/lib/client/ws_client_test.go
+++ b/rpc/lib/client/ws_client_test.go
@@ -200,8 +200,9 @@ func TestNotBlockingOnStop(t *testing.T) {
 }
 
 func startClient(t *testing.T, addr string) *WSClient {
-	c := NewWSClient(addr, "/websocket")
-	err := c.Start()
+	c, err := NewWSClient(addr, "/websocket")
+	require.Nil(t, err)
+	err = c.Start()
 	require.Nil(t, err)
 	c.SetLogger(log.TestingLogger())
 	return c

--- a/rpc/lib/rpc_test.go
+++ b/rpc/lib/rpc_test.go
@@ -274,17 +274,20 @@ func testWithWSClient(t *testing.T, cl *client.WSClient) {
 func TestServersAndClientsBasic(t *testing.T) {
 	serverAddrs := [...]string{tcpAddr, unixAddr}
 	for _, addr := range serverAddrs {
-		cl1 := client.NewURIClient(addr)
+		cl1, err := client.NewURIClient(addr)
+		require.Nil(t, err)
 		fmt.Printf("=== testing server on %s using URI client", addr)
 		testWithHTTPClient(t, cl1)
 
-		cl2 := client.NewJSONRPCClient(addr)
+		cl2, err := client.NewJSONRPCClient(addr)
+		require.Nil(t, err)
 		fmt.Printf("=== testing server on %s using JSONRPC client", addr)
 		testWithHTTPClient(t, cl2)
 
-		cl3 := client.NewWSClient(addr, websocketEndpoint)
+		cl3, err := client.NewWSClient(addr, websocketEndpoint)
+		require.Nil(t, err)
 		cl3.SetLogger(log.TestingLogger())
-		err := cl3.Start()
+		err = cl3.Start()
 		require.Nil(t, err)
 		fmt.Printf("=== testing server on %s using WS client", addr)
 		testWithWSClient(t, cl3)
@@ -293,7 +296,8 @@ func TestServersAndClientsBasic(t *testing.T) {
 }
 
 func TestHexStringArg(t *testing.T) {
-	cl := client.NewURIClient(tcpAddr)
+	cl, err := client.NewURIClient(tcpAddr)
+	require.Nil(t, err)
 	// should NOT be handled as hex
 	val := "0xabc"
 	got, err := echoViaHTTP(cl, val)
@@ -302,7 +306,8 @@ func TestHexStringArg(t *testing.T) {
 }
 
 func TestQuotedStringArg(t *testing.T) {
-	cl := client.NewURIClient(tcpAddr)
+	cl, err := client.NewURIClient(tcpAddr)
+	require.Nil(t, err)
 	// should NOT be unquoted
 	val := "\"abc\""
 	got, err := echoViaHTTP(cl, val)
@@ -311,9 +316,10 @@ func TestQuotedStringArg(t *testing.T) {
 }
 
 func TestWSNewWSRPCFunc(t *testing.T) {
-	cl := client.NewWSClient(tcpAddr, websocketEndpoint)
+	cl, err := client.NewWSClient(tcpAddr, websocketEndpoint)
+	require.Nil(t, err)
 	cl.SetLogger(log.TestingLogger())
-	err := cl.Start()
+	err = cl.Start()
 	require.Nil(t, err)
 	defer cl.Stop()
 
@@ -336,9 +342,10 @@ func TestWSNewWSRPCFunc(t *testing.T) {
 }
 
 func TestWSHandlesArrayParams(t *testing.T) {
-	cl := client.NewWSClient(tcpAddr, websocketEndpoint)
+	cl, err := client.NewWSClient(tcpAddr, websocketEndpoint)
+	require.Nil(t, err)
 	cl.SetLogger(log.TestingLogger())
-	err := cl.Start()
+	err = cl.Start()
 	require.Nil(t, err)
 	defer cl.Stop()
 
@@ -361,9 +368,10 @@ func TestWSHandlesArrayParams(t *testing.T) {
 // TestWSClientPingPong checks that a client & server exchange pings
 // & pongs so connection stays alive.
 func TestWSClientPingPong(t *testing.T) {
-	cl := client.NewWSClient(tcpAddr, websocketEndpoint)
+	cl, err := client.NewWSClient(tcpAddr, websocketEndpoint)
+	require.Nil(t, err)
 	cl.SetLogger(log.TestingLogger())
-	err := cl.Start()
+	err = cl.Start()
 	require.Nil(t, err)
 	defer cl.Stop()
 

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -37,7 +37,10 @@ var defaultOptions = Options{
 
 func waitForRPC() {
 	laddr := GetConfig().RPC.ListenAddress
-	client := rpcclient.NewJSONRPCClient(laddr)
+	client, err := rpcclient.NewJSONRPCClient(laddr)
+	if err != nil {
+		panic(err)
+	}
 	ctypes.RegisterAmino(client.Codec())
 	result := new(ctypes.ResultStatus)
 	for {


### PR DESCRIPTION
The `New*` client functions return an error instead
of panicking when the remote address is invalid.

Fixes #3953

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [x] Updated all code comments where relevant
* [x] Updated CHANGELOG_PENDING.md
