### PR TITLE
rpc: add codespace to ResultBroadcastTx

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,7 +16,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### FEATURES:
 
-- [rpc] [\#4611](https://github.com/tendermint/tendermint/pull/4611) Add `codespace` to `ResultBroadcastTx`
+- [rpc] [\#4611](https://github.com/tendermint/tendermint/pull/4611) Add `codespace` to `ResultBroadcastTx` (@whylee259)
 
 ### IMPROVEMENTS:
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,8 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### FEATURES:
 
+- [rpc] [\#4611](https://github.com/tendermint/tendermint/pull/4611) Add `codespace` to `ResultBroadcastTx`
+
 ### IMPROVEMENTS:
 
 - [p2p] [\#4548](https://github.com/tendermint/tendermint/pull/4548) Add ban list to address book (@cmwaters)

--- a/rpc/client/mock/abci.go
+++ b/rpc/client/mock/abci.go
@@ -63,7 +63,13 @@ func (a ABCIApp) BroadcastTxAsync(tx types.Tx) (*ctypes.ResultBroadcastTx, error
 	if !c.IsErr() {
 		go func() { a.App.DeliverTx(abci.RequestDeliverTx{Tx: tx}) }() // nolint: errcheck
 	}
-	return &ctypes.ResultBroadcastTx{Code: c.Code, Data: c.Data, Log: c.Log, Hash: tx.Hash()}, nil
+	return &ctypes.ResultBroadcastTx{
+		Code:      c.Code,
+		Data:      c.Data,
+		Log:       c.Log,
+		Codespace: c.Codespace,
+		Hash:      tx.Hash(),
+	}, nil
 }
 
 func (a ABCIApp) BroadcastTxSync(tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
@@ -72,7 +78,13 @@ func (a ABCIApp) BroadcastTxSync(tx types.Tx) (*ctypes.ResultBroadcastTx, error)
 	if !c.IsErr() {
 		go func() { a.App.DeliverTx(abci.RequestDeliverTx{Tx: tx}) }() // nolint: errcheck
 	}
-	return &ctypes.ResultBroadcastTx{Code: c.Code, Data: c.Data, Log: c.Log, Hash: tx.Hash()}, nil
+	return &ctypes.ResultBroadcastTx{
+		Code:      c.Code,
+		Data:      c.Data,
+		Log:       c.Log,
+		Codespace: c.Codespace,
+		Hash:      tx.Hash(),
+	}, nil
 }
 
 // ABCIMock will send all abci related request to the named app,

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -43,11 +43,11 @@ func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcas
 	res := <-resCh
 	r := res.GetCheckTx()
 	return &ctypes.ResultBroadcastTx{
-		Code: r.Code,
-		Data: r.Data,
-		Log:  r.Log,
-		Codespace:  r.Codespace,
-		Hash: tx.Hash(),
+		Code:      r.Code,
+		Data:      r.Data,
+		Log:       r.Log,
+		Codespace: r.Codespace,
+		Hash:      tx.Hash(),
 	}, nil
 }
 

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -46,6 +46,7 @@ func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcas
 		Code: r.Code,
 		Data: r.Data,
 		Log:  r.Log,
+		Codespace:  r.Codespace,
 		Hash: tx.Hash(),
 	}, nil
 }

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -148,9 +148,10 @@ type ResultConsensusState struct {
 
 // CheckTx result
 type ResultBroadcastTx struct {
-	Code uint32         `json:"code"`
-	Data bytes.HexBytes `json:"data"`
-	Log  string         `json:"log"`
+	Code      uint32         `json:"code"`
+	Data      bytes.HexBytes `json:"data"`
+	Log       string         `json:"log"`
+	Codespace string         `json:"codespace"`
 
 	Hash bytes.HexBytes `json:"hash"`
 }

--- a/rpc/swagger/swagger.yaml
+++ b/rpc/swagger/swagger.yaml
@@ -2947,6 +2947,9 @@ components:
             log:
               type: "string"
               example: ""
+            codespace:
+              type: "string"
+              example: "ibc"
             hash:
               type: "string"
               example: "0D33F2F03A5234F38706E43004489E061AC40A2E"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4606 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds a property of `codespace` to `ResultBroadcastTx` and passes it to the application.
- add `codespace` to `ResultBroadcastTx`
- set codespace before returning `ResultBroadcastTx`
- apply abci mock


______

For contributor use:

- [ ] Wrote tests
- [x] Updated CHANGELOG_PENDING.md
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [x] Re-reviewed `Files changed` in the Github PR explorer
