### PR TITLE
node: use GRPCMaxOpenConnections when creating the gRPC server

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,6 +24,5 @@ program](https://hackerone.com/tendermint).
 
 ### BUG FIXES:
 
-- [rpc] [#\4319] Check BlockMeta is not nil in Blocks & BlockByHash
-
-
+- [node] [#\4311] Use `GRPCMaxOpenConnections` when creating the gRPC server, not `MaxOpenConnections`
+- [rpc] [#\4319] Check `BlockMeta` is not nil in `/block` & `/block_by_hash`


### PR DESCRIPTION
not MaxOpenConnections

Fixes #4311

Also, set MaxBodyBytes, MaxHeaderBytes and WriteTimeout similar to HTTP
server.

<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [x] Referenced an issue explaining the need for the change
* [ ] ~~Updated all relevant documentation in docs~~
* [x] Updated all code comments where relevant
* [ ] ~~Wrote tests~~
* [x] Updated CHANGELOG_PENDING.md
