### PR TITLE
Makefile: place phony markers after targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ LD_FLAGS = -X github.com/tendermint/tendermint/version.GitCommit=`git rev-parse 
 BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
 
 all: check build test install
+.PHONY: all
 
 # The below include contains the tools.
 include tools.mk
@@ -17,24 +18,30 @@ include tests.mk
 
 build:
 	CGO_ENABLED=0 go build $(BUILD_FLAGS) -tags $(BUILD_TAGS) -o $(OUTPUT) ./cmd/tendermint/
+.PHONY: build
 
 build_c:
 	CGO_ENABLED=1 go build $(BUILD_FLAGS) -tags "$(BUILD_TAGS) cleveldb" -o $(OUTPUT) ./cmd/tendermint/
+.PHONY: build_c
 
 build_race:
 	CGO_ENABLED=1 go build -race $(BUILD_FLAGS) -tags $(BUILD_TAGS) -o $(OUTPUT) ./cmd/tendermint
+.PHONY: build_race
 
 install:
 	CGO_ENABLED=0 go install $(BUILD_FLAGS) -tags $(BUILD_TAGS) ./cmd/tendermint
+.PHONY: install
 
 install_c:
 	CGO_ENABLED=1 go install $(BUILD_FLAGS) -tags "$(BUILD_TAGS) cleveldb" ./cmd/tendermint
+.PHONY: install_c
 
 ###############################################################################
 ###                                Protobuf                                 ###
 ###############################################################################
 
 proto-all: proto-gen proto-lint proto-check-breaking
+.PHONY: proto-all
 
 proto-gen:
 	## If you get the following error,
@@ -43,14 +50,15 @@ proto-gen:
 	## Note the $< here is substituted for the %.proto
 	## Note the $@ here is substituted for the %.pb.go
 	@sh scripts/protocgen.sh
+.PHONY: proto-gen
 
 proto-lint:
 	@buf check lint --error-format=json
+.PHONY: proto-lint
 
 proto-check-breaking:
 	@buf check breaking --against-input '.git#branch=master'
-
-.PHONY: proto-all proto-gen proto-lint proto-check-breaking
+.PHONY: proto-check-breaking
 
 ###############################################################################
 ###                              Build ABCI                                 ###
@@ -58,9 +66,11 @@ proto-check-breaking:
 
 build_abci:
 	@go build -mod=readonly -i ./abci/cmd/...
+.PHONY: build_abci
 
 install_abci:
 	@go install -mod=readonly ./abci/cmd/...
+.PHONY: install_abci
 
 ###############################################################################
 ###                              Distribution                               ###
@@ -70,6 +80,7 @@ install_abci:
 # TODO add abci to these scripts
 dist:
 	@BUILD_TAGS=$(BUILD_TAGS) sh -c "'$(CURDIR)/scripts/dist.sh'"
+.PHONY: dist
 
 go-mod-cache: go.sum
 	@echo "--> Download go modules to local cache"
@@ -85,12 +96,14 @@ draw_deps:
 	@# requires brew install graphviz or apt-get install graphviz
 	go get github.com/RobotsAndPencils/goviz
 	@goviz -i github.com/tendermint/tendermint/cmd/tendermint -d 3 | dot -Tpng -o dependency-graph.png
+.PHONY: draw_deps
 
 get_deps_bin_size:
 	@# Copy of build recipe with additional flags to perform binary size analysis
 	$(eval $(shell go build -work -a $(BUILD_FLAGS) -tags $(BUILD_TAGS) -o $(OUTPUT) ./cmd/tendermint/ 2>&1))
 	@find $(WORK) -type f -name "*.a" | xargs -I{} du -hxs "{}" | sort -rh | sed -e s:${WORK}/::g > deps_bin_size.log
 	@echo "Results can be found here: $(CURDIR)/deps_bin_size.log"
+.PHONY: get_deps_bin_size
 
 ###############################################################################
 ###                                  Libs                                   ###
@@ -104,11 +117,13 @@ gen_certs: clean_certs
 	mv out/server.crt rpc/lib/server/test.crt
 	mv out/server.key rpc/lib/server/test.key
 	rm -rf out
+.PHONY: gen_certs
 
 # deletes generated certificates
 clean_certs:
 	rm -f rpc/lib/server/test.crt
 	rm -f rpc/lib/server/test.key
+.PHONY: clean_certs
 
 ###############################################################################
 ###                  Formatting, linting, and vetting                       ###
@@ -116,10 +131,12 @@ clean_certs:
 
 fmt:
 	@go fmt ./...
+.PHONY: fmt
 
 lint:
 	@echo "--> Running linter"
 	@golangci-lint run
+.PHONY: lint
 
 DESTINATION = ./index.html.md
 
@@ -135,6 +152,7 @@ build-docs:
 		cp -r .vuepress/dist/* ~/output/$${p}/ ; \
 		cp ~/output/$${p}/index.html ~/output ; \
 	done < versions ;
+.PHONY: build-docs
 
 sync-docs:
 	cd ~/output && \
@@ -152,6 +170,7 @@ build-docker:
 	cp $(OUTPUT) DOCKER/tendermint
 	docker build --label=tendermint --tag="tendermint/tendermint" DOCKER
 	rm -rf DOCKER/tendermint
+.PHONY: build-docker
 
 ###############################################################################
 ###                       Local testnet using docker                        ###
@@ -160,9 +179,11 @@ build-docker:
 # Build linux binary on other platforms
 build-linux: tools
 	GOOS=linux GOARCH=amd64 $(MAKE) build
+.PHONY: build-linux
 
 build-docker-localnode:
 	@cd networks/local && make
+.PHONY: build-docker-localnode
 
 # Runs `make build_c` from within an Amazon Linux (v2)-based Docker build
 # container in order to build an Amazon Linux-compatible binary. Produces a
@@ -170,15 +191,18 @@ build-docker-localnode:
 build_c-amazonlinux:
 	$(MAKE) -C ./DOCKER build_amazonlinux_buildimage
 	docker run --rm -it -v `pwd`:/tendermint tendermint/tendermint:build_c-amazonlinux
+.PHONY: build_c-amazonlinux
 
 # Run a 4-node testnet locally
 localnet-start: localnet-stop build-docker-localnode
 	@if ! [ -f build/node0/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/tendermint:Z tendermint/localnode testnet --config /etc/tendermint/config-template.toml --v 4 --o . --populate-persistent-peers --starting-ip-address 192.167.10.2; fi
 	docker-compose up
+.PHONY: localnet-start
 
 # Stop testnet
 localnet-stop:
 	docker-compose down
+.PHONY: localnet-stop
 
 # Build hooks for dredd, to skip or add information on some steps
 build-contract-tests-hooks:
@@ -187,6 +211,7 @@ ifeq ($(OS),Windows_NT)
 else
 	go build -mod=readonly $(BUILD_FLAGS) -o build/contract_tests ./cmd/contract_tests
 endif
+.PHONY: build-contract-tests-hooks
 
 # Run a nodejs tool to test endpoints against a localnet
 # The command takes care of starting and stopping the network
@@ -195,12 +220,4 @@ endif
 # The binaries should be built beforehand
 contract-tests:
 	dredd
-
-# To avoid unintended conflicts with file names, always add to .PHONY
-# unless there is a reason not to.
-# https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
-.PHONY: check build build_race build_abci dist install install_abci check_tools tools update_tools draw_deps \
- 	protoc_abci protoc_libs gen_certs clean_certs grpc_dbserver fmt build-linux localnet-start \
- 	localnet-stop build-docker build-docker-localnode protoc_grpc protoc_all \
- 	build_c install_c test_with_deadlock cleanup_after_test_with_deadlock lint build-contract-tests-hooks contract-tests \
-	build_c-amazonlinux
+.PHONY: contract-tests

--- a/tests.mk
+++ b/tests.mk
@@ -8,25 +8,30 @@ BINDIR ?= $(GOPATH)/bin
 ## required to be run first by most tests
 build_docker_test_image:
 	docker build -t tester -f ./test/docker/Dockerfile .
+.PHONY: build_docker_test_image
 
 ### coverage, app, persistence, and libs tests
 test_cover:
 	# run the go unit tests with coverage
 	bash test/test_cover.sh
+.PHONY: test_cover
 
 test_apps:
 	# run the app tests using bash
 	# requires `abci-cli` and `tendermint` binaries installed
 	bash test/app/test.sh
+.PHONY: test_apps
 
 test_abci_apps:
 	bash abci/tests/test_app/test.sh
+.PHONY: test_abci_apps
 
 test_abci_cli:
 	# test the cli against the examples in the tutorial at:
 	# ./docs/abci-cli.md
 	# if test fails, update the docs ^
 	@ bash abci/tests/test_cli/test.sh
+.PHONY: test_abci_cli
 
 test_persistence:
 	# run the persistence tests using bash
@@ -35,6 +40,7 @@ test_persistence:
 
 	# TODO undockerize
 	# bash test/persist/test_failure_indices.sh
+.PHONY: test_persistence
 
 test_p2p:
 	docker rm -f rsyslog || true
@@ -45,6 +51,7 @@ test_p2p:
 	# the `docker cp` takes a really long time; uncomment for debugging
 	#
 	# mkdir -p test/p2p/logs && docker cp rsyslog:/var/log test/p2p/logs
+.PHONY: test_p2p
 
 test_p2p_ipv6:
 	# IPv6 tests require Docker daemon with IPv6 enabled, e.g. in daemon.json:
@@ -63,6 +70,7 @@ test_p2p_ipv6:
 	# the `docker cp` takes a really long time; uncomment for debugging
 	#
 	# mkdir -p test/p2p/logs && docker cp rsyslog:/var/log test/p2p/logs
+.PHONY: test_p2p_ipv6
 
 test_integrations:
 	make build_docker_test_image
@@ -77,31 +85,38 @@ test_integrations:
 	make test_p2p
 	# Disabled by default since it requires Docker daemon with IPv6 enabled
 	#make test_p2p_ipv6
+.PHONY: test_integrations
 
 test_release:
 	@go test -tags release $(PACKAGES)
+.PHONY: test_release
 
 test100:
 	@for i in {1..100}; do make test; done
+.PHONY: test100
 
 vagrant_test:
 	vagrant up
 	vagrant ssh -c 'make test_integrations'
+.PHONY: vagrant_test
 
 ### go tests
 test:
 	@echo "--> Running go test"
 	@go test -p 1 $(PACKAGES)
+.PHONY: test
 
 test_race:
 	@echo "--> Running go test --race"
 	@go test -p 1 -v -race $(PACKAGES)
+.PHONY: test_race
 
 # uses https://github.com/sasha-s/go-deadlock/ to detect potential deadlocks
 test_with_deadlock:
 	make set_with_deadlock
 	make test
 	make cleanup_after_test_with_deadlock
+.PHONY: test_with_deadlock
 
 set_with_deadlock:
 	@echo "Get Goid"
@@ -111,6 +126,7 @@ set_with_deadlock:
 	find . -name "*.go" | grep -v "vendor/" | xargs -n 1 sed -i.bak 's/sync.RWMutex/deadlock.RWMutex/'
 	find . -name "*.go" | grep -v "vendor/" | xargs -n 1 sed -i.bak 's/sync.Mutex/deadlock.Mutex/'
 	find . -name "*.go" | grep -v "vendor/" | xargs -n 1 goimports -w
+.PHONY: set_with_deadlock
 
 # cleanes up after you ran test_with_deadlock
 cleanup_after_test_with_deadlock:
@@ -119,5 +135,4 @@ cleanup_after_test_with_deadlock:
 	find . -name "*.go" | grep -v "vendor/" | xargs -n 1 goimports -w
 	# cleans up the deps to not include the need libs
 	go mod tidy
-
-.PHONY: test_cover test_apps test_persistence test_p2p test test_race test_integrations test_release test100 vagrant_test
+.PHONY: cleanup_after_test_with_deadlock

--- a/tools.mk
+++ b/tools.mk
@@ -51,25 +51,31 @@ PROTOBUF     	= $(TOOLS_DESTDIR)/protoc
 GOODMAN 			= $(TOOLS_DESTDIR)/goodman
 
 all: tools
+.PHONY: all
 
 tools: certstrap protobuf goodman
+.PHONY: tools
 
 check: check_tools
+.PHONY: check
 
 check_tools:
 	@# https://stackoverflow.com/a/25668869
 	@echo "Found tools: $(foreach tool,$(notdir $(GOTOOLS)),\
         $(if $(shell which $(tool)),$(tool),$(error "No $(tool) in PATH")))"
+.PHONY: check_tools
 
 certstrap: $(CERTSTRAP)
 $(CERTSTRAP):
 	@echo "Get Certstrap"
 	@go get github.com/square/certstrap@v1.2.0
+.PHONY: certstrap
 
 protobuf: $(PROTOBUF)
 $(PROTOBUF):
 	@echo "Get GoGo Protobuf"
 	@go get github.com/gogo/protobuf/protoc-gen-gogo@v1.3.1
+.PHONY: protobuf
 
 buf: protoc-gen-buf-check-breaking protoc-gen-buf-check-lint
 	@echo "Installing buf..."
@@ -77,6 +83,7 @@ buf: protoc-gen-buf-check-breaking protoc-gen-buf-check-lint
     "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-${UNAME_S}-${UNAME_M}" \
     -o "${BIN}/buf" && \
 	chmod +x "${BIN}/buf"
+.PHONY: buf
 
 protoc-gen-buf-check-breaking:
 	@echo "Installing protoc-gen-buf-check-breaking..."
@@ -91,17 +98,20 @@ protoc-gen-buf-check-lint:
     "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/protoc-gen-buf-check-lint-${UNAME_S}-${UNAME_M}" \
     -o "${BIN}/protoc-gen-buf-check-lint" && \
 	chmod +x "${BIN}/protoc-gen-buf-check-lint"
+.PHONY: protoc-gen-buf-check-lint
 
 goodman: $(GOODMAN)
 $(GOODMAN):
 	@echo "Get Goodman"
 	@go get github.com/snikch/goodman/cmd/goodman@10e37e294daa3c9a90abded60ff9924bafab3888
+.PHONY: goodman
 
 tools-clean:
 	rm -f $(CERTSTRAP) $(PROTOBUF) $(GOX) $(GOODMAN)
 	rm -f tools-stamp
 	rm -rf /usr/local/include/google/protobuf
 	rm -f /usr/local/bin/protoc
+.PHONY: tooks-clean
 
 ###
 # Non Go tools
@@ -127,5 +137,4 @@ protoc:
 	@unzip -o $(PROTOC_ZIP) -d /usr/local bin/protoc
 	@unzip -o $(PROTOC_ZIP) -d /usr/local 'include/*'
 	@rm -f $(PROTOC_ZIP)
-
-.PHONY: all tools tools-clean protoc
+.PHONY: protoc


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

The `.PHONY` targets in the `Makefile` are usually placed far away from the actual targets, and thus aren't always updated. Placing the `.PHONY` targets right next to the targets they cover make them more visible and thus more likely to be updated when necessary.

* [x] ~Referenced an issue explaining the need for the change~
* [x] ~Updated all relevant documentation in docs~
* [x] ~Updated all code comments where relevant~
* [x] ~Wrote tests~
* [x] ~Updated CHANGELOG_PENDING.md~
