### PR TITLE
lite2: remove auto update

### DIFF
--- a/cmd/tendermint/commands/lite.go
+++ b/cmd/tendermint/commands/lite.go
@@ -102,7 +102,7 @@ func runProxy(cmd *cobra.Command, args []string) error {
 
 	db, err := dbm.NewGoLevelDB("lite-client-db", home)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "new goleveldb")
 	}
 
 	var c *lite.Client
@@ -129,16 +129,9 @@ func runProxy(cmd *cobra.Command, args []string) error {
 			lite.Logger(logger),
 		)
 	}
-
 	if err != nil {
-		return errors.Wrap(err, "failed to create")
+		return err
 	}
-	logger.Info("Starting client...")
-	err = c.Start()
-	if err != nil {
-		return errors.Wrap(err, "failed to start")
-	}
-	defer c.Stop()
 
 	rpcClient, err := rpcclient.NewHTTP(primaryAddr, "/websocket")
 	if err != nil {

--- a/docs/architecture/adr-046-light-client-implementation.md
+++ b/docs/architecture/adr-046-light-client-implementation.md
@@ -8,23 +8,13 @@
 ## Context
 
 A `Client` struct represents a light client, connected to a single blockchain.
-As soon as it's started (via `Start`), it tries to update to the latest header
-(using bisection algorithm by default).
 
-Cleaning routine is also started to remove headers outside of trusting period.
-NOTE: since it's periodic, we still need to check header is not expired in
-`TrustedHeader`, `TrustedValidatorSet` methods (and others which are using the
-latest trusted header).
-
-The user has an option to manually verify headers using `VerifyHeader` and
-`VerifyHeaderAtHeight` methods. To avoid races, `UpdatePeriod(0)` needs to be
-passed when initializing the light client (it turns off the auto update).
+The user has an option to verify headers using `VerifyHeader` or
+`VerifyHeaderAtHeight` or `Update` methods. The latter method downloads the
+latest header from primary and compares it with the currently trusted one.
 
 ```go
 type Client interface {
-	// start and stop updating & cleaning goroutines
-	Start() error
-	Stop()
 	Cleanup() error
 
 	// get trusted headers & validators
@@ -41,6 +31,7 @@ type Client interface {
 	// verify new headers
 	VerifyHeaderAtHeight(height int64, now time.Time) (*types.SignedHeader, error)
 	VerifyHeader(newHeader *types.SignedHeader, newVals *types.ValidatorSet, now time.Time) error
+	Update(now time.Time) error
 }
 ```
 

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -154,7 +154,6 @@ func TestClient_SequentialVerification(t *testing.T) {
 				)},
 				dbs.New(dbm.NewMemDB(), chainID),
 				SequentialVerification(),
