### PR TITLE
rpc/lib: fix RPC client, which was previously resolving https protoco…

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,3 +20,4 @@ program](https://hackerone.com/tendermint).
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+- [rpc/lib] [\#4051](https://github.com/tendermint/tendermint/pull/4131) Fix RPC client, which was previously resolving https protocol to http (@yenkhoon)

--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -82,12 +82,6 @@ func parseRemoteAddr(remoteAddr string) (network string, s string, err error) {
 		return "", "", fmt.Errorf("invalid addr: %s", remoteAddr)
 	}
 
-	// accept http(s) as an alias for tcp
-	switch protocol {
-	case protoHTTP, protoHTTPS:
-		protocol = protoTCP
-	}
-
 	return protocol, address, nil
 }
 
@@ -101,6 +95,12 @@ func makeHTTPDialer(remoteAddr string) func(string, string) (net.Conn, error) {
 	protocol, address, err := parseRemoteAddr(remoteAddr)
 	if err != nil {
 		return makeErrorDialer(err)
+	}
+
+	// accept http(s) as an alias for tcp
+	switch protocol {
+	case protoHTTP, protoHTTPS:
+		protocol = protoTCP
 	}
 
 	return func(proto, addr string) (net.Conn, error) {

--- a/rpc/lib/client/http_client_test.go
+++ b/rpc/lib/client/http_client_test.go
@@ -1,0 +1,22 @@
+package rpcclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPClientMakeHTTPDialer(t *testing.T) {
+	remote := []string{"https://foo-bar.com:80", "http://foo-bar.net:80"}
+
+	for _, f := range remote {
+		protocol, address, err := parseRemoteAddr(f)
+		require.NoError(t, err)
+		dialFn := makeHTTPDialer(f)
+
+		addr, err := dialFn(protocol, address)
+		require.NoError(t, err)
+		require.NotNil(t, addr)
+	}
+
+}


### PR DESCRIPTION
…l to http (#4131)

Fixes #4177 / #4051

Function `parseRemoteAddr` is forcing protocol HTTP and protocol HTTPs to tcp. This causes the bug in the issue #4051.

I find that the tcp is only needed where `net.Dial`. So I moved the switch to makeHTTPDialer.

This is a backport to the v0.32 branch. It's a cherry-pick of commit 2be4b0fe050f04ca5126d51e9bec0fc7ea8aaa25 from master.

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [X] Wrote tests
* [X] Updated CHANGELOG_PENDING.md
