### PR TITLE
docs: document open file limit in production guide

### DIFF
--- a/docs/tendermint-core/running-in-production.md
+++ b/docs/tendermint-core/running-in-production.md
@@ -96,6 +96,11 @@ connection has `MaxPacketMsgPayloadSize`, which is the maximum packet
 size and bounded send & receive queues. One can impose restrictions on
 send & receive rate per connection (`SendRate`, `RecvRate`).
 
+The number of open P2P connections can become quite large, and hit the operating system's open
+file limit (since TCP connections are considered files on UNIX-based systems). Nodes should be
+given a sizeable open file limit, e.g. 8192, via `ulimit -n 8192` or other deployment-specific
+mechanisms.
+
 ### RPC
 
 Endpoints returning multiple entries are limited by default to return 30
@@ -370,6 +375,8 @@ If you want to accept greater number of connections, you will need to increase
 these limits.
 
 [Sysctls to tune the system to be able to open more connections](https://github.com/satori-com/tcpkali/blob/master/doc/tcpkali.man.md#sysctls-to-tune-the-system-to-be-able-to-open-more-connections)
+
+The process file limits must also be increased, e.g. via `ulimit -n 8192`.
 
 ...for N connections, such as 50k:
 


### PR DESCRIPTION
See e.g. https://github.com/tendermint/tendermint/issues/4925#issuecomment-637929251 for people getting hit by this. Should we document it elsewhere as well?