### PR TITLE
types: Remove duplicated validation in VerifyCommit

### DIFF
--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -671,13 +671,6 @@ func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID,
 		return fmt.Errorf("invalid commit -- wrong block ID: want %v, got %v",
 			blockID, commit.BlockID)
 	}
-	if height != commit.Height {
-		return NewErrInvalidCommitHeight(height, commit.Height)
-	}
-	if !blockID.Equals(commit.BlockID) {
-		return fmt.Errorf("invalid commit -- wrong block ID: want %v, got %v",
-			blockID, commit.BlockID)
-	}
 
 	talliedVotingPower := int64(0)
 	votingPowerNeeded := vals.TotalVotingPower() * 2 / 3


### PR DESCRIPTION
Removes code duplication when checking `commit.Height` and `commit.BlockID`.
