### PR TITLE
evidence: remove header from phantom evidence

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -75,6 +75,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [p2p/conn] \#4795 Return err on `signChallenge()` instead of panic
 - [evidence] [\#4839](https://github.com/tendermint/tendermint/pull/4839) Reject duplicate evidence from being proposed (@cmwaters)
 - [rpc/core] [\#4844](https://github.com/tendermint/tendermint/pull/4844) Do not lock consensus state in `/validators`, `/consensus_params` and `/status` (@melekes)
+- [evidence] [\#4892](https://github.com/tendermint/tendermint/pull/4892) Remove redundant header from phantom validator evidence @cmwaters
 
 ### BUG FIXES:
 

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -136,8 +136,8 @@ func TestABCIEvidence(t *testing.T) {
 	pubKey, err := val.GetPubKey()
 	require.NoError(t, err)
 	ev := &DuplicateVoteEvidence{
-		VoteA: makeVote(t, val, chainID, 0, 10, 2, 1, blockID),
-		VoteB: makeVote(t, val, chainID, 0, 10, 2, 1, blockID2),
+		VoteA: makeVote(t, val, chainID, 0, 10, 2, 1, blockID, defaultVoteTime),
+		VoteB: makeVote(t, val, chainID, 0, 10, 2, 1, blockID2, defaultVoteTime),
 	}
 	abciEv := TM2PB.Evidence(
 		ev,


### PR DESCRIPTION
## Description

Removed header from phantom validator evidence as it is unnecesasry because each node will need to retrieve their own header at that height in order to verify that there actually was a phantom validator

Closes: #4867