-				UpdatePeriod(0),
 			)
 
 			if tc.initErr {
@@ -163,9 +162,6 @@ func TestClient_SequentialVerification(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			err = c.Start()
-			require.NoError(t, err)
-			defer c.Stop()
 
 			_, err = c.VerifyHeaderAtHeight(3, bTime.Add(3*time.Hour))
 			if tc.verifyErr {
@@ -281,7 +277,6 @@ func TestClient_SkippingVerification(t *testing.T) {
 				)},
 				dbs.New(dbm.NewMemDB(), chainID),
 				SkippingVerification(DefaultTrustLevel),
-				UpdatePeriod(0),
 			)
 			if tc.initErr {
 				require.Error(t, err)
@@ -289,9 +284,6 @@ func TestClient_SkippingVerification(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			err = c.Start()
-			require.NoError(t, err)
-			defer c.Stop()
 
 			_, err = c.VerifyHeaderAtHeight(3, bTime.Add(3*time.Hour))
 			if tc.verifyErr {
@@ -429,9 +421,6 @@ func TestClientRestoresTrustedHeaderAfterStartup2(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
-		err = c.Start()
-		require.NoError(t, err)
-		defer c.Stop()
 
 		// Check we still have the 1st header (+header+).
 		h, err := c.TrustedHeader(1)
@@ -483,9 +472,6 @@ func TestClientRestoresTrustedHeaderAfterStartup2(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
-		err = c.Start()
-		require.NoError(t, err)
-		defer c.Stop()
 
 		// Check we no longer have the invalid 1st header (+header+).
 		h, err := c.TrustedHeader(1)
@@ -520,9 +506,6 @@ func TestClientRestoresTrustedHeaderAfterStartup3(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
-		err = c.Start()
-		require.NoError(t, err)
-		defer c.Stop()
 
 		// Check we still have the 1st header (+header+).
 		h, err := c.TrustedHeader(1)
@@ -584,9 +567,6 @@ func TestClientRestoresTrustedHeaderAfterStartup3(t *testing.T) {
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
-		err = c.Start()
-		require.NoError(t, err)
-		defer c.Stop()
 
 		// Check we have swapped invalid 1st header (+header+) with correct one (+header1+).
 		h, err := c.TrustedHeader(1)
@@ -622,9 +602,6 @@ func TestClient_Update(t *testing.T) {
 		Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
-	err = c.Start()
-	require.NoError(t, err)
-	defer c.Stop()
 
 	// should result in downloading & verifying header #3
 	err = c.Update(bTime.Add(2 * time.Hour))
@@ -649,13 +626,9 @@ func TestClient_Concurrency(t *testing.T) {
 		fullNode,
 		[]provider.Provider{fullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		UpdatePeriod(0),
 		Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
-	err = c.Start()
-	require.NoError(t, err)
-	defer c.Stop()
 
 	_, err = c.VerifyHeaderAtHeight(2, bTime.Add(2*time.Hour))
 	require.NoError(t, err)
@@ -697,7 +670,6 @@ func TestClientReplacesPrimaryWithWitnessIfPrimaryIsUnavailable(t *testing.T) {
 		deadNode,
 		[]provider.Provider{fullNode, fullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		UpdatePeriod(0),
 		Logger(log.TestingLogger()),
 		MaxRetryAttempts(1),
 	)
@@ -722,7 +694,6 @@ func TestClient_BackwardsVerification(t *testing.T) {
 			fullNode,
 			[]provider.Provider{fullNode},
 			dbs.New(dbm.NewMemDB(), chainID),
-			UpdatePeriod(0),
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
@@ -755,7 +726,6 @@ func TestClient_BackwardsVerification(t *testing.T) {
 			fullNode,
 			[]provider.Provider{fullNode},
 			dbs.New(dbm.NewMemDB(), chainID),
-			UpdatePeriod(0),
 			Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
@@ -807,7 +777,6 @@ func TestClient_BackwardsVerification(t *testing.T) {
 				tc.provider,
 				[]provider.Provider{tc.provider},
 				dbs.New(dbm.NewMemDB(), chainID),
-				UpdatePeriod(0),
 				Logger(log.TestingLogger()),
 			)
 			require.NoError(t, err)
@@ -854,7 +823,6 @@ func TestNewClientErrorsIfAllWitnessesUnavailable(t *testing.T) {
 		fullNode,
 		[]provider.Provider{deadNode, deadNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		UpdatePeriod(0),
 		Logger(log.TestingLogger()),
 		MaxRetryAttempts(1),
 	)
@@ -898,7 +866,6 @@ func TestClientRemovesWitnessIfItSendsUsIncorrectHeader(t *testing.T) {
 		fullNode,
 		[]provider.Provider{badProvider1, badProvider2},
 		dbs.New(dbm.NewMemDB(), chainID),
-		UpdatePeriod(0),
 		Logger(log.TestingLogger()),
 		MaxRetryAttempts(1),
 	)
@@ -926,7 +893,6 @@ func TestClientTrustedValidatorSet(t *testing.T) {
 		fullNode,
 		[]provider.Provider{fullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		UpdatePeriod(0),
 		Logger(log.TestingLogger()),
 	)
 

--- a/lite2/doc.go
+++ b/lite2/doc.go
@@ -65,33 +65,29 @@ Example usage:
 
 		db, err := dbm.NewGoLevelDB("lite-client-db", dbDir)
 		if err != nil {
-			// return err
-			t.Fatal(err)
+			// handle error
 		}
-		c, err := NewClient(
+
+		c, err := NewHTTPClient(
 			chainID,
 			TrustOptions{
 				Period: 504 * time.Hour, // 21 days
 				Height: 100,
 				Hash:   header.Hash(),
 			},
-			httpp.New(chainID, "tcp://localhost:26657"),
-			[]provider.Provider{httpp.New(chainID, "tcp://witness1:26657")},
-			dbs.New(db, chainID),
+			"http://localhost:26657",
+			[]string{"http://witness1:26657"},
+			dbs.New(db, ""),
 		)
-
-		err = c.Start()
-		if err != nil {
-			// return err
-			t.Fatal(err)
-		}
-		defer c.Stop()
-
-		h, err := c.TrustedHeader(101)
 		if err != nil {
 			// handle error
 		}
-		fmt.Println("got header", h)
+
+		h, err := c.TrustedHeader(100)
+		if err != nil {
+			// handle error
+		}
+		fmt.Println("header", h)
 
 Check out other examples in example_test.go
 

--- a/lite2/example_test.go
+++ b/lite2/example_test.go
@@ -58,18 +58,12 @@ func ExampleClient_Update() {
 		primary,
 		[]provider.Provider{primary}, // NOTE: primary should not be used here
 		dbs.New(db, chainID),
-		UpdatePeriod(0), // NOTE: value should be greater than zero
 		// Logger(log.TestingLogger()),
 	)
 	if err != nil {
 		stdlog.Fatal(err)
 	}
-	err = c.Start()
-	if err != nil {
-		stdlog.Fatal(err)
-	}
 	defer func() {
-		c.Stop()
 		c.Cleanup()
 	}()
 
@@ -78,6 +72,7 @@ func ExampleClient_Update() {
 	// XXX: 30 * time.Minute clock drift is needed because a) Tendermint strips
 	// monotonic component (see types/time/time.go) b) single instance is being
 	// run.
+	// https://github.com/tendermint/tendermint/issues/4489
 	err = c.Update(time.Now().Add(30 * time.Minute))
 	if err != nil {
 		stdlog.Fatal(err)
@@ -137,7 +132,6 @@ func ExampleClient_VerifyHeaderAtHeight() {
 		primary,
 		[]provider.Provider{primary}, // NOTE: primary should not be used here
 		dbs.New(db, chainID),
-		UpdatePeriod(0),
 		// Logger(log.TestingLogger()),
 	)
 	if err != nil {

--- a/lite2/rpc/client.go
+++ b/lite2/rpc/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -322,20 +321,8 @@ func (c *Client) UnsubscribeAll(ctx context.Context, subscriber string) error {
 }
 
 func (c *Client) updateLiteClientIfNeededTo(height int64) (*types.SignedHeader, error) {
-	lastTrustedHeight, err := c.lc.LastTrustedHeight()
-	if err != nil {
-		return nil, errors.Wrap(err, "LastTrustedHeight")
-	}
-
-	if lastTrustedHeight < height {
-		return c.lc.VerifyHeaderAtHeight(height, time.Now())
-	}
-
-	h, err := c.lc.TrustedHeader(height)
-	if err != nil {
-		return nil, errors.Wrapf(err, "TrustedHeader(#%d)", height)
-	}
-	return h, nil
+	h, err := c.lc.VerifyHeaderAtHeight(height)
+	return h, errors.Wrapf(err, "failed to update light client to %d", height)
 }
 
 func (c *Client) RegisterOpDecoder(typ string, dec merkle.OpDecoder) {

--- a/lite2/rpc/client.go
+++ b/lite2/rpc/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -321,7 +322,7 @@ func (c *Client) UnsubscribeAll(ctx context.Context, subscriber string) error {
 }
 
 func (c *Client) updateLiteClientIfNeededTo(height int64) (*types.SignedHeader, error) {
-	h, err := c.lc.VerifyHeaderAtHeight(height)
+	h, err := c.lc.VerifyHeaderAtHeight(height, time.Now())
 	return h, errors.Wrapf(err, "failed to update light client to %d", height)
 }
 


### PR DESCRIPTION
## Description

We first introduced auto-update as a separate struct `AutoClient`, which
was wrapping `Client` and calling `Update` periodically. 

```go
// AutoClient can auto update itself by fetching headers every N seconds.
type AutoClient struct {
    base         *Client
    updatePeriod time.Duration
    quit         chan struct{}

    trustedHeaders chan *types.SignedHeader
    errs           chan error
}

// NewAutoClient creates a new client and starts a polling goroutine.
func NewAutoClient(base *Client, updatePeriod time.Duration) *AutoClient {
    c := &AutoClient{
        base:           base,
        updatePeriod:   updatePeriod,
        quit:           make(chan struct{}),
        trustedHeaders: make(chan *types.SignedHeader),
        errs:           make(chan error),
    }
    go c.autoUpdate()
    return c
}

// TrustedHeaders returns a channel onto which new trusted headers are posted.
func (c *AutoClient) TrustedHeaders() <-chan *types.SignedHeader {
    return c.trustedHeaders
}

// Err returns a channel onto which errors are posted.
func (c *AutoClient) Errs() <-chan error {
    return c.errs
}

// Stop stops the client.
func (c *AutoClient) Stop() {
    close(c.quit)
}

func (c *AutoClient) autoUpdate() {
    ticker := time.NewTicker(c.updatePeriod)
    defer ticker.Stop()

    for {
        select {
        case <-ticker.C:
            lastTrustedHeight, err := c.base.LastTrustedHeight()
            if err != nil {
                c.errs <- err
                continue
            }

            if lastTrustedHeight == -1 {
                // no headers yet => wait
                continue
            }

            newTrustedHeader, err := c.base.Update(time.Now())
            if err != nil {
                c.errs <- err
                continue
            }

            if newTrustedHeader != nil {
                 c.trustedHeaders <- newTrustedHeader
            }
        case <-c.quit:
            return
        }
    }
}
```

Later we merged it into the `Client` itself with the assumption that most clients will want it.

But now I am not sure. **Neither IBC nor cosmos/relayer are using it. It increases complexity (Start/Stop methods).**

That said, I think it makes sense to remove it until we see a need for it (until we better understand usage behavior). We can always introduce it later 😅. Maybe in the form of `AutoClient`.

______

For contributor use:

- [x] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments
- [x] Re-reviewed `Files changed` in the Github PR explorer
