### PR TITLE
lite2: don't save intermediate headers

### DIFF
--- a/lite2/client.go
+++ b/lite2/client.go
@@ -727,7 +727,6 @@ func (c *Client) sequence(
 		}
 
 		// Update trusted header and vals.
-		trustedHeader = interimHeader
 		if height == newHeader.Height-1 {
 			interimNextVals = newVals
 		} else {
@@ -742,7 +741,7 @@ func (c *Client) sequence(
 					trustedHeader.Height)
 			}
 		}
-		trustedNextVals = interimNextVals
+		trustedHeader, trustedNextVals = interimHeader, interimNextVals
 	}
 
 	return nil
@@ -774,7 +773,6 @@ func (c *Client) bisection(
 			}
 
 			// Update the lower bound to the previous upper bound
-			trustedHeader = interimHeader
 			interimVals, err = c.validatorSetFromPrimary(interimHeader.Height + 1)
 			if err != nil {
 				return err
@@ -785,8 +783,7 @@ func (c *Client) bisection(
 					interimVals.Hash(),
 					trustedHeader.Height)
 			}
-			trustedNextVals = interimVals
-
+			trustedNextVals, trustedHeader = interimVals, interimHeader
 			// Update the upper bound to the untrustedHeader
 			interimHeader, interimVals = newHeader, newVals
 

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -773,17 +773,17 @@ func (c *Client) bisection(
 			}
 
 			// Update the lower bound to the previous upper bound
-			interimVals, err = c.validatorSetFromPrimary(interimHeader.Height + 1)
+			interimNextVals, err := c.validatorSetFromPrimary(interimHeader.Height + 1)
 			if err != nil {
 				return err
 			}
