### PR TITLE
lite2: divide verify functions

### DIFF
--- a/lite2/client.go
+++ b/lite2/client.go
@@ -720,7 +720,7 @@ func (c *Client) sequence(
 			"lastHash", c.trustedHeader.Hash(),
 			"newHeight", interimHeader.Height,
 			"newHash", interimHeader.Hash())
-		err = VerifyViaSigs(c.chainID, trustedHeader, interimHeader, trustedNextVals,
+		err = VerifyAdjacent(c.chainID, trustedHeader, interimHeader, trustedNextVals,
 			c.trustingPeriod, now)
 		if err != nil {
 			return errors.Wrapf(err, "failed to verify the header #%d", height)
@@ -743,7 +743,7 @@ func (c *Client) sequence(
 	}
 
 	// 2) Verify the new header.
-	return VerifyViaSigs(c.chainID, c.trustedHeader, newHeader, newVals, c.trustingPeriod, now)
+	return VerifyAdjacent(c.chainID, c.trustedHeader, newHeader, newVals, c.trustingPeriod, now)
 }
 
 // see VerifyHeader
@@ -759,7 +759,7 @@ func (c *Client) bisection(
 		"lastHash", lastHeader.Hash(),
 		"newHeight", newHeader.Height,
 		"newHash", newHeader.Hash())
-	err := VerifyViaVals(c.chainID, lastHeader, lastVals, newHeader, newVals, c.trustingPeriod, now, c.trustLevel)
+	err := Verify(c.chainID, lastHeader, lastVals, newHeader, newVals, c.trustingPeriod, now, c.trustLevel)
 	switch err.(type) {
 	case nil:
 		return nil

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -720,8 +720,8 @@ func (c *Client) sequence(
 			"lastHash", c.trustedHeader.Hash(),
 			"newHeight", interimHeader.Height,
 			"newHash", interimHeader.Hash())
-		err = Verify(c.chainID, trustedHeader, trustedNextVals, interimHeader, trustedNextVals,
-			c.trustingPeriod, now, c.trustLevel)
+		err = VerifyViaSigs(c.chainID, trustedHeader, interimHeader, trustedNextVals,
+			c.trustingPeriod, now)
 		if err != nil {
 			return errors.Wrapf(err, "failed to verify the header #%d", height)
 		}
@@ -743,7 +743,7 @@ func (c *Client) sequence(
 	}
 
 	// 2) Verify the new header.
-	return Verify(c.chainID, c.trustedHeader, c.trustedNextVals, newHeader, newVals, c.trustingPeriod, now, c.trustLevel)
+	return VerifyViaSigs(c.chainID, c.trustedHeader, newHeader, newVals, c.trustingPeriod, now)
 }
 
 // see VerifyHeader
@@ -759,7 +759,7 @@ func (c *Client) bisection(
 		"lastHash", lastHeader.Hash(),
 		"newHeight", newHeader.Height,
 		"newHash", newHeader.Hash())
-	err := Verify(c.chainID, lastHeader, lastVals, newHeader, newVals, c.trustingPeriod, now, c.trustLevel)
+	err := VerifyViaVals(c.chainID, lastHeader, lastVals, newHeader, newVals, c.trustingPeriod, now, c.trustLevel)
 	switch err.(type) {
 	case nil:
 		return nil

--- a/lite2/verifier.go
+++ b/lite2/verifier.go
@@ -127,10 +127,9 @@ func Verify(
 	if untrustedHeader.Height != trustedHeader.Height+1 {
 		return VerifyNonAdjacent(chainID, trustedHeader, trustedNextVals, untrustedHeader, untrustedVals,
 			trustingPeriod, now, trustLevel)
-	} else {
-		return VerifyAdjacent(chainID, trustedHeader, untrustedHeader, untrustedVals, trustingPeriod, now)
 	}
 
+	return VerifyAdjacent(chainID, trustedHeader, untrustedHeader, untrustedVals, trustingPeriod, now)
 }
 
 func verifyNewHeaderAndVals(

--- a/lite2/verifier.go
+++ b/lite2/verifier.go
@@ -61,6 +61,10 @@ func VerifyNonAdjacent(
 	}
 
 	// Ensure that +2/3 of new validators signed correctly.
+	//
+	// NOTE: this should always be the last check because untrustedVals can be
+	// intentionaly made very large to DOS the light client. not the case for
+	// VerifyAdjacent, where validator set is known in advance.
 	if err := untrustedVals.VerifyCommit(chainID, untrustedHeader.Commit.BlockID, untrustedHeader.Height,
 		untrustedHeader.Commit); err != nil {
 		return err

--- a/lite2/verifier_test.go
+++ b/lite2/verifier_test.go
@@ -42,7 +42,7 @@ func TestVerifyAdjacentHeaders(t *testing.T) {
 			3 * time.Hour,
 			bTime.Add(2 * time.Hour),
 			nil,
-			"expected new header height 1 to be greater than one of old header 1",
+			"headers must be adjacent in height",
 		},
 		// different chainID -> error
 		1: {
@@ -52,7 +52,8 @@ func TestVerifyAdjacentHeaders(t *testing.T) {
 			3 * time.Hour,
 			bTime.Add(2 * time.Hour),
 			nil,
-			"h2.ValidateBasic failed: signedHeader belongs to another chain 'different-chainID' not 'TestVerifyAdjacentHeaders'",
+			"unverifiedHeader.ValidateBasic failed: signedHeader belongs to another chain 'different-chainID' not" +
+				" 'TestVerifyAdjacentHeaders'",
 		},
 		// new header's time is before old header's time -> error
 		2: {
@@ -139,8 +140,7 @@ func TestVerifyAdjacentHeaders(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			err := Verify(chainID, header, vals, tc.newHeader, tc.newVals, tc.trustingPeriod, tc.now, DefaultTrustLevel)
-
+			err := VerifyViaSigs(chainID, header, tc.newHeader, tc.newVals, tc.trustingPeriod, tc.now)
 			switch {
 			case tc.expErr != nil && assert.Error(t, err):
 				assert.Equal(t, tc.expErr, err)
@@ -254,7 +254,8 @@ func TestVerifyNonAdjacentHeaders(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			err := Verify(chainID, header, vals, tc.newHeader, tc.newVals, tc.trustingPeriod, tc.now, DefaultTrustLevel)
+			err := VerifyViaVals(chainID, header, vals, tc.newHeader, tc.newVals, tc.trustingPeriod, tc.now,
+				DefaultTrustLevel)
 
 			switch {
 			case tc.expErr != nil && assert.Error(t, err):
@@ -283,7 +284,7 @@ func TestVerifyReturnsErrorIfTrustLevelIsInvalid(t *testing.T) {
 			[]byte("app_hash"), []byte("cons_hash"), []byte("results_hash"), 0, len(keys))
 	)
 
-	err := Verify(chainID, header, vals, header, vals, 2*time.Hour, time.Now(),
+	err := VerifyViaVals(chainID, header, vals, header, vals, 2*time.Hour, time.Now(),
 		tmmath.Fraction{Numerator: 2, Denominator: 1})
 	assert.Error(t, err)
 }

--- a/lite2/verifier_test.go
+++ b/lite2/verifier_test.go
@@ -52,7 +52,7 @@ func TestVerifyAdjacentHeaders(t *testing.T) {
 			3 * time.Hour,
 			bTime.Add(2 * time.Hour),
 			nil,
-			"unverifiedHeader.ValidateBasic failed: signedHeader belongs to another chain 'different-chainID' not" +
+			"untrustedHeader.ValidateBasic failed: signedHeader belongs to another chain 'different-chainID' not" +
 				" 'TestVerifyAdjacentHeaders'",
 		},
 		// new header's time is before old header's time -> error
@@ -140,7 +140,7 @@ func TestVerifyAdjacentHeaders(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			err := VerifyViaSigs(chainID, header, tc.newHeader, tc.newVals, tc.trustingPeriod, tc.now)
+			err := VerifyAdjacent(chainID, header, tc.newHeader, tc.newVals, tc.trustingPeriod, tc.now)
 			switch {
 			case tc.expErr != nil && assert.Error(t, err):
 				assert.Equal(t, tc.expErr, err)
@@ -254,7 +254,7 @@ func TestVerifyNonAdjacentHeaders(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			err := VerifyViaVals(chainID, header, vals, tc.newHeader, tc.newVals, tc.trustingPeriod, tc.now,
+			err := VerifyNonAdjacent(chainID, header, vals, tc.newHeader, tc.newVals, tc.trustingPeriod, tc.now,
 				DefaultTrustLevel)
 
 			switch {
@@ -284,7 +284,7 @@ func TestVerifyReturnsErrorIfTrustLevelIsInvalid(t *testing.T) {
 			[]byte("app_hash"), []byte("cons_hash"), []byte("results_hash"), 0, len(keys))
 	)
 
-	err := VerifyViaVals(chainID, header, vals, header, vals, 2*time.Hour, time.Now(),
+	err := Verify(chainID, header, vals, header, vals, 2*time.Hour, time.Now(),
 		tmmath.Fraction{Numerator: 2, Denominator: 1})
 	assert.Error(t, err)
 }


### PR DESCRIPTION
Closes #4398 

Refactored current `Verify` function to `VerifyViaVals` and `VerifyViaSigs`

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
