### PR TITLE
.github: move checklist from PR description into an auto-comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,7 @@
 ## Description
 
-<!-- Add a description of the changes that this PR introduces and the files that
-are the most critical to review.
--->
+_Please add a description of the changes that this PR introduces and the files that
+are the most critical to review._ 
 
 Closes: #XXX
 
----
-
-For contributor use:
-
-- [ ] Wrote tests
-- [ ] Updated CHANGELOG_PENDING.md
-- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
-- [ ] Updated relevant documentation (`docs/`) and code comments
-- [ ] Re-reviewed `Files changed` in the Github PR explorer
-- [ ] Applied Appropriate Labels

--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -1,0 +1,15 @@
+pullRequestOpened: >
+  :wave: Thanks for creating a PR! 
+
+  Before we can merge this PR, please make sure that all the following items have been 
+  checked off. If any of the checklist items are not applicable, please leave them but
+  write a little note why. 
+
+  - [ ] Wrote tests
+  - [ ] Updated CHANGELOG_PENDING.md
+  - [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
+  - [ ] Updated relevant documentation (`docs/`) and code comments
+  - [ ] Re-reviewed `Files changed` in the Github PR explorer
+  - [ ] Applied Appropriate Labels
+
+  Thank you for your contribution to Tendermint! :rocket: 


### PR DESCRIPTION
The checklist and message in the default PR description were sometimes getting
included in commit messages. This change moves that text from the PR description
to a comment from a [Probot tool](https://probot.github.io/apps/auto-comment/).