### PR TITLE
make: add back tools cmd

### DIFF
--- a/tools.mk
+++ b/tools.mk
@@ -46,6 +46,8 @@ GOODMAN 			= $(TOOLS_DESTDIR)/goodman
 
 all: tools
 
+tools: certstrap protobuf goodman
+
 check: check_tools
 
 check_tools:


### PR DESCRIPTION
previous PR seems to have deleted the tools cmd, this adds it back in

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
