### PR TITLE
rpc/client: split out client packages

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,6 +14,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - Go API
 
+  - [rpc/client] [\#4628](https://github.com/tendermint/tendermint/pull/4628) Split out HTTP and local clients into `http` and `local` packages (@erikgrinaker).
   - [lite2] [\#4616](https://github.com/tendermint/tendermint/pull/4616) Make `maxClockDrift` an option (@melekes).
     `Verify/VerifyAdjacent/VerifyNonAdjacent` now accept `maxClockDrift time.Duration`.
 

--- a/cmd/tendermint/commands/debug/dump.go
+++ b/cmd/tendermint/commands/debug/dump.go
@@ -13,7 +13,7 @@ import (
 
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
-	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
 var dumpCmd = &cobra.Command{
@@ -59,7 +59,7 @@ func dumpCmdHandler(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	rpc, err := rpcclient.NewHTTP(nodeRPCAddr, "/websocket")
+	rpc, err := rpchttp.NewHTTP(nodeRPCAddr, "/websocket")
 	if err != nil {
 		return errors.Wrap(err, "failed to create new http client")
 	}
@@ -79,7 +79,7 @@ func dumpCmdHandler(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func dumpDebugData(outDir string, conf *cfg.Config, rpc *rpcclient.HTTP) {
+func dumpDebugData(outDir string, conf *cfg.Config, rpc *rpchttp.HTTP) {
 	start := time.Now().UTC()
 
 	tmpDir, err := ioutil.TempDir(outDir, "tendermint_debug_tmp")

--- a/cmd/tendermint/commands/debug/dump.go
+++ b/cmd/tendermint/commands/debug/dump.go
@@ -59,7 +59,7 @@ func dumpCmdHandler(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	rpc, err := rpchttp.NewHTTP(nodeRPCAddr, "/websocket")
+	rpc, err := rpchttp.New(nodeRPCAddr, "/websocket")
 	if err != nil {
 		return errors.Wrap(err, "failed to create new http client")
 	}

--- a/cmd/tendermint/commands/debug/kill.go
+++ b/cmd/tendermint/commands/debug/kill.go
@@ -44,7 +44,7 @@ func killCmdHandler(cmd *cobra.Command, args []string) error {
 		return errors.New("invalid output file")
 	}
 
-	rpc, err := rpchttp.NewHTTP(nodeRPCAddr, "/websocket")
+	rpc, err := rpchttp.New(nodeRPCAddr, "/websocket")
 	if err != nil {
 		return errors.Wrap(err, "failed to create new http client")
 	}

--- a/cmd/tendermint/commands/debug/kill.go
+++ b/cmd/tendermint/commands/debug/kill.go
@@ -16,7 +16,7 @@ import (
 
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
-	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
 var killCmd = &cobra.Command{
@@ -44,7 +44,7 @@ func killCmdHandler(cmd *cobra.Command, args []string) error {
 		return errors.New("invalid output file")
 	}
 
-	rpc, err := rpcclient.NewHTTP(nodeRPCAddr, "/websocket")
+	rpc, err := rpchttp.NewHTTP(nodeRPCAddr, "/websocket")
 	if err != nil {
 		return errors.Wrap(err, "failed to create new http client")
 	}

--- a/cmd/tendermint/commands/debug/util.go
+++ b/cmd/tendermint/commands/debug/util.go
@@ -11,12 +11,12 @@ import (
 	"github.com/pkg/errors"
 
 	cfg "github.com/tendermint/tendermint/config"
-	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
 // dumpStatus gets node status state dump from the Tendermint RPC and writes it
 // to file. It returns an error upon failure.
-func dumpStatus(rpc *rpcclient.HTTP, dir, filename string) error {
+func dumpStatus(rpc *rpchttp.HTTP, dir, filename string) error {
 	status, err := rpc.Status()
 	if err != nil {
 		return errors.Wrap(err, "failed to get node status")
@@ -27,7 +27,7 @@ func dumpStatus(rpc *rpcclient.HTTP, dir, filename string) error {
 
 // dumpNetInfo gets network information state dump from the Tendermint RPC and
 // writes it to file. It returns an error upon failure.
-func dumpNetInfo(rpc *rpcclient.HTTP, dir, filename string) error {
+func dumpNetInfo(rpc *rpchttp.HTTP, dir, filename string) error {
 	netInfo, err := rpc.NetInfo()
 	if err != nil {
 		return errors.Wrap(err, "failed to get node network information")
@@ -38,7 +38,7 @@ func dumpNetInfo(rpc *rpcclient.HTTP, dir, filename string) error {
 
 // dumpConsensusState gets consensus state dump from the Tendermint RPC and
 // writes it to file. It returns an error upon failure.
-func dumpConsensusState(rpc *rpcclient.HTTP, dir, filename string) error {
+func dumpConsensusState(rpc *rpchttp.HTTP, dir, filename string) error {
 	consDump, err := rpc.DumpConsensusState()
 	if err != nil {
 		return errors.Wrap(err, "failed to get node consensus dump")

--- a/cmd/tendermint/commands/lite.go
+++ b/cmd/tendermint/commands/lite.go
@@ -133,7 +133,7 @@ func runProxy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	rpcClient, err := rpchttp.NewHTTP(primaryAddr, "/websocket")
+	rpcClient, err := rpchttp.New(primaryAddr, "/websocket")
 	if err != nil {
 		return errors.Wrapf(err, "http client for %s", primaryAddr)
 	}

--- a/cmd/tendermint/commands/lite.go
+++ b/cmd/tendermint/commands/lite.go
@@ -18,7 +18,7 @@ import (
 	lproxy "github.com/tendermint/tendermint/lite2/proxy"
 	lrpc "github.com/tendermint/tendermint/lite2/rpc"
 	dbs "github.com/tendermint/tendermint/lite2/store/db"
-	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	rpcserver "github.com/tendermint/tendermint/rpc/lib/server"
 )
 
@@ -133,7 +133,7 @@ func runProxy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	rpcClient, err := rpcclient.NewHTTP(primaryAddr, "/websocket")
+	rpcClient, err := rpchttp.NewHTTP(primaryAddr, "/websocket")
 	if err != nil {
 		return errors.Wrapf(err, "http client for %s", primaryAddr)
 	}

--- a/lite/client/provider.go
+++ b/lite/client/provider.go
@@ -41,7 +41,7 @@ func NewProvider(chainID string, client SignStatusClient) lite.Provider {
 // NewHTTPProvider can connect to a tendermint json-rpc endpoint
 // at the given url, and uses that as a read-only provider.
 func NewHTTPProvider(chainID, remote string) (lite.Provider, error) {
-	httpClient, err := rpchttp.NewHTTP(remote, "/websocket")
+	httpClient, err := rpchttp.New(remote, "/websocket")
 	if err != nil {
 		return nil, err
 	}

--- a/lite/client/provider.go
+++ b/lite/client/provider.go
@@ -1,5 +1,5 @@
 /*
-Package client defines a provider that uses a rpcclient
+Package client defines a provider that uses a rpchttp
 to get information, which is used to get new headers
 and validators directly from a Tendermint client.
 */
@@ -12,6 +12,7 @@ import (
 	"github.com/tendermint/tendermint/lite"
 	lerr "github.com/tendermint/tendermint/lite/errors"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -40,7 +41,7 @@ func NewProvider(chainID string, client SignStatusClient) lite.Provider {
 // NewHTTPProvider can connect to a tendermint json-rpc endpoint
 // at the given url, and uses that as a read-only provider.
 func NewHTTPProvider(chainID, remote string) (lite.Provider, error) {
-	httpClient, err := rpcclient.NewHTTP(remote, "/websocket")
+	httpClient, err := rpchttp.NewHTTP(remote, "/websocket")
 	if err != nil {
 		return nil, err
 	}

--- a/lite/proxy/query_test.go
+++ b/lite/proxy/query_test.go
@@ -48,7 +48,7 @@ func _TestAppProofs(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	prt := defaultProofRuntime()
-	cl := rpclocal.NewLocal(node)
+	cl := rpclocal.New(node)
 	client.WaitForHeight(cl, 1, nil)
 
 	// This sets up our trust on the node based on some past point.
@@ -127,7 +127,7 @@ func _TestAppProofs(t *testing.T) {
 func TestTxProofs(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
-	cl := rpclocal.NewLocal(node)
+	cl := rpclocal.New(node)
 	client.WaitForHeight(cl, 1, nil)
 
 	tx := kvstoreTx([]byte("key-a"), []byte("value-a"))

--- a/lite/proxy/query_test.go
+++ b/lite/proxy/query_test.go
@@ -15,6 +15,7 @@ import (
 	certclient "github.com/tendermint/tendermint/lite/client"
 	nm "github.com/tendermint/tendermint/node"
 	"github.com/tendermint/tendermint/rpc/client"
+	rpclocal "github.com/tendermint/tendermint/rpc/client/local"
 	rpctest "github.com/tendermint/tendermint/rpc/test"
 	"github.com/tendermint/tendermint/types"
 )
@@ -47,7 +48,7 @@ func _TestAppProofs(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	prt := defaultProofRuntime()
-	cl := client.NewLocal(node)
+	cl := rpclocal.NewLocal(node)
 	client.WaitForHeight(cl, 1, nil)
 
 	// This sets up our trust on the node based on some past point.
@@ -126,7 +127,7 @@ func _TestAppProofs(t *testing.T) {
 func TestTxProofs(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
-	cl := client.NewLocal(node)
+	cl := rpclocal.NewLocal(node)
 	client.WaitForHeight(cl, 1, nil)
 
 	tx := kvstoreTx([]byte("key-a"), []byte("value-a"))

--- a/lite2/client_benchmark_test.go
+++ b/lite2/client_benchmark_test.go
@@ -1,4 +1,4 @@
-package lite
+package lite_test
 
 import (
 	"testing"
@@ -7,6 +7,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/libs/log"
+	lite "github.com/tendermint/tendermint/lite2"
 	"github.com/tendermint/tendermint/lite2/provider"
 	mockp "github.com/tendermint/tendermint/lite2/provider/mock"
 	dbs "github.com/tendermint/tendermint/lite2/store/db"
@@ -25,9 +26,9 @@ var (
 )
 
 func BenchmarkSequence(b *testing.B) {
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
-		TrustOptions{
+		lite.TrustOptions{
 			Period: 24 * time.Hour,
 			Height: 1,
 			Hash:   genesisHeader.Hash(),
@@ -35,8 +36,8 @@ func BenchmarkSequence(b *testing.B) {
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
-		SequentialVerification(),
+		lite.Logger(log.TestingLogger()),
+		lite.SequentialVerification(),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -52,9 +53,9 @@ func BenchmarkSequence(b *testing.B) {
 }
 
 func BenchmarkBisection(b *testing.B) {
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
-		TrustOptions{
+		lite.TrustOptions{
 			Period: 24 * time.Hour,
 			Height: 1,
 			Hash:   genesisHeader.Hash(),
@@ -62,7 +63,7 @@ func BenchmarkBisection(b *testing.B) {
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
+		lite.Logger(log.TestingLogger()),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -79,9 +80,9 @@ func BenchmarkBisection(b *testing.B) {
 
 func BenchmarkBackwards(b *testing.B) {
 	trustedHeader, _ := benchmarkFullNode.SignedHeader(0)
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
-		TrustOptions{
+		lite.TrustOptions{
 			Period: 24 * time.Hour,
 			Height: trustedHeader.Height,
 			Hash:   trustedHeader.Hash(),
@@ -89,7 +90,7 @@ func BenchmarkBackwards(b *testing.B) {
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
+		lite.Logger(log.TestingLogger()),
 	)
 	if err != nil {
 		b.Fatal(err)

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -1,4 +1,4 @@
-package lite
+package lite_test
 
 import (
 	"sync"
@@ -11,6 +11,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/libs/log"
+	lite "github.com/tendermint/tendermint/lite2"
 	"github.com/tendermint/tendermint/lite2/provider"
 	mockp "github.com/tendermint/tendermint/lite2/provider/mock"
 	dbs "github.com/tendermint/tendermint/lite2/store/db"
@@ -34,7 +35,7 @@ var (
 	h3 = keys.GenSignedHeaderLastBlockID(chainID, 3, bTime.Add(1*time.Hour), nil, vals, vals,
 		[]byte("app_hash"), []byte("cons_hash"), []byte("results_hash"), 0, len(keys), types.BlockID{Hash: h2.Hash()})
 	trustPeriod  = 4 * time.Hour
-	trustOptions = TrustOptions{
+	trustOptions = lite.TrustOptions{
 		Period: 4 * time.Hour,
 		Height: 1,
 		Hash:   h1.Hash(),
@@ -140,7 +141,7 @@ func TestClient_SequentialVerification(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			c, err := NewClient(
+			c, err := lite.NewClient(
 				chainID,
 				trustOptions,
 				mockp.New(
@@ -154,7 +155,7 @@ func TestClient_SequentialVerification(t *testing.T) {
 					tc.vals,
 				)},
 				dbs.New(dbm.NewMemDB(), chainID),
-				SequentialVerification(),
+				lite.SequentialVerification(),
 			)
 
 			if tc.initErr {
@@ -263,7 +264,7 @@ func TestClient_SkippingVerification(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			c, err := NewClient(
+			c, err := lite.NewClient(
 				chainID,
 				trustOptions,
 				mockp.New(
@@ -277,7 +278,7 @@ func TestClient_SkippingVerification(t *testing.T) {
 					tc.vals,
 				)},
 				dbs.New(dbm.NewMemDB(), chainID),
-				SkippingVerification(DefaultTrustLevel),
+				lite.SkippingVerification(lite.DefaultTrustLevel),
 			)
 			if tc.initErr {
 				require.Error(t, err)
@@ -297,13 +298,13 @@ func TestClient_SkippingVerification(t *testing.T) {
 }
 
 func TestClient_Cleanup(t *testing.T) {
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
 		trustOptions,
 		fullNode,
 		[]provider.Provider{fullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
+		lite.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
 	_, err = c.TrustedHeader(1)
@@ -330,13 +331,13 @@ func TestClientRestoresTrustedHeaderAfterStartup1(t *testing.T) {
 		err := trustedStore.SaveSignedHeaderAndValidatorSet(h1, vals)
 		require.NoError(t, err)
 
-		c, err := NewClient(
+		c, err := lite.NewClient(
 			chainID,
 			trustOptions,
 			fullNode,
 			[]provider.Provider{fullNode},
 			trustedStore,
-			Logger(log.TestingLogger()),
+			lite.Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
 
@@ -372,9 +373,9 @@ func TestClientRestoresTrustedHeaderAfterStartup1(t *testing.T) {
 			valSet,
 		)
 
-		c, err := NewClient(
+		c, err := lite.NewClient(
 			chainID,
-			TrustOptions{
+			lite.TrustOptions{
 				Period: 4 * time.Hour,
 				Height: 1,
 				Hash:   header1.Hash(),
@@ -382,7 +383,7 @@ func TestClientRestoresTrustedHeaderAfterStartup1(t *testing.T) {
 			primary,
 			[]provider.Provider{primary},
 			trustedStore,
-			Logger(log.TestingLogger()),
+			lite.Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
 
@@ -409,9 +410,9 @@ func TestClientRestoresTrustedHeaderAfterStartup2(t *testing.T) {
 		err := trustedStore.SaveSignedHeaderAndValidatorSet(h1, vals)
 		require.NoError(t, err)
 
-		c, err := NewClient(
+		c, err := lite.NewClient(
 			chainID,
-			TrustOptions{
+			lite.TrustOptions{
 				Period: 4 * time.Hour,
 				Height: 2,
 				Hash:   h2.Hash(),
@@ -419,7 +420,7 @@ func TestClientRestoresTrustedHeaderAfterStartup2(t *testing.T) {
 			fullNode,
 			[]provider.Provider{fullNode},
 			trustedStore,
-			Logger(log.TestingLogger()),
+			lite.Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
 
@@ -460,9 +461,9 @@ func TestClientRestoresTrustedHeaderAfterStartup2(t *testing.T) {
 			valSet,
 		)
 
-		c, err := NewClient(
+		c, err := lite.NewClient(
 			chainID,
-			TrustOptions{
+			lite.TrustOptions{
 				Period: 4 * time.Hour,
 				Height: 2,
 				Hash:   diffHeader2.Hash(),
@@ -470,7 +471,7 @@ func TestClientRestoresTrustedHeaderAfterStartup2(t *testing.T) {
 			primary,
 			[]provider.Provider{primary},
 			trustedStore,
-			Logger(log.TestingLogger()),
+			lite.Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
 
@@ -498,13 +499,13 @@ func TestClientRestoresTrustedHeaderAfterStartup3(t *testing.T) {
 		err = trustedStore.SaveSignedHeaderAndValidatorSet(h2, vals)
 		require.NoError(t, err)
 
-		c, err := NewClient(
+		c, err := lite.NewClient(
 			chainID,
 			trustOptions,
 			fullNode,
 			[]provider.Provider{fullNode},
 			trustedStore,
-			Logger(log.TestingLogger()),
+			lite.Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
 
@@ -555,9 +556,9 @@ func TestClientRestoresTrustedHeaderAfterStartup3(t *testing.T) {
 			valSet,
 		)
 
-		c, err := NewClient(
+		c, err := lite.NewClient(
 			chainID,
-			TrustOptions{
+			lite.TrustOptions{
 				Period: 4 * time.Hour,
 				Height: 1,
 				Hash:   header1.Hash(),
@@ -565,7 +566,7 @@ func TestClientRestoresTrustedHeaderAfterStartup3(t *testing.T) {
 			primary,
 			[]provider.Provider{primary},
 			trustedStore,
-			Logger(log.TestingLogger()),
+			lite.Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
 
@@ -594,13 +595,13 @@ func TestClientRestoresTrustedHeaderAfterStartup3(t *testing.T) {
 }
 
 func TestClient_Update(t *testing.T) {
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
 		trustOptions,
 		fullNode,
 		[]provider.Provider{fullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
+		lite.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
 
@@ -619,13 +620,13 @@ func TestClient_Update(t *testing.T) {
 }
 
 func TestClient_Concurrency(t *testing.T) {
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
 		trustOptions,
 		fullNode,
 		[]provider.Provider{fullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
+		lite.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
 
@@ -663,14 +664,14 @@ func TestClient_Concurrency(t *testing.T) {
 }
 
 func TestClientReplacesPrimaryWithWitnessIfPrimaryIsUnavailable(t *testing.T) {
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
 		trustOptions,
 		deadNode,
 		[]provider.Provider{fullNode, fullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
-		MaxRetryAttempts(1),
+		lite.Logger(log.TestingLogger()),
+		lite.MaxRetryAttempts(1),
 	)
 
 	require.NoError(t, err)
@@ -684,9 +685,9 @@ func TestClientReplacesPrimaryWithWitnessIfPrimaryIsUnavailable(t *testing.T) {
 func TestClient_BackwardsVerification(t *testing.T) {
 	{
 		trustHeader, _ := largeFullNode.SignedHeader(6)
-		c, err := NewClient(
+		c, err := lite.NewClient(
 			chainID,
-			TrustOptions{
+			lite.TrustOptions{
 				Period: 4 * time.Minute,
 				Height: trustHeader.Height,
 				Hash:   trustHeader.Hash(),
@@ -694,7 +695,7 @@ func TestClient_BackwardsVerification(t *testing.T) {
 			largeFullNode,
 			[]provider.Provider{largeFullNode},
 			dbs.New(dbm.NewMemDB(), chainID),
-			Logger(log.TestingLogger()),
+			lite.Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
 
@@ -769,9 +770,9 @@ func TestClient_BackwardsVerification(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			c, err := NewClient(
+			c, err := lite.NewClient(
 				chainID,
-				TrustOptions{
+				lite.TrustOptions{
 					Period: 1 * time.Hour,
 					Height: 3,
 					Hash:   h3.Hash(),
@@ -779,7 +780,7 @@ func TestClient_BackwardsVerification(t *testing.T) {
 				tc.provider,
 				[]provider.Provider{tc.provider},
 				dbs.New(dbm.NewMemDB(), chainID),
-				Logger(log.TestingLogger()),
+				lite.Logger(log.TestingLogger()),
 			)
 			require.NoError(t, err)
 
@@ -795,7 +796,7 @@ func TestClient_NewClientFromTrustedStore(t *testing.T) {
 	err := db.SaveSignedHeaderAndValidatorSet(h1, vals)
 	require.NoError(t, err)
 
-	c, err := NewClientFromTrustedStore(
+	c, err := lite.NewClientFromTrustedStore(
 		chainID,
 		trustPeriod,
 		deadNode,
@@ -819,14 +820,14 @@ func TestClient_NewClientFromTrustedStore(t *testing.T) {
 }
 
 func TestNewClientErrorsIfAllWitnessesUnavailable(t *testing.T) {
-	_, err := NewClient(
+	_, err := lite.NewClient(
 		chainID,
 		trustOptions,
 		fullNode,
 		[]provider.Provider{deadNode, deadNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
-		MaxRetryAttempts(1),
+		lite.Logger(log.TestingLogger()),
+		lite.MaxRetryAttempts(1),
 	)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "awaiting response from all witnesses exceeded dropout time")
@@ -862,14 +863,14 @@ func TestClientRemovesWitnessIfItSendsUsIncorrectHeader(t *testing.T) {
 		},
 	)
 
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
 		trustOptions,
 		fullNode,
 		[]provider.Provider{badProvider1, badProvider2},
 		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
-		MaxRetryAttempts(1),
+		lite.Logger(log.TestingLogger()),
+		lite.MaxRetryAttempts(1),
 	)
 	// witness should have behaved properly -> no error
 	require.NoError(t, err)
@@ -889,13 +890,13 @@ func TestClientRemovesWitnessIfItSendsUsIncorrectHeader(t *testing.T) {
 }
 
 func TestClientTrustedValidatorSet(t *testing.T) {
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
 		trustOptions,
 		fullNode,
 		[]provider.Provider{fullNode},
 		dbs.New(dbm.NewMemDB(), chainID),
-		Logger(log.TestingLogger()),
+		lite.Logger(log.TestingLogger()),
 	)
 
 	require.NoError(t, err)

--- a/lite2/example_test.go
+++ b/lite2/example_test.go
@@ -1,4 +1,4 @@
-package lite
+package lite_test
 
 import (
 	"fmt"
@@ -11,6 +11,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/abci/example/kvstore"
+	lite "github.com/tendermint/tendermint/lite2"
 	"github.com/tendermint/tendermint/lite2/provider"
 	httpp "github.com/tendermint/tendermint/lite2/provider/http"
 	dbs "github.com/tendermint/tendermint/lite2/store/db"
@@ -48,9 +49,9 @@ func ExampleClient_Update() {
 		stdlog.Fatal(err)
 	}
 
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
-		TrustOptions{
+		lite.TrustOptions{
 			Period: 504 * time.Hour, // 21 days
 			Height: 2,
 			Hash:   header.Hash(),
@@ -117,9 +118,9 @@ func ExampleClient_VerifyHeaderAtHeight() {
 		stdlog.Fatal(err)
 	}
 
-	c, err := NewClient(
+	c, err := lite.NewClient(
 		chainID,
-		TrustOptions{
+		lite.TrustOptions{
 			Period: 504 * time.Hour, // 21 days
 			Height: 2,
 			Hash:   header.Hash(),

--- a/lite2/helpers_test.go
+++ b/lite2/helpers_test.go
@@ -1,4 +1,4 @@
-package lite
+package lite_test
 
 import (
 	"time"

--- a/lite2/provider/http/http.go
+++ b/lite2/provider/http/http.go
@@ -29,7 +29,7 @@ type http struct {
 // New creates a HTTP provider, which is using the rpchttp.HTTP
 // client under the hood.
 func New(chainID, remote string) (provider.Provider, error) {
-	httpClient, err := rpchttp.NewHTTP(remote, "/websocket")
+	httpClient, err := rpchttp.New(remote, "/websocket")
 	if err != nil {
 		return nil, err
 	}

--- a/lite2/provider/http/http.go
+++ b/lite2/provider/http/http.go
@@ -22,8 +22,8 @@ type SignStatusClient interface {
 // http provider uses an RPC client (or SignStatusClient more generally) to
 // obtain the necessary information.
 type http struct {
-	chainID string
-	client  SignStatusClient
+	SignStatusClient // embed so interface can be converted to SignStatusClient for tests
+	chainID          string
 }
 
 // New creates a HTTP provider, which is using the rpchttp.HTTP
@@ -39,8 +39,8 @@ func New(chainID, remote string) (provider.Provider, error) {
 // NewWithClient allows you to provide custom SignStatusClient.
 func NewWithClient(chainID string, client SignStatusClient) provider.Provider {
 	return &http{
-		chainID: chainID,
-		client:  client,
+		SignStatusClient: client,
+		chainID:          chainID,
 	}
 }
 
@@ -50,7 +50,7 @@ func (p *http) ChainID() string {
 }
 
 func (p *http) String() string {
-	return fmt.Sprintf("http{%s}", p.client.Remote())
+	return fmt.Sprintf("http{%s}", p.Remote())
 }
 
 // SignedHeader fetches a SignedHeader at the given height and checks the
@@ -61,7 +61,7 @@ func (p *http) SignedHeader(height int64) (*types.SignedHeader, error) {
 		return nil, err
 	}
 
-	commit, err := p.client.Commit(h)
+	commit, err := p.SignStatusClient.Commit(h)
 	if err != nil {
 		// TODO: standartise errors on the RPC side
 		if strings.Contains(err.Error(), "height must be less than or equal") {
@@ -91,7 +91,7 @@ func (p *http) ValidatorSet(height int64) (*types.ValidatorSet, error) {
 	}
 
 	const maxPerPage = 100
-	res, err := p.client.Validators(h, 0, maxPerPage)
+	res, err := p.SignStatusClient.Validators(h, 0, maxPerPage)
 	if err != nil {
 		// TODO: standartise errors on the RPC side
 		if strings.Contains(err.Error(), "height must be less than or equal") {
@@ -107,7 +107,7 @@ func (p *http) ValidatorSet(height int64) (*types.ValidatorSet, error) {
 
 	// Check if there are more validators.
 	for len(res.Validators) == maxPerPage {
-		res, err = p.client.Validators(h, page, maxPerPage)
+		res, err = p.SignStatusClient.Validators(h, page, maxPerPage)
 		if err != nil {
 			return nil, err
 		}

--- a/lite2/provider/http/http.go
+++ b/lite2/provider/http/http.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tendermint/tendermint/lite2/provider"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -25,10 +26,10 @@ type http struct {
 	client  SignStatusClient
 }
 
-// New creates a HTTP provider, which is using the rpcclient.HTTP
+// New creates a HTTP provider, which is using the rpchttp.HTTP
 // client under the hood.
 func New(chainID, remote string) (provider.Provider, error) {
-	httpClient, err := rpcclient.NewHTTP(remote, "/websocket")
+	httpClient, err := rpchttp.NewHTTP(remote, "/websocket")
 	if err != nil {
 		return nil, err
 	}

--- a/lite2/provider/http/http_test.go
+++ b/lite2/provider/http/http_test.go
@@ -1,4 +1,4 @@
-package http
+package http_test
 
 import (
 	"os"
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/abci/example/kvstore"
+	litehttp "github.com/tendermint/tendermint/lite2/provider/http"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	rpctest "github.com/tendermint/tendermint/rpc/test"
 	"github.com/tendermint/tendermint/types"
@@ -33,12 +34,12 @@ func TestProvider(t *testing.T) {
 	}
 	chainID := genDoc.ChainID
 	t.Log("chainID:", chainID)
-	p, err := New(chainID, rpcAddr)
+	p, err := litehttp.New(chainID, rpcAddr)
 	require.Nil(t, err)
 	require.NotNil(t, p)
 
 	// let it produce some blocks
-	err = rpcclient.WaitForHeight(p.(*http).client, 6, nil)
+	err = rpcclient.WaitForHeight(p.(rpcclient.StatusClient), 6, nil)
 	require.Nil(t, err)
 
 	// let's get the highest block

--- a/lite2/verifier_test.go
+++ b/lite2/verifier_test.go
@@ -1,4 +1,4 @@
-package lite
+package lite_test
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	tmmath "github.com/tendermint/tendermint/libs/math"
+	lite "github.com/tendermint/tendermint/lite2"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -117,7 +118,7 @@ func TestVerifyAdjacentHeaders(t *testing.T) {
 			vals,
 			3 * time.Hour,
 			bTime.Add(2 * time.Hour),
-			ErrInvalidHeader{Reason: types.ErrNotEnoughVotingPowerSigned{Got: 50, Needed: 93}},
+			lite.ErrInvalidHeader{Reason: types.ErrNotEnoughVotingPowerSigned{Got: 50, Needed: 93}},
 			"",
 		},
 		// vals does not match with what we have -> error
@@ -155,7 +156,7 @@ func TestVerifyAdjacentHeaders(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			err := VerifyAdjacent(chainID, header, tc.newHeader, tc.newVals, tc.trustingPeriod, tc.now, maxClockDrift)
+			err := lite.VerifyAdjacent(chainID, header, tc.newHeader, tc.newVals, tc.trustingPeriod, tc.now, maxClockDrift)
 			switch {
 			case tc.expErr != nil && assert.Error(t, err):
 				assert.Equal(t, tc.expErr, err)
@@ -231,7 +232,7 @@ func TestVerifyNonAdjacentHeaders(t *testing.T) {
 			vals,
 			3 * time.Hour,
 			bTime.Add(2 * time.Hour),
-			ErrInvalidHeader{types.ErrNotEnoughVotingPowerSigned{Got: 50, Needed: 93}},
+			lite.ErrInvalidHeader{types.ErrNotEnoughVotingPowerSigned{Got: 50, Needed: 93}},
 			"",
 		},
 		// 3/3 new vals signed, 2/3 old vals present -> no error
@@ -261,7 +262,7 @@ func TestVerifyNonAdjacentHeaders(t *testing.T) {
 			lessThanOneThirdVals,
 			3 * time.Hour,
 			bTime.Add(2 * time.Hour),
-			ErrNewValSetCantBeTrusted{types.ErrNotEnoughVotingPowerSigned{Got: 20, Needed: 46}},
+			lite.ErrNewValSetCantBeTrusted{types.ErrNotEnoughVotingPowerSigned{Got: 20, Needed: 46}},
 			"",
 		},
 	}
@@ -269,9 +270,9 @@ func TestVerifyNonAdjacentHeaders(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			err := VerifyNonAdjacent(chainID, header, vals, tc.newHeader, tc.newVals, tc.trustingPeriod,
+			err := lite.VerifyNonAdjacent(chainID, header, vals, tc.newHeader, tc.newVals, tc.trustingPeriod,
 				tc.now, maxClockDrift,
-				DefaultTrustLevel)
+				lite.DefaultTrustLevel)
 
 			switch {
 			case tc.expErr != nil && assert.Error(t, err):
@@ -300,7 +301,7 @@ func TestVerifyReturnsErrorIfTrustLevelIsInvalid(t *testing.T) {
 			[]byte("app_hash"), []byte("cons_hash"), []byte("results_hash"), 0, len(keys))
 	)
 
-	err := Verify(chainID, header, vals, header, vals, 2*time.Hour, time.Now(), maxClockDrift,
+	err := lite.Verify(chainID, header, vals, header, vals, 2*time.Hour, time.Now(), maxClockDrift,
 		tmmath.Fraction{Numerator: 2, Denominator: 1})
 	assert.Error(t, err)
 }
@@ -327,7 +328,7 @@ func TestValidateTrustLevel(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err := ValidateTrustLevel(tc.lvl)
+		err := lite.ValidateTrustLevel(tc.lvl)
 		if !tc.valid {
 			assert.Error(t, err)
 		} else {

--- a/rpc/client/examples_test.go
+++ b/rpc/client/examples_test.go
@@ -19,7 +19,7 @@ func ExampleHTTP_simple() {
 
 	// Create our RPC client
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c, err := rpchttp.NewHTTP(rpcAddr, "/websocket")
+	c, err := rpchttp.New(rpcAddr, "/websocket")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func ExampleHTTP_batching() {
 
 	// Create our RPC client
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c, err := rpchttp.NewHTTP(rpcAddr, "/websocket")
+	c, err := rpchttp.New(rpcAddr, "/websocket")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/rpc/client/examples_test.go
+++ b/rpc/client/examples_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/tendermint/tendermint/abci/example/kvstore"
-	"github.com/tendermint/tendermint/rpc/client"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	rpctest "github.com/tendermint/tendermint/rpc/test"
 )
@@ -19,7 +19,7 @@ func ExampleHTTP_simple() {
 
 	// Create our RPC client
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c, err := client.NewHTTP(rpcAddr, "/websocket")
+	c, err := rpchttp.NewHTTP(rpcAddr, "/websocket")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func ExampleHTTP_batching() {
 
 	// Create our RPC client
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c, err := client.NewHTTP(rpcAddr, "/websocket")
+	c, err := rpchttp.NewHTTP(rpcAddr, "/websocket")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -1,4 +1,4 @@
-package client
+package http
 
 import (
 	"context"
@@ -110,27 +110,27 @@ var _ rpcClient = (*baseRPCClient)(nil)
 // NewHTTP takes a remote endpoint in the form <protocol>://<host>:<port> and
 // the websocket path (which always seems to be "/websocket")
 // An error is returned on invalid remote. The function panics when remote is nil.
-func NewHTTP(remote, wsEndpoint string) (*HTTP, error) {
+func New(remote, wsEndpoint string) (*HTTP, error) {
 	httpClient, err := rpcclientlib.DefaultHTTPClient(remote)
 	if err != nil {
 		return nil, err
 	}
-	return NewHTTPWithClient(remote, wsEndpoint, httpClient)
+	return NewWithClient(remote, wsEndpoint, httpClient)
 }
 
 // Create timeout enabled http client
-func NewHTTPWithTimeout(remote, wsEndpoint string, timeout uint) (*HTTP, error) {
+func NewWithTimeout(remote, wsEndpoint string, timeout uint) (*HTTP, error) {
 	httpClient, err := rpcclientlib.DefaultHTTPClient(remote)
 	if err != nil {
 		return nil, err
 	}
 	httpClient.Timeout = time.Duration(timeout) * time.Second
-	return NewHTTPWithClient(remote, wsEndpoint, httpClient)
+	return NewWithClient(remote, wsEndpoint, httpClient)
 }
 
 // NewHTTPWithClient allows for setting a custom http client (See NewHTTP).
 // An error is returned on invalid remote. The function panics when remote is nil.
-func NewHTTPWithClient(remote, wsEndpoint string, client *http.Client) (*HTTP, error) {
+func NewWithClient(remote, wsEndpoint string, client *http.Client) (*HTTP, error) {
 	if client == nil {
 		panic("nil http.Client provided")
 	}

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -41,7 +41,7 @@ the example for more details.
 
 Example:
 
-		c, err := NewHTTP("http://192.168.1.10:26657", "/websocket")
+		c, err := New("http://192.168.1.10:26657", "/websocket")
 		if err != nil {
 			// handle error
 		}
@@ -107,7 +107,7 @@ var _ rpcClient = (*baseRPCClient)(nil)
 //-----------------------------------------------------------------------------
 // HTTP
 
-// NewHTTP takes a remote endpoint in the form <protocol>://<host>:<port> and
+// New takes a remote endpoint in the form <protocol>://<host>:<port> and
 // the websocket path (which always seems to be "/websocket")
 // An error is returned on invalid remote. The function panics when remote is nil.
 func New(remote, wsEndpoint string) (*HTTP, error) {
@@ -128,7 +128,7 @@ func NewWithTimeout(remote, wsEndpoint string, timeout uint) (*HTTP, error) {
 	return NewWithClient(remote, wsEndpoint, httpClient)
 }
 
-// NewHTTPWithClient allows for setting a custom http client (See NewHTTP).
+// NewWithClient allows for setting a custom http client (See New).
 // An error is returned on invalid remote. The function panics when remote is nil.
 func NewWithClient(remote, wsEndpoint string, client *http.Client) (*HTTP, error) {
 	if client == nil {

--- a/rpc/client/http/httpclient.go
+++ b/rpc/client/http/httpclient.go
@@ -15,8 +15,9 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	"github.com/tendermint/tendermint/libs/service"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
-	rpcclient "github.com/tendermint/tendermint/rpc/lib/client"
+	rpcclientlib "github.com/tendermint/tendermint/rpc/lib/client"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -61,7 +62,7 @@ Example:
 */
 type HTTP struct {
 	remote string
-	rpc    *rpcclient.JSONRPCClient
+	rpc    *rpcclientlib.JSONRPCClient
 
 	*baseRPCClient
 	*WSEvents
@@ -78,7 +79,7 @@ type HTTP struct {
 // batch, but ordering of transactions in the batch cannot be guaranteed in such
 // an example.
 type BatchHTTP struct {
-	rpcBatch *rpcclient.JSONRPCRequestBatch
+	rpcBatch *rpcclientlib.JSONRPCRequestBatch
 	*baseRPCClient
 }
 
@@ -86,17 +87,17 @@ type BatchHTTP struct {
 // non-batch) must conform. Acts as an additional code-level sanity check to
 // make sure the implementations stay coherent.
 type rpcClient interface {
-	ABCIClient
-	HistoryClient
-	NetworkClient
-	SignClient
-	StatusClient
+	rpcclient.ABCIClient
+	rpcclient.HistoryClient
+	rpcclient.NetworkClient
+	rpcclient.SignClient
+	rpcclient.StatusClient
 }
 
 // baseRPCClient implements the basic RPC method logic without the actual
 // underlying RPC call functionality, which is provided by `caller`.
 type baseRPCClient struct {
-	caller rpcclient.JSONRPCCaller
+	caller rpcclientlib.JSONRPCCaller
 }
 
 var _ rpcClient = (*HTTP)(nil)
@@ -110,7 +111,7 @@ var _ rpcClient = (*baseRPCClient)(nil)
 // the websocket path (which always seems to be "/websocket")
 // An error is returned on invalid remote. The function panics when remote is nil.
 func NewHTTP(remote, wsEndpoint string) (*HTTP, error) {
-	httpClient, err := rpcclient.DefaultHTTPClient(remote)
+	httpClient, err := rpcclientlib.DefaultHTTPClient(remote)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +120,7 @@ func NewHTTP(remote, wsEndpoint string) (*HTTP, error) {
 
 // Create timeout enabled http client
 func NewHTTPWithTimeout(remote, wsEndpoint string, timeout uint) (*HTTP, error) {
-	httpClient, err := rpcclient.DefaultHTTPClient(remote)
+	httpClient, err := rpcclientlib.DefaultHTTPClient(remote)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +135,7 @@ func NewHTTPWithClient(remote, wsEndpoint string, client *http.Client) (*HTTP, e
 		panic("nil http.Client provided")
 	}
 
-	rc, err := rpcclient.NewJSONRPCClientWithHTTPClient(remote, client)
+	rc, err := rpcclientlib.NewJSONRPCClientWithHTTPClient(remote, client)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func NewHTTPWithClient(remote, wsEndpoint string, client *http.Client) (*HTTP, e
 	return httpClient, nil
 }
 
-var _ Client = (*HTTP)(nil)
+var _ rpcclient.Client = (*HTTP)(nil)
 
 // SetLogger sets a logger.
 func (c *HTTP) SetLogger(l log.Logger) {
@@ -224,13 +225,13 @@ func (c *baseRPCClient) ABCIInfo() (*ctypes.ResultABCIInfo, error) {
 }
 
 func (c *baseRPCClient) ABCIQuery(path string, data bytes.HexBytes) (*ctypes.ResultABCIQuery, error) {
-	return c.ABCIQueryWithOptions(path, data, DefaultABCIQueryOptions)
+	return c.ABCIQueryWithOptions(path, data, rpcclient.DefaultABCIQueryOptions)
 }
 
 func (c *baseRPCClient) ABCIQueryWithOptions(
 	path string,
 	data bytes.HexBytes,
-	opts ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
+	opts rpcclient.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
 	result := new(ctypes.ResultABCIQuery)
 	_, err := c.caller.Call("abci_query",
 		map[string]interface{}{"path": path, "data": data, "height": opts.Height, "prove": opts.Prove},
@@ -440,7 +441,7 @@ type WSEvents struct {
 	cdc      *amino.Codec
 	remote   string
 	endpoint string
-	ws       *rpcclient.WSClient
+	ws       *rpcclientlib.WSClient
 
 	mtx           sync.RWMutex
 	subscriptions map[string]chan ctypes.ResultEvent // query -> chan
@@ -456,7 +457,7 @@ func newWSEvents(cdc *amino.Codec, remote, endpoint string) (*WSEvents, error) {
 	w.BaseService = *service.NewBaseService(nil, "WSEvents", w)
 
 	var err error
-	w.ws, err = rpcclient.NewWSClient(w.remote, w.endpoint, rpcclient.OnReconnect(func() {
+	w.ws, err = rpcclientlib.NewWSClient(w.remote, w.endpoint, rpcclientlib.OnReconnect(func() {
 		// resubscribe immediately
 		w.redoSubscriptionsAfter(0 * time.Second)
 	}))

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -11,6 +11,7 @@ import (
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
 	nm "github.com/tendermint/tendermint/node"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/core"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	rpctypes "github.com/tendermint/tendermint/rpc/lib/types"
@@ -58,7 +59,7 @@ func NewLocal(node *nm.Node) *Local {
 	}
 }
 
-var _ Client = (*Local)(nil)
+var _ rpcclient.Client = (*Local)(nil)
 
 // SetLogger allows to set a logger on the client.
 func (c *Local) SetLogger(l log.Logger) {
@@ -74,13 +75,13 @@ func (c *Local) ABCIInfo() (*ctypes.ResultABCIInfo, error) {
 }
 
 func (c *Local) ABCIQuery(path string, data bytes.HexBytes) (*ctypes.ResultABCIQuery, error) {
-	return c.ABCIQueryWithOptions(path, data, DefaultABCIQueryOptions)
+	return c.ABCIQueryWithOptions(path, data, rpcclient.DefaultABCIQueryOptions)
 }
 
 func (c *Local) ABCIQueryWithOptions(
 	path string,
 	data bytes.HexBytes,
-	opts ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
+	opts rpcclient.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
 	return core.ABCIQuery(c.ctx, path, data, opts.Height, opts.Prove)
 }
 

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -1,4 +1,4 @@
-package client
+package local
 
 import (
 	"context"
@@ -50,7 +50,7 @@ type Local struct {
 // you can only have one node per process.  So make sure test cases
 // don't run in parallel, or try to simulate an entire network in
 // one process...
-func NewLocal(node *nm.Node) *Local {
+func New(node *nm.Node) *Local {
 	node.ConfigureRPC()
 	return &Local{
 		EventBus: node.EventBus(),

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -33,7 +33,7 @@ import (
 
 func getHTTPClient() *rpchttp.HTTP {
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c, err := rpchttp.NewHTTP(rpcAddr, "/websocket")
+	c, err := rpchttp.New(rpcAddr, "/websocket")
 	if err != nil {
 		panic(err)
 	}
@@ -43,7 +43,7 @@ func getHTTPClient() *rpchttp.HTTP {
 
 func getHTTPClientWithTimeout(timeout uint) *rpchttp.HTTP {
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c, err := rpchttp.NewHTTPWithTimeout(rpcAddr, "/websocket", timeout)
+	c, err := rpchttp.NewWithTimeout(rpcAddr, "/websocket", timeout)
 	if err != nil {
 		panic(err)
 	}
@@ -52,7 +52,7 @@ func getHTTPClientWithTimeout(timeout uint) *rpchttp.HTTP {
 }
 
 func getLocalClient() *rpclocal.Local {
-	return rpclocal.NewLocal(node)
+	return rpclocal.New(node)
 }
 
 // GetClients returns a slice of clients for table-driven tests
@@ -65,7 +65,7 @@ func GetClients() []client.Client {
 
 func TestNilCustomHTTPClient(t *testing.T) {
 	require.Panics(t, func() {
-		_, _ = rpchttp.NewHTTPWithClient("http://example.com", "/websocket", nil)
+		_, _ = rpchttp.NewWithClient("http://example.com", "/websocket", nil)
 	})
 	require.Panics(t, func() {
 		_, _ = rpcclient.NewJSONRPCClientWithHTTPClient("http://example.com", nil)
@@ -74,7 +74,7 @@ func TestNilCustomHTTPClient(t *testing.T) {
 
 func TestCustomHTTPClient(t *testing.T) {
 	remote := rpctest.GetConfig().RPC.ListenAddress
-	c, err := rpchttp.NewHTTPWithClient(remote, "/websocket", http.DefaultClient)
+	c, err := rpchttp.NewWithClient(remote, "/websocket", http.DefaultClient)
 	require.Nil(t, err)
 	status, err := c.Status()
 	require.NoError(t, err)

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -23,15 +23,17 @@ import (
 	mempl "github.com/tendermint/tendermint/mempool"
 	"github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/rpc/client"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+	rpclocal "github.com/tendermint/tendermint/rpc/client/local"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	rpcclient "github.com/tendermint/tendermint/rpc/lib/client"
 	rpctest "github.com/tendermint/tendermint/rpc/test"
 	"github.com/tendermint/tendermint/types"
 )
 
-func getHTTPClient() *client.HTTP {
+func getHTTPClient() *rpchttp.HTTP {
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c, err := client.NewHTTP(rpcAddr, "/websocket")
+	c, err := rpchttp.NewHTTP(rpcAddr, "/websocket")
 	if err != nil {
 		panic(err)
 	}
@@ -39,9 +41,9 @@ func getHTTPClient() *client.HTTP {
 	return c
 }
 
-func getHTTPClientWithTimeout(timeout uint) *client.HTTP {
+func getHTTPClientWithTimeout(timeout uint) *rpchttp.HTTP {
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
-	c, err := client.NewHTTPWithTimeout(rpcAddr, "/websocket", timeout)
+	c, err := rpchttp.NewHTTPWithTimeout(rpcAddr, "/websocket", timeout)
 	if err != nil {
 		panic(err)
 	}
@@ -49,8 +51,8 @@ func getHTTPClientWithTimeout(timeout uint) *client.HTTP {
 	return c
 }
 
-func getLocalClient() *client.Local {
-	return client.NewLocal(node)
+func getLocalClient() *rpclocal.Local {
+	return rpclocal.NewLocal(node)
 }
 
 // GetClients returns a slice of clients for table-driven tests
@@ -63,7 +65,7 @@ func GetClients() []client.Client {
 
 func TestNilCustomHTTPClient(t *testing.T) {
 	require.Panics(t, func() {
-		_, _ = client.NewHTTPWithClient("http://example.com", "/websocket", nil)
+		_, _ = rpchttp.NewHTTPWithClient("http://example.com", "/websocket", nil)
 	})
 	require.Panics(t, func() {
 		_, _ = rpcclient.NewJSONRPCClientWithHTTPClient("http://example.com", nil)
@@ -72,7 +74,7 @@ func TestNilCustomHTTPClient(t *testing.T) {
 
 func TestCustomHTTPClient(t *testing.T) {
 	remote := rpctest.GetConfig().RPC.ListenAddress
-	c, err := client.NewHTTPWithClient(remote, "/websocket", http.DefaultClient)
+	c, err := rpchttp.NewHTTPWithClient(remote, "/websocket", http.DefaultClient)
 	require.Nil(t, err)
 	status, err := c.Status()
 	require.NoError(t, err)
@@ -701,7 +703,7 @@ func TestBatchedJSONRPCCalls(t *testing.T) {
 	testBatchedJSONRPCCalls(t, c)
 }
 
-func testBatchedJSONRPCCalls(t *testing.T, c *client.HTTP) {
+func testBatchedJSONRPCCalls(t *testing.T, c *rpchttp.HTTP) {
 	k1, v1, tx1 := MakeTxKV()
 	k2, v2, tx2 := MakeTxKV()
 

--- a/rpc/swagger/swagger.yaml
+++ b/rpc/swagger/swagger.yaml
@@ -253,9 +253,10 @@ paths:
         https://godoc.org/github.com/tendermint/tendermint/libs/pubsub/query.
 
         ```go
+        import rpchttp "github.com/tendermint/rpc/client/http"
         import "github.com/tendermint/tendermint/types"
 
-        client := client.NewHTTP("tcp:0.0.0.0:26657", "/websocket")
+        client := rpchttp.New("tcp:0.0.0.0:26657", "/websocket")
         err := client.Start()
         if err != nil {
           handle error
@@ -309,7 +310,7 @@ paths:
       operationId: unsubscribe
       description: |
         ```go
-        client := client.NewHTTP("tcp:0.0.0.0:26657", "/websocket")
+        client := rpchttp.New("tcp:0.0.0.0:26657", "/websocket")
         err := client.Start()
         if err != nil {
            handle error


### PR DESCRIPTION
Fixes #4626:

* Split `rpc/client` implementations into `rpc/client/http` and `rpc/client/local`, and rename constructors.
* Split `lite2` tests into separate `lite_test` package.
  * Embed `SignStatusClient` in `http.http` struct, so tests can convert it.

______

For contributor use:

- [x] Wrote tests
- [x] Updated CHANGELOG_PENDING.md
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments
- [x] Re-reviewed `Files changed` in the Github PR explorer
