### PR TITLE
Use docs-staging branch for docs preview website

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ workflows:
           filters:
             branches:
               only:
-                - docs-theme-latest
+                - docs-staging
       - setup_dependencies
       - test_abci_apps:
           requires:


### PR DESCRIPTION
We've renamed the branch for staging docs from `docs-theme-latest` to `docs-staging`. This makes so that CircleCI uses the correct branch for https://docs.staging-tendermint.com