### PR TITLE
lite2: prune-headers

### DIFF
--- a/lite2/client.go
+++ b/lite2/client.go
@@ -22,9 +22,9 @@ const (
 	sequential mode = iota + 1
 	skipping
 
-	defaultUpdatePeriod                       = 5 * time.Second
-	defaultRemoveNoLongerTrustedHeadersPeriod = 24 * time.Hour
-	defaultMaxRetryAttempts                   = 10
+	defaultUpdatePeriod     = 5 * time.Second
+	defaultPruningSize      = 1000
+	defaultMaxRetryAttempts = 10
 )
 
 // Option sets a parameter for the light client.
@@ -62,13 +62,14 @@ func UpdatePeriod(d time.Duration) Option {
 	}
 }
 
-// RemoveNoLongerTrustedHeadersPeriod option can be used to define how often
-// the routine, which cleans up no longer trusted headers (outside of trusting
-// period), is run. Default: once a day. When set to zero, the routine won't be
-// started.
-func RemoveNoLongerTrustedHeadersPeriod(d time.Duration) Option {
+// PruningSize option sets the maximum amount of headers and validator sets that
+// the light client stores. When Prune() is run, all headers that are earlier than
+// the h amount of headers will be removed from the store. If UpdatePeriod is used,
+// prune will automatically run. Default: 1000. A pruning size of 0 will not prune
+// the lite client at all.
+func PruningSize(h uint64) Option {
 	return func(c *Client) {
-		c.removeNoLongerTrustedHeadersPeriod = d
+		c.pruningSize = h
 	}
 }
 
@@ -128,7 +129,7 @@ type Client struct {
 	// See UpdatePeriod option
 	updatePeriod time.Duration
 	// See RemoveNoLongerTrustedHeadersPeriod option
-	removeNoLongerTrustedHeadersPeriod time.Duration
+	pruningSize uint64
 	// See ConfirmationFunction option
 	confirmationFn func(action string) bool
 
@@ -191,19 +192,19 @@ func NewClientFromTrustedStore(
 	options ...Option) (*Client, error) {
 
 	c := &Client{
-		chainID:                            chainID,
-		trustingPeriod:                     trustingPeriod,
-		verificationMode:                   skipping,
-		trustLevel:                         DefaultTrustLevel,
-		maxRetryAttempts:                   defaultMaxRetryAttempts,
-		primary:                            primary,
-		witnesses:                          witnesses,
-		trustedStore:                       trustedStore,
-		updatePeriod:                       defaultUpdatePeriod,
-		removeNoLongerTrustedHeadersPeriod: defaultRemoveNoLongerTrustedHeadersPeriod,
-		confirmationFn:                     func(action string) bool { return true },
-		quit:                               make(chan struct{}),
-		logger:                             log.NewNopLogger(),
+		chainID:          chainID,
+		trustingPeriod:   trustingPeriod,
+		verificationMode: skipping,
+		trustLevel:       DefaultTrustLevel,
+		maxRetryAttempts: defaultMaxRetryAttempts,
+		primary:          primary,
+		witnesses:        witnesses,
+		trustedStore:     trustedStore,
+		updatePeriod:     defaultUpdatePeriod,
+		pruningSize:      defaultPruningSize,
+		confirmationFn:   func(action string) bool { return true },
+		quit:             make(chan struct{}),
+		logger:           log.NewNopLogger(),
 	}
 
 	for _, o := range options {
@@ -304,7 +305,10 @@ func (c *Client) checkTrustedHeaderUsingOptions(options TrustOptions) error {
 			c.latestTrustedHeader.Height, c.latestTrustedHeader.Hash())
 		if c.confirmationFn(action) {
 			// remove all the headers (options.Height, trustedHeader.Height]
-			c.cleanup(options.Height + 1)
+			err := c.cleanup(options.Height+1, 0)
+			if err != nil {
+				return errors.Wrap(err, "unable to check trusted header using options")
+			}
 
 			c.logger.Info("Rolled back to older header (newer headers were removed)",
 				"old", options.Height)
@@ -387,11 +391,6 @@ func (c *Client) initializeWithTrustOptions(options TrustOptions) error {
 // Start starts two processes: 1) auto updating 2) removing outdated headers.
 func (c *Client) Start() error {
 	c.logger.Info("Starting light client")
-
-	if c.removeNoLongerTrustedHeadersPeriod > 0 {
-		c.routinesWaitGroup.Add(1)
-		go c.removeNoLongerTrustedHeadersRoutine()
-	}
 
 	if c.updatePeriod > 0 {
 		c.routinesWaitGroup.Add(1)
@@ -557,6 +556,7 @@ func (c *Client) VerifyHeader(newHeader *types.SignedHeader, newVals *types.Vali
 	// Check if newHeader already verified.
 	h, err := c.TrustedHeader(newHeader.Height)
 	if err == nil {
+		// Make sure it's the same header.
 		if !bytes.Equal(h.Hash(), newHeader.Hash()) {
 			return errors.Errorf("existing trusted header %X does not match newHeader %X", h.Hash(), newHeader.Hash())
 		}
@@ -630,13 +630,14 @@ func (c *Client) Witnesses() []provider.Provider {
 // client must be stopped at this point.
 func (c *Client) Cleanup() error {
 	c.logger.Info("Removing all the data")
-	return c.cleanup(0)
+	return c.cleanup(0, 0)
 }
 
-// cleanup deletes all headers & validator sets between +stopHeight+ and latest
-// height included. It also sets trustedHeader (vals) to the latest header
-// (vals) if such exists.
-func (c *Client) cleanup(stopHeight int64) error {
+// cleanup deletes all headers & validator sets between startHeight and stopHeight (inclusive).
+// Using a height of 0 will default to the oldest and newest heights respectively.
+// It also resets latestTrustedHeader to the latest header.
+func (c *Client) cleanup(startHeight, stopHeight int64) error {
+
 	// 1) Get the oldest height.
 	oldestHeight, err := c.trustedStore.FirstSignedHeaderHeight()
 	if err != nil {
@@ -649,15 +650,34 @@ func (c *Client) cleanup(stopHeight int64) error {
 		return errors.Wrap(err, "can't get last trusted height")
 	}
 
-	// 3) Remove all headers and validator sets.
-	if stopHeight < oldestHeight {
-		stopHeight = oldestHeight
+	// 3) Ensure the start height and stop height are within the range of headers stored.
+	if stopHeight == 0 || stopHeight > latestHeight {
+		stopHeight = latestHeight
 	}
-	for height := stopHeight; height <= latestHeight; height++ {
-		err = c.trustedStore.DeleteSignedHeaderAndValidatorSet(height)
+	if startHeight < oldestHeight {
+		startHeight = oldestHeight
+	}
+	if startHeight > stopHeight {
+		return errors.Errorf("startHeight of %d must be less than stopHeight %d", startHeight, stopHeight)
+	}
+
+	for startHeight <= stopHeight {
+		// 4a) Delete the header and next validator set
+		err = c.trustedStore.DeleteSignedHeaderAndValidatorSet(startHeight)
 		if err != nil {
-			c.logger.Error("can't remove a trusted header & validator set", "err", err, "height", height)
-			continue
+			c.logger.Error("can't remove a trusted header & validator set", "err", err, "height",
+				startHeight)
+		}
+		// 4b) Jump to the next height
+		if startHeight < stopHeight {
+			h, err := c.trustedStore.SignedHeaderAfter(startHeight)
+			if err != nil {
+				return errors.Wrap(err, "tried to clean up headers")
+			}
+			startHeight = h.Height
+		} else {
+			// 4c) all headers in between have been deleted
+			startHeight = stopHeight + 1
 		}
 	}
 
@@ -776,7 +796,10 @@ func (c *Client) updateTrustedHeaderAndVals(h *types.SignedHeader, vals *types.V
 		return errors.Wrap(err, "failed to save trusted header")
 	}
 
-	// Only update latestTrustedHeader if we move forward (not backwards).
+	if err := c.trustedStore.Prune(c.pruningSize); err != nil {
+		return errors.Wrap(err, "failed to save trusted header")
+	}
+
 	if c.latestTrustedHeader == nil || h.Height > c.latestTrustedHeader.Height {
 		c.latestTrustedHeader = h
 		c.latestTrustedVals = vals
@@ -918,72 +941,6 @@ func (c *Client) removeWitness(idx int) {
 	default:
 		c.witnesses[idx] = c.witnesses[len(c.witnesses)-1]
 		c.witnesses = c.witnesses[:len(c.witnesses)-1]
-	}
-}
-
-func (c *Client) removeNoLongerTrustedHeadersRoutine() {
-	defer c.routinesWaitGroup.Done()
-
-	ticker := time.NewTicker(c.removeNoLongerTrustedHeadersPeriod)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			c.RemoveNoLongerTrustedHeaders(time.Now())
-		case <-c.quit:
-			return
-		}
-	}
-}
-
-// RemoveNoLongerTrustedHeaders removes no longer trusted headers (due to
-// expiration).
-//
-// Exposed for testing.
-func (c *Client) RemoveNoLongerTrustedHeaders(now time.Time) {
-	// 1) Get the oldest height.
-	oldestHeight, err := c.FirstTrustedHeight()
-	if err != nil {
-		c.logger.Error("can't get first trusted height", "err", err)
-		return
-	}
-	if oldestHeight == -1 { // no headers yet => wait
-		return
-	}
-
-	// 2) Get the latest height.
-	latestHeight, err := c.LastTrustedHeight()
-	if err != nil {
-		c.logger.Error("can't get last trusted height", "err", err)
-		return
-	}
-	if latestHeight == -1 { // no headers yet => wait
-		return
-	}
-
-	// 3) Remove all headers that are outside of the trusting period.
-	//
-	// NOTE: even the latest header can be removed. it's okay because
-	// c.latestTrustedHeader will retain it in memory so other funcs like VerifyHeader
-	// don't crash.
-	for height := oldestHeight; height <= latestHeight; height++ {
-		h, err := c.trustedStore.SignedHeader(height)
-		if err != nil {
-			c.logger.Error("can't get a trusted header", "err", err, "height", height)
-			continue
-		}
-
-		// Stop if the header is within the trusting period.
-		if !HeaderExpired(h, c.trustingPeriod, now) {
-			break
-		}
-
-		err = c.trustedStore.DeleteSignedHeaderAndValidatorSet(height)
-		if err != nil {
-			c.logger.Error("can't remove a trusted header & validator set", "err", err, "height", height)
-			continue
-		}
 	}
 }
 

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -67,7 +67,7 @@ func UpdatePeriod(d time.Duration) Option {
 // the associated validator set) that are earlier than the h amount of headers
 // will be removed from the store. Default: 1000. A pruning size of 0 will not
 // prune the lite client at all.
-func PruningSize(h uint64) Option {
+func PruningSize(h uint32) Option {
 	return func(c *Client) {
 		c.pruningSize = h
 	}
@@ -129,7 +129,7 @@ type Client struct {
 	// See UpdatePeriod option
 	updatePeriod time.Duration
 	// See RemoveNoLongerTrustedHeadersPeriod option
-	pruningSize uint64
+	pruningSize uint32
 	// See ConfirmationFunction option
 	confirmationFn func(action string) bool
 

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -67,7 +67,7 @@ func UpdatePeriod(d time.Duration) Option {
 // the associated validator set) that are earlier than the h amount of headers
 // will be removed from the store. Default: 1000. A pruning size of 0 will not
 // prune the lite client at all.
-func PruningSize(h uint32) Option {
+func PruningSize(h uint16) Option {
 	return func(c *Client) {
 		c.pruningSize = h
 	}
@@ -129,7 +129,7 @@ type Client struct {
 	// See UpdatePeriod option
 	updatePeriod time.Duration
 	// See RemoveNoLongerTrustedHeadersPeriod option
-	pruningSize uint32
+	pruningSize uint16
 	// See ConfirmationFunction option
 	confirmationFn func(action string) bool
 

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -306,47 +306,6 @@ func TestClient_SkippingVerification(t *testing.T) {
 	}
 }
 
-func TestClientRemovesNoLongerTrustedHeaders(t *testing.T) {
-	c, err := NewClient(
-		chainID,
-		trustOptions,
-		fullNode,
-		[]provider.Provider{fullNode},
-		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
-	)
-
-	assert.NotPanics(t, func() {
-		now := bTime.Add(4 * time.Hour).Add(1 * time.Second)
-		c.RemoveNoLongerTrustedHeaders(now)
-	})
-
-	require.NoError(t, err)
-	err = c.Start()
-	require.NoError(t, err)
-	defer c.Stop()
-
-	// Verify new headers.
-	_, err = c.VerifyHeaderAtHeight(2, bTime.Add(2*time.Hour).Add(1*time.Second))
-	require.NoError(t, err)
-	now := bTime.Add(4 * time.Hour).Add(1 * time.Second)
-	_, err = c.VerifyHeaderAtHeight(3, now)
-	require.NoError(t, err)
-
-	// Remove expired headers.
-	c.RemoveNoLongerTrustedHeaders(now)
-
-	// Check expired headers are no longer available.
-	h, err := c.TrustedHeader(1)
-	assert.Error(t, err)
-	assert.Nil(t, h)
-
-	// Check not expired headers are available.
-	h, err = c.TrustedHeader(2)
-	assert.NoError(t, err)
-	assert.NotNil(t, h)
-}
-
 func TestClient_Cleanup(t *testing.T) {
 	c, err := NewClient(
 		chainID,

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -316,10 +316,9 @@ func TestClient_Cleanup(t *testing.T) {
 		Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
-	err = c.Start()
+	_, err = c.TrustedHeader(1)
 	require.NoError(t, err)
 
-	c.Stop()
 	err = c.Cleanup()
 	require.NoError(t, err)
 

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -345,9 +345,6 @@ func TestClientRestoresTrustedHeaderAfterStartup1(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
-		err = c.Start()
-		require.NoError(t, err)
-		defer c.Stop()
 
 		h, err := c.TrustedHeader(1)
 		assert.NoError(t, err)
@@ -387,14 +384,12 @@ func TestClientRestoresTrustedHeaderAfterStartup1(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
-		err = c.Start()
-		require.NoError(t, err)
-		defer c.Stop()
 
 		h, err := c.TrustedHeader(1)
 		assert.NoError(t, err)
-		assert.NotNil(t, h)
-		assert.Equal(t, h.Hash(), header1.Hash())
+		if assert.NotNil(t, h) {
+			assert.Equal(t, h.Hash(), header1.Hash())
+		}
 	}
 }
 

--- a/lite2/store/db/db.go
+++ b/lite2/store/db/db.go
@@ -181,6 +181,10 @@ func (s *dbs) SignedHeaderAfter(height int64) (*types.SignedHeader, error) {
 	panic(fmt.Sprintf("no header after height %d. make sure height is not greater than latest existing height", height))
 }
 
+func (s *dbs) Prune(size uint64) error {
+	return nil
+}
+
 func (s *dbs) shKey(height int64) []byte {
 	return []byte(fmt.Sprintf("sh/%s/%020d", s.prefix, height))
 }

--- a/lite2/store/db/db.go
+++ b/lite2/store/db/db.go
@@ -204,7 +204,7 @@ func (s *dbs) FirstSignedHeaderHeight() (int64, error) {
 }
 
 // SignedHeaderAfter iterates over headers until it finds a header after one at
-// height. It panics if no such header exists.
+// height. It returns ErrSignedHeaderNotFound if no such header exists.
 //
 // Safe for concurrent use by multiple goroutines.
 func (s *dbs) SignedHeaderAfter(height int64) (*types.SignedHeader, error) {
@@ -230,7 +230,7 @@ func (s *dbs) SignedHeaderAfter(height int64) (*types.SignedHeader, error) {
 		itr.Next()
 	}
 
-	panic(fmt.Sprintf("no header after height %d. make sure height is not greater than latest existing height", height))
+	return nil, store.ErrSignedHeaderNotFound
 }
 
 // Prune prunes header & validator set pairs until there are only size pairs

--- a/lite2/store/db/db.go
+++ b/lite2/store/db/db.go
@@ -212,7 +212,7 @@ func (s *dbs) SignedHeaderAfter(height int64) (*types.SignedHeader, error) {
 		panic("negative or zero height")
 	}
 
-	itr, err := s.db.ReverseIterator(
+	itr, err := s.db.Iterator(
 		s.shKey(height+1),
 		append(s.shKey(1<<63-1), byte(0x00)),
 	)

--- a/lite2/store/db/db_test.go
+++ b/lite2/store/db/db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,4 +93,70 @@ func Test_SignedHeaderAfter(t *testing.T) {
 	if assert.NotNil(t, h) {
 		assert.EqualValues(t, 2, h.Height)
 	}
+}
+
+func Test_Prune(t *testing.T) {
+	dbStore := New(dbm.NewMemDB(), "Test_Prune")
+
+	// Empty store
+	assert.EqualValues(t, 0, dbStore.Size())
+	err := dbStore.Prune(0)
+	require.NoError(t, err)
+
+	// One header
+	err = dbStore.SaveSignedHeaderAndValidatorSet(
+		&types.SignedHeader{Header: &types.Header{Height: 2}}, &types.ValidatorSet{})
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, dbStore.Size())
+
+	err = dbStore.Prune(1)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, dbStore.Size())
+
+	err = dbStore.Prune(0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, dbStore.Size())
+
+	// Multiple headers
+	for i := 1; i <= 10; i++ {
+		err = dbStore.SaveSignedHeaderAndValidatorSet(
+			&types.SignedHeader{Header: &types.Header{Height: int64(i)}}, &types.ValidatorSet{})
+		require.NoError(t, err)
+	}
+
+	err = dbStore.Prune(11)
+	require.NoError(t, err)
+	assert.EqualValues(t, 10, dbStore.Size())
+
+	err = dbStore.Prune(7)
+	require.NoError(t, err)
+	assert.EqualValues(t, 7, dbStore.Size())
+}
+
+func Test_Concurrency(t *testing.T) {
+	dbStore := New(dbm.NewMemDB(), "Test_Prune")
+
+	var wg sync.WaitGroup
+	for i := 1; i <= 100; i++ {
+		wg.Add(1)
+		go func(i int64) {
+			defer wg.Done()
+
+			dbStore.SaveSignedHeaderAndValidatorSet(
+				&types.SignedHeader{Header: &types.Header{Height: i}}, &types.ValidatorSet{})
+
+			dbStore.SignedHeader(i)
+			dbStore.ValidatorSet(i)
+			dbStore.LastSignedHeaderHeight()
+			dbStore.FirstSignedHeaderHeight()
+
+			dbStore.Prune(2)
+			assert.NotZero(t, dbStore.Size())
+
+			dbStore.DeleteSignedHeaderAndValidatorSet(1)
+		}(int64(i))
+	}
+
+	wg.Wait()
 }

--- a/lite2/store/db/db_test.go
+++ b/lite2/store/db/db_test.go
@@ -152,7 +152,7 @@ func Test_Concurrency(t *testing.T) {
 			dbStore.FirstSignedHeaderHeight()
 
 			dbStore.Prune(2)
-			assert.NotZero(t, dbStore.Size())
+			_ = dbStore.Size()
 
 			dbStore.DeleteSignedHeaderAndValidatorSet(1)
 		}(int64(i))

--- a/lite2/store/store.go
+++ b/lite2/store/store.go
@@ -46,6 +46,7 @@ type Store interface {
 	// height must be > 0 && <= LastSignedHeaderHeight.
 	SignedHeaderAfter(height int64) (*types.SignedHeader, error)
 
-	// Prune, removes headers when the database reaches a defined size in order from oldest to newest
-	Prune(size uint64) error
+	// Prune removes headers & the associated validator sets when Store reaches a
+	// defined size (number of header & validator set pairs).
+	Prune(size uint32) error
 }

--- a/lite2/store/store.go
+++ b/lite2/store/store.go
@@ -45,4 +45,7 @@ type Store interface {
 	//
 	// height must be > 0 && <= LastSignedHeaderHeight.
 	SignedHeaderAfter(height int64) (*types.SignedHeader, error)
+
+	// Prune, removes headers when the database reaches a defined size in order from oldest to newest
+	Prune(size uint64) error
 }

--- a/lite2/store/store.go
+++ b/lite2/store/store.go
@@ -48,5 +48,8 @@ type Store interface {
 
 	// Prune removes headers & the associated validator sets when Store reaches a
 	// defined size (number of header & validator set pairs).
-	Prune(size uint32) error
+	Prune(size uint16) error
+
+	// Size returns a number of currently existing header & validator set pairs.
+	Size() uint16
 }


### PR DESCRIPTION
closes #4469

Improved speed of cleanup by using `SignedHeaderAfter` instead of `TrustedHeader` to jump from header to header.

`Prune()` is now called when a new header and validator set are saved and is a function dealt by the database itself