### PR TITLE
tests: bind test servers to 127.0.0.1

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,8 +19,6 @@ program](https://hackerone.com/tendermint).
 
 ### IMPROVEMENTS:
 
-- [tests] [#\4322](https://github.com/tendermint/tendermint/pull/4322) Bind test servers to 127.0.0.1 (@erikgrinaker)
-
 ### BUG FIXES:
 
 - [rpc] [#\4319] Check BlockMeta is not nil in Blocks & BlockByHash

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,7 +19,7 @@ program](https://hackerone.com/tendermint).
 
 ### IMPROVEMENTS:
 
-- [tests] Bind test servers to 127.0.0.1
+- [tests] [#\4322](https://github.com/tendermint/tendermint/pull/4322) Bind test servers to 127.0.0.1 (@erikgrinaker)
 
 ### BUG FIXES:
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,6 +19,8 @@ program](https://hackerone.com/tendermint).
 
 ### IMPROVEMENTS:
 
+- [tests] Bind test servers to 127.0.0.1
+
 ### BUG FIXES:
 
 - [rpc] [#\4319] Check BlockMeta is not nil in Blocks & BlockByHash

--- a/config/config.go
+++ b/config/config.go
@@ -415,8 +415,8 @@ func DefaultRPCConfig() *RPCConfig {
 // TestRPCConfig returns a configuration for testing the RPC server
 func TestRPCConfig() *RPCConfig {
 	cfg := DefaultRPCConfig()
-	cfg.ListenAddress = "tcp://0.0.0.0:36657"
-	cfg.GRPCListenAddress = "tcp://0.0.0.0:36658"
+	cfg.ListenAddress = "tcp://127.0.0.1:36657"
+	cfg.GRPCListenAddress = "tcp://127.0.0.1:36658"
 	cfg.Unsafe = true
 	return cfg
 }
@@ -584,7 +584,7 @@ func DefaultP2PConfig() *P2PConfig {
 // TestP2PConfig returns a configuration for testing the peer-to-peer layer
 func TestP2PConfig() *P2PConfig {
 	cfg := DefaultP2PConfig()
-	cfg.ListenAddress = "tcp://0.0.0.0:36656"
+	cfg.ListenAddress = "tcp://127.0.0.1:36656"
 	cfg.FlushThrottleTimeout = 10 * time.Millisecond
 	cfg.AllowDuplicateIP = true
 	return cfg

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -125,9 +125,9 @@ func randPort() int {
 
 func makeAddrs() (string, string, string) {
 	start := randPort()
-	return fmt.Sprintf("tcp://0.0.0.0:%d", start),
-		fmt.Sprintf("tcp://0.0.0.0:%d", start+1),
-		fmt.Sprintf("tcp://0.0.0.0:%d", start+2)
+	return fmt.Sprintf("tcp://127.0.0.1:%d", start),
+		fmt.Sprintf("tcp://127.0.0.1:%d", start+1),
+		fmt.Sprintf("tcp://127.0.0.1:%d", start+2)
 }
 
 // getConfig returns a config for test cases

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -48,7 +48,7 @@ func NewNetAddress(id ID, addr net.Addr) *NetAddress {
 		if flag.Lookup("test.v") == nil { // normal run
 			panic(fmt.Sprintf("Only TCPAddrs are supported. Got: %v", addr))
 		} else { // in testing
-			netAddr := NewNetAddressIPPort(net.IP("0.0.0.0"), 0)
+			netAddr := NewNetAddressIPPort(net.IP("127.0.0.1"), 0)
 			netAddr.ID = id
 			return netAddr
 		}

--- a/rpc/lib/rpc_test.go
+++ b/rpc/lib/rpc_test.go
@@ -28,7 +28,7 @@ import (
 
 // Client and Server should work over tcp or unix sockets
 const (
-	tcpAddr = "tcp://0.0.0.0:47768"
+	tcpAddr = "tcp://127.0.0.1:47768"
 
 	unixSocket = "/tmp/rpc_test.sock"
 	unixAddr   = "unix://" + unixSocket

--- a/rpc/lib/test/main.go
+++ b/rpc/lib/test/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	rpcserver.RegisterRPCFuncs(mux, routes, cdc, logger)
 	config := rpcserver.DefaultConfig()
-	listener, err := rpcserver.Listen("0.0.0.0:8008", config)
+	listener, err := rpcserver.Listen("tcp://127.0.0.1:8008", config)
 	if err != nil {
 		tmos.Exit(err.Error())
 	}

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -85,9 +85,9 @@ func randPort() int {
 }
 
 func makeAddrs() (string, string, string) {
-	return fmt.Sprintf("tcp://0.0.0.0:%d", randPort()),
-		fmt.Sprintf("tcp://0.0.0.0:%d", randPort()),
-		fmt.Sprintf("tcp://0.0.0.0:%d", randPort())
+	return fmt.Sprintf("tcp://127.0.0.1:%d", randPort()),
+		fmt.Sprintf("tcp://127.0.0.1:%d", randPort()),
+		fmt.Sprintf("tcp://127.0.0.1:%d", randPort())
 }
 
 func createConfig() *cfg.Config {


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
* [x] ~Referenced an issue explaining the need for the change~
* [x] ~Updated all relevant documentation in docs~
* [x] ~Updated all code comments where relevant~

The test servers bind to public interfaces by default, triggering about a dozen macOS firewall dialogs that have to be rejected each time tests are run. Binding to the loopback interface instead prevents these warnings.