### PR TITLE
test: split unit and integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
             mkdir -p /tmp/logs /tmp/workspace/profiles
             for pkg in $(go list github.com/tendermint/tendermint/... | circleci tests split --split-by=timings); do
               id=$(basename "$pkg")
-              go test -timeout 7m -mod=readonly -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
+              go test -timeout 7m -mod=readonly -tags unit,integration -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
             done
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,11 @@ linters:
   disable:
     - errcheck
 
+run:
+  build-tags:
+  - unit
+  - integration
+
 issues:
   exclude-rules:
     - linters:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,7 +240,7 @@ Each PR should have one commit once it lands on `master`; this can be accomplish
 #### Major Release
 
 1. start on `master`
-2. run integration tests (see `test_integrations` in Makefile)
+2. run integration tests (see `test_all` in Makefile)
 3. prepare release in a pull request against `master` (to be squash merged):
    - copy `CHANGELOG_PENDING.md` to top of `CHANGELOG.md`
    - run `python ./scripts/linkify_changelog.py CHANGELOG.md` to add links for
@@ -258,7 +258,7 @@ Each PR should have one commit once it lands on `master`; this can be accomplish
 Minor releases are done differently from major releases: They are built off of long-lived release candidate branches, rather than from master. 
 
 1. Checkout the long-lived release candidate branch: `git checkout rcX/vX.X.X` 
-2. Run integration tests: `make test_integrations` 
+2. Run integration tests: `make test_all` 
 3. Prepare the release:
 	- Copy `CHANGELOG_PENDING.md` to top of `CHANGELOG.md`
 	- Run `python ./scripts/linkify_changelog.py CHANGELOG.md` to add links for all issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,7 +240,7 @@ Each PR should have one commit once it lands on `master`; this can be accomplish
 #### Major Release
 
 1. start on `master`
-2. run integration tests (see `test_all` in Makefile)
+2. run end-to-end tests and other tests (see `test_all` in Makefile)
 3. prepare release in a pull request against `master` (to be squash merged):
    - copy `CHANGELOG_PENDING.md` to top of `CHANGELOG.md`
    - run `python ./scripts/linkify_changelog.py CHANGELOG.md` to add links for
@@ -258,7 +258,7 @@ Each PR should have one commit once it lands on `master`; this can be accomplish
 Minor releases are done differently from major releases: They are built off of long-lived release candidate branches, rather than from master. 
 
 1. Checkout the long-lived release candidate branch: `git checkout rcX/vX.X.X` 
-2. Run integration tests: `make test_all` 
+2. Run end-to-end tests and other tests: `make test_all` 
 3. Prepare the release:
 	- Copy `CHANGELOG_PENDING.md` to top of `CHANGELOG.md`
 	- Run `python ./scripts/linkify_changelog.py CHANGELOG.md` to add links for all issues

