### PR TITLE
blockchain/v2: don't broadcast base if height is 0

### DIFF
--- a/blockchain/v2/io.go
+++ b/blockchain/v2/io.go
@@ -105,6 +105,9 @@ func (sio *switchIO) trySwitchToConsensus(state state.State, blocksSynced int) {
 }
 
 func (sio *switchIO) broadcastStatusRequest(base int64, height int64) {
+	if height == 0 && base > 0 {
+		base = 0
+	}
 	msgBytes := cdc.MustMarshalBinaryBare(&bcStatusRequestMessage{
 		Base:   base,
 		Height: height,


### PR DESCRIPTION
## Description

Fixes a bug where the reactor would broadcast a base with height=0.

______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [x] Re-reviewed `Files changed` in the Github PR explorer
