### PR TITLE
JSON tests related changes

### DIFF
--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -97,7 +97,9 @@ func newBlockchainReactor(
 				lastBlockMeta.BlockID,
 				state.Validators,
 				privVals[0],
-				lastBlock.Header.ChainID)
+				lastBlock.Header.ChainID,
+				time.Now(),
+			)
 			if err != nil {
 				panic(err)
 			}

--- a/blockchain/v2/reactor_test.go
+++ b/blockchain/v2/reactor_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"

--- a/blockchain/v2/reactor_test.go
+++ b/blockchain/v2/reactor_test.go
@@ -493,7 +493,9 @@ func newReactorStore(
 				lastBlockMeta.BlockID,
 				state.Validators,
 				privVals[0],
-				lastBlock.Header.ChainID)
+				lastBlock.Header.ChainID,
+				time.Now(),
+			)
 			if err != nil {
 				panic(err)
 			}

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -54,7 +54,7 @@ func TestByzantine(t *testing.T) {
 		if i == 0 {
 			// NOTE: Now, test validators are MockPV, which by default doesn't
 			// do any safety checks.
-			css[i].privValidator.(*types.MockPV).DisableChecks()
+			css[i].privValidator.(types.MockPV).DisableChecks()
 			css[i].decideProposal = func(j int) func(int64, int) {
 				return func(height int64, round int) {
 					byzantineDecideProposalFunc(t, height, round, css[j], switches[j])

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -892,7 +892,8 @@ func makeBlock(state sm.State, lastBlock *types.Block, lastBlockMeta *types.Bloc
 			lastBlockMeta.BlockID,
 			state.Validators,
 			privVal,
-			lastBlock.Header.ChainID)
+			lastBlock.Header.ChainID,
+			time.Now())
 		lastCommit = types.NewCommit(vote.Height, vote.Round,
 			lastBlockMeta.BlockID, []types.CommitSig{vote.CommitSig()})
 	}

--- a/libs/math/fraction.go
+++ b/libs/math/fraction.go
@@ -6,10 +6,10 @@ import "fmt"
 // format.
 type Fraction struct {
 	// The portion of the denominator in the faction, e.g. 2 in 2/3.
-	Numerator int64
+	Numerator int64 `json:"numerator"`
 	// The value by which the numerator is divided, e.g. 3 in 2/3. Must be
 	// positive.
-	Denominator int64
+	Denominator int64 `json:"denominator"`
 }
 
 func (fr Fraction) String() string {

--- a/state/helpers_test.go
+++ b/state/helpers_test.go
@@ -82,7 +82,7 @@ func makeValidCommit(
 	sigs := make([]types.CommitSig, 0)
 	for i := 0; i < vals.Size(); i++ {
 		_, val := vals.GetByIndex(i)
-		vote, err := types.MakeVote(height, blockID, vals, privVals[val.Address.String()], chainID)
+		vote, err := types.MakeVote(height, blockID, vals, privVals[val.Address.String()], chainID, time.Now())
 		if err != nil {
 			return nil, err
 		}

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -162,7 +162,7 @@ func TestValidateBlockCommit(t *testing.T) {
 		/*
 			wrongSigsCommit is fine except for the extra bad precommit
 		*/
-		goodVote, err := types.MakeVote(height, blockID, state.Validators, privVals[proposerAddr.String()], chainID)
+		goodVote, err := types.MakeVote(height, blockID, state.Validators, privVals[proposerAddr.String()], chainID, time.Now())
 		require.NoError(t, err, "height %d", height)
 		badVote := &types.Vote{
 			ValidatorAddress: badPrivVal.GetPubKey().Address(),

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -163,13 +163,13 @@ func TestValidateBlockCommit(t *testing.T) {
 		/*
 			wrongSigsCommit is fine except for the extra bad precommit
 		*/
-		goodVote, err := types.MakeVote(height, 
-						blockID, 
-						state.Validators, 
-						privVals[proposerAddr.String()], 
-						chainID, 
-						time.Now(),
-					       )
+		goodVote, err := types.MakeVote(height,
+			blockID,
+			state.Validators,
+			privVals[proposerAddr.String()],
+			chainID,
+			time.Now(),
+		)
 		require.NoError(t, err, "height %d", height)
 		badVote := &types.Vote{
 			ValidatorAddress: badPrivVal.GetPubKey().Address(),

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -163,7 +163,13 @@ func TestValidateBlockCommit(t *testing.T) {
 		/*
 			wrongSigsCommit is fine except for the extra bad precommit
 		*/
-		goodVote, err := types.MakeVote(height, blockID, state.Validators, privVals[proposerAddr.String()], chainID, time.Now())
+		goodVote, err := types.MakeVote(height, 
+						blockID, 
+						state.Validators, 
+						privVals[proposerAddr.String()], 
+						chainID, 
+						time.Now(),
+					       )
 		require.NoError(t, err, "height %d", height)
 		badVote := &types.Vote{
 			ValidatorAddress: badPrivVal.GetPubKey().Address(),

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -117,6 +117,7 @@ func TestValidateBlockCommit(t *testing.T) {
 				state.Validators,
 				privVals[proposerAddr.String()],
 				chainID,
+				time.Now(),
 			)
 			require.NoError(t, err, "height %d", height)
 			wrongHeightCommit := types.NewCommit(

--- a/types/block.go
+++ b/types/block.go
@@ -752,7 +752,6 @@ type SignedHeader struct {
 
 // ValidateBasic does basic consistency checks and makes sure the header
 // and commit are consistent.
-//
 // NOTE: This does not actually check the cryptographic signatures.  Make
 // sure to use a Verifier to validate the signatures actually provide a
 // significantly strong proof for this header's validity.

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -37,7 +37,7 @@ func TestBlockAddEvidence(t *testing.T) {
 	h := int64(3)
 
 	voteSet, valSet, vals := randVoteSet(h-1, 1, PrecommitType, 10, 1)
-	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals)
+	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals, time.Now())
 	require.NoError(t, err)
 
 	ev := NewMockEvidence(h, time.Now(), 0, valSet.Validators[0].Address)
@@ -57,7 +57,7 @@ func TestBlockValidateBasic(t *testing.T) {
 	h := int64(3)
 
 	voteSet, valSet, vals := randVoteSet(h-1, 1, PrecommitType, 10, 1)
-	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals)
+	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals, time.Now())
 	require.NoError(t, err)
 
 	ev := NewMockEvidence(h, time.Now(), 0, valSet.Validators[0].Address)
@@ -120,7 +120,7 @@ func TestBlockMakePartSetWithEvidence(t *testing.T) {
 	h := int64(3)
 
 	voteSet, valSet, vals := randVoteSet(h-1, 1, PrecommitType, 10, 1)
-	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals)
+	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals, time.Now())
 	require.NoError(t, err)
 
 	ev := NewMockEvidence(h, time.Now(), 0, valSet.Validators[0].Address)
@@ -137,7 +137,7 @@ func TestBlockHashesTo(t *testing.T) {
 	lastID := makeBlockIDRandom()
 	h := int64(3)
 	voteSet, valSet, vals := randVoteSet(h-1, 1, PrecommitType, 10, 1)
-	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals)
+	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals, time.Now())
 	require.NoError(t, err)
 
 	ev := NewMockEvidence(h, time.Now(), 0, valSet.Validators[0].Address)
@@ -210,7 +210,7 @@ func TestCommit(t *testing.T) {
 	lastID := makeBlockIDRandom()
 	h := int64(3)
 	voteSet, _, vals := randVoteSet(h-1, 1, PrecommitType, 10, 1)
-	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals)
+	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals, time.Now())
 	require.NoError(t, err)
 
 	assert.Equal(t, h-1, commit.Height)
@@ -241,7 +241,7 @@ func TestCommitValidateBasic(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
-			com := randCommit()
+			com := randCommit(time.Now())
 			tc.malleateCommit(com)
 			assert.Equal(t, tc.expectErr, com.ValidateBasic() != nil, "Validate Basic had an unexpected result")
 		})
@@ -431,7 +431,7 @@ func TestCommitToVoteSet(t *testing.T) {
 	h := int64(3)
 
 	voteSet, valSet, vals := randVoteSet(h-1, 1, PrecommitType, 10, 1)
-	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals)
+	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals, time.Now())
 	assert.NoError(t, err)
 
 	chainID := voteSet.ChainID()
@@ -506,7 +506,7 @@ func TestCommitToVoteSetWithVotesForNilBlock(t *testing.T) {
 }
 
 func TestSignedHeaderValidateBasic(t *testing.T) {
-	commit := randCommit()
+	commit := randCommit(time.Now())
 	chainID := "𠜎"
 	timestamp := time.Date(math.MaxInt64, 0, 0, 0, 0, 0, math.MaxInt64, time.UTC)
 	h := Header{

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -348,11 +348,11 @@ func TestMaxHeaderBytes(t *testing.T) {
 	assert.EqualValues(t, MaxHeaderBytes, int64(len(bz)))
 }
 
-func randCommit() *Commit {
+func randCommit(now time.Time) *Commit {
 	lastID := makeBlockIDRandom()
 	h := int64(3)
 	voteSet, _, vals := randVoteSet(h-1, 1, PrecommitType, 10, 1)
-	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals)
+	commit, err := MakeCommit(lastID, h-1, 1, voteSet, vals, now)
 	if err != nil {
 		panic(err)
 	}

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -44,35 +44,35 @@ func (pvs PrivValidatorsByAddress) Swap(i, j int) {
 // MockPV implements PrivValidator without any safety or persistence.
 // Only use it for testing.
 type MockPV struct {
-	privKey              crypto.PrivKey
+	PrivKey              crypto.PrivKey
 	breakProposalSigning bool
 	breakVoteSigning     bool
 }
 
-func NewMockPV() *MockPV {
-	return &MockPV{ed25519.GenPrivKey(), false, false}
+func NewMockPV() MockPV {
+	return MockPV{ed25519.GenPrivKey(), false, false}
 }
 
 // NewMockPVWithParams allows one to create a MockPV instance, but with finer
 // grained control over the operation of the mock validator. This is useful for
 // mocking test failures.
-func NewMockPVWithParams(privKey crypto.PrivKey, breakProposalSigning, breakVoteSigning bool) *MockPV {
-	return &MockPV{privKey, breakProposalSigning, breakVoteSigning}
+func NewMockPVWithParams(privKey crypto.PrivKey, breakProposalSigning, breakVoteSigning bool) MockPV {
+	return MockPV{privKey, breakProposalSigning, breakVoteSigning}
 }
 
 // Implements PrivValidator.
-func (pv *MockPV) GetPubKey() crypto.PubKey {
-	return pv.privKey.PubKey()
+func (pv MockPV) GetPubKey() crypto.PubKey {
+	return pv.PrivKey.PubKey()
 }
 
 // Implements PrivValidator.
-func (pv *MockPV) SignVote(chainID string, vote *Vote) error {
+func (pv MockPV) SignVote(chainID string, vote *Vote) error {
 	useChainID := chainID
 	if pv.breakVoteSigning {
 		useChainID = "incorrect-chain-id"
 	}
 	signBytes := vote.SignBytes(useChainID)
-	sig, err := pv.privKey.Sign(signBytes)
+	sig, err := pv.PrivKey.Sign(signBytes)
 	if err != nil {
 		return err
 	}
@@ -81,13 +81,13 @@ func (pv *MockPV) SignVote(chainID string, vote *Vote) error {
 }
 
 // Implements PrivValidator.
-func (pv *MockPV) SignProposal(chainID string, proposal *Proposal) error {
+func (pv MockPV) SignProposal(chainID string, proposal *Proposal) error {
 	useChainID := chainID
 	if pv.breakProposalSigning {
 		useChainID = "incorrect-chain-id"
 	}
 	signBytes := proposal.SignBytes(useChainID)
-	sig, err := pv.privKey.Sign(signBytes)
+	sig, err := pv.PrivKey.Sign(signBytes)
 	if err != nil {
 		return err
 	}
@@ -96,19 +96,19 @@ func (pv *MockPV) SignProposal(chainID string, proposal *Proposal) error {
 }
 
 // String returns a string representation of the MockPV.
-func (pv *MockPV) String() string {
+func (pv MockPV) String() string {
 	addr := pv.GetPubKey().Address()
 	return fmt.Sprintf("MockPV{%v}", addr)
 }
 
 // XXX: Implement.
-func (pv *MockPV) DisableChecks() {
+func (pv MockPV) DisableChecks() {
 	// Currently this does nothing,
 	// as MockPV has no safety checks at all.
 }
 
 type erroringMockPV struct {
-	*MockPV
+	MockPV
 }
 
 var ErroringMockPVErr = errors.New("erroringMockPV always returns an error")
@@ -125,5 +125,5 @@ func (pv *erroringMockPV) SignProposal(chainID string, proposal *Proposal) error
 
 // NewErroringMockPV returns a MockPV that fails on each signing request. Again, for testing only.
 func NewErroringMockPV() *erroringMockPV {
-	return &erroringMockPV{&MockPV{ed25519.GenPrivKey(), false, false}}
+	return &erroringMockPV{MockPV{ed25519.GenPrivKey(), false, false}}
 }

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -107,7 +107,7 @@ func (pv MockPV) DisableChecks() {
 	// as MockPV has no safety checks at all.
 }
 
-type erroringMockPV struct {
+type ErroringMockPV struct {
 	MockPV
 }
 
@@ -125,6 +125,6 @@ func (pv *ErroringMockPV) SignProposal(chainID string, proposal *Proposal) error
 
 // NewErroringMockPV returns a MockPV that fails on each signing request. Again, for testing only.
 
-func NewErroringMockPV() *erroringMockPV {
-	return &erroringMockPV{MockPV{ed25519.GenPrivKey(), false, false}}
+func NewErroringMockPV() *ErroringMockPV {
+	return &ErroringMockPV{MockPV{ed25519.GenPrivKey(), false, false}}
 }

--- a/types/test_util.go
+++ b/types/test_util.go
@@ -1,11 +1,11 @@
 package types
 
 import (
-	tmtime "github.com/tendermint/tendermint/types/time"
+	"time"
 )
 
 func MakeCommit(blockID BlockID, height int64, round int,
-	voteSet *VoteSet, validators []PrivValidator) (*Commit, error) {
+	voteSet *VoteSet, validators []PrivValidator, now time.Time) (*Commit, error) {
 
 	// all sign
 	for i := 0; i < len(validators); i++ {
@@ -17,7 +17,7 @@ func MakeCommit(blockID BlockID, height int64, round int,
 			Round:            round,
 			Type:             PrecommitType,
 			BlockID:          blockID,
-			Timestamp:        tmtime.Now(),
+			Timestamp:        now,
 		}
 
 		_, err := signAddVote(validators[i], vote, voteSet)
@@ -43,6 +43,7 @@ func MakeVote(
 	valSet *ValidatorSet,
 	privVal PrivValidator,
 	chainID string,
+	now time.Time,
 ) (*Vote, error) {
 	addr := privVal.GetPubKey().Address()
 	idx, _ := valSet.GetByAddress(addr)
@@ -51,7 +52,7 @@ func MakeVote(
 		ValidatorIndex:   idx,
 		Height:           height,
 		Round:            0,
-		Timestamp:        tmtime.Now(),
+		Timestamp:        now,
 		Type:             PrecommitType,
 		BlockID:          blockID,
 	}


### PR DESCRIPTION
JSON test file generation requires some changes in the go test files and they are proposed in this PR as below :

- test functions take `time.Time` as a parameter instead of setting the `timestamp` to `tmtime.Now()`. This gives more control over testing the `trusting_period` specifically
- exported `Privkey` (i.e. `MockPV.Privkey`) so that amino can serialize it
- pointers to MockPV were not needed 
- added JSON tags to `Fraction struct`


* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
