### PR TITLE
rpc: add BlockByHash to supported methods

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -35,7 +35,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [statesync] Add state sync support, where a new node can be rapidly bootstrapped by fetching state snapshots from peers instead of replaying blocks. See the `[statesync]` config section.
 - [evidence] [\#4532](https://github.com/tendermint/tendermint/pull/4532) Handle evidence from light clients (@melekes)
 - [lite2] [\#4532](https://github.com/tendermint/tendermint/pull/4532) Submit conflicting headers, if any, to a full node & all witnesses (@melekes)
-- [rpc] [\#4532](https://github.com/tendermint/tendermint/pull/4923) Support `BlockByHash` query.
+- [rpc] [\#4532](https://github.com/tendermint/tendermint/pull/4923) Support `BlockByHash` query (@fedekunze)
 
 ### IMPROVEMENTS:
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -35,6 +35,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [statesync] Add state sync support, where a new node can be rapidly bootstrapped by fetching state snapshots from peers instead of replaying blocks. See the `[statesync]` config section.
 - [evidence] [\#4532](https://github.com/tendermint/tendermint/pull/4532) Handle evidence from light clients (@melekes)
 - [lite2] [\#4532](https://github.com/tendermint/tendermint/pull/4532) Submit conflicting headers, if any, to a full node & all witnesses (@melekes)
+- [rpc] [\#4532](https://github.com/tendermint/tendermint/pull/4923) Support `BlockByHash` query.
 
 ### IMPROVEMENTS:
 

--- a/lite/proxy/proxy.go
+++ b/lite/proxy/proxy.go
@@ -68,13 +68,14 @@ func RPCRoutes(c rpcclient.Client) map[string]*rpcserver.RPCFunc {
 		"unsubscribe_all": rpcserver.NewWSRPCFunc(c.(Wrapper).UnsubscribeAllWS, ""),
 
 		// info API
-		"status":     rpcserver.NewRPCFunc(makeStatusFunc(c), ""),
-		"blockchain": rpcserver.NewRPCFunc(makeBlockchainInfoFunc(c), "minHeight,maxHeight"),
-		"genesis":    rpcserver.NewRPCFunc(makeGenesisFunc(c), ""),
-		"block":      rpcserver.NewRPCFunc(makeBlockFunc(c), "height"),
-		"commit":     rpcserver.NewRPCFunc(makeCommitFunc(c), "height"),
-		"tx":         rpcserver.NewRPCFunc(makeTxFunc(c), "hash,prove"),
-		"validators": rpcserver.NewRPCFunc(makeValidatorsFunc(c), "height"),
+		"status":        rpcserver.NewRPCFunc(makeStatusFunc(c), ""),
+		"blockchain":    rpcserver.NewRPCFunc(makeBlockchainInfoFunc(c), "minHeight,maxHeight"),
+		"genesis":       rpcserver.NewRPCFunc(makeGenesisFunc(c), ""),
+		"block":         rpcserver.NewRPCFunc(makeBlockFunc(c), "height"),
+		"block_by_hash": rpcserver.NewRPCFunc(makeBlockByHashFunc(c), "hash"),
+		"commit":        rpcserver.NewRPCFunc(makeCommitFunc(c), "height"),
+		"tx":            rpcserver.NewRPCFunc(makeTxFunc(c), "hash,prove"),
+		"validators":    rpcserver.NewRPCFunc(makeValidatorsFunc(c), "height"),
 
 		// broadcast API
 		"broadcast_tx_commit": rpcserver.NewRPCFunc(makeBroadcastTxCommitFunc(c), "tx"),
@@ -112,6 +113,12 @@ func makeGenesisFunc(c rpcclient.Client) func(ctx *rpctypes.Context) (*ctypes.Re
 func makeBlockFunc(c rpcclient.Client) func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultBlock, error) {
 	return func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultBlock, error) {
 		return c.Block(height)
+	}
+}
+
+func makeBlockByHashFunc(c rpcclient.Client) func(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error) {
+	return func(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error) {
+		return c.BlockByHash(hash)
 	}
 }
 

--- a/lite/proxy/wrapper.go
+++ b/lite/proxy/wrapper.go
@@ -112,6 +112,26 @@ func (w Wrapper) Block(height *int64) (*ctypes.ResultBlock, error) {
 	return resBlock, nil
 }
 
+// BlockByHash returns an entire block and verifies all signatures
+func (w Wrapper) BlockByHash(hash []byte) (*ctypes.ResultBlock, error) {
+	resBlock, err := w.Client.BlockByHash(hash)
+	if err != nil {
+		return nil, err
+	}
+	// get a checkpoint to verify from
+	resCommit, err := w.Commit(&resBlock.Block.Height)
+	if err != nil {
+		return nil, err
+	}
+	sh := resCommit.SignedHeader
+
+	err = ValidateBlock(resBlock.Block, sh)
+	if err != nil {
+		return nil, err
+	}
+	return resBlock, nil
+}
+
 // Commit downloads the Commit and certifies it with the lite.
 //
 // This is the foundation for all other verification in this module

--- a/lite2/proxy/routes.go
+++ b/lite2/proxy/routes.go
@@ -23,6 +23,7 @@ func RPCRoutes(c *lrpc.Client) map[string]*rpcserver.RPCFunc {
 		"blockchain":           rpcserver.NewRPCFunc(makeBlockchainInfoFunc(c), "minHeight,maxHeight"),
 		"genesis":              rpcserver.NewRPCFunc(makeGenesisFunc(c), ""),
 		"block":                rpcserver.NewRPCFunc(makeBlockFunc(c), "height"),
+		"block_by_hash":        rpcserver.NewRPCFunc(makeBlockByHashFunc(c), "hash"),
 		"block_results":        rpcserver.NewRPCFunc(makeBlockResultsFunc(c), "height"),
 		"commit":               rpcserver.NewRPCFunc(makeCommitFunc(c), "height"),
 		"tx":                   rpcserver.NewRPCFunc(makeTxFunc(c), "hash,prove"),
@@ -94,6 +95,14 @@ type rpcBlockFunc func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultBloc
 func makeBlockFunc(c *lrpc.Client) rpcBlockFunc {
 	return func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultBlock, error) {
 		return c.Block(height)
+	}
+}
+
+type rpcBlockByHashFunc func(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error)
+
+func makeBlockByHashFunc(c *lrpc.Client) rpcBlockByHashFunc {
+	return func(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error) {
+		return c.BlockByHash(hash)
 	}
 }
 

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -367,6 +367,18 @@ func (c *baseRPCClient) Block(height *int64) (*ctypes.ResultBlock, error) {
 	return result, nil
 }
 
+func (c *baseRPCClient) BlockByHash(hash []byte) (*ctypes.ResultBlock, error) {
+	result := new(ctypes.ResultBlock)
+	params := map[string]interface{}{
+		"hash": hash,
+	}
+	_, err := c.caller.Call("block_by_hash", params, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (c *baseRPCClient) BlockResults(height *int64) (*ctypes.ResultBlockResults, error) {
 	result := new(ctypes.ResultBlockResults)
 	params := make(map[string]interface{})

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -65,6 +65,7 @@ type ABCIClient interface {
 // and prove anything about the chain.
 type SignClient interface {
 	Block(height *int64) (*ctypes.ResultBlock, error)
+	BlockByHash(hash []byte) (*ctypes.ResultBlock, error)
 	BlockResults(height *int64) (*ctypes.ResultBlockResults, error)
 	Commit(height *int64) (*ctypes.ResultCommit, error)
 	Validators(height *int64, page, perPage int) (*ctypes.ResultValidators, error)

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -144,6 +144,10 @@ func (c *Local) Block(height *int64) (*ctypes.ResultBlock, error) {
 	return core.Block(c.ctx, height)
 }
 
+func (c *Local) BlockByHash(hash []byte) (*ctypes.ResultBlock, error) {
+	return core.BlockByHash(c.ctx, hash)
+}
+
 func (c *Local) BlockResults(height *int64) (*ctypes.ResultBlockResults, error) {
 	return core.BlockResults(c.ctx, height)
 }

--- a/rpc/client/mock/client.go
+++ b/rpc/client/mock/client.go
@@ -150,6 +150,10 @@ func (c Client) Block(height *int64) (*ctypes.ResultBlock, error) {
 	return core.Block(&rpctypes.Context{}, height)
 }
 
+func (c Client) BlockByHash(hash []byte) (*ctypes.ResultBlock, error) {
+	return core.BlockByHash(&rpctypes.Context{}, hash)
+}
+
 func (c Client) Commit(height *int64) (*ctypes.ResultCommit, error) {
 	return core.Commit(&rpctypes.Context{}, height)
 }

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -249,6 +249,10 @@ func TestAppCalls(t *testing.T) {
 		assert.True(len(appHash) > 0)
 		assert.EqualValues(apph, block.Block.Header.Height)
 
+		blockByHash, err := c.BlockByHash(block.BlockID.Hash)
+		require.NoError(err)
+		require.Equal(block, blockByHash)
+
 		// now check the results
 		blockResults, err := c.BlockResults(&txh)
 		require.Nil(err, "%d: %+v", i, err)


### PR DESCRIPTION
## Description

_Please add a description of the changes that this PR introduces and the files that
are the most critical to review._ 

* Adds [`BlockByHash`](https://docs.tendermint.com/master/rpc/#/Info/block_by_hash) to supported rpc Client methods. 

### Problem 

Ethermint currently has to maintain a map `height`-> `block hash` on the store (see [here](https://github.com/ChainSafe/ethermint/blob/03de80b68eba37da6421b133dec57f4fd0704d78/x/evm/keeper/keeper.go#L58-L81)) as it needs to expose the [`eth_getBlockByHash`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbyhash) JSON-RPC query for Web3 compatibility. This query is currently not supported by the tendermint RPC client.