### PR TITLE
consensus: increase ensureTimeout

### DIFF
--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -50,7 +50,7 @@ type cleanupFunc func()
 var (
 	config                *cfg.Config // NOTE: must be reset for each _test.go file
 	consensusReplayConfig *cfg.Config
-	ensureTimeout         = time.Millisecond * 100
+	ensureTimeout         = time.Millisecond * 200
 )
 
 func ensureDir(dir string, mode os.FileMode) {

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -45,13 +45,15 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 func TestMempoolProgressAfterCreateEmptyBlocksInterval(t *testing.T) {
 	config := ResetConfig("consensus_mempool_txs_available_test")
 	defer os.RemoveAll(config.RootDir)
+
 	config.Consensus.CreateEmptyBlocksInterval = ensureTimeout
 	state, privVals := randGenesisState(1, false, 10)
 	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
+
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
-	height, round := cs.Height, cs.Round
+
 	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
-	startTestRound(cs, height, round)
+	startTestRound(cs, cs.Height, cs.Round)
 
 	ensureNewEventOnChannel(newBlockCh)   // first block gets committed
 	ensureNoNewEventOnChannel(newBlockCh) // then we dont make a block ...


### PR DESCRIPTION
attempt to fix #4270, https://github.com/tendermint/tendermint/issues/3897

TestMempoolProgressAfterCreateEmptyBlocksInterval and other tests which
rely on ensureTimeout