### PR TITLE
rpc: pass `outCapacity` to `eventBus#Subscribe` when subscribing using a l…

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -142,3 +142,4 @@ program](https://hackerone.com/tendermint).
   efforts of @gchaincl and @ancazamfir)
 - [p2p] \#4140 `SecretConnection`: use the transcript solely for authentication (i.e. MAC)
 - [consensus/types] \#4243 fix BenchmarkRoundStateDeepCopy panics (@cuonglm)
+- [rpc] \#4256 Pass `outCapacity` to `eventBus#Subscribe` when subscribing using a local client

--- a/rpc/client/localclient.go
+++ b/rpc/client/localclient.go
@@ -177,14 +177,20 @@ func (c *Local) Subscribe(
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse query")
 	}
-	sub, err := c.EventBus.Subscribe(ctx, subscriber, q)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to subscribe")
-	}
 
 	outCap := 1
 	if len(outCapacity) > 0 {
 		outCap = outCapacity[0]
+	}
+
+	var sub types.Subscription
+	if outCap > 0 {
+		sub, err = c.EventBus.Subscribe(ctx, subscriber, q, outCapacity...)
+	} else {
+		sub, err = c.EventBus.SubscribeUnbuffered(ctx, subscriber, q)
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to subscribe")
 	}
 
 	outc := make(chan ctypes.ResultEvent, outCap)

--- a/rpc/client/localclient.go
+++ b/rpc/client/localclient.go
@@ -185,7 +185,7 @@ func (c *Local) Subscribe(
 
 	var sub types.Subscription
 	if outCap > 0 {
-		sub, err = c.EventBus.Subscribe(ctx, subscriber, q, outCapacity...)
+		sub, err = c.EventBus.Subscribe(ctx, subscriber, q, outCap)
 	} else {
 		sub, err = c.EventBus.SubscribeUnbuffered(ctx, subscriber, q)
 	}


### PR DESCRIPTION
…ocal client

Fixes #4256

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
