### PR TITLE
lite2: replace primary provider with alternative when unavailable

### DIFF
--- a/lite2/client.go
+++ b/lite2/client.go
@@ -894,7 +894,7 @@ func (c *Client) signedHeaderFromPrimary(height int64) (*types.SignedHeader, err
 		if err == nil || err == provider.ErrSignedHeaderNotFound {
 			return h, err
 		}
-		time.Sleep(time.Duration(1*attempt*attempt)*time.Second + time.Duration(rand.Intn(1000))*time.Millisecond)
+		time.Sleep(time.Duration(500*attempt*attempt)*time.Millisecond + time.Duration(rand.Intn(1000))*time.Millisecond)
 	}
 	c.logger.Info("Primary is unavailable. Replacing with the first witness")
 	err := c.replacePrimaryProvider()
@@ -915,7 +915,7 @@ func (c *Client) validatorSetFromPrimary(height int64) (*types.ValidatorSet, err
 		if err == nil || err == provider.ErrValidatorSetNotFound {
 			return h, err
 		}
-		time.Sleep(time.Duration(1*attempt*attempt)*time.Second + time.Duration(rand.Intn(1000))*time.Millisecond)
+		time.Sleep(time.Duration(500*attempt*attempt)*time.Millisecond + time.Duration(rand.Intn(1000))*time.Millisecond)
 	}
 	c.logger.Info("Primary is unavailable. Replacing with the first witness")
 	err := c.replacePrimaryProvider()

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -894,7 +894,7 @@ func (c *Client) signedHeaderFromPrimary(height int64) (*types.SignedHeader, err
 		if err == nil || err == provider.ErrSignedHeaderNotFound {
 			return h, err
 		}
-		time.Sleep(time.Duration(1<<attempt)*time.Second + time.Duration(rand.Intn(1000))*time.Millisecond)
+		time.Sleep(time.Duration(1*attempt*attempt)*time.Second + time.Duration(rand.Intn(1000))*time.Millisecond)
 	}
 	c.logger.Info("Primary is unavailable. Replacing with the first witness")
 	err := c.replacePrimaryProvider()
@@ -915,7 +915,7 @@ func (c *Client) validatorSetFromPrimary(height int64) (*types.ValidatorSet, err
 		if err == nil || err == provider.ErrValidatorSetNotFound {
 			return h, err
 		}
-		time.Sleep(time.Duration(1<<attempt)*time.Second + time.Duration(rand.Intn(1000))*time.Millisecond)
+		time.Sleep(time.Duration(1*attempt*attempt)*time.Second + time.Duration(rand.Intn(1000))*time.Millisecond)
 	}
 	c.logger.Info("Primary is unavailable. Replacing with the first witness")
 	err := c.replacePrimaryProvider()

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -53,7 +53,8 @@ const (
 	defaultUpdatePeriod                       = 5 * time.Second
 	defaultRemoveNoLongerTrustedHeadersPeriod = 24 * time.Hour
 	maxAttempts                               = 5
-	backOffBase                               = 1000
+	backOffBase                               = 1
+	jitter                                    = 5
 )
 
 // Option sets a parameter for the light client.
@@ -200,6 +201,8 @@ func NewClient(
 		quit:                               make(chan struct{}),
 		logger:                             log.NewNopLogger(),
 	}
