### PR TITLE
lite2: fix pivot height

### DIFF
--- a/lite2/client.go
+++ b/lite2/client.go
@@ -728,8 +728,8 @@ func (c *Client) bisection(
 		case ErrNewValSetCantBeTrusted:
 			// do add another header to the end of the cache
 			if depth == len(headerCache)-1 {
-				pivotHeight := (headerCache[depth].sh.Height + trustedHeader.
-					Height) * bisectionNumerator / bisectionDenominator
+				pivotHeight := trustedHeader.Height + (headerCache[depth].sh.Height-trustedHeader.
+					Height)*bisectionNumerator/bisectionDenominator
 				interimHeader, interimVals, err := c.fetchHeaderAndValsAtHeight(pivotHeight)
 				if err != nil {
 					return err


### PR DESCRIPTION
## Description

previously:
```
pivotHeight := (headerCache[depth].sh.Height + 
trustedHeader.Height) * bisectionNumerator / bisectionDenominator
```

This had the possibility of picking a height that exceeded the range the node is bisecting through

now:
```
pivotHeight := trustedHeader.Height + (headerCache[depth].sh.Height - 
trustedHeader.Height) * bisectionNumerator / bisectionDenominator
```

also added a test to make sure it catches an instance that would have previously returned an error

