### PR TITLE
.github: fix whitespace for auto-comment

### DIFF
--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -1,17 +1,16 @@
-pullRequestOpened: >
-  :wave: Thanks for creating a PR! <br />
+pullRequestOpened: |
+  :wave: Thanks for creating a PR!   
 
   Before we can merge this PR, please make sure that all the following items have been 
   checked off. If any of the checklist items are not applicable, please leave them but
   write a little note why.   
 
-  - [ ] Wrote tests <br /> 
-  - [ ] Updated CHANGELOG_PENDING.md <br />  
-  - [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work <br />
-  - [ ] Updated relevant documentation (`docs/`) and code comments <br />
-  - [ ] Re-reviewed `Files changed` in the Github PR explorer <br />
-  - [ ] Applied Appropriate Labels  <br />
+  - [ ] Wrote tests  
+  - [ ] Updated CHANGELOG_PENDING.md   
+  - [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.  
+  - [ ] Updated relevant documentation (`docs/`) and code comments  
+  - [ ] Re-reviewed `Files changed` in the Github PR explorer  
+  - [ ] Applied Appropriate Labels  
 
-  <br />
 
   Thank you for your contribution to Tendermint! :rocket:   

--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -1,16 +1,17 @@
 pullRequestOpened: >
-  :wave: Thanks for creating a PR!   
+  :wave: Thanks for creating a PR! <br />
 
   Before we can merge this PR, please make sure that all the following items have been 
   checked off. If any of the checklist items are not applicable, please leave them but
   write a little note why.   
 
-  - [ ] Wrote tests  
-  - [ ] Updated CHANGELOG_PENDING.md   
-  - [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.  
-  - [ ] Updated relevant documentation (`docs/`) and code comments  
-  - [ ] Re-reviewed `Files changed` in the Github PR explorer  
-  - [ ] Applied Appropriate Labels  
+  - [ ] Wrote tests <br /> 
+  - [ ] Updated CHANGELOG_PENDING.md <br />  
+  - [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work <br />
+  - [ ] Updated relevant documentation (`docs/`) and code comments <br />
+  - [ ] Re-reviewed `Files changed` in the Github PR explorer <br />
+  - [ ] Applied Appropriate Labels  <br />
 
+  <br />
 
   Thank you for your contribution to Tendermint! :rocket:   


### PR DESCRIPTION
Looks like the whitespace is still broken in auto-comment. I wish there was a way to test this without merging to master, but here we are. 
