### PR TITLE
lite2: fetch missing headers

### DIFF
--- a/lite2/client.go
+++ b/lite2/client.go
@@ -980,20 +980,6 @@ func (c *Client) Update(now time.Time) error {
 	return nil
 }
 
-func (c *Client) previousTrustedHeight(height int64) (int64, error) {
-	firstTrustedHeight, err := c.FirstTrustedHeight()
-	if err != nil {
-		return -1, err
-	}
-	for i := height - 1; i > firstTrustedHeight; i-- {
-		previousTrustedHeader, err := c.trustedStore.SignedHeader(i)
-		if err == nil {
-			return previousTrustedHeader.Height, nil
-		}
-	}
-	return firstTrustedHeight, nil
-}
-
 // replaceProvider takes the first alternative provider and promotes it as the primary provider
 func (c *Client) replacePrimaryProvider() error {
 	c.providerMutex.Lock()

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -479,7 +479,7 @@ func (c *Client) TrustedHeader(height int64, now time.Time) (*types.SignedHeader
 // Safe for concurrent use by multiple goroutines.
 func (c *Client) TrustedValidatorSet(height int64, now time.Time) (*types.ValidatorSet, error) {
 	// Checks height is positive and header (note: height - 1) is not expired.
-	// Additionaly, it fetches validator set from primary if it's missing in
+	// Additionally, it fetches validator set from primary if it's missing in
 	// store.
 	_, err := c.TrustedHeader(height-1, now)
 	if err != nil {

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -486,6 +486,9 @@ func (c *Client) updateMissingTrustedHeaderAndVals(height int64) (*types.SignedH
 		return nil, nil, err
 	}
 	newVals, err = c.primary.ValidatorSet(height)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// updates store if valid
 	err = c.sequence(newHeader, newVals, time.Now())
@@ -910,7 +913,7 @@ func (c *Client) previousTrustedHeight(height int64) (int64, error) {
 		return -1, err
 	}
 	if height < FirstTrustedHeight {
-		return -1, errors.New("height is less than first trusted height.")
+		return -1, errors.New("height is less than first trusted height")
 	}
 	for i := height - 1; i > FirstTrustedHeight; i-- {
 		previousTrustedHeader, err := c.trustedStore.SignedHeader(i)

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -413,7 +413,7 @@ func (c *Client) Stop() {
 //  - there are some issues with the trusted store, although that should not
 //  happen normally;
 //  - negative height is passed;
-//  - header is not found.
+//  - header has not been verified yet
 //
 // Safe for concurrent use by multiple goroutines.
 func (c *Client) TrustedHeader(height int64, now time.Time) (*types.SignedHeader, error) {
@@ -474,7 +474,7 @@ func (c *Client) TrustedHeader(height int64, now time.Time) (*types.SignedHeader
 //  - there are some issues with the trusted store, although that should not
 //  happen normally;
 //  - negative height is passed;
-//  - validator set is not found.
+//  - header signed by that validator set has not been verified yet
 //
 // Safe for concurrent use by multiple goroutines.
 func (c *Client) TrustedValidatorSet(height int64, now time.Time) (*types.ValidatorSet, error) {

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -853,3 +853,20 @@ func (c *Client) Update(now time.Time) error {
 
 	return nil
 }
+
+func (c *Client) previousTrustedHeight(height int64) (int64, error) {
+	FirstTrustedHeight, err := c.FirstTrustedHeight()
+	if err != nil {
+		return -1, err
+	}
+	if height < FirstTrustedHeight {
+		return -1, errors.New("height is less than first trusted height.")
+	}
+	for i := height - 1; i > FirstTrustedHeight; i-- {
+		previousTrustedHeader, err := c.trustedStore.SignedHeader(i)
+		if err == nil {
+			return previousTrustedHeader.Height, nil
+		}
+	}
+	return FirstTrustedHeight, nil
+}

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -984,4 +984,5 @@ func TestProvider_TrustedHeaderFetchesMissingHeader(t *testing.T) {
 	// 2) header is missing, but it's expired => expect error
 	h, err = c.TrustedHeader(1, bTime.Add(1*time.Hour).Add(1*time.Second))
 	assert.Error(t, err)
+	assert.Nil(t, h)
 }

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -919,7 +919,69 @@ func TestProvider_Replacement(t *testing.T) {
 	err = c.Start()
 	require.NoError(t, err)
 	defer c.Stop()
+
 	assert.NotEqual(t, c.Primary(), primary)
 	assert.Equal(t, 0, len(c.Witnesses()))
+}
 
+func TestProvider_TrustedHeaderFetchesMissingHeader(t *testing.T) {
+	const (
+		chainID = "TestProvider_TrustedHeaderFetchesMissingHeader"
+	)
+
+	var (
+		keys = genPrivKeys(4)
+		// 20, 30, 40, 50 - the first 3 don't have 2/3, the last 3 do!
+		vals     = keys.ToValidators(20, 10)
+		bTime, _ = time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+		h1       = keys.GenSignedHeader(chainID, 1, bTime, nil, vals, vals,
+			[]byte("app_hash"), []byte("cons_hash"), []byte("results_hash"), 0, len(keys))
+		h2 = keys.GenSignedHeaderLastBlockID(chainID, 2, bTime.Add(30*time.Minute), nil, vals, vals,
+			[]byte("app_hash"), []byte("cons_hash"), []byte("results_hash"), 0, len(keys), types.BlockID{Hash: h1.Hash()})
+		h3 = keys.GenSignedHeaderLastBlockID(chainID, 3, bTime.Add(1*time.Hour), nil, vals, vals,
+			[]byte("app_hash"), []byte("cons_hash"), []byte("results_hash"), 0, len(keys), types.BlockID{Hash: h2.Hash()})
+		primary = mockp.New(
+			chainID,
+			map[int64]*types.SignedHeader{
+				1: h1,
+				2: h2,
+				3: h3,
+			},
+			map[int64]*types.ValidatorSet{
+				1: vals,
+				2: vals,
+				3: vals,
+				4: vals,
+			},
+		)
+	)
+
+	c, err := NewClient(
+		chainID,
+		TrustOptions{
+			Period: 1 * time.Hour,
+			Height: 3,
+			Hash:   h3.Hash(),
+		},
+		primary,
+		[]provider.Provider{primary},
+		dbs.New(dbm.NewMemDB(), chainID),
+		UpdatePeriod(0),
+		Logger(log.TestingLogger()),
+	)
+	require.NoError(t, err)
+	err = c.Start()
+	require.NoError(t, err)
+	defer c.Stop()
+
+	// 1) header is missing => expect no error
+	h, err := c.TrustedHeader(2, bTime.Add(1*time.Hour).Add(1*time.Second))
+	require.NoError(t, err)
+	if assert.NotNil(t, h) {
+		assert.EqualValues(t, 2, h.Height)
+	}
+
+	// 2) header is missing, but it's expired => expect error
+	h, err = c.TrustedHeader(1, bTime.Add(1*time.Hour).Add(1*time.Second))
+	assert.Error(t, err)
 }

--- a/lite2/store/db/db.go
+++ b/lite2/store/db/db.go
@@ -160,7 +160,7 @@ func (s *dbs) SignedHeaderAfter(height int64) (*types.SignedHeader, error) {
 	}
 
 	itr, err := s.db.ReverseIterator(
-		s.shKey(height),
+		s.shKey(height+1),
 		append(s.shKey(1<<63-1), byte(0x00)),
 	)
 	if err != nil {

--- a/lite2/store/db/db.go
+++ b/lite2/store/db/db.go
@@ -155,6 +155,10 @@ func (s *dbs) FirstSignedHeaderHeight() (int64, error) {
 }
 
 func (s *dbs) SignedHeaderAfter(height int64) (*types.SignedHeader, error) {
+	if height <= 0 {
+		panic("negative or zero height")
+	}
+
 	itr, err := s.db.ReverseIterator(
 		s.shKey(height),
 		append(s.shKey(1<<63-1), byte(0x00)),

--- a/lite2/store/db/db.go
+++ b/lite2/store/db/db.go
@@ -81,7 +81,7 @@ func (s *dbs) SignedHeader(height int64) (*types.SignedHeader, error) {
 		panic(err)
 	}
 	if len(bz) == 0 {
-		return nil, errors.New("signed header not found")
+		return nil, store.ErrSignedHeaderNotFound
 	}
 
 	var signedHeader *types.SignedHeader
@@ -100,7 +100,7 @@ func (s *dbs) ValidatorSet(height int64) (*types.ValidatorSet, error) {
 		panic(err)
 	}
 	if len(bz) == 0 {
-		return nil, errors.New("validator set not found")
+		return nil, store.ErrValidatorSetNotFound
 	}
 
 	var valSet *types.ValidatorSet
@@ -152,6 +152,28 @@ func (s *dbs) FirstSignedHeaderHeight() (int64, error) {
 	}
 
 	return -1, nil
+}
+
+func (s *dbs) SignedHeaderAfter(height int64) (*types.SignedHeader, error) {
+	itr, err := s.db.ReverseIterator(
+		s.shKey(height),
+		append(s.shKey(1<<63-1), byte(0x00)),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer itr.Close()
+
+	for itr.Valid() {
+		key := itr.Key()
+		_, existingHeight, ok := parseShKey(key)
+		if ok {
+			return s.SignedHeader(existingHeight)
+		}
+		itr.Next()
+	}
+
+	panic(fmt.Sprintf("no header after height %d. make sure height is not greater than latest existing height", height))
 }
 
 func (s *dbs) shKey(height int64) []byte {

--- a/lite2/store/db/db_test.go
+++ b/lite2/store/db/db_test.go
@@ -74,3 +74,7 @@ func Test_SaveSignedHeaderAndNextValidatorSet(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, valSet)
 }
+
+func Test_SignedHeaderAfter(t *testing.T) {
+	// TODO
+}

--- a/lite2/store/db/db_test.go
+++ b/lite2/store/db/db_test.go
@@ -76,5 +76,20 @@ func Test_SaveSignedHeaderAndNextValidatorSet(t *testing.T) {
 }
 
 func Test_SignedHeaderAfter(t *testing.T) {
-	// TODO
+	dbStore := New(dbm.NewMemDB(), "Test_SignedHeaderAfter")
+
+	assert.Panics(t, func() {
+		dbStore.SignedHeaderAfter(0)
+		dbStore.SignedHeaderAfter(100)
+	})
+
+	err := dbStore.SaveSignedHeaderAndNextValidatorSet(
+		&types.SignedHeader{Header: &types.Header{Height: 2}}, &types.ValidatorSet{})
+	require.NoError(t, err)
+
+	h, err := dbStore.SignedHeaderAfter(1)
+	require.NoError(t, err)
+	if assert.NotNil(t, h) {
+		assert.EqualValues(t, 2, h.Height)
+	}
 }

--- a/lite2/store/errors.go
+++ b/lite2/store/errors.go
@@ -1,0 +1,12 @@
+package store
+
+import "errors"
+
+var (
+	// ErrSignedHeaderNotFound is returned when a store does not have the
+	// requested header.
+	ErrSignedHeaderNotFound = errors.New("signed header not found")
+	// ErrValidatorSetNotFound is returned when a store does not have the
+	// requested validator set.
+	ErrValidatorSetNotFound = errors.New("validator set not found")
+)

--- a/lite2/store/store.go
+++ b/lite2/store/store.go
@@ -21,14 +21,14 @@ type Store interface {
 	//
 	// height must be > 0.
 	//
-	// If SignedHeader is not found, an error is returned.
+	// If SignedHeader is not found, ErrSignedHeaderNotFound is returned.
 	SignedHeader(height int64) (*types.SignedHeader, error)
 
 	// ValidatorSet returns the ValidatorSet that corresponds to height.
 	//
 	// height must be > 0.
 	//
-	// If ValidatorSet is not found, an error is returned.
+	// If ValidatorSet is not found, ErrValidatorSetNotFound is returned.
 	ValidatorSet(height int64) (*types.ValidatorSet, error)
 
 	// LastSignedHeaderHeight returns the last (newest) SignedHeader height.
@@ -40,4 +40,9 @@ type Store interface {
 	//
 	// If the store is empty, -1 and nil error are returned.
 	FirstSignedHeaderHeight() (int64, error)
+
+	// SignedHeaderAfter returns the SignedHeader after the certain height.
+	//
+	// height must be > 0 && <= LastSignedHeaderHeight.
+	SignedHeaderAfter(height int64) (*types.SignedHeader, error)
 }

--- a/lite2/test_helpers.go
+++ b/lite2/test_helpers.go
@@ -147,3 +147,15 @@ func (pkz privKeys) GenSignedHeader(chainID string, height int64, bTime time.Tim
 		Commit: pkz.signHeader(header, first, last),
 	}
 }
+
+// GenSignedHeaderLastBlockID calls genHeader and signHeader and combines them into a SignedHeader.
+func (pkz privKeys) GenSignedHeaderLastBlockID(chainID string, height int64, bTime time.Time, txs types.Txs,
+	valset, nextValset *types.ValidatorSet, appHash, consHash, resHash []byte, first, last int, lastBlockID types.BlockID) *types.SignedHeader {
+
+	header := genHeader(chainID, height, bTime, txs, valset, nextValset, appHash, consHash, resHash)
+	header.LastBlockID = lastBlockID
+	return &types.SignedHeader{
+		Header: header,
+		Commit: pkz.signHeader(header, first, last),
+	}
+}

--- a/lite2/test_helpers.go
+++ b/lite2/test_helpers.go
@@ -150,7 +150,8 @@ func (pkz privKeys) GenSignedHeader(chainID string, height int64, bTime time.Tim
 
 // GenSignedHeaderLastBlockID calls genHeader and signHeader and combines them into a SignedHeader.
 func (pkz privKeys) GenSignedHeaderLastBlockID(chainID string, height int64, bTime time.Time, txs types.Txs,
-	valset, nextValset *types.ValidatorSet, appHash, consHash, resHash []byte, first, last int, lastBlockID types.BlockID) *types.SignedHeader {
+	valset, nextValset *types.ValidatorSet, appHash, consHash, resHash []byte, first, last int,
+	lastBlockID types.BlockID) *types.SignedHeader {
 
 	header := genHeader(chainID, height, bTime, txs, valset, nextValset, appHash, consHash, resHash)
 	header.LastBlockID = lastBlockID


### PR DESCRIPTION
Closes #4328 

When `TrustedHeader(height)` is called, if the height is less than the trusted height but the header is not in the trusted store then a function finds the previous lowest height with a trusted header and performs a forwards sequential verification to the header of the height that was given. If no error is found it updates the trusted store with the header and validator set for that height and can then return them to the user. 

* [x] Referenced an issue explaining the need for the change
* [ ] ~~Updated all relevant documentation in docs~~
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] ~~Updated CHANGELOG_PENDING.md~~
