### PR TITLE
blockchain: enable v2 to be set

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -321,7 +321,7 @@ max_tx_bytes = {{ .Mempool.MaxTxBytes }}
 # Fast Sync version to use:
 #   1) "v0" (default) - the legacy fast sync implementation
 #   2) "v1" - refactor of v0 version for better testability
-# 	3) "v2" - refactor of v1 version for better usabilit
+#   3) "v2" - refactor of v1 version for better usabilit
 version = "{{ .FastSync.Version }}"
 
 ##### consensus configuration options #####

--- a/config/toml.go
+++ b/config/toml.go
@@ -321,6 +321,7 @@ max_tx_bytes = {{ .Mempool.MaxTxBytes }}
 # Fast Sync version to use:
 #   1) "v0" (default) - the legacy fast sync implementation
 #   2) "v1" - refactor of v0 version for better testability
+# 	3) "v2" - refactor of v1 version for better usabilit
 version = "{{ .FastSync.Version }}"
 
 ##### consensus configuration options #####

--- a/config/toml.go
+++ b/config/toml.go
@@ -321,7 +321,7 @@ max_tx_bytes = {{ .Mempool.MaxTxBytes }}
 # Fast Sync version to use:
 #   1) "v0" (default) - the legacy fast sync implementation
 #   2) "v1" - refactor of v0 version for better testability
-#   3) "v2" - refactor of v1 version for better usabilit
+#   3) "v2" - refactor of v1 version for better usability
 version = "{{ .FastSync.Version }}"
 
 ##### consensus configuration options #####

--- a/node/node.go
+++ b/node/node.go
@@ -22,6 +22,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	bcv0 "github.com/tendermint/tendermint/blockchain/v0"
 	bcv1 "github.com/tendermint/tendermint/blockchain/v1"
+	bcv2 "github.com/tendermint/tendermint/blockchain/v2"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/consensus"
 	cs "github.com/tendermint/tendermint/consensus"
@@ -366,6 +367,8 @@ func createBlockchainReactor(config *cfg.Config,
 		bcReactor = bcv0.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
 	case "v1":
 		bcReactor = bcv1.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
+	case "v2":
+		bcReactor = bcv2.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
 	default:
 		return nil, fmt.Errorf("unknown fastsync version %s", config.FastSync.Version)
 	}
@@ -1094,6 +1097,8 @@ func makeNodeInfo(
 		bcChannel = bcv0.BlockchainChannel
 	case "v1":
 		bcChannel = bcv1.BlockchainChannel
+	case "v2":
+		bcChannel = bcv2.BlockchainChannel
 	default:
 		return nil, fmt.Errorf("unknown fastsync version %s", config.FastSync.Version)
 	}


### PR DESCRIPTION
## Description

- enable v2 to be set via config paramarters 
______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
