### PR TITLE
test: revert Go 1.13→1.14 bump

### DIFF
--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.13
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \


### PR DESCRIPTION
Since we support 1.13 and above, let's use that as a baseline for tests.