### PR TITLE
lite2: filter valid witnesses

### DIFF
--- a/lite2/client.go
+++ b/lite2/client.go
@@ -89,16 +89,12 @@ func SkippingVerification(trustLevel tmmath.Fraction) Option {
 // current primary is unavailable.
 func Witnesses(providers []provider.Provider) Option {
 	return func(c *Client) {
-		validWitnesses := make([]provider.Provider, 0)
 		for _, witness := range providers {
-			if witness.ChainID() == c.ChainID() {
-				validWitnesses = append(validWitnesses, witness)
-			} else {
-				c.logger.Info("Witness possessed a different chain ID and was excluded from lite client witnesses",
-					"witness chain id", witness.ChainID())
+			if witness.ChainID() != c.ChainID() {
+				panic("Witness chainID is not equal to the Lite Client chainID")
 			}
 		}
-		c.witnesses = validWitnesses
+		c.witnesses = providers
 	}
 }
 

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -89,11 +89,16 @@ func SkippingVerification(trustLevel tmmath.Fraction) Option {
 // current primary is unavailable.
 func Witnesses(providers []provider.Provider) Option {
 	return func(c *Client) {
+		validWitnesses := make([]provider.Provider, 0)
 		for _, witness := range providers {
 			if witness.ChainID() == c.ChainID() {
-				c.witnesses = append(c.witnesses, witness)
+				validWitnesses = append(validWitnesses, witness)
+			} else {
+				c.logger.Info("Witness possessed a different chain ID and was excluded from lite client witnesses",
+					"witness chain id", witness.ChainID())
 			}
 		}
+		c.witnesses = validWitnesses
 	}
 }
 

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -89,7 +89,11 @@ func SkippingVerification(trustLevel tmmath.Fraction) Option {
 // current primary is unavailable.
 func Witnesses(providers []provider.Provider) Option {
 	return func(c *Client) {
-		c.witnesses = providers
+		for _, witness := range providers {
+			if witness.ChainID() == c.ChainID() {
+				c.witnesses = append(c.witnesses, witness)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #4350

Checks that the chain ID of the witness and that of the lite client are the same before updating the witness list.

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
