### PR TITLE
lite2: remove expiration checks on functions that don't require them

### DIFF
--- a/docs/architecture/adr-046-light-client-implementation.md
+++ b/docs/architecture/adr-046-light-client-implementation.md
@@ -27,8 +27,8 @@ type Client interface {
 	Cleanup() error
 
 	// get trusted headers & validators
-	TrustedHeader(height int64, now time.Time) (*types.SignedHeader, error)
-	TrustedValidatorSet(height int64, now time.Time) (*types.ValidatorSet, error)
+	TrustedHeader(height int64) (*types.SignedHeader, error)
+	TrustedValidatorSet(height int64) (*types.ValidatorSet, error)
 	LastTrustedHeight() (int64, error)
 	FirstTrustedHeight() (int64, error)
 

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -428,7 +428,7 @@ func (c *Client) Stop() {
 //  - header has not been verified yet
 //
 // Safe for concurrent use by multiple goroutines.
-func (c *Client) TrustedHeader(height int64, now time.Time) (*types.SignedHeader, error) {
+func (c *Client) TrustedHeader(height int64) (*types.SignedHeader, error) {
 	if height < 0 {
 		return nil, errors.New("negative height")
 	}
@@ -479,7 +479,7 @@ func (c *Client) TrustedValidatorSet(height int64, now time.Time) (*types.Valida
 	// Checks height is positive and header is not expired.
 	// Additionally, it fetches validator set from primary if it's missing in
 	// store.
-	_, err := c.TrustedHeader(height, now)
+	_, err := c.TrustedHeader(height)
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +523,7 @@ func (c *Client) VerifyHeaderAtHeight(height int64, now time.Time) (*types.Signe
 	}
 
 	// Check if header already verified.
-	h, err := c.TrustedHeader(height, now)
+	h, err := c.TrustedHeader(height)
 	switch err.(type) {
 	case nil:
 		c.logger.Info("Header has already been verified", "height", height, "hash", hash2str(h.Hash()))
@@ -563,7 +563,7 @@ func (c *Client) VerifyHeaderAtHeight(height int64, now time.Time) (*types.Signe
 // provider.ErrValidatorSetNotFound error is returned.
 func (c *Client) VerifyHeader(newHeader *types.SignedHeader, newVals *types.ValidatorSet, now time.Time) error {
 	// Check if newHeader already verified.
-	h, err := c.TrustedHeader(newHeader.Height, now)
+	h, err := c.TrustedHeader(newHeader.Height)
 	switch err.(type) {
 	case nil:
 		// Make sure it's the same header.

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -411,8 +411,6 @@ func (c *Client) Stop() {
 }
 
 // TrustedHeader returns a trusted header at the given height (0 - the latest).
-// If a header is missing in trustedStore (e.g. it was skipped during
-// bisection), it will be downloaded from primary.
 //
 // Headers along with validator sets, which can't be trusted anymore, are
 // removed once a day (can be changed with RemoveNoLongerTrustedHeadersPeriod

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -811,12 +811,10 @@ func (c *Client) backwards(
 	}
 
 	var (
-		trustedHeader *types.SignedHeader
+		trustedHeader = initiallyTrustedHeader
 		interimHeader *types.SignedHeader
 		err           error
 	)
-
-	trustedHeader = initiallyTrustedHeader
 
 	for trustedHeader.Height > newHeader.Height {
 		interimHeader, err = c.signedHeaderFromPrimary(trustedHeader.Height - 1)

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -777,6 +777,7 @@ func (c *Client) updateTrustedHeaderAndVals(h *types.SignedHeader, vals *types.V
 		return errors.Wrap(err, "failed to save trusted header")
 	}
 
+	// Only update latestTrustedHeader if we move forward (not backwards).
 	if c.latestTrustedHeader == nil || h.Height > c.latestTrustedHeader.Height {
 		c.latestTrustedHeader = h
 		c.latestTrustedVals = vals
@@ -800,8 +801,11 @@ func (c *Client) fetchHeaderAndValsAtHeight(height int64) (*types.SignedHeader, 
 }
 
 // Backwards verification (see VerifyHeaderBackwards func in the spec)
-func (c *Client) backwards(initiallyTrustedHeader *types.SignedHeader, newHeader *types.SignedHeader,
+func (c *Client) backwards(
+	initiallyTrustedHeader *types.SignedHeader,
+	newHeader *types.SignedHeader,
 	now time.Time) error {
+
 	if HeaderExpired(initiallyTrustedHeader, c.trustingPeriod, now) {
 		return ErrOldHeaderExpired{initiallyTrustedHeader.Time.Add(c.trustingPeriod), now}
 	}
@@ -839,6 +843,7 @@ func (c *Client) backwards(initiallyTrustedHeader *types.SignedHeader, newHeader
 		trustedHeader = interimHeader
 	}
 
+	// Initially trusted header might have expired at this point.
 	if HeaderExpired(initiallyTrustedHeader, c.trustingPeriod, now) {
 		return ErrOldHeaderExpired{initiallyTrustedHeader.Time.Add(c.trustingPeriod), now}
 	}

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -421,11 +421,10 @@ func (c *Client) Stop() {
 // height must be >= 0.
 //
 // It returns an error if:
-//  - header expired, therefore can't be trusted (ErrOldHeaderExpired);
 //  - there are some issues with the trusted store, although that should not
 //  happen normally;
 //  - negative height is passed;
-//  - header has not been verified yet
+//  - header has not been verified yet and is therefore not in the store
 //
 // Safe for concurrent use by multiple goroutines.
 func (c *Client) TrustedHeader(height int64) (*types.SignedHeader, error) {
@@ -457,31 +456,26 @@ func (c *Client) TrustedHeader(height int64) (*types.SignedHeader, error) {
 	return h, nil
 }
 
-// TrustedValidatorSet returns a trusted validator set at the given height. If
-// a validator set is missing in trustedStore (e.g. the associated header was
-// skipped during bisection), it will be downloaded from primary.
+// TrustedValidatorSet returns a trusted validator set at the given height (0 -
+// latest).
 //
 // height must be >= 0.
 //
-// Headers along with validator sets, which can't be trusted anymore, are
+// Headers along with validator sets are
 // removed once a day (can be changed with RemoveNoLongerTrustedHeadersPeriod
 // option).
 //
-// It returns an error if:
-//	- header signed by that validator set expired (ErrOldHeaderExpired)
+// Function returns an error if:
 //  - there are some issues with the trusted store, although that should not
 //  happen normally;
 //  - negative height is passed;
 //  - header signed by that validator set has not been verified yet
 //
 // Safe for concurrent use by multiple goroutines.
-func (c *Client) TrustedValidatorSet(height int64, now time.Time) (*types.ValidatorSet, error) {
-	// Checks height is positive and header is not expired.
-	// Additionally, it fetches validator set from primary if it's missing in
-	// store.
-	_, err := c.TrustedHeader(height)
-	if err != nil {
-		return nil, err
+func (c *Client) TrustedValidatorSet(height int64) (*types.ValidatorSet, error) {
+	// Checks height is positive.
+	if height < 0 {
+		return nil, errors.New("negative height")
 	}
 
 	return c.trustedStore.ValidatorSet(height)
@@ -524,13 +518,10 @@ func (c *Client) VerifyHeaderAtHeight(height int64, now time.Time) (*types.Signe
 
 	// Check if header already verified.
 	h, err := c.TrustedHeader(height)
-	switch err.(type) {
-	case nil:
+	if err == nil {
 		c.logger.Info("Header has already been verified", "height", height, "hash", hash2str(h.Hash()))
 		// Return already trusted header
 		return h, nil
-	case ErrOldHeaderExpired:
-		return nil, err
 	}
 
 	// Request the header and the vals.
@@ -562,19 +553,19 @@ func (c *Client) VerifyHeaderAtHeight(height int64, now time.Time) (*types.Signe
 // provider, provider.ErrSignedHeaderNotFound /
 // provider.ErrValidatorSetNotFound error is returned.
 func (c *Client) VerifyHeader(newHeader *types.SignedHeader, newVals *types.ValidatorSet, now time.Time) error {
+	if newHeader.Height <= 0 {
+		return errors.New("negative or zero height")
+	}
+
 	// Check if newHeader already verified.
 	h, err := c.TrustedHeader(newHeader.Height)
-	switch err.(type) {
-	case nil:
-		// Make sure it's the same header.
+	if err == nil {
 		if !bytes.Equal(h.Hash(), newHeader.Hash()) {
 			return errors.Errorf("existing trusted header %X does not match newHeader %X", h.Hash(), newHeader.Hash())
 		}
 		c.logger.Info("Header has already been verified",
 			"height", newHeader.Height, "hash", hash2str(newHeader.Hash()))
 		return nil
-	case ErrOldHeaderExpired:
-		return err
 	}
 
 	return c.verifyHeader(newHeader, newVals, now)

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -841,8 +841,8 @@ func (c *Client) backwards(initiallyTrustedHeader *types.SignedHeader, newHeader
 		trustedHeader = interimHeader
 	}
 
-	if HeaderExpired(initialTrustedHeader, c.trustingPeriod, now) {
-		return ErrOldHeaderExpired{initialTrustedHeader.Time.Add(c.trustingPeriod), now}
+	if HeaderExpired(initiallyTrustedHeader, c.trustingPeriod, now) {
+		return ErrOldHeaderExpired{initiallyTrustedHeader.Time.Add(c.trustingPeriod), now}
 	}
 
 	return nil

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -357,12 +357,12 @@ func TestClientRemovesNoLongerTrustedHeaders(t *testing.T) {
 	c.RemoveNoLongerTrustedHeaders(now)
 
 	// Check expired headers are no longer available.
-	h, err := c.TrustedHeader(1, now)
+	h, err := c.TrustedHeader(1)
 	assert.Error(t, err)
 	assert.Nil(t, h)
 
 	// Check not expired headers are available.
-	h, err = c.TrustedHeader(2, now)
+	h, err = c.TrustedHeader(2)
 	assert.NoError(t, err)
 	assert.NotNil(t, h)
 }
@@ -385,7 +385,7 @@ func TestClient_Cleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check no headers exist after Cleanup.
-	h, err := c.TrustedHeader(1, bTime.Add(1*time.Second))
+	h, err := c.TrustedHeader(1)
 	assert.Error(t, err)
 	assert.Nil(t, h)
 }
@@ -411,7 +411,7 @@ func TestClientRestoresTrustedHeaderAfterStartup1(t *testing.T) {
 		require.NoError(t, err)
 		defer c.Stop()
 
-		h, err := c.TrustedHeader(1, bTime.Add(1*time.Second))
+		h, err := c.TrustedHeader(1)
 		assert.NoError(t, err)
 		assert.NotNil(t, h)
 		assert.Equal(t, h.Hash(), h1.Hash())
@@ -455,7 +455,7 @@ func TestClientRestoresTrustedHeaderAfterStartup1(t *testing.T) {
 		require.NoError(t, err)
 		defer c.Stop()
 
-		h, err := c.TrustedHeader(1, bTime.Add(1*time.Second))
+		h, err := c.TrustedHeader(1)
 		assert.NoError(t, err)
 		assert.NotNil(t, h)
 		assert.Equal(t, h.Hash(), header1.Hash())
@@ -488,7 +488,7 @@ func TestClientRestoresTrustedHeaderAfterStartup2(t *testing.T) {
 		defer c.Stop()
 
 		// Check we still have the 1st header (+header+).
-		h, err := c.TrustedHeader(1, bTime.Add(2*time.Hour).Add(1*time.Second))
+		h, err := c.TrustedHeader(1)
 		assert.NoError(t, err)
 		assert.NotNil(t, h)
 		assert.Equal(t, h.Hash(), h1.Hash())
@@ -538,7 +538,7 @@ func TestClientRestoresTrustedHeaderAfterStartup2(t *testing.T) {
 		defer c.Stop()
 
 		// Check we no longer have the invalid 1st header (+header+).
-		h, err := c.TrustedHeader(1, bTime.Add(2*time.Hour).Add(1*time.Second))
+		h, err := c.TrustedHeader(1)
 		assert.Error(t, err)
 		assert.Nil(t, h)
 	}
@@ -583,13 +583,13 @@ func TestClientRestoresTrustedHeaderAfterStartup3(t *testing.T) {
 		defer c.Stop()
 
 		// Check we still have the 1st header (+header+).
-		h, err := c.TrustedHeader(1, bTime.Add(2*time.Hour).Add(1*time.Second))
+		h, err := c.TrustedHeader(1)
 		assert.NoError(t, err)
 		assert.NotNil(t, h)
 		assert.Equal(t, h.Hash(), h1.Hash())
 
 		// Check we no longer have 2nd header (+header2+).
-		h, err = c.TrustedHeader(2, bTime.Add(2*time.Hour).Add(1*time.Second))
+		h, err = c.TrustedHeader(2)
 		assert.Error(t, err)
 		assert.Nil(t, h)
 	}
@@ -638,13 +638,13 @@ func TestClientRestoresTrustedHeaderAfterStartup3(t *testing.T) {
 		defer c.Stop()
 
 		// Check we have swapped invalid 1st header (+header+) with correct one (+header1+).
-		h, err := c.TrustedHeader(1, bTime.Add(2*time.Hour).Add(1*time.Second))
+		h, err := c.TrustedHeader(1)
 		assert.NoError(t, err)
 		assert.NotNil(t, h)
 		assert.Equal(t, h.Hash(), header1.Hash())
 
 		// Check we no longer have invalid 2nd header (+header2+).
-		h, err = c.TrustedHeader(2, bTime.Add(2*time.Hour).Add(1*time.Second))
+		h, err = c.TrustedHeader(2)
 		assert.Error(t, err)
 		assert.Nil(t, h)
 	}
@@ -668,7 +668,7 @@ func TestClient_Update(t *testing.T) {
 	err = c.Update(bTime.Add(2 * time.Hour))
 	require.NoError(t, err)
 
-	h, err := c.TrustedHeader(3, bTime.Add(2*time.Hour))
+	h, err := c.TrustedHeader(3)
 	assert.NoError(t, err)
 	require.NotNil(t, h)
 	assert.EqualValues(t, 3, h.Height)
@@ -709,7 +709,7 @@ func TestClient_Concurrency(t *testing.T) {
 			_, err = c.FirstTrustedHeight()
 			assert.NoError(t, err)
 
-			h, err := c.TrustedHeader(1, bTime.Add(2*time.Hour))
+			h, err := c.TrustedHeader(1)
 			assert.NoError(t, err)
 			assert.NotNil(t, h)
 
@@ -810,7 +810,7 @@ func TestClient_NewClientFromTrustedStore(t *testing.T) {
 
 	// 2) Check header exists (deadNode is being used to ensure we're not getting
 	// it from primary)
-	h, err := c.TrustedHeader(1, bTime.Add(1*time.Second))
+	h, err := c.TrustedHeader(1)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, h.Height)
 }

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -348,7 +348,6 @@ func TestClientRemovesNoLongerTrustedHeaders(t *testing.T) {
 }
 
 func TestClient_Cleanup(t *testing.T) {
-
 	c, err := NewClient(
 		chainID,
 		trustOptions,

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -714,7 +714,7 @@ func TestClient_Concurrency(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, h)
 
-			vals, err := c.TrustedValidatorSet(2, bTime.Add(2*time.Hour))
+			vals, err := c.TrustedValidatorSet(2)
 			assert.NoError(t, err)
 			assert.NotNil(t, vals)
 		}()

--- a/lite2/example_test.go
+++ b/lite2/example_test.go
@@ -76,7 +76,7 @@ func TestExample_Client_AutoUpdate(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	h, err := c.TrustedHeader(0, time.Now())
+	h, err := c.TrustedHeader(0)
 	if err != nil {
 		stdlog.Fatal(err)
 	}
@@ -146,7 +146,7 @@ func TestExample_Client_ManualUpdate(t *testing.T) {
 		stdlog.Fatal(err)
 	}
 
-	h, err := c.TrustedHeader(3, time.Now())
+	h, err := c.TrustedHeader(3)
 	if err != nil {
 		stdlog.Fatal(err)
 	}

--- a/lite2/rpc/client.go
+++ b/lite2/rpc/client.go
@@ -191,7 +191,7 @@ func (c *Client) BlockchainInfo(minHeight, maxHeight int64) (*ctypes.ResultBlock
 
 	// Verify each of the BlockMetas.
 	for _, meta := range res.BlockMetas {
-		h, err := c.lc.TrustedHeader(meta.Header.Height, time.Now())
+		h, err := c.lc.TrustedHeader(meta.Header.Height)
 		if err != nil {
 			return nil, errors.Wrapf(err, "TrustedHeader(%d)", meta.Header.Height)
 		}
@@ -331,7 +331,7 @@ func (c *Client) updateLiteClientIfNeededTo(height int64) (*types.SignedHeader, 
 		return c.lc.VerifyHeaderAtHeight(height, time.Now())
 	}
 
-	h, err := c.lc.TrustedHeader(height, time.Now())
+	h, err := c.lc.TrustedHeader(height)
 	if err != nil {
 		return nil, errors.Wrapf(err, "TrustedHeader(#%d)", height)
 	}


### PR DESCRIPTION
closes: #4455

Verifying backwards checks that the trustedHeader hasn't expired both before and after the loop in case of verifying many headers (a longer operation), but not during the loop itself.

TrustedHeader() no longer checks whether the header saved in the store has expired.

Tests have been updated to reflect the changes

* [x] Referenced an issue explaining the need for the change
* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [ ] ~~Updated CHANGELOG_PENDING.md~~
