### PR TITLE
rpc/test: wait for subscription in TestTxEventsSentWithBroadcastTxAsync

### DIFF
--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -98,6 +98,9 @@ func testTxEventsSent(t *testing.T, broadcastMethod string) {
 				defer c.Stop()
 			}
 
+			// wait for the client subscription to get set up
+			time.Sleep(100 * time.Millisecond)
+
 			// make the tx
 			_, _, tx := MakeTxKV()
 			evtTyp := types.EventTx


### PR DESCRIPTION
Mitigates race condition causing these test failures:

```
=== RUN   TestTxEventsSentWithBroadcastTxAsync
=== RUN   TestTxEventsSentWithBroadcastTxAsync/*http.HTTP
I[2020-05-25|12:29:08.477] Starting WSEvents service                    impl=WSEvents
    TestTxEventsSentWithBroadcastTxAsync/*http.HTTP: event_test.go:124: 
        	Error Trace:	event_test.go:124
        	Error:      	Expected nil, but got: &errors.errorString{s:"timed out waiting for event"}
        	Test:       	TestTxEventsSentWithBroadcastTxAsync/*http.HTTP
        	Messages:   	0: timed out waiting for event
```