--- a/abci/client/socket_client_test.go
+++ b/abci/client/socket_client_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package abcicli_test
 
 import (

--- a/abci/example/example_test.go
+++ b/abci/example/example_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package example
 
 import (

--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package kvstore
 
 import (

--- a/abci/tests/client_server_test.go
+++ b/abci/tests/client_server_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package tests
 
 import (

--- a/abci/types/messages_test.go
+++ b/abci/types/messages_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/behaviour/reporter_test.go
+++ b/behaviour/reporter_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package behaviour_test
 
 import (

--- a/blockchain/v0/pool_test.go
+++ b/blockchain/v0/pool_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package v0
 
 import (

--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package v0
 
 import (

--- a/blockchain/v1/peer_test.go
+++ b/blockchain/v1/peer_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package v1
 
 import (

--- a/blockchain/v1/pool_test.go
+++ b/blockchain/v1/pool_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package v1
 
 import (

--- a/blockchain/v1/reactor_fsm_test.go
+++ b/blockchain/v1/reactor_fsm_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package v1
 
 import (

--- a/blockchain/v1/reactor_test.go
+++ b/blockchain/v1/reactor_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package v1
 
 import (

--- a/blockchain/v2/processor_test.go
+++ b/blockchain/v2/processor_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package v2
 
 import (

--- a/blockchain/v2/reactor_test.go
+++ b/blockchain/v2/reactor_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package v2
 
 import (

--- a/blockchain/v2/routine_test.go
+++ b/blockchain/v2/routine_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package v2
 
 import (

--- a/blockchain/v2/scheduler_test.go
+++ b/blockchain/v2/scheduler_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package v2
 
 import (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package config
 
 import (

--- a/config/toml_test.go
+++ b/config/toml_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package config
 
 import (

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package consensus
 
 import (

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -80,6 +80,10 @@ func ensureDir(dir string, mode os.FileMode) {
 	}
 }
 
+func assertMempool(txn txNotifier) mempl.Mempool {
+	return txn.(mempl.Mempool)
+}
+
 //-------------------------------------------------------------------------------
 // validator stub (a kvstore consensus peer we control)
 

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -1,3 +1,5 @@
+// +build unit integration
+
 package consensus
 
 import (

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package consensus
 
 import (

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -20,11 +20,6 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-// for testing
-func assertMempool(txn txNotifier) mempl.Mempool {
-	return txn.(mempl.Mempool)
-}
-
 func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 	config := ResetConfig("consensus_mempool_txs_available_test")
 	defer os.RemoveAll(config.RootDir)

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package consensus
 
 import (

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package consensus
 
 import (

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -35,21 +35,6 @@ import (
 	"github.com/tendermint/tendermint/version"
 )
 
-func TestMain(m *testing.M) {
-	config = ResetConfig("consensus_reactor_test")
-	consensusReplayConfig = ResetConfig("consensus_replay_test")
-	configStateTest := ResetConfig("consensus_state_test")
-	configMempoolTest := ResetConfig("consensus_mempool_test")
-	configByzantineTest := ResetConfig("consensus_byzantine_test")
-	code := m.Run()
-	os.RemoveAll(config.RootDir)
-	os.RemoveAll(consensusReplayConfig.RootDir)
-	os.RemoveAll(configStateTest.RootDir)
-	os.RemoveAll(configMempoolTest.RootDir)
-	os.RemoveAll(configByzantineTest.RootDir)
-	os.Exit(code)
-}
-
 // These tests ensure we can always recover from failure at any part of the consensus process.
 // There are two general failure scenarios: failure during consensus, and failure while applying the block.
 // Only the latter interacts with the app and store,
@@ -618,21 +603,6 @@ func TestMockProxyApp(t *testing.T) {
 	})
 	assert.True(t, validTxs == 1)
 	assert.True(t, invalidTxs == 0)
-}
-
-func tempWALWithData(data []byte) string {
-	walFile, err := ioutil.TempFile("", "wal")
-	if err != nil {
-		panic(fmt.Sprintf("failed to create temp WAL file: %v", err))
-	}
-	_, err = walFile.Write(data)
-	if err != nil {
-		panic(fmt.Sprintf("failed to write to temp WAL file: %v", err))
-	}
-	if err := walFile.Close(); err != nil {
-		panic(fmt.Sprintf("failed to close temp WAL file: %v", err))
-	}
-	return walFile.Name()
 }
 
 // Make some blocks. Start a fresh app and apply nBlocks blocks.

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package consensus
 
 import (

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -4,7 +4,6 @@ package consensus
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -15,7 +14,6 @@ import (
 	"github.com/tendermint/tendermint/abci/example/counter"
 	cstypes "github.com/tendermint/tendermint/consensus/types"
 	"github.com/tendermint/tendermint/libs/log"
-	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	p2pmock "github.com/tendermint/tendermint/p2p/mock"
 	"github.com/tendermint/tendermint/types"
@@ -1798,22 +1796,4 @@ func TestStateOutputVoteStats(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 
-}
-
-// subscribe subscribes test client to the given query and returns a channel with cap = 1.
-func subscribe(eventBus *types.EventBus, q tmpubsub.Query) <-chan tmpubsub.Message {
-	sub, err := eventBus.Subscribe(context.Background(), testSubscriber, q)
-	if err != nil {
-		panic(fmt.Sprintf("failed to subscribe %s to %v", testSubscriber, q))
-	}
-	return sub.Out()
-}
-
-// subscribe subscribes test client to the given query and returns a channel with cap = 0.
-func subscribeUnBuffered(eventBus *types.EventBus, q tmpubsub.Query) <-chan tmpubsub.Message {
-	sub, err := eventBus.SubscribeUnbuffered(context.Background(), testSubscriber, q)
-	if err != nil {
-		panic(fmt.Sprintf("failed to subscribe %s to %v", testSubscriber, q))
-	}
-	return sub.Out()
 }

--- a/consensus/types/height_vote_set_test.go
+++ b/consensus/types/height_vote_set_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/consensus/wal_test.go
+++ b/consensus/wal_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package consensus
 
 import (

--- a/crypto/armor/armor_test.go
+++ b/crypto/armor/armor_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package armor
 
 import (

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package ed25519_test
 
 import (

--- a/crypto/encoding/amino/encode_test.go
+++ b/crypto/encoding/amino/encode_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package cryptoamino
 
 import (

--- a/crypto/example_test.go
+++ b/crypto/example_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2017 Tendermint. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/crypto/merkle/proof_key_path_test.go
+++ b/crypto/merkle/proof_key_path_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package merkle
 
 import (

--- a/crypto/merkle/proof_test.go
+++ b/crypto/merkle/proof_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package merkle
 
 import (

--- a/crypto/merkle/rfc6962_test.go
+++ b/crypto/merkle/rfc6962_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package merkle
 
 // Copyright 2016 Google Inc. All Rights Reserved.

--- a/crypto/merkle/simple_proof_test.go
+++ b/crypto/merkle/simple_proof_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package merkle
 
 import (

--- a/crypto/merkle/simple_tree_test.go
+++ b/crypto/merkle/simple_tree_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package merkle
 
 import (

--- a/crypto/multisig/bitarray/compact_bit_array_test.go
+++ b/crypto/multisig/bitarray/compact_bit_array_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package bitarray
 
 import (

--- a/crypto/multisig/threshold_pubkey_test.go
+++ b/crypto/multisig/threshold_pubkey_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package multisig
 
 import (

--- a/crypto/random_test.go
+++ b/crypto/random_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package crypto_test
 
 import (

--- a/crypto/secp256k1/secp256k1_cgo_test.go
+++ b/crypto/secp256k1/secp256k1_cgo_test.go
@@ -1,4 +1,4 @@
-// +build libsecp256k1
+// +build libsecp256k1 unit
 
 package secp256k1
 

--- a/crypto/secp256k1/secp256k1_cgo_test.go
+++ b/crypto/secp256k1/secp256k1_cgo_test.go
@@ -1,4 +1,4 @@
-// +build libsecp256k1 unit
+// +build libsecp256k1,unit
 
 package secp256k1
 

--- a/crypto/secp256k1/secp256k1_internal_test.go
+++ b/crypto/secp256k1/secp256k1_internal_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package secp256k1
 
 import (

--- a/crypto/secp256k1/secp256k1_nocgo_test.go
+++ b/crypto/secp256k1/secp256k1_nocgo_test.go
@@ -1,4 +1,4 @@
-// +build !libsecp256k1
+// +build !libsecp256k1 unit
 
 package secp256k1
 

--- a/crypto/secp256k1/secp256k1_nocgo_test.go
+++ b/crypto/secp256k1/secp256k1_nocgo_test.go
@@ -1,4 +1,4 @@
-// +build !libsecp256k1 unit
+// +build !libsecp256k1,unit
 
 package secp256k1
 

--- a/crypto/secp256k1/secp256k1_test.go
+++ b/crypto/secp256k1/secp256k1_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package secp256k1_test
 
 import (

--- a/crypto/sr25519/sr25519_test.go
+++ b/crypto/sr25519/sr25519_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package sr25519_test
 
 import (

--- a/crypto/tmhash/hash_test.go
+++ b/crypto/tmhash/hash_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package tmhash_test
 
 import (

--- a/crypto/xchacha20poly1305/vector_test.go
+++ b/crypto/xchacha20poly1305/vector_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package xchacha20poly1305
 
 import (

--- a/crypto/xchacha20poly1305/xchachapoly_test.go
+++ b/crypto/xchacha20poly1305/xchachapoly_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package xchacha20poly1305
 
 import (

--- a/crypto/xsalsa20symmetric/symmetric_test.go
+++ b/crypto/xsalsa20symmetric/symmetric_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package xsalsa20symmetric
 
 import (

--- a/evidence/common_test.go
+++ b/evidence/common_test.go
@@ -1,0 +1,89 @@
+// +build unit integration
+
+package evidence
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	sm "github.com/tendermint/tendermint/state"
+	"github.com/tendermint/tendermint/store"
+	"github.com/tendermint/tendermint/types"
+	tmtime "github.com/tendermint/tendermint/types/time"
+	dbm "github.com/tendermint/tm-db"
+)
+
+func TestMain(m *testing.M) {
+	RegisterMockEvidences()
+
+	code := m.Run()
+	os.Exit(code)
+}
+
+// initializeBlockStore creates a block storage and populates it w/ a dummy
+// block at +height+.
+func initializeBlockStore(db dbm.DB, state sm.State, valAddr []byte) *store.BlockStore {
+	blockStore := store.NewBlockStore(db)
+
+	for i := int64(1); i <= state.LastBlockHeight; i++ {
+		lastCommit := makeCommit(i-1, valAddr)
+		block, _ := state.MakeBlock(i, []types.Tx{}, lastCommit, nil,
+			state.Validators.GetProposer().Address)
+
+		const parts = 1
+		partSet := block.MakePartSet(parts)
+
+		seenCommit := makeCommit(i, valAddr)
+		blockStore.SaveBlock(block, partSet, seenCommit)
+	}
+
+	return blockStore
+}
+
+func initializeValidatorState(valAddr []byte, height int64) dbm.DB {
+	stateDB := dbm.NewMemDB()
+
+	// create validator set and state
+	valSet := &types.ValidatorSet{
+		Validators: []*types.Validator{
+			{Address: valAddr, VotingPower: 0},
+		},
+	}
+	state := sm.State{
+		LastBlockHeight:             height,
+		LastBlockTime:               tmtime.Now(),
+		LastValidators:              valSet,
+		Validators:                  valSet,
+		NextValidators:              valSet.CopyIncrementProposerPriority(1),
+		LastHeightValidatorsChanged: 1,
+		ConsensusParams: types.ConsensusParams{
+			Block: types.BlockParams{
+				MaxBytes: 22020096,
+				MaxGas:   -1,
+			},
+			Evidence: types.EvidenceParams{
+				MaxAgeNumBlocks: 20,
+				MaxAgeDuration:  48 * time.Hour,
+			},
+		},
+	}
+
+	// save all states up to height
+	for i := int64(0); i <= height; i++ {
+		state.LastBlockHeight = i
+		sm.SaveState(stateDB, state)
+	}
+
+	return stateDB
+}
+
+func makeCommit(height int64, valAddr []byte) *types.Commit {
+	commitSigs := []types.CommitSig{{
+		BlockIDFlag:      types.BlockIDFlagCommit,
+		ValidatorAddress: valAddr,
+		Timestamp:        time.Now(),
+		Signature:        []byte("Signature"),
+	}}
+	return types.NewCommit(height, 0, types.BlockID{}, commitSigs)
+}

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -3,7 +3,6 @@
 package evidence
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -13,17 +12,8 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	sm "github.com/tendermint/tendermint/state"
-	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
-	tmtime "github.com/tendermint/tendermint/types/time"
 )
-
-func TestMain(m *testing.M) {
-	RegisterMockEvidences()
-
-	code := m.Run()
-	os.Exit(code)
-}
 
 func TestEvidencePool(t *testing.T) {
 	var (
@@ -278,71 +268,4 @@ func TestRecoverPendingEvidence(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, pool.evidenceList.Len())
 	assert.True(t, pool.IsPending(goodEvidence))
-}
-
-func initializeValidatorState(valAddr []byte, height int64) dbm.DB {
-	stateDB := dbm.NewMemDB()
-
-	// create validator set and state
-	valSet := &types.ValidatorSet{
-		Validators: []*types.Validator{
-			{Address: valAddr, VotingPower: 0},
-		},
-	}
-	state := sm.State{
-		LastBlockHeight:             height,
-		LastBlockTime:               tmtime.Now(),
-		LastValidators:              valSet,
-		Validators:                  valSet,
-		NextValidators:              valSet.CopyIncrementProposerPriority(1),
-		LastHeightValidatorsChanged: 1,
-		ConsensusParams: types.ConsensusParams{
-			Block: types.BlockParams{
-				MaxBytes: 22020096,
-				MaxGas:   -1,
-			},
-			Evidence: types.EvidenceParams{
-				MaxAgeNumBlocks: 20,
-				MaxAgeDuration:  48 * time.Hour,
-			},
-		},
-	}
-
-	// save all states up to height
-	for i := int64(0); i <= height; i++ {
-		state.LastBlockHeight = i
-		sm.SaveState(stateDB, state)
-	}
-
-	return stateDB
-}
-
-// initializeBlockStore creates a block storage and populates it w/ a dummy
-// block at +height+.
-func initializeBlockStore(db dbm.DB, state sm.State, valAddr []byte) *store.BlockStore {
-	blockStore := store.NewBlockStore(db)
-
-	for i := int64(1); i <= state.LastBlockHeight; i++ {
-		lastCommit := makeCommit(i-1, valAddr)
-		block, _ := state.MakeBlock(i, []types.Tx{}, lastCommit, nil,
-			state.Validators.GetProposer().Address)
-
-		const parts = 1
-		partSet := block.MakePartSet(parts)
-
-		seenCommit := makeCommit(i, valAddr)
-		blockStore.SaveBlock(block, partSet, seenCommit)
-	}
-
-	return blockStore
-}
-
-func makeCommit(height int64, valAddr []byte) *types.Commit {
-	commitSigs := []types.CommitSig{{
-		BlockIDFlag:      types.BlockIDFlagCommit,
-		ValidatorAddress: valAddr,
-		Timestamp:        time.Now(),
-		Signature:        []byte("Signature"),
-	}}
-	return types.NewCommit(height, 0, types.BlockID{}, commitSigs)
 }

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package evidence
 
 import (

--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package evidence
 
 import (

--- a/libs/async/async_test.go
+++ b/libs/async/async_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package async
 
 import (

--- a/libs/autofile/autofile_test.go
+++ b/libs/autofile/autofile_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package autofile
 
 import (

--- a/libs/autofile/group_test.go
+++ b/libs/autofile/group_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package autofile
 
 import (

--- a/libs/bits/bit_array_test.go
+++ b/libs/bits/bit_array_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package bits
 
 import (

--- a/libs/bytes/bytes_test.go
+++ b/libs/bytes/bytes_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package bytes
 
 import (

--- a/libs/cli/flags/log_level_test.go
+++ b/libs/cli/flags/log_level_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package flags_test
 
 import (

--- a/libs/cli/setup_test.go
+++ b/libs/cli/setup_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package cli
 
 import (

--- a/libs/clist/clist_test.go
+++ b/libs/clist/clist_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package clist
 
 import (

--- a/libs/cmap/cmap_test.go
+++ b/libs/cmap/cmap_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package cmap
 
 import (

--- a/libs/events/event_cache_test.go
+++ b/libs/events/event_cache_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package events
 
 import (

--- a/libs/events/events_test.go
+++ b/libs/events/events_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package events
 
 import (

--- a/libs/flowrate/io_test.go
+++ b/libs/flowrate/io_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 //
 // Written by Maxim Khitrov (November 2012)
 //

--- a/libs/log/filter_test.go
+++ b/libs/log/filter_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package log_test
 
 import (

--- a/libs/log/tm_logger_test.go
+++ b/libs/log/tm_logger_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package log_test
 
 import (

--- a/libs/log/tmfmt_logger_test.go
+++ b/libs/log/tmfmt_logger_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package log_test
 
 import (

--- a/libs/log/tracing_logger_test.go
+++ b/libs/log/tracing_logger_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package log_test
 
 import (

--- a/libs/net/net_test.go
+++ b/libs/net/net_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package net
 
 import (

--- a/libs/pubsub/example_test.go
+++ b/libs/pubsub/example_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package pubsub_test
 
 import (

--- a/libs/pubsub/pubsub_test.go
+++ b/libs/pubsub/pubsub_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package pubsub_test
 
 import (

--- a/libs/pubsub/pubsub_test.go
+++ b/libs/pubsub/pubsub_test.go
@@ -1,4 +1,4 @@
-// +build integration
+// +build unit
 
 package pubsub_test
 

--- a/libs/pubsub/query/empty_test.go
+++ b/libs/pubsub/query/empty_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package query_test
 
 import (

--- a/libs/pubsub/query/fuzz_test/main.go
+++ b/libs/pubsub/query/fuzz_test/main.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package fuzz_test
 
 import (

--- a/libs/pubsub/query/parser_test.go
+++ b/libs/pubsub/query/parser_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package query_test
 
 import (

--- a/libs/pubsub/query/query_test.go
+++ b/libs/pubsub/query/query_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package query_test
 
 import (

--- a/libs/rand/random_test.go
+++ b/libs/rand/random_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package rand
 
 import (

--- a/libs/service/service_test.go
+++ b/libs/service/service_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package service
 
 import (

--- a/libs/strings/string_test.go
+++ b/libs/strings/string_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package strings
 
 import (

--- a/libs/tempfile/tempfile_test.go
+++ b/libs/tempfile/tempfile_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package tempfile
 
 // Need access to internal variables, so can't use _test package

--- a/libs/test/mutate.go
+++ b/libs/test/mutate.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package test
 
 import (

--- a/libs/test/mutate.go
+++ b/libs/test/mutate.go
@@ -1,5 +1,3 @@
-// +build unit
-
 package test
 
 import (

--- a/libs/timer/throttle_timer_test.go
+++ b/libs/timer/throttle_timer_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package timer
 
 import (

--- a/lite/base_verifier_test.go
+++ b/lite/base_verifier_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package lite
 
 import (

--- a/lite/client/provider_test.go
+++ b/lite/client/provider_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package client
 
 import (

--- a/lite/dynamic_verifier_test.go
+++ b/lite/dynamic_verifier_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package lite
 
 import (

--- a/lite/provider_test.go
+++ b/lite/provider_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package lite
 
 import (

--- a/lite/proxy/query_test.go
+++ b/lite/proxy/query_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package proxy
 
 import (

--- a/lite/proxy/validate_test.go
+++ b/lite/proxy/validate_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package proxy_test
 
 import (

--- a/lite2/client_benchmark_test.go
+++ b/lite2/client_benchmark_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package lite_test
 
 import (

--- a/lite2/client_test.go
+++ b/lite2/client_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package lite_test
 
 import (

--- a/lite2/example_test.go
+++ b/lite2/example_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package lite_test
 
 import (

--- a/lite2/helpers_test.go
+++ b/lite2/helpers_test.go
@@ -1,3 +1,5 @@
+// +build unit integration
+
 package lite_test
 
 import (

--- a/lite2/provider/http/http_test.go
+++ b/lite2/provider/http/http_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package http_test
 
 import (

--- a/lite2/rpc/query_test.go
+++ b/lite2/rpc/query_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package rpc
 
 //import (

--- a/lite2/store/db/db_test.go
+++ b/lite2/store/db/db_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package db
 
 import (

--- a/lite2/verifier_test.go
+++ b/lite2/verifier_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package lite_test
 
 import (

--- a/mempool/cache_test.go
+++ b/mempool/cache_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package mempool
 
 import (

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -3,16 +3,13 @@
 package mempool
 
 import (
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
 	mrand "math/rand"
-	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,67 +27,6 @@ import (
 	"github.com/tendermint/tendermint/proxy"
 	"github.com/tendermint/tendermint/types"
 )
-
-// A cleanupFunc cleans up any config / test files created for a particular
-// test.
-type cleanupFunc func()
-
-func newMempoolWithApp(cc proxy.ClientCreator) (*CListMempool, cleanupFunc) {
-	return newMempoolWithAppAndConfig(cc, cfg.ResetTestRoot("mempool_test"))
-}
-
-func newMempoolWithAppAndConfig(cc proxy.ClientCreator, config *cfg.Config) (*CListMempool, cleanupFunc) {
-	appConnMem, _ := cc.NewABCIClient()
-	appConnMem.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "mempool"))
-	err := appConnMem.Start()
-	if err != nil {
-		panic(err)
-	}
-	mempool := NewCListMempool(config.Mempool, appConnMem, 0)
-	mempool.SetLogger(log.TestingLogger())
-	return mempool, func() { os.RemoveAll(config.RootDir) }
-}
-
-func ensureNoFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
-	timer := time.NewTimer(time.Duration(timeoutMS) * time.Millisecond)
-	select {
-	case <-ch:
-		t.Fatal("Expected not to fire")
-	case <-timer.C:
-	}
-}
-
-func ensureFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
-	timer := time.NewTimer(time.Duration(timeoutMS) * time.Millisecond)
-	select {
-	case <-ch:
-	case <-timer.C:
-		t.Fatal("Expected to fire")
-	}
-}
-
-func checkTxs(t *testing.T, mempool Mempool, count int, peerID uint16) types.Txs {
-	txs := make(types.Txs, count)
-	txInfo := TxInfo{SenderID: peerID}
-	for i := 0; i < count; i++ {
-		txBytes := make([]byte, 20)
-		txs[i] = txBytes
-		_, err := rand.Read(txBytes)
-		if err != nil {
-			t.Error(err)
-		}
-		if err := mempool.CheckTx(txBytes, nil, txInfo); err != nil {
-			// Skip invalid txs.
-			// TestMempoolFilters will fail otherwise. It asserts a number of txs
-			// returned.
-			if IsPreCheckError(err) {
-				continue
-			}
-			t.Fatalf("CheckTx failed: %v while checking #%d tx", err, i)
-		}
-	}
-	return txs
-}
 
 func TestReapMaxBytesMaxGas(t *testing.T) {
 	app := kvstore.NewApplication()

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package mempool
 
 import (

--- a/mempool/common_test.go
+++ b/mempool/common_test.go
@@ -1,0 +1,76 @@
+// +build unit integration
+
+package mempool
+
+import (
+	"crypto/rand"
+	"os"
+	"testing"
+	"time"
+
+	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/proxy"
+	"github.com/tendermint/tendermint/types"
+)
+
+// A cleanupFunc cleans up any config / test files created for a particular
+// test.
+type cleanupFunc func()
+
+func newMempoolWithApp(cc proxy.ClientCreator) (*CListMempool, cleanupFunc) {
+	return newMempoolWithAppAndConfig(cc, cfg.ResetTestRoot("mempool_test"))
+}
+
+func newMempoolWithAppAndConfig(cc proxy.ClientCreator, config *cfg.Config) (*CListMempool, cleanupFunc) {
+	appConnMem, _ := cc.NewABCIClient()
+	appConnMem.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "mempool"))
+	err := appConnMem.Start()
+	if err != nil {
+		panic(err)
+	}
+	mempool := NewCListMempool(config.Mempool, appConnMem, 0)
+	mempool.SetLogger(log.TestingLogger())
+	return mempool, func() { os.RemoveAll(config.RootDir) }
+}
+
+func ensureNoFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
+	timer := time.NewTimer(time.Duration(timeoutMS) * time.Millisecond)
+	select {
+	case <-ch:
+		t.Fatal("Expected not to fire")
+	case <-timer.C:
+	}
+}
+
+func ensureFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
+	timer := time.NewTimer(time.Duration(timeoutMS) * time.Millisecond)
+	select {
+	case <-ch:
+	case <-timer.C:
+		t.Fatal("Expected to fire")
+	}
+}
+
+func checkTxs(t *testing.T, mempool Mempool, count int, peerID uint16) types.Txs {
+	txs := make(types.Txs, count)
+	txInfo := TxInfo{SenderID: peerID}
+	for i := 0; i < count; i++ {
+		txBytes := make([]byte, 20)
+		txs[i] = txBytes
+		_, err := rand.Read(txBytes)
+		if err != nil {
+			t.Error(err)
+		}
+		if err := mempool.CheckTx(txBytes, nil, txInfo); err != nil {
+			// Skip invalid txs.
+			// TestMempoolFilters will fail otherwise. It asserts a number of txs
+			// returned.
+			if IsPreCheckError(err) {
+				continue
+			}
+			t.Fatalf("CheckTx failed: %v while checking #%d tx", err, i)
+		}
+	}
+	return txs
+}

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package mempool
 
 import (

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package node
 
 import (

--- a/p2p/conn/connection_test.go
+++ b/p2p/conn/connection_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package conn
 
 import (

--- a/p2p/conn/secret_connection_test.go
+++ b/p2p/conn/secret_connection_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package conn
 
 import (

--- a/p2p/key_test.go
+++ b/p2p/key_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package p2p
 
 import (

--- a/p2p/netaddress_test.go
+++ b/p2p/netaddress_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package p2p
 
 import (

--- a/p2p/node_info_test.go
+++ b/p2p/node_info_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package p2p
 
 import (

--- a/p2p/peer_set_test.go
+++ b/p2p/peer_set_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package p2p
 
 import (

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package pex
 
 import (

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package pex
 
 import (

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package p2p
 
 import (

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -24,70 +23,8 @@ import (
 
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/p2p/conn"
 )
-
-var (
-	cfg *config.P2PConfig
-)
-
-func init() {
-	cfg = config.DefaultP2PConfig()
-	cfg.PexReactor = true
-	cfg.AllowDuplicateIP = true
-}
-
-type PeerMessage struct {
-	PeerID  ID
-	Bytes   []byte
-	Counter int
-}
-
-type TestReactor struct {
-	BaseReactor
-
-	mtx          sync.Mutex
-	channels     []*conn.ChannelDescriptor
-	logMessages  bool
-	msgsCounter  int
-	msgsReceived map[byte][]PeerMessage
-}
-
-func NewTestReactor(channels []*conn.ChannelDescriptor, logMessages bool) *TestReactor {
-	tr := &TestReactor{
-		channels:     channels,
-		logMessages:  logMessages,
-		msgsReceived: make(map[byte][]PeerMessage),
-	}
-	tr.BaseReactor = *NewBaseReactor("TestReactor", tr)
-	tr.SetLogger(log.TestingLogger())
-	return tr
-}
-
-func (tr *TestReactor) GetChannels() []*conn.ChannelDescriptor {
-	return tr.channels
-}
-
-func (tr *TestReactor) AddPeer(peer Peer) {}
-
-func (tr *TestReactor) RemovePeer(peer Peer, reason interface{}) {}
-
-func (tr *TestReactor) Receive(chID byte, peer Peer, msgBytes []byte) {
-	if tr.logMessages {
-		tr.mtx.Lock()
-		defer tr.mtx.Unlock()
-		//fmt.Printf("Received: %X, %X\n", chID, msgBytes)
-		tr.msgsReceived[chID] = append(tr.msgsReceived[chID], PeerMessage{peer.ID(), msgBytes, tr.msgsCounter})
-		tr.msgsCounter++
-	}
-}
-
-func (tr *TestReactor) getMsgs(chID byte) []PeerMessage {
-	tr.mtx.Lock()
-	defer tr.mtx.Unlock()
-	return tr.msgsReceived[chID]
-}
 
 //-----------------------------------------------------------------------------
 

--- a/p2p/test_util.go
+++ b/p2p/test_util.go
@@ -1,3 +1,5 @@
+// +build unit integration
+
 package p2p
 
 import (

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package p2p
 
 import (

--- a/p2p/trust/metric_test.go
+++ b/p2p/trust/metric_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package trust
 
 import (

--- a/p2p/trust/store_test.go
+++ b/p2p/trust/store_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 // Copyright 2017 Tendermint. All rights reserved.
 // Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 

--- a/privval/file_test.go
+++ b/privval/file_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package privval
 
 import (

--- a/privval/signer_client_test.go
+++ b/privval/signer_client_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package privval
 
 import (

--- a/privval/signer_listener_endpoint_test.go
+++ b/privval/signer_listener_endpoint_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package privval
 
 import (

--- a/privval/socket_dialers_test.go
+++ b/privval/socket_dialers_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package privval
 
 import (

--- a/privval/socket_listeners_test.go
+++ b/privval/socket_listeners_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package privval
 
 import (

--- a/privval/utils_test.go
+++ b/privval/utils_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package privval
 
 import (

--- a/proxy/app_conn_test.go
+++ b/proxy/app_conn_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package proxy
 
 import (

--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package client_test
 
 import (

--- a/rpc/client/evidence_test.go
+++ b/rpc/client/evidence_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package client_test
 
 import (

--- a/rpc/client/examples_test.go
+++ b/rpc/client/examples_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package client_test
 
 import (

--- a/rpc/client/helpers_test.go
+++ b/rpc/client/helpers_test.go
@@ -1,3 +1,5 @@
+// +build unit integration
+
 package client_test
 
 import (

--- a/rpc/client/main_test.go
+++ b/rpc/client/main_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package client_test
 
 import (

--- a/rpc/client/mock/abci_test.go
+++ b/rpc/client/mock/abci_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package mock_test
 
 import (

--- a/rpc/client/mock/status_test.go
+++ b/rpc/client/mock/status_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package mock_test
 
 import (

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package client_test
 
 import (

--- a/rpc/core/blocks_test.go
+++ b/rpc/core/blocks_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package core
 
 import (

--- a/rpc/core/env_test.go
+++ b/rpc/core/env_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package core
 
 import (

--- a/rpc/core/net_test.go
+++ b/rpc/core/net_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package core
 
 import (

--- a/rpc/core/net_test.go
+++ b/rpc/core/net_test.go
@@ -21,6 +21,7 @@ func TestUnsafeDialSeeds(t *testing.T) {
 	require.NoError(t, err)
 	defer sw.Stop()
 
+	env = &Environment{}
 	env.Logger = log.TestingLogger()
 	env.P2PPeers = sw
 

--- a/rpc/core/types/responses_test.go
+++ b/rpc/core/types/responses_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package coretypes
 
 import (

--- a/rpc/grpc/grpc_test.go
+++ b/rpc/grpc/grpc_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package coregrpc_test
 
 import (

--- a/rpc/jsonrpc/client/args_test.go
+++ b/rpc/jsonrpc/client/args_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package client
 
 import (

--- a/rpc/jsonrpc/client/http_json_client_test.go
+++ b/rpc/jsonrpc/client/http_json_client_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package client
 
 import (

--- a/rpc/jsonrpc/client/ws_client_test.go
+++ b/rpc/jsonrpc/client/ws_client_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package client
 
 import (

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package jsonrpc
 
 import (

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package server
 
 import (

--- a/rpc/jsonrpc/server/http_server_test.go
+++ b/rpc/jsonrpc/server/http_server_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package server
 
 import (

--- a/rpc/jsonrpc/server/parse_test.go
+++ b/rpc/jsonrpc/server/parse_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package server
 
 import (

--- a/rpc/jsonrpc/server/ws_handler_test.go
+++ b/rpc/jsonrpc/server/ws_handler_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package server
 
 import (

--- a/rpc/jsonrpc/test/main.go
+++ b/rpc/jsonrpc/test/main.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/rpc/jsonrpc/types/types_test.go
+++ b/rpc/jsonrpc/types/types_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package state_test
 
 import (

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -22,12 +22,6 @@ import (
 	tmtime "github.com/tendermint/tendermint/types/time"
 )
 
-var (
-	chainID      = "execution_chain"
-	testPartSize = 65536
-	nTxsPerBlock = 10
-)
-
 func TestApplyBlock(t *testing.T) {
 	app := kvstore.NewApplication()
 	app.RetainBlocks = 1

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1,3 +1,5 @@
+// +build integration unit
+
 package state
 
 import (

--- a/state/helpers_test.go
+++ b/state/helpers_test.go
@@ -19,6 +19,12 @@ import (
 	tmtime "github.com/tendermint/tendermint/types/time"
 )
 
+var (
+	chainID      = "execution_chain"
+	testPartSize = 65536
+	nTxsPerBlock = 10
+)
+
 type paramsChangeTestCase struct {
 	height int64
 	params types.ConsensusParams

--- a/state/helpers_test.go
+++ b/state/helpers_test.go
@@ -1,3 +1,5 @@
+// +build unit integration
+
 package state_test
 
 import (

--- a/state/main_test.go
+++ b/state/main_test.go
@@ -1,3 +1,5 @@
+// +build unit integration
+
 package state_test
 
 import (

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package state_test
 
 import (

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package state_test
 
 import (

--- a/state/tx_filter_test.go
+++ b/state/tx_filter_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package state_test
 
 import (

--- a/state/txindex/indexer_service_test.go
+++ b/state/txindex/indexer_service_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package txindex_test
 
 import (

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package kv
 
 import (

--- a/state/txindex/kv/utils_test.go
+++ b/state/txindex/kv/utils_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package kv
 
 import (

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package state_test
 
 import (

--- a/statesync/chunks_test.go
+++ b/statesync/chunks_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package statesync
 
 import (

--- a/statesync/messages_test.go
+++ b/statesync/messages_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package statesync
 
 import (

--- a/statesync/reactor_test.go
+++ b/statesync/reactor_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package statesync
 
 import (

--- a/statesync/snapshots_test.go
+++ b/statesync/snapshots_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package statesync
 
 import (

--- a/statesync/syncer_test.go
+++ b/statesync/syncer_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package statesync
 
 import (

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package store
 
 import (

--- a/test/README.md
+++ b/test/README.md
@@ -2,8 +2,8 @@
 
 Unit tests have build tag `unit`, and can be run with `make test` (i.e. go test -tags unit).
 Component integration tests have build tag `integration`, and can be run with
-`make test_integration`. All tests, including Docker-based full-system integration tests,
-can be run with `make test_all`.
+`make test_integration`. All tests, including Docker-based end-to-end tests, can be run with
+`make test_all`.
 
 Running `make all` will build a docker container with local version of tendermint and run the
 following tests in docker containers:

--- a/test/README.md
+++ b/test/README.md
@@ -1,10 +1,12 @@
 # Tendermint Tests
 
-The unit tests (ie. the `go test` s) can be run with `make test`.
-The integration tests can be run with `make test_integrations`.
+Unit tests have build tag `unit`, and can be run with `make test` (i.e. go test -tags unit).
+Component integration tests have build tag `integration`, and can be run with
+`make test_integration`. All tests, including Docker-based full-system integration tests,
+can be run with `make test_all`.
 
-Running the integrations test will build a docker container with local version of tendermint
-and run the following tests in docker containers:
+Running `make all` will build a docker container with local version of tendermint and run the
+following tests in docker containers:
 
 - go tests, with --race
 	- includes test coverage

--- a/test/test_cover.sh
+++ b/test/test_cover.sh
@@ -6,7 +6,7 @@ set -e
 
 echo "mode: atomic" > coverage.txt
 for pkg in ${PKGS[@]}; do
-	go test -timeout 5m -race -coverprofile=profile.out -covermode=atomic "$pkg"
+	go test -tags unit,integration -timeout 5m -race -coverprofile=profile.out -covermode=atomic "$pkg"
 	if [ -f profile.out ]; then
 		tail -n +2 profile.out >> coverage.txt;
 		rm profile.out

--- a/tests.mk
+++ b/tests.mk
@@ -72,7 +72,7 @@ test_p2p_ipv6:
 	# mkdir -p test/p2p/logs && docker cp rsyslog:/var/log test/p2p/logs
 .PHONY: test_p2p_ipv6
 
-test_integrations:
+test_all:
 	make build_docker_test_image
 	make tools
 	make install
@@ -85,10 +85,10 @@ test_integrations:
 	make test_p2p
 	# Disabled by default since it requires Docker daemon with IPv6 enabled
 	#make test_p2p_ipv6
-.PHONY: test_integrations
+.PHONY: test_all
 
 test_release:
-	@go test -tags release $(PACKAGES)
+	@go test -tags unit,integration,release $(PACKAGES)
 .PHONY: test_release
 
 test100:
@@ -97,18 +97,26 @@ test100:
 
 vagrant_test:
 	vagrant up
-	vagrant ssh -c 'make test_integrations'
+	vagrant ssh -c 'make test_all'
 .PHONY: vagrant_test
 
 ### go tests
-test:
-	@echo "--> Running go test"
-	@go test -p 1 $(PACKAGES)
+test: test_unit test_int
 .PHONY: test
 
+test_unit:
+	@echo "--> Running go test -tags unit"
+	@go test -tags unit $(PACKAGES)
+.PHONY: test_unit
+
+test_integration:
+	@echo "--> Running go test -tags integration"
+	@go test -p 1 -tags integration $(PACKAGES)
+.PHONY: test_int
+
 test_race:
-	@echo "--> Running go test --race"
-	@go test -p 1 -v -race $(PACKAGES)
+	@echo "--> Running go test -tags unit,integration -race"
+	@go test -p 1 -v -tags unit,integration -race $(PACKAGES)
 .PHONY: test_race
 
 # uses https://github.com/sasha-s/go-deadlock/ to detect potential deadlocks

--- a/types/block_meta_test.go
+++ b/types/block_meta_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import "testing"

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/params_test.go
+++ b/types/params_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/proto3_test.go
+++ b/types/proto3_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/results_test.go
+++ b/types/results_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/validator_test.go
+++ b/types/validator_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (


### PR DESCRIPTION
Splits unit- and integration-tests by using build tags `unit` and `integration` respectively. Uses the following terminology:

* Unit test: single unit of code being tested directly, via public or private APIs, e.g. the block store.

* Integration test: integrations of smaller units into a component, typically blackbox-tested via network or public API, e.g. consensus reactor tests.

* End-to-end test: spinning up one or more complete Tendermint nodes from a binaries and testing them, e.g. Docker-based P2P tests.

This requires changes to e.g. `Makefile`, golangci-lint, VSCode, and other tooling to take build tags into account. It also looks like gopls (VSCode language server) won't pick them up, so code navigation no longer works.

Test files with no build tags will be run both for for unit- and integration-tests, so be sure to include tags. `go test` with no tags should run nothing. Modifies the `Makefile` build targets to take this into account.

Why not `!integration` instead of `unit`? Impossible to make VSCode run any test. Why not only `integration` without `unit`? Impossible to run only integration tests.