### PR TITLE
ci: add timeouts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,7 @@ jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v2
       - uses: technote-space/get-diff-action@v1

--- a/.github/workflows/net.yml
+++ b/.github/workflows/net.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   net-short:
     runs-on: ubuntu-latest
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v2
       - name: 10 Blocks

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -8,12 +8,14 @@ on:
 jobs:
   proto-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@master
       - name: lint
         run: make proto-lint
   proto-breakage:
     runs-on: ubuntu-latest
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@master
       - name: check-breakage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v2
       - uses: technote-space/get-diff-action@v1
@@ -47,6 +48,7 @@ jobs:
   test_abci_apps:
     runs-on: ubuntu-latest
     needs: Build
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v2
       - uses: technote-space/get-diff-action@v1
@@ -73,6 +75,7 @@ jobs:
   test_abci_cli:
     runs-on: ubuntu-latest
     needs: Build
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v2
       - uses: technote-space/get-diff-action@v1
@@ -98,6 +101,7 @@ jobs:
   test_apps:
     runs-on: ubuntu-latest
     needs: Build
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v2
       - uses: technote-space/get-diff-action@v1


### PR DESCRIPTION
## Description

Add Timeouts to Github action jobs. The goal of adding timeouts is so if a job is hanging on something it gets killed and the author will get notified. 

I picked these times based on previous circle and Github action times then doubled & in some places tripled the times. 

Closes: #XXX

