### PR TITLE
clarify service logging

### DIFF
--- a/libs/service/service.go
+++ b/libs/service/service.go
@@ -130,12 +130,13 @@ func (bs *BaseService) SetLogger(l log.Logger) {
 func (bs *BaseService) Start() error {
 	if atomic.CompareAndSwapUint32(&bs.started, 0, 1) {
 		if atomic.LoadUint32(&bs.stopped) == 1 {
-			bs.Logger.Error(fmt.Sprintf("Not starting %v -- already stopped", bs.name), "impl", bs.impl)
+			bs.Logger.Error(fmt.Sprintf("Not starting %v service -- already stopped", bs.name),
+				"impl", bs.impl)
 			// revert flag
 			atomic.StoreUint32(&bs.started, 0)
 			return ErrAlreadyStopped
 		}
-		bs.Logger.Info(fmt.Sprintf("Starting %v", bs.name), "impl", bs.impl)
+		bs.Logger.Info(fmt.Sprintf("Starting %v service", bs.name), "impl", bs.impl)
 		err := bs.impl.OnStart()
 		if err != nil {
 			// revert flag
@@ -144,7 +145,7 @@ func (bs *BaseService) Start() error {
 		}
 		return nil
 	}
-	bs.Logger.Debug(fmt.Sprintf("Not starting %v -- already started", bs.name), "impl", bs.impl)
+	bs.Logger.Debug(fmt.Sprintf("Not starting %v service -- already started", bs.name), "impl", bs.impl)
 	return ErrAlreadyStarted
 }
 
@@ -158,17 +159,18 @@ func (bs *BaseService) OnStart() error { return nil }
 func (bs *BaseService) Stop() error {
 	if atomic.CompareAndSwapUint32(&bs.stopped, 0, 1) {
 		if atomic.LoadUint32(&bs.started) == 0 {
-			bs.Logger.Error(fmt.Sprintf("Not stopping %v -- have not been started yet", bs.name), "impl", bs.impl)
+			bs.Logger.Error(fmt.Sprintf("Not stopping %v service -- has not been started yet", bs.name),
+				"impl", bs.impl)
 			// revert flag
 			atomic.StoreUint32(&bs.stopped, 0)
 			return ErrNotStarted
 		}
-		bs.Logger.Info(fmt.Sprintf("Stopping %v", bs.name), "impl", bs.impl)
+		bs.Logger.Info(fmt.Sprintf("Stopping %v service", bs.name), "impl", bs.impl)
 		bs.impl.OnStop()
 		close(bs.quit)
 		return nil
 	}
-	bs.Logger.Debug(fmt.Sprintf("Stopping %v (ignoring: already stopped)", bs.name), "impl", bs.impl)
+	bs.Logger.Debug(fmt.Sprintf("Stopping %v service (already stopped)", bs.name), "impl", bs.impl)
 	return ErrAlreadyStopped
 }
 
@@ -181,7 +183,7 @@ func (bs *BaseService) OnStop() {}
 // will be returned if the service is running.
 func (bs *BaseService) Reset() error {
 	if !atomic.CompareAndSwapUint32(&bs.stopped, 1, 0) {
-		bs.Logger.Debug(fmt.Sprintf("Can't reset %v. Not stopped", bs.name), "impl", bs.impl)
+		bs.Logger.Debug(fmt.Sprintf("Can't reset %v service. Not stopped", bs.name), "impl", bs.impl)
 		return fmt.Errorf("can't reset running %s", bs.name)
 	}
 


### PR DESCRIPTION
The service logging can be a bit unclear. For example, with state sync it would log:

```
I[2020-04-20|08:40:47.366] Starting StateSync     module=statesync impl=Reactor
I[2020-04-20|08:40:47.834] Starting state sync    module=statesync
```

Where the first message is the reactor service startup, and the second message is the start of the actual state sync process. This clarifies the first message by changing it to `Starting StateSync service`.

______

For contributor use:

- [ ] ~Wrote tests~
- [ ] ~Updated CHANGELOG_PENDING.md~
- [ ] ~Linked to Github issue with discussion and accepted design OR link to spec that describes this work.~
- [ ] ~Updated relevant documentation (`docs/`) and code comments~
- [x] Re-reviewed `Files changed` in the Github PR explorer