+
+	rand.Seed(time.Now().UnixNano())
 
 	for _, o := range options {
 		o(c)
@@ -927,8 +930,7 @@ func (c *Client) validatorSetFromPrimary(height int64) (*types.ValidatorSet, err
 
 // generates a backoff time between operations that is calculated as a random duration between 0 and a set cap
 func backoffAndJitterTime(attempt int) time.Duration {
-	rand.Seed(time.Now().UnixNano())
-	return time.Duration(rand.Intn(backOffBase*attempt*attempt)) * time.Second
+	return time.Duration((backOffBase*attempt*attempt)+rand.Intn(jitter)) * time.Second
 }
 
 // Primary returns the primary provider for the lite client

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -53,8 +53,7 @@ const (
 	defaultUpdatePeriod                       = 5 * time.Second
 	defaultRemoveNoLongerTrustedHeadersPeriod = 24 * time.Hour
 	maxAttempts                               = 5
-	// max backOff in seconds
-	backOffCap = 1000
+	backOffBase                               = 1000
 )
 
 // Option sets a parameter for the light client.
@@ -929,7 +928,7 @@ func (c *Client) validatorSetFromPrimary(height int64) (*types.ValidatorSet, err
 // generates a backoff time between operations that is calculated as a random duration between 0 and a set cap
 func backoffAndJitterTime(attempt int) time.Duration {
 	rand.Seed(time.Now().UnixNano())
-	return time.Duration(rand.Intn(backOffCap/maxAttempts*attempt)) * time.Millisecond
+	return time.Duration(rand.Intn(backOffBase*attempt*attempt)) * time.Second
 }
 
 // Primary returns the primary provider for the lite client

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -852,3 +852,18 @@ func (c *Client) Update(now time.Time) error {
 
 	return nil
 }
+
+func (c *Client) swapProvider() error {
+	switch x := len(c.alternatives); {
+	case x == 1: // straight swap
+		c.primary, c.alternatives[0] = c.alternatives[0], c.primary
+		return nil
+	case x > 1: // implement queue system
+		temp := c.primary
+		c.primary, c.alternatives = c.alternatives[0], c.alternatives[1:]
+		c.alternatives = append(c.alternatives, temp)
+		return nil
+	default:
+		return errors.Errorf("unable to replace provider. It is likely that no alternatives have been declared.")
+	}
+}

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -53,8 +53,6 @@ const (
 	defaultUpdatePeriod                       = 5 * time.Second
 	defaultRemoveNoLongerTrustedHeadersPeriod = 24 * time.Hour
 	maxAttempts                               = 5
-	backOffBase                               = 1
-	jitter                                    = 5
 )
 
 // Option sets a parameter for the light client.
@@ -896,7 +894,7 @@ func (c *Client) signedHeaderFromPrimary(height int64) (*types.SignedHeader, err
 		if err == nil || err == provider.ErrSignedHeaderNotFound {
 			return h, err
 		}
-		time.Sleep(backoffAndJitterTime(attempt + 1))
+		time.Sleep(backoffAndJitterTime(attempt+1, 1, 5))
 	}
 	c.logger.Info("Primary is unavailable. Replacing with the first witness")
 	err := c.replacePrimaryProvider()
@@ -917,7 +915,7 @@ func (c *Client) validatorSetFromPrimary(height int64) (*types.ValidatorSet, err
 		if err == nil || err == provider.ErrValidatorSetNotFound {
 			return h, err
 		}
-		time.Sleep(backoffAndJitterTime(attempt + 1))
+		time.Sleep(backoffAndJitterTime(attempt+1, 1, 5))
 	}
 	c.logger.Info("Primary is unavailable. Replacing with the first witness")
 	err := c.replacePrimaryProvider()
@@ -929,7 +927,7 @@ func (c *Client) validatorSetFromPrimary(height int64) (*types.ValidatorSet, err
 }
 
 // generates a backoff time between operations that is calculated as a random duration between 0 and a set cap
-func backoffAndJitterTime(attempt int) time.Duration {
+func backoffAndJitterTime(attempt, backOffBase, jitter int) time.Duration {
 	return time.Duration((backOffBase*attempt*attempt)+rand.Intn(jitter)) * time.Second
 }
 

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -200,8 +200,6 @@ func NewClient(
 		logger:                             log.NewNopLogger(),
 	}
 
-	rand.Seed(time.Now().UnixNano())
-
 	for _, o := range options {
 		o(c)
 	}
@@ -894,6 +892,7 @@ func (c *Client) signedHeaderFromPrimary(height int64) (*types.SignedHeader, err
 		if err == nil || err == provider.ErrSignedHeaderNotFound {
 			return h, err
 		}
+		// add exponential backoff and jitter between attempts  - 0.5s -> 2s -> 4.5s -> 8s -> 12.5 with 1s variation
 		time.Sleep(time.Duration(500*attempt*attempt)*time.Millisecond + time.Duration(rand.Intn(1000))*time.Millisecond)
 	}
 	c.logger.Info("Primary is unavailable. Replacing with the first witness")
@@ -915,6 +914,7 @@ func (c *Client) validatorSetFromPrimary(height int64) (*types.ValidatorSet, err
 		if err == nil || err == provider.ErrValidatorSetNotFound {
 			return h, err
 		}
+		// add exponential backoff and jitter between attempts  - 0.5s -> 2s -> 4.5s -> 8s -> 12.5 with 1s variation
 		time.Sleep(time.Duration(500*attempt*attempt)*time.Millisecond + time.Duration(rand.Intn(1000))*time.Millisecond)
 	}
 	c.logger.Info("Primary is unavailable. Replacing with the first witness")

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -926,11 +926,6 @@ func (c *Client) validatorSetFromPrimary(height int64) (*types.ValidatorSet, err
 
 }
 
-// generates a backoff time between operations that is calculated as a random duration between 0 and a set cap
-func backoffAndJitterTime(attempt, backOffBase, jitter int) time.Duration {
-	return time.Duration((backOffBase*attempt*attempt)+rand.Intn(jitter)) * time.Second
-}
-
 // Primary returns the primary provider.
 func (c *Client) Primary() provider.Provider {
 	c.providerMutex.Lock()

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -855,9 +855,8 @@ func (c *Client) Update(now time.Time) error {
 	return nil
 }
 
-// swapProvider takes the first alternative provider and promotes it as the primary provider
-func (c *Client) swapProvider() error {
-	//TODO: Use Mutex to lock and unlock the variable
+// replaceProvider takes the first alternative provider and promotes it as the primary provider
+func (c *Client) replaceProvider() error {
 	if len(c.alternatives) == 0 {
 		return errors.Errorf("unable to replace provider. No other alternatives exist.")
 	}

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -137,6 +137,8 @@ func TestClient_SequentialVerification(t *testing.T) {
 		} else {
 			require.NoError(t, err)
 		}
+		err = c.Start()
+		require.NoError(t, err)
 		defer c.Stop()
 
 		_, err = c.VerifyHeaderAtHeight(3, bTime.Add(3*time.Hour))
@@ -235,6 +237,8 @@ func TestClient_SkippingVerification(t *testing.T) {
 		} else {
 			require.NoError(t, err)
 		}
+		err = c.Start()
+		require.NoError(t, err)
 		defer c.Stop()
 
 		_, err = c.VerifyHeaderAtHeight(3, bTime.Add(3*time.Hour))
@@ -289,6 +293,8 @@ func TestClientRemovesNoLongerTrustedHeaders(t *testing.T) {
 		dbs.New(dbm.NewMemDB(), chainID),
 		Logger(log.TestingLogger()),
 	)
+	require.NoError(t, err)
+	err = c.Start()
 	require.NoError(t, err)
 	defer c.Stop()
 
@@ -349,6 +355,8 @@ func TestClient_Cleanup(t *testing.T) {
 		Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
+	err = c.Start()
+	require.NoError(t, err)
 
 	c.Stop()
 	c.Cleanup()
@@ -402,6 +410,9 @@ func TestClientRestoreTrustedHeaderAfterStartup1(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
+		err = c.Start()
+		require.NoError(t, err)
+		defer c.Stop()
 
 		h, err := c.TrustedHeader(1, bTime.Add(1*time.Second))
 		assert.NoError(t, err)
@@ -441,6 +452,9 @@ func TestClientRestoreTrustedHeaderAfterStartup1(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
+		err = c.Start()
+		require.NoError(t, err)
+		defer c.Stop()
 
 		h, err := c.TrustedHeader(1, bTime.Add(1*time.Second))
 		assert.NoError(t, err)
@@ -496,6 +510,9 @@ func TestClientRestoreTrustedHeaderAfterStartup2(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
+		err = c.Start()
+		require.NoError(t, err)
+		defer c.Stop()
 
 		// Check we still have the 1st header (+header+).
 		h, err := c.TrustedHeader(1, bTime.Add(2*time.Hour).Add(1*time.Second))
@@ -541,6 +558,9 @@ func TestClientRestoreTrustedHeaderAfterStartup2(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
+		err = c.Start()
+		require.NoError(t, err)
+		defer c.Stop()
 
 		// Check we no longer have the invalid 1st header (+header+).
 		h, err := c.TrustedHeader(1, bTime.Add(2*time.Hour).Add(1*time.Second))
@@ -598,6 +618,9 @@ func TestClientRestoreTrustedHeaderAfterStartup3(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
+		err = c.Start()
+		require.NoError(t, err)
+		defer c.Stop()
 
 		// Check we still have the 1st header (+header+).
 		h, err := c.TrustedHeader(1, bTime.Add(2*time.Hour).Add(1*time.Second))
@@ -648,6 +671,9 @@ func TestClientRestoreTrustedHeaderAfterStartup3(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
+		err = c.Start()
+		require.NoError(t, err)
+		defer c.Stop()
 
 		// Check we have swapped invalid 1st header (+header+) with correct one (+header1+).
 		h, err := c.TrustedHeader(1, bTime.Add(2*time.Hour).Add(1*time.Second))
@@ -706,6 +732,8 @@ func TestClient_Update(t *testing.T) {
 		Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
+	err = c.Start()
+	require.NoError(t, err)
 	defer c.Stop()
 
 	// should result in downloading & verifying header #3
@@ -763,6 +791,13 @@ func TestClient_Concurrency(t *testing.T) {
 		Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
+	err = c.Start()
+	require.NoError(t, err)
+	defer c.Stop()
+
+	_, err = c.VerifyHeaderAtHeight(2, bTime.Add(2*time.Hour))
+	require.NoError(t, err)
+
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
@@ -783,6 +818,10 @@ func TestClient_Concurrency(t *testing.T) {
 			h, err := c.TrustedHeader(1, bTime.Add(2*time.Hour))
 			assert.NoError(t, err)
 			assert.NotNil(t, h)
+
+			vals, err := c.TrustedValidatorSet(2, bTime.Add(2*time.Hour))
+			assert.NoError(t, err)
+			assert.NotNil(t, vals)
 		}()
 	}
 

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -11,6 +11,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/lite2/provider"
 	mockp "github.com/tendermint/tendermint/lite2/provider/mock"
 	dbs "github.com/tendermint/tendermint/lite2/store/db"
 	"github.com/tendermint/tendermint/types"
@@ -826,4 +827,60 @@ func TestClient_Concurrency(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestProvider_Replacement(t *testing.T) {
+	const (
+		chainID = "TestProvider_Replacement"
+	)
+
+	var (
+		keys = genPrivKeys(4)
+		// 20, 30, 40, 50 - the first 3 don't have 2/3, the last 3 do!
+		vals     = keys.ToValidators(20, 10)
+		bTime, _ = time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+		header   = keys.GenSignedHeader(chainID, 1, bTime, nil, vals, vals,
+			[]byte("app_hash"), []byte("cons_hash"), []byte("results_hash"), 0, len(keys))
+		primary = mockp.NewDeadMock(chainID)
+		witness = mockp.New(
+			chainID,
+			map[int64]*types.SignedHeader{
+				// trusted header
+				1: header,
+				// interim header (3/3 signed)
+				2: keys.GenSignedHeader(chainID, 2, bTime.Add(30*time.Minute), nil, vals, vals,
+					[]byte("app_hash"), []byte("cons_hash"), []byte("results_hash"), 0, len(keys)),
+				// last header (3/3 signed)
+				3: keys.GenSignedHeader(chainID, 3, bTime.Add(1*time.Hour), nil, vals, vals,
+					[]byte("app_hash"), []byte("cons_hash"), []byte("results_hash"), 0, len(keys)),
+			},
+			map[int64]*types.ValidatorSet{
+				1: vals,
+				2: vals,
+				3: vals,
+				4: vals,
+			},
+		)
+	)
+
+	c, err := NewClient(
+		chainID,
+		TrustOptions{
+			Period: 4 * time.Hour,
+			Height: 1,
+			Hash:   header.Hash(),
+		},
+		primary,
+		dbs.New(dbm.NewMemDB(), chainID),
+		UpdatePeriod(0),
+		Logger(log.TestingLogger()),
+		Witnesses([]provider.Provider{witness}),
+	)
+	require.NoError(t, err)
+	err = c.Start()
+	require.NoError(t, err)
+	defer c.Stop()
+	assert.NotEqual(t, c.primary, primary)
+	assert.Equal(t, 0, len(c.witnesses))
+
 }

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -910,10 +910,10 @@ func TestProvider_Replacement(t *testing.T) {
 			Hash:   header.Hash(),
 		},
 		primary,
+		[]provider.Provider{witness},
 		dbs.New(dbm.NewMemDB(), chainID),
 		UpdatePeriod(0),
 		Logger(log.TestingLogger()),
-		Witnesses([]provider.Provider{witness}),
 	)
 	require.NoError(t, err)
 	err = c.Start()

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -881,6 +881,6 @@ func TestProvider_Replacement(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Stop()
 	assert.NotEqual(t, c.Primary(), primary)
-	assert.Equal(t, 0, len(c.witnesses))
+	assert.Equal(t, 0, len(c.Witnesses()))
 
 }

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -880,7 +880,7 @@ func TestProvider_Replacement(t *testing.T) {
 	err = c.Start()
 	require.NoError(t, err)
 	defer c.Stop()
-	assert.NotEqual(t, c.primary, primary)
+	assert.NotEqual(t, c.Primary(), primary)
 	assert.Equal(t, 0, len(c.witnesses))
 
 }

--- a/lite2/example_test.go
+++ b/lite2/example_test.go
@@ -63,6 +63,10 @@ func TestExample_Client_AutoUpdate(t *testing.T) {
 	if err != nil {
 		stdlog.Fatal(err)
 	}
+	err = c.Start()
+	if err != nil {
+		stdlog.Fatal(err)
+	}
 	defer func() {
 		c.Stop()
 		c.Cleanup()
@@ -122,6 +126,10 @@ func TestExample_Client_ManualUpdate(t *testing.T) {
 		UpdatePeriod(0),
 		Logger(log.TestingLogger()),
 	)
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+	err = c.Start()
 	if err != nil {
 		stdlog.Fatal(err)
 	}

--- a/lite2/provider/mock/mock.go
+++ b/lite2/provider/mock/mock.go
@@ -60,9 +60,9 @@ func (p *deadMock) ChainID() string {
 }
 
 func (p *deadMock) SignedHeader(height int64) (*types.SignedHeader, error) {
-	return nil, errors.New("No response from provider")
+	return nil, errors.New("no response from provider")
 }
 
 func (p *deadMock) ValidatorSet(height int64) (*types.ValidatorSet, error) {
-	return nil, errors.New("No response from provider")
+	return nil, errors.New("no response from provider")
 }

--- a/lite2/provider/mock/mock.go
+++ b/lite2/provider/mock/mock.go
@@ -2,19 +2,19 @@ package mock
 
 import (
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/tendermint/lite2/provider"
 	"github.com/tendermint/tendermint/types"
 )
 
-// mock provider allows to directly set headers & vals, which can be handy when
-// testing.
 type mock struct {
 	chainID string
 	headers map[int64]*types.SignedHeader
 	vals    map[int64]*types.ValidatorSet
 }
 
-// New creates a mock provider.
+// New creates a mock provider with the given set of headers and validator
+// sets.
 func New(chainID string, headers map[int64]*types.SignedHeader, vals map[int64]*types.ValidatorSet) provider.Provider {
 	return &mock{
 		chainID: chainID,
@@ -51,6 +51,7 @@ type deadMock struct {
 	chainID string
 }
 
+// NewDeadMock creates a mock provider that always errors.
 func NewDeadMock(chainID string) provider.Provider {
 	return &deadMock{chainID: chainID}
 }

--- a/lite2/provider/mock/mock.go
+++ b/lite2/provider/mock/mock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"github.com/pkg/errors"
 	"github.com/tendermint/tendermint/lite2/provider"
 	"github.com/tendermint/tendermint/types"
 )
@@ -44,4 +45,24 @@ func (p *mock) ValidatorSet(height int64) (*types.ValidatorSet, error) {
 		return p.vals[height], nil
 	}
 	return nil, provider.ErrValidatorSetNotFound
+}
+
+type deadMock struct {
+	chainID string
+}
+
+func NewDeadMock(chainID string) provider.Provider {
+	return &deadMock{chainID: chainID}
+}
+
+func (p *deadMock) ChainID() string {
+	return p.chainID
+}
+
+func (p *deadMock) SignedHeader(height int64) (*types.SignedHeader, error) {
+	return nil, errors.New("No response from provider")
+}
+
+func (p *deadMock) ValidatorSet(height int64) (*types.ValidatorSet, error) {
+	return nil, errors.New("No response from provider")
 }


### PR DESCRIPTION
Closes issue #4338 

Uses a wrapper function around both the signedHeader and validatorSet calls to the primary provider which attempts to retrieve the information 5 times before deeming the provider unavailable and replacing the primary provider with the first alternative before trying recursively again (until all alternatives are depleted)

Employs a mutex lock for any operations involving the providers of the light client to ensure no operations occurs whilst the new primary is chosen.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
