### PR TITLE
DOCKER: update with defaults

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [p2p] [\#4548](https://github.com/tendermint/tendermint/pull/4548) Add ban list to address book (@cmwaters)
 - [privval] \#4534 Add `error` as a return value on`GetPubKey()`
+- [Docker] \#4569 Default configuration added to docker image (you can still mount your own config the same way) (@greg-szabo)
 
 ### BUG FIXES:
 

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -22,17 +22,32 @@ RUN apk update && \
 # Run the container with tmuser by default. (UID=100, GID=1000)
 USER tmuser
 
-# Expose the data directory as a volume since there's mutable state in there
-VOLUME [ $TMHOME ]
-
 WORKDIR $TMHOME
 
 # p2p and rpc port
-EXPOSE 26656 26657
+EXPOSE 26656 26657 26660
 
 ENTRYPOINT ["/usr/bin/tendermint"]
-CMD ["node", "--moniker=`hostname`"]
+CMD ["node"]
 STOPSIGNAL SIGTERM
 
 ARG BINARY=tendermint
 COPY $BINARY /usr/bin/tendermint
+
+# Create default configuration for docker run.
+RUN /usr/bin/tendermint init && \
+    sed -i \
+      -e 's/^proxy_app\s*=.*/proxy_app = "kvstore"/' \
+      -e 's/^moniker\s*=.*/moniker = "dockernode"/' \
+      -e 's/^addr_book_strict\s*=.*/addr_book_strict = false/' \
+      -e 's/^timeout_commit\s*=.*/timeout_commit = "500ms"/' \
+      -e 's/^index_all_tags\s*=.*/index_all_tags = true/' \
+      -e 's/^prometheus\s*=.*/prometheus = true/' \
+      $TMHOME/config/config.toml && \
+    sed -i \
+      -e 's/^\s*"chain_id":.*/  "chain_id": "dockerchain",/' \
+      $TMHOME/config/genesis.json
+
+# Expose the data directory as a volume since there's mutable state in there
+VOLUME [ $TMHOME ]
+


### PR DESCRIPTION
Closes: #4569 

## Description
This change updates the `Dockerfile` to include defaults for a one-node `kvstore` testnet. It can be overwritten by adding a volume to mount point `/tendermint` as it was available before.
This change is a non-breaking change.
This change allows a developer to run `docker run tendermint/tendermint` and have a locally available one-node testnet at once (without running `init` beforehand).

Note: The `VOLUME` command was moved to the bottom of the file. The reason for this is that any files added to the mount point after this command ran would get lost during the build process. (The files have to be added before this command.)
______

For contributor use:

- [ ] Wrote tests - tested docker build on the local machine, no Go code change was introduced
- [X] Updated CHANGELOG_PENDING.md
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments - no code comments or new Go code was introduced
- [X] Re-reviewed `Files changed` in the Github PR explorer
