### PR TITLE
mergify: use PR title and body for squash merge commit

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,5 @@
 pull_request_rules:
-  - name: automerge to master with label S:automerge and branch protection passing
+  - name: Automerge to master
     conditions:
       - base=master
       - label=S:automerge
@@ -7,3 +7,4 @@ pull_request_rules:
       merge:
         method: squash
         strict: true
+        commit_message: title+body


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

The Mergify folks were kind enough to add an option for using the PR title and body as the squash merge commit message (https://github.com/Mergifyio/mergify-engine/pull/939). The GitHub default uses all branch commit messages, which is a bit noisy.

______

For contributor use:

- [x] ~Wrote tests~
- [x] ~Updated CHANGELOG_PENDING.md~
- [x] ~Linked to Github issue with discussion and accepted design OR link to spec that describes this work.~
- [x] ~Updated relevant documentation (`docs/`) and code comments~
- [x] ~Re-reviewed `Files changed` in the Github PR explorer~
