### PR TITLE
evidence: check evidence hasn't already been stored

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -40,6 +40,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [lite2] [\#4575](https://github.com/tendermint/tendermint/pull/4575) Use bisection for within-range verification (@cmwaters)
 - [tools] \#4615 Allow developers to use Docker to generate proto stubs, via `make proto-gen-docker`.
 - [p2p] \#4621(https://github.com/tendermint/tendermint/pull/4621) ban peers when messages are unsolicited or too frequent (@cmwaters)
+- [evidence] [\#4632](https://github.com/tendermint/tendermint/pull/4632) Inbound evidence checked if already existing (@cmwaters)
 
 ### BUG FIXES:
 

--- a/evidence/errors.go
+++ b/evidence/errors.go
@@ -1,0 +1,21 @@
+package evidence
+
+import (
+	"fmt"
+)
+
+// ErrInvalidEvidence returns when evidence failed to validate
+type ErrInvalidEvidence struct {
+	Reason error
+}
+
+func (e ErrInvalidEvidence) Error() string {
+	return fmt.Sprintf("evidence is not valid: %v ", e.Reason)
+}
+
+// ErrEvidenceAlreadyStored indicates that the evidence has already been stored in the evidence db
+type ErrEvidenceAlreadyStored struct{}
+
+func (e ErrEvidenceAlreadyStored) Error() string {
+	return "evidence is already stored"
+}

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -70,7 +70,7 @@ func TestEvidencePool(t *testing.T) {
 
 	// bad evidence
 	err := pool.AddEvidence(badEvidence)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	// err: evidence created at 2019-01-01 00:00:00 +0000 UTC has expired. Evidence can not be older than: ...
 
 	var wg sync.WaitGroup
@@ -81,14 +81,14 @@ func TestEvidencePool(t *testing.T) {
 	}()
 
 	err = pool.AddEvidence(goodEvidence)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	wg.Wait()
 
 	assert.Equal(t, 1, pool.evidenceList.Len())
 
-	// if we send it again, it shouldnt change the size
+	// if we send it again, it shouldnt add and return an error
 	err = pool.AddEvidence(goodEvidence)
-	assert.Nil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, 1, pool.evidenceList.Len())
 }
 

--- a/evidence/store_test.go
+++ b/evidence/store_test.go
@@ -1,6 +1,7 @@
 package evidence
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -21,11 +22,13 @@ func TestStoreAddDuplicate(t *testing.T) {
 	priority := int64(10)
 	ev := types.NewMockEvidence(2, time.Now().UTC(), 1, []byte("val1"))
 
-	added := store.AddNewEvidence(ev, priority)
+	added, err := store.AddNewEvidence(ev, priority)
+	require.NoError(t, err)
 	assert.True(added)
 
 	// cant add twice
-	added = store.AddNewEvidence(ev, priority)
+	added, err = store.AddNewEvidence(ev, priority)
+	require.NoError(t, err)
 	assert.False(added)
 }
 
@@ -40,7 +43,8 @@ func TestStoreCommitDuplicate(t *testing.T) {
 
 	store.MarkEvidenceAsCommitted(ev)
 
-	added := store.AddNewEvidence(ev, priority)
+	added, err := store.AddNewEvidence(ev, priority)
+	require.NoError(t, err)
 	assert.False(added)
 }
 
@@ -59,7 +63,8 @@ func TestStoreMark(t *testing.T) {
 	priority := int64(10)
 	ev := types.NewMockEvidence(2, time.Now().UTC(), 1, []byte("val1"))
 
-	added := store.AddNewEvidence(ev, priority)
+	added, err := store.AddNewEvidence(ev, priority)
+	require.NoError(t, err)
 	assert.True(added)
 
 	// get the evidence. verify. should be uncommitted
@@ -116,7 +121,8 @@ func TestStorePriority(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		added := store.AddNewEvidence(c.ev, c.priority)
+		added, err := store.AddNewEvidence(c.ev, c.priority)
+		require.NoError(t, err)
 		assert.True(added)
 	}
 

--- a/rpc/core/evidence.go
+++ b/rpc/core/evidence.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"github.com/tendermint/tendermint/evidence"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	rpctypes "github.com/tendermint/tendermint/rpc/lib/types"
 	"github.com/tendermint/tendermint/types"
@@ -10,8 +11,8 @@ import (
 // More: https://docs.tendermint.com/master/rpc/#/Info/broadcast_evidence
 func BroadcastEvidence(ctx *rpctypes.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
 	err := evidencePool.AddEvidence(ev)
-	if err != nil {
-		return nil, err
+	if _, ok := err.(evidence.ErrEvidenceAlreadyStored); err == nil || ok {
+		return &ctypes.ResultBroadcastEvidence{Hash: ev.Hash()}, nil
 	}
-	return &ctypes.ResultBroadcastEvidence{Hash: ev.Hash()}, nil
+	return nil, err
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #4614

## Description

Uses the `Has()` function from the DB store interface to first confirm that a piece of received evidence is not already stored before commencing verification

______

For contributor use:

- [x] Wrote tests
- [x] Updated CHANGELOG_PENDING.md
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
