### PR TITLE
Expose max_peer_height

### DIFF
--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -118,7 +118,7 @@ func newBlockchainReactor(
 		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)
 	}
 
-	bcReactor := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
+	bcReactor, _ := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
 	bcReactor.SetLogger(logger.With("module", "blockchain"))
 
 	return BlockchainReactorPair{bcReactor, proxyApp}

--- a/blockchain/v1/reactor_test.go
+++ b/blockchain/v1/reactor_test.go
@@ -131,7 +131,7 @@ func newBlockchainReactor(
 		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)
 	}
 
-	bcReactor := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
+	bcReactor, _ := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
 	bcReactor.SetLogger(logger.With("module", "blockchain"))
 
 	return bcReactor

--- a/rpc/core/pipe.go
+++ b/rpc/core/pipe.go
@@ -65,6 +65,7 @@ var (
 	consensusState Consensus
 	p2pPeers       peers
 	p2pTransport   transport
+	bcState        types.BlockchainState
 
 	// objects
 	pubKey           crypto.PubKey
@@ -105,6 +106,10 @@ func SetP2PPeers(p peers) {
 
 func SetP2PTransport(t transport) {
 	p2pTransport = t
+}
+
+func SetBlockchainState(s types.BlockchainState) {
+	bcState = s
 }
 
 func SetPubKey(pk crypto.PubKey) {

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -27,6 +27,7 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 		latestBlockHash     tmbytes.HexBytes
 		latestAppHash       tmbytes.HexBytes
 		latestBlockTimeNano int64
+		maxPeerHeight       int64
 	)
 	if latestHeight != 0 {
 		latestBlockMeta = blockStore.LoadBlockMeta(latestHeight)
@@ -36,7 +37,10 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 	}
 
 	latestBlockTime := time.Unix(0, latestBlockTimeNano)
-	maxPeerHeight := bcState.GetMaxPeerHeight()
+
+	if bcState != nil {
+		maxPeerHeight = bcState.GetMaxPeerHeight()
+	}
 
 	var votingPower int64
 	if val := validatorAtHeight(latestHeight); val != nil {

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -36,6 +36,7 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 	}
 
 	latestBlockTime := time.Unix(0, latestBlockTimeNano)
+	maxPeerHeight := bcState.GetMaxPeerHeight()
 
 	var votingPower int64
 	if val := validatorAtHeight(latestHeight); val != nil {
@@ -49,6 +50,7 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 			LatestAppHash:     latestAppHash,
 			LatestBlockHeight: latestHeight,
 			LatestBlockTime:   latestBlockTime,
+			MaxPeerHeight:     maxPeerHeight,
 			CatchingUp:        consensusReactor.FastSync(),
 		},
 		ValidatorInfo: ctypes.ValidatorInfo{

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -65,6 +65,7 @@ type SyncInfo struct {
 	LatestAppHash     bytes.HexBytes `json:"latest_app_hash"`
 	LatestBlockHeight int64          `json:"latest_block_height"`
 	LatestBlockTime   time.Time      `json:"latest_block_time"`
+	MaxPeerHeight     int64          `json:"max_peer_height"`
 	CatchingUp        bool           `json:"catching_up"`
 }
 

--- a/rpc/swagger/swagger.yaml
+++ b/rpc/swagger/swagger.yaml
@@ -1114,6 +1114,9 @@ components:
         latest_block_time:
           type: string
           example: "2019-08-01T11:52:22.818762194Z"
+        max_peer_height:
+          type: string
+          example: "1262202"
         catching_up:
           type: boolean
           example: false

--- a/types/blockchain.go
+++ b/types/blockchain.go
@@ -1,0 +1,7 @@
+package types
+
+// BlockchainState captures status information from the BlockchainReactor
+// The interface is implemented in the blockchain package
+type BlockchainState interface {
+	GetMaxPeerHeight() int64
+}


### PR DESCRIPTION
Addresses #3365 

- Creates new interface for exposing data from the blockchain reactor's peer pool
- Adds max_peer_height to the RPC status output

This PR is a work in progress.

To implement:
* [x] Max peer height during fastSync
* [ ] Max peer height during consensus
* [ ] Event fastSync => consensus

PR todo:
* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
