### PR TITLE
lite: simple concurrent verification

### DIFF
--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -161,11 +161,7 @@ func TestClient_SequentialVerification(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
-
 			require.NoError(t, err)
-			err = c.Start()
-			require.NoError(t, err)
-			defer c.Stop()
 
 			_, err = c.VerifyHeaderAtHeight(3, bTime.Add(3*time.Hour))
 			if tc.verifyErr {
@@ -287,11 +283,7 @@ func TestClient_SkippingVerification(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
-
 			require.NoError(t, err)
-			err = c.Start()
-			require.NoError(t, err)
-			defer c.Stop()
 
 			_, err = c.VerifyHeaderAtHeight(3, bTime.Add(3*time.Hour))
 			if tc.verifyErr {
@@ -429,9 +421,6 @@ func TestClientRestoresTrustedHeaderAfterStartup2(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
-		err = c.Start()
-		require.NoError(t, err)
-		defer c.Stop()
 
 		// Check we still have the 1st header (+header+).
 		h, err := c.TrustedHeader(1)
@@ -483,9 +472,6 @@ func TestClientRestoresTrustedHeaderAfterStartup2(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
-		err = c.Start()
-		require.NoError(t, err)
-		defer c.Stop()
 
 		// Check we no longer have the invalid 1st header (+header+).
 		h, err := c.TrustedHeader(1)
@@ -520,9 +506,6 @@ func TestClientRestoresTrustedHeaderAfterStartup3(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
-		err = c.Start()
-		require.NoError(t, err)
-		defer c.Stop()
 
 		// Check we still have the 1st header (+header+).
 		h, err := c.TrustedHeader(1)
@@ -584,9 +567,6 @@ func TestClientRestoresTrustedHeaderAfterStartup3(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
-		err = c.Start()
-		require.NoError(t, err)
-		defer c.Stop()
 
 		// Check we have swapped invalid 1st header (+header+) with correct one (+header1+).
 		h, err := c.TrustedHeader(1)
@@ -622,9 +602,6 @@ func TestClient_Update(t *testing.T) {
 		Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
-	err = c.Start()
-	require.NoError(t, err)
-	defer c.Stop()
 
 	// should result in downloading & verifying header #3
 	err = c.Update(bTime.Add(2 * time.Hour))
@@ -649,13 +626,9 @@ func TestClient_Concurrency(t *testing.T) {
 		fullNode,
 		[]provider.Provider{fullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		UpdatePeriod(0),
 		Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
-	err = c.Start()
-	require.NoError(t, err)
-	defer c.Stop()
 
 	_, err = c.VerifyHeaderAtHeight(2, bTime.Add(2*time.Hour))
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4396

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Instead of using locks, this PR implements a simple bool value which allows for the running of one `autoUpdateRoutine` and the blocking of any manual forward verification.

NOTE: that backwards verification still operates irrelevant of autoUpdate

NOTE: There is a second PR that uses locks to allow for concurrent verification


______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