-			if !bytes.Equal(interimHeader.NextValidatorsHash, interimVals.Hash()) {
+			if !bytes.Equal(interimHeader.NextValidatorsHash, interimNextVals.Hash()) {
 				return errors.Errorf("expected next validator's hash %X, but got %X (height #%d)",
 					interimHeader.NextValidatorsHash,
-					interimVals.Hash(),
+					interimNextVals.Hash(),
 					interimHeader.Height)
 			}
-			trustedNextVals, trustedHeader = interimVals, interimHeader
+			trustedHeader, trustedNextVals = interimHeader, interimNextVals
 			// Update the upper bound to the untrustedHeader
 			interimHeader, interimVals = newHeader, newVals
 

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -777,11 +777,11 @@ func (c *Client) bisection(
 			if err != nil {
 				return err
 			}
-			if !bytes.Equal(trustedHeader.NextValidatorsHash, interimVals.Hash()) {
+			if !bytes.Equal(interimHeader.NextValidatorsHash, interimVals.Hash()) {
 				return errors.Errorf("expected next validator's hash %X, but got %X (height #%d)",
-					trustedHeader.NextValidatorsHash,
+					interimHeader.NextValidatorsHash,
 					interimVals.Hash(),
-					trustedHeader.Height)
+					interimHeader.Height)
 			}
 			trustedNextVals, trustedHeader = interimVals, interimHeader
 			// Update the upper bound to the untrustedHeader

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -703,10 +703,11 @@ func (c *Client) sequence(
 	newHeader *types.SignedHeader,
 	newVals *types.ValidatorSet,
 	now time.Time) error {
+
 	// 1) Verify any intermediate headers.
 	var (
-		interimNextVals *types.ValidatorSet
 		interimHeader   *types.SignedHeader
+		interimNextVals *types.ValidatorSet
 		err             error
 	)
 	for height := trustedHeader.Height + 1; height <= newHeader.Height; height++ {

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -709,7 +709,7 @@ func (c *Client) sequence(
 		interimHeader   *types.SignedHeader
 		err             error
 	)
-	for height := trustedHeader.Height + 1; height < newHeader.Height; height++ {
+	for height := trustedHeader.Height + 1; height <= newHeader.Height; height++ {
 		interimHeader, err = c.signedHeaderFromPrimary(height)
 		if err != nil {
 			return errors.Wrapf(err, "failed to obtain the header #%d", height)

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -775,16 +775,17 @@ func (c *Client) bisection(
 
 			// Update the lower bound to the previous upper bound
 			trustedHeader = interimHeader
-			trustedNextVals, err = c.validatorSetFromPrimary(interimHeader.Height + 1)
+			interimVals, err = c.validatorSetFromPrimary(interimHeader.Height + 1)
 			if err != nil {
 				return err
 			}
-			if !bytes.Equal(trustedHeader.NextValidatorsHash, trustedNextVals.Hash()) {
+			if !bytes.Equal(trustedHeader.NextValidatorsHash, interimVals.Hash()) {
 				return errors.Errorf("expected next validator's hash %X, but got %X (height #%d)",
 					trustedHeader.NextValidatorsHash,
-					trustedNextVals.Hash(),
+					interimVals.Hash(),
 					trustedHeader.Height)
 			}
+			trustedNextVals = interimVals
 
 			// Update the upper bound to the untrustedHeader
 			interimHeader, interimVals = newHeader, newVals

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -629,12 +629,6 @@ func (c *Client) verifyHeader(newHeader *types.SignedHeader, newVals *types.Vali
 	if err != nil {
 		return err
 	}
-	if !bytes.Equal(newHeader.NextValidatorsHash, nextVals.Hash()) {
-		return errors.Errorf("expected next validator's hash %X, but got %X (height #%d)",
-			newHeader.NextValidatorsHash,
-			nextVals.Hash(),
-			newHeader.Height)
-	}
 
 	return c.updateTrustedHeaderAndNextVals(newHeader, nextVals)
 }

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -734,11 +734,11 @@ func (c *Client) sequence(
 			if err != nil {
 				return errors.Wrapf(err, "failed to obtain the vals #%d", height+1)
 			}
-			if !bytes.Equal(trustedHeader.NextValidatorsHash, interimNextVals.Hash()) {
+			if !bytes.Equal(interimHeader.NextValidatorsHash, interimNextVals.Hash()) {
 				return errors.Errorf("expected next validator's hash %X, but got %X (height #%d)",
-					trustedHeader.NextValidatorsHash,
+					interimHeader.NextValidatorsHash,
 					interimNextVals.Hash(),
-					trustedHeader.Height)
+					interimHeader.Height)
 			}
 		}
 		trustedHeader, trustedNextVals = interimHeader, interimNextVals

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -142,7 +142,7 @@ func TestClient_SequentialVerification(t *testing.T) {
 			true,
 		},
 		{
-			"bad: different validator set",
+			"bad: different validator set at height 3",
 			map[int64]*types.SignedHeader{
 				// trusted header
 				1: h1,

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -57,6 +57,9 @@ var (
 )
 
 func TestClient_SequentialVerification(t *testing.T) {
+	newKeys := genPrivKeys(4)
+	newVals := newKeys.ToValidators(10, 1)
+
 	testCases := []struct {
 		name         string
 		otherHeaders map[int64]*types.SignedHeader // all except ^
@@ -134,6 +137,25 @@ func TestClient_SequentialVerification(t *testing.T) {
 				2: vals,
 				3: vals,
 				4: vals,
+			},
+			false,
+			true,
+		},
+		{
+			"bad: different validator set",
+			map[int64]*types.SignedHeader{
+				// trusted header
+				1: h1,
+				// interim header (3/3 signed)
+				2: h2,
+				// last header (3/3 signed)
+				3: h3,
+			},
+			map[int64]*types.ValidatorSet{
+				1: vals,
+				2: vals,
+				3: newVals,
+				4: newVals,
 			},
 			false,
 			true,

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -747,9 +747,6 @@ func TestClient_BackwardsVerification(t *testing.T) {
 		Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
-	err = c.Start()
-	require.NoError(t, err)
-	defer c.Stop()
 
 	// 1) header is missing => expect no error
 	h, err := c.VerifyHeaderAtHeight(2, bTime.Add(1*time.Hour).Add(1*time.Second))
@@ -762,6 +759,15 @@ func TestClient_BackwardsVerification(t *testing.T) {
 	h, err = c.VerifyHeaderAtHeight(1, bTime.Add(1*time.Hour).Add(1*time.Second))
 	assert.Error(t, err)
 	assert.NotNil(t, h)
+
+	// 3) already stored headers should return the header without error
+	h, err = c.VerifyHeaderAtHeight(3, bTime.Add(1*time.Hour).Add(1*time.Second))
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
+
+	// 4) cannot verify a header in the future
+	h, err = c.VerifyHeaderAtHeight(4, bTime.Add(1*time.Hour).Add(1*time.Second))
+	assert.Error(t, err)
 }
 
 func TestClient_NewClientFromTrustedStore(t *testing.T) {

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -368,7 +368,8 @@ func TestClient_Cleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	c.Stop()
-	c.Cleanup()
+	err = c.Cleanup()
+	require.NoError(t, err)
 
 	// Check no headers exist after Cleanup.
 	h, err := c.TrustedHeader(1, bTime.Add(1*time.Second))

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -767,7 +767,7 @@ func TestClient_BackwardsVerification(t *testing.T) {
 	assert.NotNil(t, h)
 
 	// 4) cannot verify a header in the future
-	h, err = c.VerifyHeaderAtHeight(4, bTime.Add(1*time.Hour).Add(1*time.Second))
+	_, err = c.VerifyHeaderAtHeight(4, bTime.Add(1*time.Hour).Add(1*time.Second))
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
closes #4426

The sequence and bisection methods no longer save the intermediate headers and validator sets that they require to verify a currently untrusted header. 

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
