### PR TITLE
scripts/release: format

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,8 +6,8 @@ if [ -z $VERSION ]; then
 	VERSION=$(awk -F\" 'TMCoreSemVer =/ { print $2; exit }' < version/version.go)
 fi
 if [ -z "$VERSION" ]; then
-    echo "Please specify a version."
-    exit 1
+	echo "Please specify a version."
+	exit 1
 fi
 echo "==> Releasing version $VERSION..."
 


### PR DESCRIPTION
should force CircleCI to update the code cache

```
Found a cache from build 100135 at go-src-v1-b215e07ecdc6ad5c363c3b420580aa6b52913feb
Size: 65 MiB
Cached paths:
* /go/src/github.com/tendermint/tendermint/.git
```

because we have v0.33.1-dev3 tag, bump-semver.py script is thinking the
next tag should be v0.33.1, not v0.33.2:

```
if re.match('[0-9]+$',patch) is None:
  patchfound = re.match('([0-9]+)',patch)
patch = int(patchfound.group(1))
  else:
  patch = int(patch) + 1
  ```

  The last tag it finds is v0.33.1-dev3. So it hits the first branch. But
  the first branch only fetches the number, and doesn't increment it, so
  the result is v0.33.1.

  if there exists a patch tag like 1-dev3, then the next version should be
  0.33.1. But in this case, 0.33.1 has already been released.