### PR TITLE
test: fix p2p test build breakage caused by Debian testing

### DIFF
--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,7 +1,4 @@
-FROM golang:1.13
-
-# Add testing deps for curl
-RUN echo 'deb http://httpredir.debian.org/debian testing main non-free contrib' >> /etc/apt/sources.list
+FROM golang:1.14
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \
@@ -28,11 +25,11 @@ RUN make install_abci
 RUN make install
 
 RUN tendermint testnet \
-        --config $REPO/test/docker/config-template.toml \
-        --node-dir-prefix="mach" \
-        --v=4 \
-        --populate-persistent-peers=false \
-        --o=$REPO/test/p2p/data
+  --config $REPO/test/docker/config-template.toml \
+  --node-dir-prefix="mach" \
+  --v=4 \
+  --populate-persistent-peers=false \
+  --o=$REPO/test/p2p/data
 
 # Now copy in the code
 # NOTE: this will overwrite whatever is in vendor/


### PR DESCRIPTION
Debian testing caused Docker image build failures:

```
The following packages have unmet dependencies:
 
 libc6-dev : Breaks: libgcc-8-dev (< 8.4.0-2~) but 8.3.0-6 is to be installed
 
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
```

It does not appear that we actually need testing, so removing it.