### PR TITLE
add command to generate shell completion scripts

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,6 +27,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [abci] Add `ResponseCommit.retain_height` field, which will automatically remove blocks below this height.
 - [rpc] Add `/status` response fields for the earliest block available on the node
 - [rpc] [\#4611](https://github.com/tendermint/tendermint/pull/4611) Add `codespace` to `ResultBroadcastTx` (@whylee259)
+- [cmd] [\#4665](https://github.com/tendermint/tendermint/pull/4665) New `tedermint completion` command to generate Bash/Zsh completion scripts (@alessio).
 
 ### IMPROVEMENTS:
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,14 @@ data into the new chain.
 However, any bump in the PATCH version should be compatible with existing histories
 (if not please open an [issue](https://github.com/tendermint/tendermint/issues)).
 
-For more information on upgrading, see [UPGRADING.md](./UPGRADING.md)
+For more information on upgrading, see [UPGRADING.md](./UPGRADING.md).
+
+### Supported Versions
+
+Because we are a small core team, we only ship patch updates, including security updates, 
+to the most recent minor release and the second-most recent minor release. Consequently, 
+we strongly recommend keeping Tendermint up-to-date. Upgrading instructions can be found 
+in [UPGRADING.md](./UPGRADING.md).
 
 ## Resources
 

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -4,11 +4,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/tendermint/tendermint/libs/cli"
-
 	cmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	"github.com/tendermint/tendermint/cmd/tendermint/commands/debug"
 	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/cli"
 	nm "github.com/tendermint/tendermint/node"
 )
 
@@ -29,6 +28,7 @@ func main() {
 		cmd.GenNodeKeyCmd,
 		cmd.VersionCmd,
 		debug.DebugCmd,
+		cli.NewCompletionCmd(rootCmd, true),
 	)
 
 	// NOTE:

--- a/libs/cli/helper.go
+++ b/libs/cli/helper.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/spf13/cobra"
 )
 
 // WriteConfigVals writes a toml file with the given values.
@@ -84,4 +86,43 @@ func RunCaptureWithArgs(cmd Executable, args []string, env map[string]string) (s
 	stdout = <-*outC
 	stderr = <-*errC
 	return stdout, stderr, err
+}
+
+// NewCompletionCmd returns a cobra.Command that generates bash and zsh
+// completion scripts for the given root command. If hidden is true, the
+// command will not show up in the root command's list of available commands.
+func NewCompletionCmd(rootCmd *cobra.Command, hidden bool) *cobra.Command {
+	flagZsh := "zsh"
+	cmd := &cobra.Command{
+		Use:   "completion",
+		Short: "Generate shell completion scripts",
+		Long: fmt.Sprintf(`Generate Bash and Zsh completion scripts and print them to STDOUT.
+
+Once saved to file, a completion script can be loaded in the shell's
+current session as shown:
+
+   $ . <(%s completion)
+
+To configure your bash shell to load completions for each session add to
+your $HOME/.bashrc or $HOME/.profile the following instruction:
+
+   . <(%s completion)
+`, rootCmd.Use, rootCmd.Use),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			zsh, err := cmd.Flags().GetBool(flagZsh)
+			if err != nil {
+				return err
+			}
+			if zsh {
+				return rootCmd.GenZshCompletion(cmd.OutOrStdout())
+			}
+			return rootCmd.GenBashCompletion(cmd.OutOrStdout())
+		},
+		Hidden: hidden,
+		Args:   cobra.NoArgs,
+	}
+
+	cmd.Flags().Bool(flagZsh, false, "Generate Zsh completion script")
+
+	return cmd
 }


### PR DESCRIPTION
New `tendermint completion` command to generate Bash/Zsh completion scripts.

How to use it:

```bash
$ . <(tendermint completion)
```

Note that the `completion` command does not show up in the help screen,
though it comes with its own `--help` option.
This is a port of the feature provided by cosmos-sdk.

______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
