### PR TITLE
types/test: remove slow test cases in TestValSetUpdatePriorityOrderTests

### DIFF
--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -1212,10 +1212,6 @@ func TestValSetUpdatePriorityOrderTests(t *testing.T) {
 		6: randTestVSetCfg(t, 100, 1000),
 
 		7: randTestVSetCfg(t, 1000, 1000),
-
-		8: randTestVSetCfg(t, 10000, 1000),
-
-		9: randTestVSetCfg(t, 1000, 10000),
 	}
 
 	for _, cfg := range testCases {


### PR DESCRIPTION
These test cases are extremely slow when running with the race detector, often taking more that 2 minutes on my local machine. I can easily see them timing out on the much slower CI machines, causing these failures:

```
panic: test timed out after 5m0s

goroutine 234 [running]:
testing.(*M).startAlarm.func1()
	/usr/local/go/src/testing/testing.go:1460 +0x11c
created by time.goFunc
	/usr/local/go/src/time/sleep.go:168 +0x52

goroutine 1 [chan receive, 4 minutes]:
testing.(*T).Run(0xc000172c60, 0x107a5a2, 0x22, 0x11bfc68, 0x1)
	/usr/local/go/src/testing/testing.go:1044 +0x699
testing.runTests.func1(0xc000172c60)
	/usr/local/go/src/testing/testing.go:1285 +0xa7
testing.tRunner(0xc000172c60, 0xc00012bcc8)
	/usr/local/go/src/testing/testing.go:992 +0x1ec
testing.runTests(0xc00000e2c0, 0x1901500, 0x72, 0x72, 0x0)
	/usr/local/go/src/testing/testing.go:1283 +0x528
testing.(*M).Run(0xc000214380, 0x0)
	/usr/local/go/src/testing/testing.go:1200 +0x300
github.com/tendermint/tendermint/types.TestMain(0xc000214380)
	/go/src/github.com/tendermint/tendermint/types/block_test.go:30 +0x59
main.main()
	_testmain.go:380 +0x334

goroutine 255 [runnable]:
bytes.Equal(...)
	/usr/local/go/src/bytes/bytes.go:20
github.com/tendermint/tendermint/types.(*ValidatorSet).GetByAddress(0xc005499020, 0xc006056650, 0x5, 0x8, 0x13af, 0xc005514100)
	/go/src/github.com/tendermint/tendermint/types/validator_set.go:253 +0xfd
github.com/tendermint/tendermint/types.verifyUpdates.func1(0xc00614b940, 0xc005499020, 0x47cd)
	/go/src/github.com/tendermint/tendermint/types/validator_set.go:415 +0x84
github.com/tendermint/tendermint/types.verifyUpdates(0xc006110000, 0x11b7, 0x1780, 0xc005499020, 0xb52ff, 0x0, 0x0, 0x5c9)
	/go/src/github.com/tendermint/tendermint/types/validator_set.go:429 +0x220
github.com/tendermint/tendermint/types.(*ValidatorSet).updateWithChangeSet(0xc005499020, 0xc00602c000, 0x1780, 0x1780, 0xc006098201, 0xc00608d4b8, 0xc006037bf8)
	/go/src/github.com/tendermint/tendermint/types/validator_set.go:600 +0x2f3
github.com/tendermint/tendermint/types.(*ValidatorSet).UpdateWithChangeSet(0xc005499020, 0xc00602c000, 0x1780, 0x1780, 0x1780, 0x1780)
	/go/src/github.com/tendermint/tendermint/types/validator_set.go:636 +0x78
github.com/tendermint/tendermint/types.applyChangesToValSet(0xc0005c8ea0, 0x0, 0x0, 0xc005499020, 0xc0005d1160, 0x3, 0x3)
	/go/src/github.com/tendermint/tendermint/types/validator_set_test.go:1169 +0x1bb
github.com/tendermint/tendermint/types.verifyValSetUpdatePriorityOrder(0xc0005c8ea0, 0xc005499020, 0x0, 0x0, 0xc005600000, 0x2710, 0x2710, 0xc0055c8000, 0x5c9, 0x5c9, ...)
	/go/src/github.com/tendermint/tendermint/types/validator_set_test.go:1239 +0x217
github.com/tendermint/tendermint/types.TestValSetUpdatePriorityOrderTests(0xc0005c8ea0)
	/go/src/github.com/tendermint/tendermint/types/validator_set_test.go:1228 +0x1205
testing.tRunner(0xc0005c8ea0, 0x11bfc68)
	/usr/local/go/src/testing/testing.go:992 +0x1ec
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1043 +0x661
FAIL	github.com/tendermint/tendermint/types	300.677s
FAIL
```