### PR TITLE
Use uint64 for consensus.Reactor.SwitchToConsensus() blocksSynced

### DIFF
--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -41,7 +41,7 @@ const (
 type consensusReactor interface {
 	// for when we switch from blockchain reactor and fast sync to
 	// the consensus machine
-	SwitchToConsensus(sm.State, int)
+	SwitchToConsensus(sm.State, uint64)
 }
 
 type peerError struct {
@@ -214,7 +214,7 @@ func (bcR *BlockchainReactor) poolRoutine() {
 	statusUpdateTicker := time.NewTicker(statusUpdateIntervalSeconds * time.Second)
 	switchToConsensusTicker := time.NewTicker(switchToConsensusIntervalSeconds * time.Second)
 
-	blocksSynced := 0
+	blocksSynced := uint64(0)
 
 	chainID := bcR.initialState.ChainID
 	state := bcR.initialState

--- a/blockchain/v1/reactor.go
+++ b/blockchain/v1/reactor.go
@@ -43,7 +43,7 @@ var (
 type consensusReactor interface {
 	// for when we switch from blockchain reactor and fast sync to
 	// the consensus machine
-	SwitchToConsensus(sm.State, int)
+	SwitchToConsensus(sm.State, uint64)
 }
 
 // BlockchainReactor handles long-term catchup syncing.
@@ -59,7 +59,7 @@ type BlockchainReactor struct {
 	fastSync bool
 
 	fsm          *BcReactorFSM
-	blocksSynced int
+	blocksSynced uint64
 
 	// Receive goroutine forwards messages to this channel to be processed in the context of the poolRoutine.
 	messagesForFSMCh chan bcReactorMessage

--- a/blockchain/v1/reactor_test.go
+++ b/blockchain/v1/reactor_test.go
@@ -157,7 +157,7 @@ type consensusReactorTest struct {
 	mtx                 sync.Mutex
 }
 
-func (conR *consensusReactorTest) SwitchToConsensus(state sm.State, blocksSynced int) {
+func (conR *consensusReactorTest) SwitchToConsensus(state sm.State, blocksSynced uint64) {
 	conR.mtx.Lock()
 	defer conR.mtx.Unlock()
 	conR.switchedToConsensus = true

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -98,7 +98,7 @@ func (conR *Reactor) OnStop() {
 
 // SwitchToConsensus switches from fast_sync mode to consensus mode.
 // It resets the state, turns off fast_sync, and starts the consensus state-machine
-func (conR *Reactor) SwitchToConsensus(state sm.State, blocksSynced int) {
+func (conR *Reactor) SwitchToConsensus(state sm.State, blocksSynced uint64) {
 	conR.Logger.Info("SwitchToConsensus")
 	conR.conS.reconstructLastCommit(state)
 	// NOTE: The line below causes broadcastNewRoundStepRoutine() to


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

Fixes #4416. Since we officially only support 64-bit archs, `int` already implies `int64`, but explicit is better than implicit. Also, we don't need nor want negative numbers, so made it `uint64`.

* [x] Referenced an issue explaining the need for the change
* [x] ~Updated all relevant documentation in docs~
* [x] ~Updated all code comments where relevant~
* [x] ~Wrote tests~
* [x] ~Updated CHANGELOG_PENDING.md~