### PR TITLE
rpc: fix txsearch test corner-case

### DIFF
--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/rand"
 	"net/http"
 	"strings"
@@ -508,7 +509,7 @@ func TestTxSearch(t *testing.T) {
 		seen := map[int64]bool{}
 		maxHeight := int64(0)
 		perPage := 3
-		pages := txCount/perPage + 1
+		pages := int(math.Ceil(float64(txCount) / float64(perPage)))
 		for page := 1; page <= pages; page++ {
 			result, err = c.TxSearch("tx.height >= 1", false, page, perPage, "asc")
 			require.NoError(t, err)


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

Tests are non-deterministic due to shared test fixtures, and occasionally this caused the tx_search tests to submit invalid page numbers.

* [x] ~Referenced an issue explaining the need for the change~
* [x] ~Updated all relevant documentation in docs~
* [x] ~Updated all code comments where relevant~
* [x] ~Wrote tests~
* [x] ~Updated CHANGELOG_PENDING.md~
