### PR TITLE
blockstore: allow initial SaveBlock() at any height

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -187,8 +187,6 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 		ChainID: "block_test",
 		Time:    tmtime.Now(),
 	}
-	header2 := header1
-	header2.Height = 4
 
 	// End of setup, test data
 
@@ -218,9 +216,12 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 		},
 
 		{
-			block:     newBlock(header2, commitAtH10),
-			parts:     uncontiguousPartSet,
-			wantPanic: "only save contiguous blocks", // and incomplete and uncontiguous parts
+			block: newBlock( // New block at height 5 in empty block store is fine
+				types.Header{Height: 5, ChainID: "block_test", Time: tmtime.Now()},
+				makeTestCommit(5, tmtime.Now()),
+			),
+			parts:      validPartSet,
+			seenCommit: makeTestCommit(5, tmtime.Now()),
 		},
 
 		{


### PR DESCRIPTION
Followup from #4588. Allow the first `SaveBlock()` call in an empty block store to be at any height, to start from a truncated block history. Subsequent `SaveBlock()` calls must be for contiguous blocks.

______

For contributor use:

- [x] Wrote tests
- [ ] ~Updated CHANGELOG_PENDING.md~
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments
- [x] Re-reviewed `Files changed` in the Github PR explorer
