### PR TITLE
Release/v0.32.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v0.32.9
+
+_January, 9, 2020_
+
+Special thanks to external contributors on this release: @greg-szabo, @gregzaitsev, @yenkhoon
+
+Friendly reminder, we have a [bug bounty
+program](https://hackerone.com/tendermint).
+
+
+### FEATURES:
+
+- [rpc/lib] [\#4248](https://github.com/tendermint/tendermint/issues/4248) RPC client basic authentication support (@greg-szabo)
+
+- [metrics] [\#4294](https://github.com/tendermint/tendermint/pull/4294) Add
+  - `consensus_validator_power`: track your validators power
+  - `consensus_validator_last_signed_height`: track at which height the validator last signed
+  - `consensus_validator_missed_blocks`: total amount of missed blocks for a validator
+    as gauges in prometheus for validator specific metrics
+
+
+### BUG FIXES:
+
+- [rpc/lib] [\#4051](https://github.com/tendermint/tendermint/pull/4131) Fix RPC client, which was previously resolving https protocol to http (@yenkhoon)
+- [cs] [\#4069](https://github.com/tendermint/tendermint/issues/4069) Don't panic when block meta is not found in store (@gregzaitsev)
+
 ## v0.32.8
 
 Special thanks to external contributors on this release: @erikgrinaker, @guagualvcha, @hsyis, @cosmostuba, @whunmr, @austinabell

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,7 @@ program](https://hackerone.com/tendermint).
 - Go API
 
 ### FEATURES:
+- [rpc/lib] [\#4248](https://github.com/tendermint/tendermint/issues/4248) RPC client basic authentication support (@greg-szabo)
 
 ### IMPROVEMENTS:
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,4 @@
-## v0.32.9
+## v0.32.10
 
 \*\*
 
@@ -17,17 +17,7 @@ program](https://hackerone.com/tendermint).
 
 ### FEATURES:
 
-- [rpc/lib] [\#4248](https://github.com/tendermint/tendermint/issues/4248) RPC client basic authentication support (@greg-szabo)
-
-- [metrics] \#4263 Add
-  - `consensus_validator_power`: track your validators power
-  - `consensus_validator_last_signed_height`: track at which height the validator last signed
-  - `consensus_validator_missed_blocks`: total amount of missed blocks for a validator
-    as gauges in prometheus for validator specific metrics
-
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
 
-- [rpc/lib] [\#4051](https://github.com/tendermint/tendermint/pull/4131) Fix RPC client, which was previously resolving https protocol to http (@yenkhoon)
-- [cs] \#4069 Don't panic when block meta is not found in store (@gregzaitsev)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,10 +16,18 @@ program](https://hackerone.com/tendermint).
 - Go API
 
 ### FEATURES:
+
 - [rpc/lib] [\#4248](https://github.com/tendermint/tendermint/issues/4248) RPC client basic authentication support (@greg-szabo)
+
+- [metrics] \#4263 Add
+  - `consensus_validator_power`: track your validators power
+  - `consensus_validator_last_signed_height`: track at which height the validator last signed
+  - `consensus_validator_missed_blocks`: total amount of missed blocks for a validator
+    as gauges in prometheus for validator specific metrics
 
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+
 - [rpc/lib] [\#4051](https://github.com/tendermint/tendermint/pull/4131) Fix RPC client, which was previously resolving https protocol to http (@yenkhoon)
 - [cs] \#4069 Don't panic when block meta is not found in store (@gregzaitsev)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,3 +20,4 @@ program](https://hackerone.com/tendermint).
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+- [cs] \#4069 Don't panic when block meta is not found in store (@gregzaitsev)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,4 +20,5 @@ program](https://hackerone.com/tendermint).
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+- [rpc/lib] [\#4051](https://github.com/tendermint/tendermint/pull/4131) Fix RPC client, which was previously resolving https protocol to http (@yenkhoon)
 - [cs] \#4069 Don't panic when block meta is not found in store (@gregzaitsev)

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -19,6 +19,9 @@ type Metrics struct {
 	// Height of the chain.
 	Height metrics.Gauge
 
+	// ValidatorLastSignedHeight of a validator.
+	ValidatorLastSignedHeight metrics.Gauge
+
 	// Number of rounds.
 	Rounds metrics.Gauge
 
@@ -26,6 +29,10 @@ type Metrics struct {
 	Validators metrics.Gauge
 	// Total power of all validators.
 	ValidatorsPower metrics.Gauge
+	// Power of a validator.
+	ValidatorPower metrics.Gauge
+	// Amount of blocks missed by a validator.
+	ValidatorMissedBlocks metrics.Gauge
 	// Number of validators who did not sign.
 	MissingValidators metrics.Gauge
 	// Total power of the missing validators.
@@ -81,12 +88,30 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "validators",
 			Help:      "Number of validators.",
 		}, labels).With(labelsAndValues...),
+		ValidatorLastSignedHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "validator_last_signed_height",
+			Help:      "Last signed height for a validator",
+		}, append(labels, "validator_address")).With(labelsAndValues...),
+		ValidatorMissedBlocks: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "validator_missed_blocks",
+			Help:      "Total missed blocks for a validator",
+		}, append(labels, "validator_address")).With(labelsAndValues...),
 		ValidatorsPower: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "validators_power",
 			Help:      "Total power of all validators.",
 		}, labels).With(labelsAndValues...),
+		ValidatorPower: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "validator_power",
+			Help:      "Power of a validator",
+		}, append(labels, "validator_address")).With(labelsAndValues...),
 		MissingValidators: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -163,10 +188,14 @@ func NopMetrics() *Metrics {
 	return &Metrics{
 		Height: discard.NewGauge(),
 
+		ValidatorLastSignedHeight: discard.NewGauge(),
+
 		Rounds: discard.NewGauge(),
 
 		Validators:               discard.NewGauge(),
 		ValidatorsPower:          discard.NewGauge(),
+		ValidatorPower:           discard.NewGauge(),
+		ValidatorMissedBlocks:    discard.NewGauge(),
 		MissingValidators:        discard.NewGauge(),
 		MissingValidatorsPower:   discard.NewGauge(),
 		ByzantineValidators:      discard.NewGauge(),

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -501,10 +501,12 @@ OUTER_LOOP:
 			if prs.ProposalBlockParts == nil {
 				blockMeta := conR.conS.blockStore.LoadBlockMeta(prs.Height)
 				if blockMeta == nil {
-					panic(fmt.Sprintf("Failed to load block %d when blockStore is at %d",
-						prs.Height, conR.conS.blockStore.Height()))
+					heightLogger.Error("Failed to load block meta",
+						"blockstoreHeight", conR.conS.blockStore.Height())
+					time.Sleep(conR.conS.config.PeerGossipSleepDuration)
+				} else {
+					ps.InitProposalBlockParts(blockMeta.BlockID.PartsHeader)
 				}
-				ps.InitProposalBlockParts(blockMeta.BlockID.PartsHeader)
 				// continue the loop since prs is a copy and not effected by this initialization
 				continue OUTER_LOOP
 			}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1459,8 +1459,11 @@ func (cs *ConsensusState) finalizeCommit(height int64) {
 func (cs *ConsensusState) recordMetrics(height int64, block *types.Block) {
 	cs.metrics.Validators.Set(float64(cs.Validators.Size()))
 	cs.metrics.ValidatorsPower.Set(float64(cs.Validators.TotalVotingPower()))
-	missingValidators := 0
-	missingValidatorsPower := int64(0)
+
+	var (
+		missingValidators      = 0
+		missingValidatorsPower int64
+	)
 	for i, val := range cs.Validators.Validators {
 		var vote *types.CommitSig
 		if i < len(block.LastCommit.Precommits) {
@@ -1470,9 +1473,22 @@ func (cs *ConsensusState) recordMetrics(height int64, block *types.Block) {
 			missingValidators++
 			missingValidatorsPower += val.VotingPower
 		}
+
+		if cs.privValidator != nil && bytes.Equal(val.Address, cs.privValidator.GetPubKey().Address()) {
+			label := []string{
+				"validator_address", val.Address.String(),
+			}
+			cs.metrics.ValidatorPower.With(label...).Set(float64(val.VotingPower))
+			if vote != nil {
+				cs.metrics.ValidatorLastSignedHeight.With(label...).Set(float64(height))
+			} else {
+				cs.metrics.ValidatorMissedBlocks.With(label...).Add(float64(1))
+			}
+		}
 	}
 	cs.metrics.MissingValidators.Set(float64(missingValidators))
 	cs.metrics.MissingValidatorsPower.Set(float64(missingValidatorsPower))
+
 	cs.metrics.ByzantineValidators.Set(float64(len(block.Evidence.Evidence)))
 	byzantineValidatorsPower := int64(0)
 	for _, ev := range block.Evidence.Evidence {
@@ -1493,7 +1509,6 @@ func (cs *ConsensusState) recordMetrics(height int64, block *types.Block) {
 	cs.metrics.BlockSizeBytes.Set(float64(block.Size()))
 	cs.metrics.TotalTxs.Set(float64(block.TotalTxs))
 	cs.metrics.CommittedHeight.Set(float64(block.Height))
-
 }
 
 //-----------------------------------------------------------------------------

--- a/docs/tendermint-core/metrics.md
+++ b/docs/tendermint-core/metrics.md
@@ -18,34 +18,37 @@ Listen address can be changed in the config file (see
 
 The following metrics are available:
 
-| **Name**                                | **Type**  | **Since** | **Tags**       | **Description**                                                 |
-| --------------------------------------- | --------- | --------- | -------------- | --------------------------------------------------------------- |
-| consensus\_height                       | Gauge     | 0.21.0    |                | Height of the chain                                             |
-| consensus\_validators                   | Gauge     | 0.21.0    |                | Number of validators                                            |
-| consensus\_validators\_power            | Gauge     | 0.21.0    |                | Total voting power of all validators                            |
-| consensus\_missing\_validators          | Gauge     | 0.21.0    |                | Number of validators who did not sign                           |
-| consensus\_missing\_validators\_power   | Gauge     | 0.21.0    |                | Total voting power of the missing validators                    |
-| consensus\_byzantine\_validators        | Gauge     | 0.21.0    |                | Number of validators who tried to double sign                   |
-| consensus\_byzantine\_validators\_power | Gauge     | 0.21.0    |                | Total voting power of the byzantine validators                  |
-| consensus\_block\_interval\_seconds     | Histogram | 0.21.0    |                | Time between this and last block (Block.Header.Time) in seconds |
-| consensus\_rounds                       | Gauge     | 0.21.0    |                | Number of rounds                                                |
-| consensus\_num\_txs                     | Gauge     | 0.21.0    |                | Number of transactions                                          |
-| consensus\_block\_parts                 | counter   | on dev    | peer\_id       | number of blockparts transmitted by peer                        |
-| consensus\_latest\_block\_height        | gauge     | on dev    |                | /status sync\_info number                                       |
-| consensus\_fast\_syncing                | gauge     | on dev    |                | either 0 (not fast syncing) or 1 (syncing)                      |
-| consensus\_total\_txs                   | Gauge     | 0.21.0    |                | Total number of transactions committed                          |
-| consensus\_block\_size\_bytes           | Gauge     | 0.21.0    |                | Block size in bytes                                             |
-| p2p\_peers                              | Gauge     | 0.21.0    |                | Number of peers node's connected to                             |
-| p2p\_peer\_receive\_bytes\_total        | counter   | on dev    | peer\_id, chID | number of bytes per channel received from a given peer          |
-| p2p\_peer\_send\_bytes\_total           | counter   | on dev    | peer\_id, chID | number of bytes per channel sent to a given peer                |
-| p2p\_peer\_pending\_send\_bytes         | gauge     | on dev    | peer\_id       | number of pending bytes to be sent to a given peer              |
-| p2p\_num\_txs                           | gauge     | on dev    | peer\_id       | number of transactions submitted by each peer\_id               |
-| p2p\_pending\_send\_bytes               | gauge     | on dev    | peer\_id       | amount of data pending to be sent to peer                       |
-| mempool\_size                           | Gauge     | 0.21.0    |                | Number of uncommitted transactions                              |
-| mempool\_tx\_size\_bytes                | histogram | on dev    |                | transaction sizes in bytes                                      |
-| mempool\_failed\_txs                    | counter   | on dev    |                | number of failed transactions                                   |
-| mempool\_recheck\_times                 | counter   | on dev    |                | number of transactions rechecked in the mempool                 |
-| state\_block\_processing\_time          | histogram | on dev    |                | time between BeginBlock and EndBlock in ms                      |
+| **Name**                               | **Type**  | **Since** | **Tags**      | **Description**                                                        |
+| -------------------------------------- | --------- | --------- | ------------- | ---------------------------------------------------------------------- |
+| consensus_height                       | Gauge     | 0.21.0    |               | Height of the chain                                                    |
+| consensus_validators                   | Gauge     | 0.21.0    |               | Number of validators                                                   |
+| consensus_validators_power             | Gauge     | 0.21.0    |               | Total voting power of all validators                                   |
+| consensus_validator_power              | Gauge     | 0.33.0    |               | Voting power of the node if in the validator set                       |
+| consensus_validator_last_signed_height | Gauge     | 0.33.0    |               | Last height the node signed a block, if the node is a validator        |
+| consensus_validator_missed_blocks      | Gauge     | 0.33.0    |               | Total amount of blocks missed for the node, if the node is a validator |
+| consensus_missing_validators           | Gauge     | 0.21.0    |               | Number of validators who did not sign                                  |
+| consensus_missing_validators_power     | Gauge     | 0.21.0    |               | Total voting power of the missing validators                           |
+| consensus_byzantine_validators         | Gauge     | 0.21.0    |               | Number of validators who tried to double sign                          |
+| consensus_byzantine_validators_power   | Gauge     | 0.21.0    |               | Total voting power of the byzantine validators                         |
+| consensus_block_interval_seconds       | Histogram | 0.21.0    |               | Time between this and last block (Block.Header.Time) in seconds        |
+| consensus_rounds                       | Gauge     | 0.21.0    |               | Number of rounds                                                       |
+| consensus_num_txs                      | Gauge     | 0.21.0    |               | Number of transactions                                                 |
+| consensus_total_txs                    | Gauge     | 0.21.0    |               | Total number of transactions committed                                 |
+| consensus_block_parts                  | counter   | on dev    | peer_id       | number of blockparts transmitted by peer                               |
+| consensus_latest_block_height          | gauge     | on dev    |               | /status sync_info number                                               |
+| consensus_fast_syncing                 | gauge     | on dev    |               | either 0 (not fast syncing) or 1 (syncing)                             |
+| consensus_block_size_bytes             | Gauge     | 0.21.0    |               | Block size in bytes                                                    |
+| p2p_peers                              | Gauge     | 0.21.0    |               | Number of peers node's connected to                                    |
+| p2p_peer_receive_bytes_total           | counter   | on dev    | peer_id, chID | number of bytes per channel received from a given peer                 |
+| p2p_peer_send_bytes_total              | counter   | on dev    | peer_id, chID | number of bytes per channel sent to a given peer                       |
+| p2p_peer_pending_send_bytes            | gauge     | on dev    | peer_id       | number of pending bytes to be sent to a given peer                     |
+| p2p_num_txs                            | gauge     | on dev    | peer_id       | number of transactions submitted by each peer_id                       |
+| p2p_pending_send_bytes                 | gauge     | on dev    | peer_id       | amount of data pending to be sent to peer                              |
+| mempool_size                           | Gauge     | 0.21.0    |               | Number of uncommitted transactions                                     |
+| mempool_tx_size_bytes                  | histogram | on dev    |               | transaction sizes in bytes                                             |
+| mempool_failed_txs                     | counter   | on dev    |               | number of failed transactions                                          |
+| mempool_recheck_times                  | counter   | on dev    |               | number of transactions rechecked in the mempool                        |
+| state_block_processing_time            | histogram | on dev    |               | time between BeginBlock and EndBlock in ms                             |
 
 ## Useful queries
 

--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -82,12 +82,6 @@ func parseRemoteAddr(remoteAddr string) (network string, s string, err error) {
 		return "", "", fmt.Errorf("invalid addr: %s", remoteAddr)
 	}
 
-	// accept http(s) as an alias for tcp
-	switch protocol {
-	case protoHTTP, protoHTTPS:
-		protocol = protoTCP
-	}
-
 	return protocol, address, nil
 }
 
@@ -101,6 +95,12 @@ func makeHTTPDialer(remoteAddr string) func(string, string) (net.Conn, error) {
 	protocol, address, err := parseRemoteAddr(remoteAddr)
 	if err != nil {
 		return makeErrorDialer(err)
+	}
+
+	// accept http(s) as an alias for tcp
+	switch protocol {
+	case protoHTTP, protoHTTPS:
+		protocol = protoTCP
 	}
 
 	return func(proto, addr string) (net.Conn, error) {

--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -28,61 +28,60 @@ const (
 	protoTCP   = "tcp"
 )
 
+// Parsed URL structure
+type parsedURL struct {
+	url.URL
+}
+
+// Parse URL and set defaults
+func newParsedURL(remoteAddr string) (*parsedURL, error) {
+	u, err := url.Parse(remoteAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	// default to tcp if nothing specified
+	if u.Scheme == "" {
+		u.Scheme = protoTCP
+	}
+
+	return &parsedURL{*u}, nil
+}
+
+// Change protocol to HTTP for unknown protocols and TCP protocol - useful for RPC connections
+func (u *parsedURL) SetDefaultSchemeHTTP() {
+	// protocol to use for http operations, to support both http and https
+	switch u.Scheme {
+	case protoHTTP, protoHTTPS, protoWS, protoWSS:
+		// known protocols not changed
+	default:
+		// default to http for unknown protocols (ex. tcp)
+		u.Scheme = protoHTTP
+	}
+}
+
+// Get full address without the protocol - useful for Dialer connections
+func (u parsedURL) GetHostWithPath() string {
+	// Remove protocol, userinfo and # fragment, assume opaque is empty
+	return u.Host + u.EscapedPath()
+}
+
+// Get a trimmed address - useful for WS connections
+func (u parsedURL) GetTrimmedHostWithPath() string {
+	// replace / with . for http requests (kvstore domain)
+	return strings.Replace(u.GetHostWithPath(), "/", ".", -1)
+}
+
+// Get a trimmed address with protocol - useful as address in RPC connections
+func (u parsedURL) GetTrimmedURL() string {
+	return u.Scheme + "://" + u.GetTrimmedHostWithPath()
+}
+
 // HTTPClient is a common interface for JSONRPCClient and URIClient.
 type HTTPClient interface {
 	Call(method string, params map[string]interface{}, result interface{}) (interface{}, error)
 	Codec() *amino.Codec
 	SetCodec(*amino.Codec)
-}
-
-// protocol - client's protocol (for example, "http", "https", "wss", "ws", "tcp")
-// trimmedS - rest of the address (for example, "192.0.2.1:25", "[2001:db8::1]:80") with "/" replaced with "."
-func toClientAddrAndParse(remoteAddr string) (network string, trimmedS string, err error) {
-	protocol, address, err := parseRemoteAddr(remoteAddr)
-	if err != nil {
-		return "", "", err
-	}
-
-	// protocol to use for http operations, to support both http and https
-	var clientProtocol string
-	// default to http for unknown protocols (ex. tcp)
-	switch protocol {
-	case protoHTTP, protoHTTPS, protoWS, protoWSS:
-		clientProtocol = protocol
-	default:
-		clientProtocol = protoHTTP
-	}
-
-	// replace / with . for http requests (kvstore domain)
-	trimmedAddress := strings.Replace(address, "/", ".", -1)
-	return clientProtocol, trimmedAddress, nil
-}
-
-func toClientAddress(remoteAddr string) (string, error) {
-	clientProtocol, trimmedAddress, err := toClientAddrAndParse(remoteAddr)
-	if err != nil {
-		return "", err
-	}
-	return clientProtocol + "://" + trimmedAddress, nil
-}
-
-// network - name of the network (for example, "tcp", "unix")
-// s - rest of the address (for example, "192.0.2.1:25", "[2001:db8::1]:80")
-// TODO: Deprecate support for IP:PORT or /path/to/socket
-func parseRemoteAddr(remoteAddr string) (network string, s string, err error) {
-	parts := strings.SplitN(remoteAddr, "://", 2)
-	var protocol, address string
-	switch {
-	case len(parts) == 1:
-		// default to tcp if nothing specified
-		protocol, address = protoTCP, remoteAddr
-	case len(parts) == 2:
-		protocol, address = parts[0], parts[1]
-	default:
-		return "", "", fmt.Errorf("invalid addr: %s", remoteAddr)
-	}
-
-	return protocol, address, nil
 }
 
 func makeErrorDialer(err error) func(string, string) (net.Conn, error) {
@@ -92,10 +91,12 @@ func makeErrorDialer(err error) func(string, string) (net.Conn, error) {
 }
 
 func makeHTTPDialer(remoteAddr string) func(string, string) (net.Conn, error) {
-	protocol, address, err := parseRemoteAddr(remoteAddr)
+	u, err := newParsedURL(remoteAddr)
 	if err != nil {
 		return makeErrorDialer(err)
 	}
+
+	protocol := u.Scheme
 
 	// accept http(s) as an alias for tcp
 	switch protocol {
@@ -104,7 +105,7 @@ func makeHTTPDialer(remoteAddr string) func(string, string) (net.Conn, error) {
 	}
 
 	return func(proto, addr string) (net.Conn, error) {
-		return net.Dial(protocol, address)
+		return net.Dial(protocol, u.GetHostWithPath())
 	}
 }
 
@@ -142,10 +143,12 @@ type JSONRPCRequestBatch struct {
 
 // JSONRPCClient takes params as a slice
 type JSONRPCClient struct {
-	address string
-	client  *http.Client
-	id      types.JSONRPCStringID
-	cdc     *amino.Codec
+	address  string
+	username string
+	password string
+	client   *http.Client
+	id       types.JSONRPCStringID
+	cdc      *amino.Codec
 }
 
 // JSONRPCCaller implementers can facilitate calling the JSON RPC endpoint.
@@ -170,16 +173,24 @@ func NewJSONRPCClientWithHTTPClient(remote string, client *http.Client) *JSONRPC
 		panic("nil http.Client provided")
 	}
 
-	clientAddress, err := toClientAddress(remote)
+	parsedURL, err := newParsedURL(remote)
 	if err != nil {
 		panic(fmt.Sprintf("invalid remote %s: %s", remote, err))
 	}
 
+	parsedURL.SetDefaultSchemeHTTP()
+
+	address := parsedURL.GetTrimmedURL()
+	username := parsedURL.User.Username()
+	password, _ := parsedURL.User.Password()
+
 	return &JSONRPCClient{
-		address: clientAddress,
-		client:  client,
-		id:      types.JSONRPCStringID("jsonrpc-client-" + cmn.RandStr(8)),
-		cdc:     amino.NewCodec(),
+		address:  address,
+		username: username,
+		password: password,
+		client:   client,
+		id:       types.JSONRPCStringID("jsonrpc-client-" + cmn.RandStr(8)),
+		cdc:      amino.NewCodec(),
 	}
 }
 
@@ -195,7 +206,15 @@ func (c *JSONRPCClient) Call(method string, params map[string]interface{}, resul
 		return nil, err
 	}
 	requestBuf := bytes.NewBuffer(requestBytes)
-	httpResponse, err := c.client.Post(c.address, "text/json", requestBuf)
+	httpRequest, err := http.NewRequest(http.MethodPost, c.address, requestBuf)
+	if err != nil {
+		return nil, err
+	}
+	httpRequest.Header.Set("Content-Type", "text/json")
+	if c.username != "" || c.password != "" {
+		httpRequest.SetBasicAuth(c.username, c.password)
+	}
+	httpResponse, err := c.client.Do(httpRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +247,15 @@ func (c *JSONRPCClient) sendBatch(requests []*jsonRPCBufferedRequest) ([]interfa
 	if err != nil {
 		return nil, err
 	}
-	httpResponse, err := c.client.Post(c.address, "text/json", bytes.NewBuffer(requestBytes))
+	httpRequest, err := http.NewRequest(http.MethodPost, c.address, bytes.NewBuffer(requestBytes))
+	if err != nil {
+		return nil, err
+	}
+	httpRequest.Header.Set("Content-Type", "text/json")
+	if c.username != "" || c.password != "" {
+		httpRequest.SetBasicAuth(c.username, c.password)
+	}
+	httpResponse, err := c.client.Do(httpRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -315,12 +342,15 @@ type URIClient struct {
 
 // The function panics if the provided remote is invalid.
 func NewURIClient(remote string) *URIClient {
-	clientAddress, err := toClientAddress(remote)
+	parsedURL, err := newParsedURL(remote)
 	if err != nil {
 		panic(fmt.Sprintf("invalid remote %s: %s", remote, err))
 	}
+
+	parsedURL.SetDefaultSchemeHTTP()
+
 	return &URIClient{
-		address: clientAddress,
+		address: parsedURL.GetTrimmedURL(),
 		client:  DefaultHTTPClient(remote),
 		cdc:     amino.NewCodec(),
 	}

--- a/rpc/lib/client/http_client_test.go
+++ b/rpc/lib/client/http_client_test.go
@@ -1,0 +1,22 @@
+package rpcclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPClientMakeHTTPDialer(t *testing.T) {
+	remote := []string{"https://foo-bar.com:80", "http://foo-bar.net:80"}
+
+	for _, f := range remote {
+		protocol, address, err := parseRemoteAddr(f)
+		require.NoError(t, err)
+		dialFn := makeHTTPDialer(f)
+
+		addr, err := dialFn(protocol, address)
+		require.NoError(t, err)
+		require.NotNil(t, addr)
+	}
+
+}

--- a/rpc/lib/client/http_client_test.go
+++ b/rpc/lib/client/http_client_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestHTTPClientMakeHTTPDialer(t *testing.T) {
-	remote := []string{"https://foo-bar.com:80", "http://foo-bar.net:80"}
+	remote := []string{"https://foo-bar.com:80", "http://foo-bar.net:80", "https://user:pass@foo-bar.net:80"}
 
 	for _, f := range remote {
-		protocol, address, err := parseRemoteAddr(f)
+		u, err := newParsedURL(f)
 		require.NoError(t, err)
 		dialFn := makeHTTPDialer(f)
 
-		addr, err := dialFn(protocol, address)
+		addr, err := dialFn(u.Scheme, u.GetHostWithPath())
 		require.NoError(t, err)
 		require.NotNil(t, addr)
 	}

--- a/rpc/lib/client/ws_client_test.go
+++ b/rpc/lib/client/ws_client_test.go
@@ -64,7 +64,8 @@ func TestWSClientReconnectsAfterReadFailure(t *testing.T) {
 	s := httptest.NewServer(h)
 	defer s.Close()
 
-	c := startClient(t, s.Listener.Addr().String())
+	// https://github.com/golang/go/issues/19297#issuecomment-282651469
+	c := startClient(t, "//" + s.Listener.Addr().String())
 	defer c.Stop()
 
 	wg.Add(1)
@@ -96,7 +97,8 @@ func TestWSClientReconnectsAfterWriteFailure(t *testing.T) {
 	h := &myHandler{}
 	s := httptest.NewServer(h)
 
-	c := startClient(t, s.Listener.Addr().String())
+	// https://github.com/golang/go/issues/19297#issuecomment-282651469
+	c := startClient(t, "//" + s.Listener.Addr().String())
 	defer c.Stop()
 
 	wg.Add(2)
@@ -124,7 +126,8 @@ func TestWSClientReconnectFailure(t *testing.T) {
 	h := &myHandler{}
 	s := httptest.NewServer(h)
 
-	c := startClient(t, s.Listener.Addr().String())
+	// https://github.com/golang/go/issues/19297#issuecomment-282651469
+	c := startClient(t, "//" + s.Listener.Addr().String())
 	defer c.Stop()
 
 	go func() {
@@ -173,7 +176,7 @@ func TestWSClientReconnectFailure(t *testing.T) {
 func TestNotBlockingOnStop(t *testing.T) {
 	timeout := 2 * time.Second
 	s := httptest.NewServer(&myHandler{})
-	c := startClient(t, s.Listener.Addr().String())
+	c := startClient(t, "//" + s.Listener.Addr().String())
 	c.Call(context.Background(), "a", make(map[string]interface{}))
 	// Let the readRoutine get around to blocking
 	time.Sleep(time.Second)

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ const (
 	// XXX: Don't change the name of this variable or you will break
 	// automation :)
 
-	TMCoreSemVer = "0.32.8"
+	TMCoreSemVer = "0.32.9"
 
 	// ABCISemVer is the semantic version of the ABCI library
 	ABCISemVer  = "0.16.1"


### PR DESCRIPTION
back port of: 

- [rpc/lib] [\#4248](https://github.com/tendermint/tendermint/issues/4248) RPC client basic authentication support (@greg-szabo)

- [metrics] \#4263 Add
  - `consensus_validator_power`: track your validators power
  - `consensus_validator_last_signed_height`: track at which height the validator last signed
  - `consensus_validator_missed_blocks`: total amount of missed blocks for a validator
    as gauges in prometheus for validator specific metrics

- [rpc/lib] [\#4051](https://github.com/tendermint/tendermint/pull/4131) Fix RPC client, which was previously resolving https protocol to http (@yenkhoon)
- [cs] \#4069 Don't panic when block meta is not found in store (@gregzaitsev)

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
