### PR TITLE
mergify: remove unnecessary conditions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,6 @@
 pull_request_rules:
-  - name: automatic merge for master when CI passes and 1 reviews and has label S:automerge
+  - name: automerge to master with label S:automerge and branch protection passing
     conditions:
-      - "#approved-reviews-by>=1"
-      - "status-success=ci/circleci - Pull Request"
       - base=master
       - label=S:automerge
     actions:


### PR DESCRIPTION
Removes unnecessary Mergify conditions, and rely on branch protection instead.