### PR TITLE
p2p: use curve25519.X25519() instead of ScalarMult()

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,8 @@ program](https://hackerone.com/tendermint).
 
 - Go API
 
+  - [p2p] [\#4449](https://github.com/tendermint/tendermint/pull/4449) Removed `conn.ErrSharedSecretIsZero`. A generic error is returned for this condition instead. (@erikgrinaker)
+
 ### FEATURES:
 
 ### IMPROVEMENTS:

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,8 +15,6 @@ program](https://hackerone.com/tendermint).
 
 - Go API
 
-  - [p2p] [\#4449](https://github.com/tendermint/tendermint/pull/4449) Removed `conn.ErrSharedSecretIsZero`. A generic error is returned for this condition instead. (@erikgrinaker)
-
 ### FEATURES:
 
 ### IMPROVEMENTS:

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -361,9 +361,9 @@ func computeDHSecret(remPubKey, locPrivKey *[32]byte) (*[32]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var array [32]byte
-	copy(array[:], shrKey)
-	return &array, nil
+	var shrKeyArray [32]byte
+	copy(shrKeyArray[:], shrKey)
+	return &shrKeyArray, nil
 }
 
 func sort32(foo, bar *[32]byte) (lo, hi *[32]byte) {

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -5,7 +5,6 @@ import (
 	"crypto/cipher"
 	crand "crypto/rand"
 	"crypto/sha256"
-	"crypto/subtle"
 	"encoding/binary"
 	"io"
 	"math"
@@ -38,7 +37,6 @@ const (
 
 var (
 	ErrSmallOrderRemotePubKey = errors.New("detected low order point from remote peer")
-	ErrSharedSecretIsZero     = errors.New("shared secret is all zeroes")
 
 	labelEphemeralLowerPublicKey = []byte("EPHEMERAL_LOWER_PUBLIC_KEY")
 	labelEphemeralUpperPublicKey = []byte("EPHEMERAL_UPPER_PUBLIC_KEY")
@@ -358,19 +356,14 @@ func deriveSecrets(
 
 // computeDHSecret computes a Diffie-Hellman shared secret key
 // from our own local private key and the other's public key.
-//
-// It returns an error if the computed shared secret is all zeroes.
-func computeDHSecret(remPubKey, locPrivKey *[32]byte) (shrKey *[32]byte, err error) {
-	shrKey = new([32]byte)
-	curve25519.ScalarMult(shrKey, locPrivKey, remPubKey)
-
-	// reject if the returned shared secret is all zeroes
-	// related to: https://github.com/tendermint/tendermint/issues/3010
-	zero := new([32]byte)
-	if subtle.ConstantTimeCompare(shrKey[:], zero[:]) == 1 {
-		return nil, ErrSharedSecretIsZero
+func computeDHSecret(remPubKey, locPrivKey *[32]byte) (*[32]byte, error) {
+	shrKey, err := curve25519.X25519(locPrivKey[:], remPubKey[:])
+	if err != nil {
+		return nil, err
 	}
-	return
+	var array [32]byte
+	copy(array[:], shrKey)
+	return &array, nil
 }
 
 func sort32(foo, bar *[32]byte) (lo, hi *[32]byte) {


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

Replaces a call to `curve25519.ScalarMult()` with `X25519()`, which fixes the following linter warning towards #4447:

```
p2p/conn/secret_connection.go:365:2: SA1019: curve25519.ScalarMult is deprecated: when provided a low-order point, ScalarMult will set dst to all zeroes, irrespective of the scalar. Instead, use the X25519 function, which will return an error.  (staticcheck)
	curve25519.ScalarMult(shrKey, locPrivKey, remPubKey)
	^
```

The zero check is now handled by `X25519()`, and can safely be removed.

Technically a breaking change, since we're removing `ErrSharedSecretIsZero`.

* [x] Referenced an issue explaining the need for the change
* [x] ~Updated all relevant documentation in docs~
* [x] ~Updated all code comments where relevant~
* [x] ~Wrote tests~
* [x] ~Updated CHANGELOG_PENDING.md~
