### PR TITLE
proto: use docker to generate stubs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,7 +23,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [Docker] \#4569 Default configuration added to docker image (you can still mount your own config the same way) (@greg-szabo)
 - [lite2] [\#4562](https://github.com/tendermint/tendermint/pull/4562) Cache headers when using bisection (@cmwaters)
 - [all] [\#4608](https://github.com/tendermint/tendermint/pull/4608) Give reactors descriptive names when they're initialized
-- [tools] \#4615 Allow developers to use docker to generate proto stubs.
+- [tools] \#4615 Allow developers to use Docker to generate proto stubs, via `make proto-gen-docker`.
 
 ### BUG FIXES:
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,7 +22,8 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [privval] \#4534 Add `error` as a return value on`GetPubKey()`
 - [Docker] \#4569 Default configuration added to docker image (you can still mount your own config the same way) (@greg-szabo)
 - [lite2] [\#4562](https://github.com/tendermint/tendermint/pull/4562) Cache headers when using bisection (@cmwaters)
-- [all] [\4608](https://github.com/tendermint/tendermint/pull/4608) Give reactors descriptive names when they're initialized
+- [all] [\#4608](https://github.com/tendermint/tendermint/pull/4608) Give reactors descriptive names when they're initialized
+- [tools] \#4615 Allow developers to use docker to generate proto stubs.
 
 ### BUG FIXES:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,10 @@ We use [Protocol Buffers](https://developers.google.com/protocol-buffers) along 
 
 For linting and checking breaking changes, we use [buf](https://buf.build/). If you would like to run linting and check if the changes you have made are breaking then you will need to have docker running locally. Then the linting cmd will be `make proto-lint` and the breaking changes check will be `make proto-check-breaking`.
 
-To generate new stubs based off of your changes you can run `make proto-gen` after installing `protoc` and gogoproto.
+There are two ways to generate your proto stubs.
+
+1. Use Docker, pull an image that will generate your proto stubs with no need to install anything. `make proto-gen-docker`
+2. Run `make proto-gen` after installing `protoc` and gogoproto.
 
 ### Installation Instructions
 

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ proto-gen:
 .PHONY: proto-gen
 
 proto-gen-docker:
-	docker run -v $(shell pwd):/workspace --workdir /workspace tendermintdev/docker-build-proto sh ./scripts/protocgen.sh
+	@echo "Generating Protobuf files"
+	@docker run -v $(shell pwd):/workspace --workdir /workspace tendermintdev/docker-build-proto sh ./scripts/protocgen.sh
 .PHONY: proto-gen-docker
 
 proto-lint:

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ proto-gen:
 	@sh scripts/protocgen.sh
 .PHONY: proto-gen
 
+proto-gen-docker:
+	docker run -v $(shell pwd):/workspace --workdir /workspace tendermintdev/build-proto sh ./scripts/protocgen.sh
+.PHONY: proto-gen-docker
+
 proto-lint:
 	@$(DOCKER_BUF) check lint --error-format=json
 .PHONY: proto-lint

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ proto-gen:
 .PHONY: proto-gen
 
 proto-gen-docker:
-	docker run -v $(shell pwd):/workspace --workdir /workspace tendermintdev/build-proto sh ./scripts/protocgen.sh
+	docker run -v $(shell pwd):/workspace --workdir /workspace tendermintdev/docker-build-proto sh ./scripts/protocgen.sh
 .PHONY: proto-gen-docker
 
 proto-lint:

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -7,5 +7,5 @@ for dir in $proto_dirs; do
   protoc \
   -I. \
   --gogo_out=Mgoogle/protobuf/timestamp.proto=github.com/golang/protobuf/ptypes/timestamp,Mgoogle/protobuf/duration.proto=github.com/golang/protobuf/ptypes/duration,plugins=grpc,paths=source_relative:. \
-  $(find "${dir}" -name '*.proto')
+  "$(find "${dir}" -name '*.proto')"
 done

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -7,5 +7,5 @@ for dir in $proto_dirs; do
   protoc \
   -I. \
   --gogo_out=Mgoogle/protobuf/timestamp.proto=github.com/golang/protobuf/ptypes/timestamp,Mgoogle/protobuf/duration.proto=github.com/golang/protobuf/ptypes/duration,plugins=grpc,paths=source_relative:. \
-  "$(find "${dir}" -name '*.proto')"
+  $(find "${dir}" -name '*.proto')
 done


### PR DESCRIPTION
## Description

Add command to generate proto stubs with docker. This PR should not be merged till https://github.com/tendermint/images/pull/48 is and it is tested again.

Kept non-docker to generate proto files as some people may not want to run docker non-stop.

closes #4579

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

~~- [] Wrote tests~~
- [x] Updated CHANGELOG_PENDING.md
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments
- [x] Re-reviewed `Files changed` in the Github PR explorer
