### PR TITLE
mempool: allow ReapX and CheckTx functions to run in parallel

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - Go API
 
   - [privval] [\#4744](https://github.com/tendermint/tendermint/pull/4744) Remove deprecated `OldFilePV` (@melekes)
+  - [mempool] [\#4759](https://github.com/tendermint/tendermint/pull/4759) Modify `Mempool#InitWAL` to return an error (@melekes)
 
 - Blockchain Protocol
 
@@ -32,6 +33,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
   - nostrip: don't strip debugging symbols nor DWARF tables.
   - cleveldb: use cleveldb as db backend instead of goleveldb.
   - race: pass -race to go build and enable data race detection.
+- [mempool] [\#4759](https://github.com/tendermint/tendermint/pull/4759) Allow ReapX and CheckTx functions to run in parallel (@melekes)
 
 ### BUG FIXES:
 

--- a/libs/os/os.go
+++ b/libs/os/os.go
@@ -46,7 +46,7 @@ func EnsureDir(dir string, mode os.FileMode) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		err := os.MkdirAll(dir, mode)
 		if err != nil {
-			return fmt.Errorf("could not create directory %v. %v", dir, err)
+			return fmt.Errorf("could not create directory %v: %w", dir, err)
 		}
 	}
 	return nil

--- a/mempool/doc.go
+++ b/mempool/doc.go
@@ -6,19 +6,18 @@
 // safely by calling .NextWait() on each element.
 
 // So we have several go-routines:
-// 1. Consensus calling Update() and Reap() synchronously
+// 1. Consensus calling Update() and ReapMaxBytesMaxGas() synchronously
 // 2. Many mempool reactor's peer routines calling CheckTx()
 // 3. Many mempool reactor's peer routines traversing the txs linked list
-// 4. Another goroutine calling GarbageCollectTxs() periodically
 
 // To manage these goroutines, there are three methods of locking.
 // 1. Mutations to the linked-list is protected by an internal mtx (CList is goroutine-safe)
 // 2. Mutations to the linked-list elements are atomic
-// 3. CheckTx() calls can be paused upon Update() and Reap(), protected by .proxyMtx
+// 3. CheckTx() and/or ReapMaxBytesMaxGas() calls can be paused upon Update(), protected by .updateMtx
 
-// Garbage collection of old elements from mempool.txs is handlde via
-// the DetachPrev() call, which makes old elements not reachable by
-// peer broadcastTxRoutine() automatically garbage collected.
+// Garbage collection of old elements from mempool.txs is handlde via the
+// DetachPrev() call, which makes old elements not reachable by peer
+// broadcastTxRoutine().
 
 // TODO: Better handle abci client errors. (make it automatically handle connection errors)
 package mempool

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -37,7 +37,7 @@ type Mempool interface {
 
 	// Update informs the mempool that the given txs were committed and can be discarded.
 	// NOTE: this should be called *after* block is committed by consensus.
-	// NOTE: unsafe; Lock/Unlock must be managed by caller
+	// NOTE: Lock/Unlock must be managed by caller
 	Update(
 		blockHeight int64,
 		blockTxs types.Txs,
@@ -48,6 +48,7 @@ type Mempool interface {
 
 	// FlushAppConn flushes the mempool connection to ensure async reqResCb calls are
 	// done. E.g. from CheckTx.
+	// NOTE: Lock/Unlock must be managed by caller
 	FlushAppConn() error
 
 	// Flush removes all transactions from the mempool and cache
@@ -68,8 +69,9 @@ type Mempool interface {
 	// TxsBytes returns the total size of all txs in the mempool.
 	TxsBytes() int64
 
-	// InitWAL creates a directory for the WAL file and opens a file itself.
-	InitWAL()
+	// InitWAL creates a directory for the WAL file and opens a file itself. If
+	// there is an error, it will be of type *PathError.
+	InitWAL() error
 
 	// CloseWAL closes and discards the underlying WAL file.
 	// Any further writes will not be relayed to disk.

--- a/mock/mempool.go
+++ b/mock/mempool.go
@@ -38,5 +38,5 @@ func (Mempool) TxsBytes() int64               { return 0 }
 func (Mempool) TxsFront() *clist.CElement    { return nil }
 func (Mempool) TxsWaitChan() <-chan struct{} { return nil }
 
-func (Mempool) InitWAL()  {}
-func (Mempool) CloseWAL() {}
+func (Mempool) InitWAL() error { return nil }
+func (Mempool) CloseWAL()      {}

--- a/node/node.go
+++ b/node/node.go
@@ -773,7 +773,10 @@ func (n *Node) OnStart() error {
 	n.isListening = true
 
 	if n.config.Mempool.WalEnabled() {
-		n.mempool.InitWAL() // no need to have the mempool wal during tests
+		err = n.mempool.InitWAL()
+		if err != nil {
+			return fmt.Errorf("init mempool WAL: %w", err)
+		}
 	}
 
 	// Start the switch (the P2P server).


### PR DESCRIPTION
allow ReapX and CheckTx functions to run in parallel, making it not possible to block certain proposers from creating a new block.

Closes: #2972
