### PR TITLE
RPC client basic authentication with URL parsing refactored

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,7 @@ program](https://hackerone.com/tendermint).
 - Go API
 
 ### FEATURES:
+- [rpc/lib] [\#4248](https://github.com/tendermint/tendermint/issues/4248) RPC client basic authentication support (@greg-szabo)
 
 ### IMPROVEMENTS:
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,3 +20,4 @@ program](https://hackerone.com/tendermint).
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+- [rpc/lib] [\#4051](https://github.com/tendermint/tendermint/pull/4131) Fix RPC client, which was previously resolving https protocol to http (@yenkhoon)

--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -82,12 +82,6 @@ func parseRemoteAddr(remoteAddr string) (network string, s string, err error) {
 		return "", "", fmt.Errorf("invalid addr: %s", remoteAddr)
 	}
 
-	// accept http(s) as an alias for tcp
-	switch protocol {
-	case protoHTTP, protoHTTPS:
-		protocol = protoTCP
-	}
-
 	return protocol, address, nil
 }
 
@@ -101,6 +95,12 @@ func makeHTTPDialer(remoteAddr string) func(string, string) (net.Conn, error) {
 	protocol, address, err := parseRemoteAddr(remoteAddr)
 	if err != nil {
 		return makeErrorDialer(err)
+	}
+
+	// accept http(s) as an alias for tcp
+	switch protocol {
+	case protoHTTP, protoHTTPS:
+		protocol = protoTCP
 	}
 
 	return func(proto, addr string) (net.Conn, error) {

--- a/rpc/lib/client/http_client_test.go
+++ b/rpc/lib/client/http_client_test.go
@@ -1,0 +1,22 @@
+package rpcclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPClientMakeHTTPDialer(t *testing.T) {
+	remote := []string{"https://foo-bar.com:80", "http://foo-bar.net:80"}
+
+	for _, f := range remote {
+		protocol, address, err := parseRemoteAddr(f)
+		require.NoError(t, err)
+		dialFn := makeHTTPDialer(f)
+
+		addr, err := dialFn(protocol, address)
+		require.NoError(t, err)
+		require.NotNil(t, addr)
+	}
+
+}

--- a/rpc/lib/client/http_client_test.go
+++ b/rpc/lib/client/http_client_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestHTTPClientMakeHTTPDialer(t *testing.T) {
-	remote := []string{"https://foo-bar.com:80", "http://foo-bar.net:80"}
+	remote := []string{"https://foo-bar.com:80", "http://foo-bar.net:80", "https://user:pass@foo-bar.net:80"}
 
 	for _, f := range remote {
-		protocol, address, err := parseRemoteAddr(f)
+		u, err := newParsedURL(f)
 		require.NoError(t, err)
 		dialFn := makeHTTPDialer(f)
 
-		addr, err := dialFn(protocol, address)
+		addr, err := dialFn(u.Scheme, u.GetHostWithPath())
 		require.NoError(t, err)
 		require.NotNil(t, addr)
 	}

--- a/rpc/lib/client/ws_client_test.go
+++ b/rpc/lib/client/ws_client_test.go
@@ -64,7 +64,8 @@ func TestWSClientReconnectsAfterReadFailure(t *testing.T) {
 	s := httptest.NewServer(h)
 	defer s.Close()
 
-	c := startClient(t, s.Listener.Addr().String())
+	// https://github.com/golang/go/issues/19297#issuecomment-282651469
+	c := startClient(t, "//" + s.Listener.Addr().String())
 	defer c.Stop()
 
 	wg.Add(1)
@@ -96,7 +97,8 @@ func TestWSClientReconnectsAfterWriteFailure(t *testing.T) {
 	h := &myHandler{}
 	s := httptest.NewServer(h)
 
-	c := startClient(t, s.Listener.Addr().String())
+	// https://github.com/golang/go/issues/19297#issuecomment-282651469
+	c := startClient(t, "//" + s.Listener.Addr().String())
 	defer c.Stop()
 
 	wg.Add(2)
@@ -124,7 +126,8 @@ func TestWSClientReconnectFailure(t *testing.T) {
 	h := &myHandler{}
 	s := httptest.NewServer(h)
 
-	c := startClient(t, s.Listener.Addr().String())
+	// https://github.com/golang/go/issues/19297#issuecomment-282651469
+	c := startClient(t, "//" + s.Listener.Addr().String())
 	defer c.Stop()
 
 	go func() {
@@ -173,7 +176,7 @@ func TestWSClientReconnectFailure(t *testing.T) {
 func TestNotBlockingOnStop(t *testing.T) {
 	timeout := 2 * time.Second
 	s := httptest.NewServer(&myHandler{})
-	c := startClient(t, s.Listener.Addr().String())
+	c := startClient(t, "//" + s.Listener.Addr().String())
 	c.Call(context.Background(), "a", make(map[string]interface{}))
 	// Let the readRoutine get around to blocking
 	time.Sleep(time.Second)


### PR DESCRIPTION
Enable basic authentication in the RPC client using the https://username:password@node:port format.

Issue #4248 has details about what was refactored/enhanced (it's not as bad as it looks.)

I'm open to suggestions on where/how the documentation should be updated.

Please note that PR #4284 is superseded with this PR. The reason for this is because both PR makes changes to the same code.

* [X] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [X] Wrote tests
* [X] Updated CHANGELOG_PENDING.md
