### PR TITLE
example/kvstore: return ABCI query height

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,8 +4,7 @@
 
 Special thanks to external contributors on this release:
 
-Friendly reminder, we have a [bug bounty
-program](https://hackerone.com/tendermint).
+Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermint).
 
 ### BREAKING CHANGES:
 
@@ -20,6 +19,8 @@ program](https://hackerone.com/tendermint).
 ### IMPROVEMENTS:
 
 - [types] [\#4417](https://github.com/tendermint/tendermint/issues/4417) VerifyCommitX() functions should return as soon as +2/3 threashold is reached.
+
+- [examples/kvstore] ABCI query now returns the proper height (@erikgrinaker)
 
 ### BUG FIXES:
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,7 +20,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [types] [\#4417](https://github.com/tendermint/tendermint/issues/4417) VerifyCommitX() functions should return as soon as +2/3 threashold is reached.
 
-- [examples/kvstore] ABCI query now returns the proper height (@erikgrinaker)
+- [examples/kvstore] [\#4509](https://github.com/tendermint/tendermint/pull/4509) ABCI query now returns the proper height (@erikgrinaker)
 
 ### BUG FIXES:
 

--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -136,6 +136,7 @@ func (app *Application) Query(reqQuery types.RequestQuery) (resQuery types.Respo
 		resQuery.Index = -1 // TODO make Proof return index
 		resQuery.Key = reqQuery.Data
 		resQuery.Value = value
+		resQuery.Height = app.state.Height
 
 		return
 	}
@@ -151,6 +152,7 @@ func (app *Application) Query(reqQuery types.RequestQuery) (resQuery types.Respo
 		resQuery.Log = "exists"
 	}
 	resQuery.Value = value
+	resQuery.Height = app.state.Height
 
 	return resQuery
 }

--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -30,6 +30,11 @@ func testKVStore(t *testing.T, app types.Application, tx []byte, key, value stri
 	// repeating tx doesn't raise error
 	ar = app.DeliverTx(req)
 	require.False(t, ar.IsErr(), ar)
+	// commit
+	app.Commit()
+
+	info := app.Info(types.RequestInfo{})
+	require.NotZero(t, info.LastBlockHeight)
 
 	// make sure query is fine
 	resQuery := app.Query(types.RequestQuery{
@@ -37,7 +42,9 @@ func testKVStore(t *testing.T, app types.Application, tx []byte, key, value stri
 		Data: []byte(key),
 	})
 	require.Equal(t, code.CodeTypeOK, resQuery.Code)
+	require.Equal(t, key, string(resQuery.Key))
 	require.Equal(t, value, string(resQuery.Value))
+	require.EqualValues(t, info.LastBlockHeight, resQuery.Height)
 
 	// make sure proof is fine
 	resQuery = app.Query(types.RequestQuery{
@@ -46,7 +53,9 @@ func testKVStore(t *testing.T, app types.Application, tx []byte, key, value stri
 		Prove: true,
 	})
 	require.EqualValues(t, code.CodeTypeOK, resQuery.Code)
+	require.Equal(t, key, string(resQuery.Key))
 	require.Equal(t, value, string(resQuery.Value))
+	require.EqualValues(t, info.LastBlockHeight, resQuery.Height)
 }
 
 func TestKVStoreKV(t *testing.T) {
@@ -300,6 +309,13 @@ func testClient(t *testing.T, app abcicli.Client, tx []byte, key, value string) 
 	ar, err = app.DeliverTxSync(types.RequestDeliverTx{Tx: tx})
 	require.NoError(t, err)
 	require.False(t, ar.IsErr(), ar)
+	// commit
+	_, err = app.CommitSync()
+	require.NoError(t, err)
+
+	info, err := app.InfoSync(types.RequestInfo{})
+	require.NoError(t, err)
+	require.NotZero(t, info.LastBlockHeight)
 
 	// make sure query is fine
 	resQuery, err := app.QuerySync(types.RequestQuery{
@@ -308,7 +324,9 @@ func testClient(t *testing.T, app abcicli.Client, tx []byte, key, value string) 
 	})
 	require.Nil(t, err)
 	require.Equal(t, code.CodeTypeOK, resQuery.Code)
+	require.Equal(t, key, string(resQuery.Key))
 	require.Equal(t, value, string(resQuery.Value))
+	require.EqualValues(t, info.LastBlockHeight, resQuery.Height)
 
 	// make sure proof is fine
 	resQuery, err = app.QuerySync(types.RequestQuery{
@@ -318,5 +336,7 @@ func testClient(t *testing.T, app abcicli.Client, tx []byte, key, value string) 
 	})
 	require.Nil(t, err)
 	require.Equal(t, code.CodeTypeOK, resQuery.Code)
+	require.Equal(t, key, string(resQuery.Key))
 	require.Equal(t, value, string(resQuery.Value))
+	require.EqualValues(t, info.LastBlockHeight, resQuery.Height)
 }

--- a/abci/tests/test_cli/ex1.abci.out
+++ b/abci/tests/test_cli/ex1.abci.out
@@ -27,7 +27,7 @@
 > query "abc"
 -> code: OK
 -> log: exists
--> height: 0
+-> height: 2
 -> key: abc
 -> key.hex: 616263
 -> value: abc
@@ -43,7 +43,7 @@
 > query "def"
 -> code: OK
 -> log: exists
--> height: 0
+-> height: 3
 -> key: def
 -> key.hex: 646566
 -> value: xyz

--- a/docs/app-dev/abci-cli.md
+++ b/docs/app-dev/abci-cli.md
@@ -192,7 +192,7 @@ Try running these commands:
 > query "abc"
 -> code: OK
 -> log: exists
--> height: 0
+-> height: 2
 -> value: abc
 -> value.hex: 616263
 
@@ -206,7 +206,7 @@ Try running these commands:
 > query "def"
 -> code: OK
 -> log: exists
--> height: 0
+-> height: 3
 -> value: xyz
 -> value.hex: 78797A
 ```


### PR DESCRIPTION
Fixes #4507. I'm assuming we don't consider this a breaking change.

______

For contributor use:

- [x] Wrote tests
- [x] Updated CHANGELOG_PENDING.md
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments
- [x] Re-reviewed `Files changed` in the Github PR explorer
