### PR TITLE
.github: fix whitespace for auto-comment

### DIFF
--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -1,15 +1,16 @@
 pullRequestOpened: >
-  :wave: Thanks for creating a PR! 
+  :wave: Thanks for creating a PR!   
 
   Before we can merge this PR, please make sure that all the following items have been 
   checked off. If any of the checklist items are not applicable, please leave them but
-  write a little note why. 
+  write a little note why.   
 
-  - [ ] Wrote tests
-  - [ ] Updated CHANGELOG_PENDING.md
-  - [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
-  - [ ] Updated relevant documentation (`docs/`) and code comments
-  - [ ] Re-reviewed `Files changed` in the Github PR explorer
-  - [ ] Applied Appropriate Labels
+  - [ ] Wrote tests  
+  - [ ] Updated CHANGELOG_PENDING.md   
+  - [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.  
+  - [ ] Updated relevant documentation (`docs/`) and code comments  
+  - [ ] Re-reviewed `Files changed` in the Github PR explorer  
+  - [ ] Applied Appropriate Labels  
 
-  Thank you for your contribution to Tendermint! :rocket: 
+
+  Thank you for your contribution to Tendermint! :rocket:   


### PR DESCRIPTION

![Screenshot from 2020-04-27 14-41-49](https://user-images.githubusercontent.com/773524/80373916-1e1e5e00-8896-11ea-89ed-0b45992ac5a5.png)

Whoops.

This change should fix that.

