### PR TITLE
consensus: fix startnextheightcorrectly test

### DIFF
--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -625,6 +625,14 @@ func ensureVote(voteCh <-chan tmpubsub.Message, height int64, round int,
 	}
 }
 
+func ensurePrecommitTimeout(ch <-chan tmpubsub.Message) {
+	select {
+	case <-time.After(ensureTimeout):
+		panic("Timeout expired while waiting for the Precommit to Timeout")
+	case <-ch:
+	}
+}
+
 func ensureNewEventOnChannel(ch <-chan tmpubsub.Message) {
 	select {
 	case <-time.After(ensureTimeout):

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1458,7 +1458,7 @@ func (n *fakeTxNotifier) Notify() {
 	n.ch <- struct{}{}
 }
 
-// 2 vals precommit votes for a block but node times out waiting for the third. Move to next round 
+// 2 vals precommit votes for a block but node times out waiting for the third. Move to next round
 // and third precommit arrives which leads to the commit of that header and the correct
 // start of the next round
 func TestStartNextHeightCorrectlyAfterTimeout(t *testing.T) {
@@ -1501,11 +1501,11 @@ func TestStartNextHeightCorrectlyAfterTimeout(t *testing.T) {
 	// add precommits
 	signAddVotes(cs1, types.PrecommitType, nil, types.PartSetHeader{}, vs2)
 	signAddVotes(cs1, types.PrecommitType, theBlockHash, theBlockParts, vs3)
-	
+
 	// wait till timeout occurs
 	ensurePrecommitTimeout(precommitTimeoutCh)
 
-	ensureNewRound(newRoundCh, height, round + 1)
+	ensureNewRound(newRoundCh, height, round+1)
 
 	// majority is now reached
 	signAddVotes(cs1, types.PrecommitType, theBlockHash, theBlockParts, vs4)

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1458,7 +1458,10 @@ func (n *fakeTxNotifier) Notify() {
 	n.ch <- struct{}{}
 }
 
-func TestStartNextHeightCorrectly(t *testing.T) {
+// 2 vals precommit votes for a block but node times out waiting for the third. Move to next round 
+// and third precommit arrives which leads to the commit of that header and the correct
+// start of the next round
+func TestStartNextHeightCorrectlyAfterTimeout(t *testing.T) {
 	config.Consensus.SkipTimeoutCommit = false
 	cs1, vss := randState(4)
 	cs1.txNotifier = &fakeTxNotifier{ch: make(chan struct{})}
@@ -1468,6 +1471,7 @@ func TestStartNextHeightCorrectly(t *testing.T) {
 
 	proposalCh := subscribe(cs1.eventBus, types.EventQueryCompleteProposal)
 	timeoutProposeCh := subscribe(cs1.eventBus, types.EventQueryTimeoutPropose)
+	precommitTimeoutCh := subscribe(cs1.eventBus, types.EventQueryTimeoutWait)
 
 	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
 	newBlockHeader := subscribe(cs1.eventBus, types.EventQueryNewBlockHeader)
@@ -1497,11 +1501,14 @@ func TestStartNextHeightCorrectly(t *testing.T) {
 	// add precommits
 	signAddVotes(cs1, types.PrecommitType, nil, types.PartSetHeader{}, vs2)
 	signAddVotes(cs1, types.PrecommitType, theBlockHash, theBlockParts, vs3)
-	time.Sleep(5 * time.Millisecond)
-	signAddVotes(cs1, types.PrecommitType, theBlockHash, theBlockParts, vs4)
+	
+	// wait till timeout occurs
+	ensurePrecommitTimeout(precommitTimeoutCh)
 
-	rs = cs1.GetRoundState()
-	assert.True(t, rs.TriggeredTimeoutPrecommit)
+	ensureNewRound(newRoundCh, height, round + 1)
+
+	// majority is now reached
+	signAddVotes(cs1, types.PrecommitType, theBlockHash, theBlockParts, vs4)
 
 	ensureNewBlockHeader(newBlockHeader, height, theBlockHash)
 


### PR DESCRIPTION
## Description

I've taken out the timer aspect and now it just waits on a channel for an event to occur. To be honest I wasn't exactly sure what the test was testing, there seemed to be more involved than making sure that it starts the next height but I found that it wasn't so clearly commented so I tried to add a few extra comments in.  

Closes: #XXX

