### PR TITLE
state: export InitStateVersion

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -41,7 +41,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
   - nostrip: don't strip debugging symbols nor DWARF tables.
   - cleveldb: use cleveldb as db backend instead of goleveldb.
   - race: pass -race to go build and enable data race detection.
-- [state] Export `InitStateVersion` for the initial state version (@erikgrinaker)
+- [state] [\#4781](https://github.com/tendermint/tendermint/pull/4781) Export `InitStateVersion` for the initial state version (@erikgrinaker)
 
 ### BUG FIXES:
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -41,6 +41,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
   - nostrip: don't strip debugging symbols nor DWARF tables.
   - cleveldb: use cleveldb as db backend instead of goleveldb.
   - race: pass -race to go build and enable data race detection.
+- [state] Export `InitStateVersion` for the initial state version (@erikgrinaker)
 
 ### BUG FIXES:
 

--- a/state/state.go
+++ b/state/state.go
@@ -27,11 +27,11 @@ type Version struct {
 	Software  string
 }
 
-// initStateVersion sets the Consensus.Block and Software versions,
+// InitStateVersion sets the Consensus.Block and Software versions,
 // but leaves the Consensus.App version blank.
 // The Consensus.App version will be set during the Handshake, once
 // we hear from the app what protocol version it is running.
-var initStateVersion = Version{
+var InitStateVersion = Version{
 	Consensus: version.Consensus{
 		Block: version.BlockProtocol,
 		App:   0,
@@ -231,7 +231,7 @@ func MakeGenesisState(genDoc *types.GenesisDoc) (State, error) {
 	}
 
 	return State{
-		Version: initStateVersion,
+		Version: InitStateVersion,
 		ChainID: genDoc.ChainID,
 
 		LastBlockHeight: 0,


### PR DESCRIPTION
This is useful for custom state sync `StateProvider` implementations that need to build new states for bootstrapping the node. It will also be useful when implementing other mechanisms to bootstrap nodes, e.g. #4642 and #3713.