### PR TITLE
p2p/test: fix Switch test race condition

### DIFF
--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -320,6 +320,9 @@ func (sw *Switch) Peers() IPeerSet {
 // TODO: make record depending on reason.
 func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 	sw.Logger.Error("Stopping peer for error", "peer", peer, "err", reason)
+	if peer == nil {
+		return
+	}
 	sw.stopAndRemovePeer(peer, reason)
 
 	if peer.IsPersistent() {

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -706,11 +706,15 @@ func TestSwitchInitPeerIsNotCalledBeforeRemovePeer(t *testing.T) {
 	defer rp.Stop()
 	_, err = rp.Dial(sw.NetAddress())
 	require.NoError(t, err)
-	// wait till the switch adds rp to the peer set
-	time.Sleep(50 * time.Millisecond)
 
-	// stop peer asynchronously
-	go sw.StopPeerForError(sw.Peers().Get(rp.ID()), "test")
+	// wait till the switch adds rp to the peer set, then stop the peer asynchronously
+	for {
+		time.Sleep(20 * time.Millisecond)
+		if peer := sw.Peers().Get(rp.ID()); peer != nil {
+			go sw.StopPeerForError(peer, "test")
+			break
+		}
+	}
 
 	// simulate peer reconnecting to us
 	_, err = rp.Dial(sw.NetAddress())


### PR DESCRIPTION
Fixes the following race condition, and also the nil pointer dereferencing it triggered.

```
=== RUN   TestSwitchInitPeerIsNotCalledBeforeRemovePeer
I[2020-05-25|12:39:48.550] Starting P2P Switch service                  switch=1 impl="P2P Switch"
E[2020-05-25|12:39:48.841] Stopping peer for error                      switch=1 peer=null err=test
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x18c76d4]

goroutine 818 [running]:
github.com/tendermint/tendermint/p2p.(*MultiplexTransport).Cleanup(0xc0004378c0, 0x0, 0x0)
        /Users/erik/Projects/tendermint/tendermint/p2p/transport.go:334 +0x34
github.com/tendermint/tendermint/p2p.(*Switch).stopAndRemovePeer(0xc000437e60, 0x0, 0x0, 0x194b380, 0x1c4e1d0)
        /Users/erik/Projects/tendermint/tendermint/p2p/switch.go:350 +0x94
github.com/tendermint/tendermint/p2p.(*Switch).StopPeerForError(0xc000437e60, 0x0, 0x0, 0x194b380, 0x1c4e1d0)
        /Users/erik/Projects/tendermint/tendermint/p2p/switch.go:323 +0x1c2 
created by github.com/tendermint/tendermint/p2p.TestSwitchInitPeerIsNotCalledBeforeRemovePeer
        /Users/erik/Projects/tendermint/tendermint/p2p/switch_test.go:713 +0x789 
FAIL    github.com/tendermint/tendermint/p2p    5.740s 
```