### PR TITLE
lite2/rpc: verify block results and validators

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -42,6 +42,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [tools] \#4615 Allow developers to use Docker to generate proto stubs, via `make proto-gen-docker`.
 - [p2p] \#4621(https://github.com/tendermint/tendermint/pull/4621) ban peers when messages are unsolicited or too frequent (@cmwaters)
 - [evidence] [\#4632](https://github.com/tendermint/tendermint/pull/4632) Inbound evidence checked if already existing (@cmwaters)
+- [rpc] [\#4703](https://github.com/tendermint/tendermint/pull/4703) Add `count` and `total` to `/validators` response (@melekes)
 
 ### BUG FIXES:
 

--- a/lite2/rpc/client.go
+++ b/lite2/rpc/client.go
@@ -403,7 +403,10 @@ func (c *Client) UnsubscribeAll(ctx context.Context, subscriber string) error {
 
 func (c *Client) updateLiteClientIfNeededTo(height int64) (*types.SignedHeader, error) {
 	h, err := c.lc.VerifyHeaderAtHeight(height, time.Now())
-	return h, fmt.Errorf("failed to update light client to %d: %w", height, err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update light client to %d: %w", height, err)
+	}
+	return h, nil
 }
 
 func (c *Client) RegisterOpDecoder(typ string, dec merkle.OpDecoder) {

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -176,6 +176,8 @@ func TestGenesisAndValidators(t *testing.T) {
 		vals, err := c.Validators(nil, 0, 0)
 		require.Nil(t, err, "%d: %+v", i, err)
 		require.Equal(t, 1, len(vals.Validators))
+		require.Equal(t, 1, vals.Count)
+		require.Equal(t, 1, vals.Total)
 		val := vals.Validators[0]
 
 		// make sure the current set is also the genesis set

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -10,9 +10,11 @@ import (
 )
 
 // Validators gets the validator set at the given block height.
-// If no height is provided, it will fetch the current validator set.
-// Note the validators are sorted by their address - this is the canonical
-// order for the validators in the set as used in computing their Merkle root.
+//
+// If no height is provided, it will fetch the current validator set. Note the
+// validators are sorted by their address - this is the canonical order for the
+// validators in the set as used in computing their Merkle root.
+//
 // More: https://docs.tendermint.com/master/rpc/#/Info/validators
 func Validators(ctx *rpctypes.Context, heightPtr *int64, page, perPage int) (*ctypes.ResultValidators, error) {
 	// The latest validator that we know is the
@@ -43,7 +45,7 @@ func Validators(ctx *rpctypes.Context, heightPtr *int64, page, perPage int) (*ct
 		BlockHeight: height,
 		Validators:  v,
 		Count:       len(v),
-		Total:       len(validators)}, nil
+		Total:       totalCount}, nil
 }
 
 // DumpConsensusState dumps consensus state.

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -41,7 +41,9 @@ func Validators(ctx *rpctypes.Context, heightPtr *int64, page, perPage int) (*ct
 
 	return &ctypes.ResultValidators{
 		BlockHeight: height,
-		Validators:  v}, nil
+		Validators:  v,
+		Count:       len(v),
+		Total:       len(validators)}, nil
 }
 
 // DumpConsensusState dumps consensus state.

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -126,6 +126,8 @@ type Peer struct {
 type ResultValidators struct {
 	BlockHeight int64              `json:"block_height"`
 	Validators  []*types.Validator `json:"validators"`
+	Count       int                `json:"count"`
+	Total       int                `json:"total"`
 }
 
 // ConsensusParams for given height

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -122,12 +122,14 @@ type Peer struct {
 	RemoteIP         string               `json:"remote_ip"`
 }
 
-// Validators for a height
+// Validators for a height.
 type ResultValidators struct {
 	BlockHeight int64              `json:"block_height"`
 	Validators  []*types.Validator `json:"validators"`
-	Count       int                `json:"count"`
-	Total       int                `json:"total"`
+	// Count of actual validators in this result
+	Count int `json:"count"`
+	// Total number of validators
+	Total int `json:"total"`
 }
 
 // ConsensusParams for given height

--- a/rpc/swagger/swagger.yaml
+++ b/rpc/swagger/swagger.yaml
@@ -1922,6 +1922,12 @@ components:
                   proposer_priority:
                     type: "string"
                     example: "13769415"
+            count:
+              type: "number"
+              example: 1
+            total:
+              type: "number"
+              example: 25
           type: "object"
     GenesisResponse:
       type: object


### PR DESCRIPTION
Closes: #4695

## Description

Verify `/block_results` and `/validators` responses from an HTTP client using the light client.

Added `count` and `total` to `/validators` response.

Refs #3113
______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [x] Re-reviewed `Files changed` in the Github PR explorer
