### PR TITLE
consensus: bring back log.Error statement

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -734,11 +734,9 @@ func (cs *State) handleMsg(mi msgInfo) {
 		return
 	}
 
-	if err != nil { // nolint:staticcheck
-		// Causes TestReactorValidatorSetChanges to timeout
-		// https://github.com/tendermint/tendermint/issues/3406
-		// cs.Logger.Error("Error with msg", "height", cs.Height, "round", cs.Round,
-		// 	"peer", peerID, "err", err, "msg", msg)
+	if err != nil {
+		cs.Logger.Error("Error with msg", "height", cs.Height, "round", cs.Round,
+			"peer", peerID, "err", err, "msg", msg)
 	}
 }
 


### PR DESCRIPTION
Refs #3406

cs.Logger is protected by a global mutex, so it cannot be a reason for
the halt in #3401.