### PR TITLE
consensus: implement double sign risk reduction adr-051

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -94,6 +94,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [rpc] \#5017 Add `/check_tx` endpoint to check transactions without executing them or adding them to the mempool (@melekes)
 - [abci] \#5031 Add `AppVersion` to consensus parameters (@james-ray)
   ... making it possible to update your ABCI application version via `EndBlock` response
+- [config] Add `--double_sign_check_height` flag and `DoubleSignCheckHeight` config variable. See [ADR-51](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-051-double-signing-risk-reduction.md)
 
 ### IMPROVEMENTS:
 

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -37,6 +37,9 @@ func AddNodeFlags(cmd *cobra.Command) {
 		"genesis_hash",
 		[]byte{},
 		"Optional SHA-256 hash of the genesis file")
+	cmd.Flags().Int64("double_sign_check_height", config.Consensus.DoubleSignCheckHeight,
+		"How many blocks looks back to check existence of the node's "+
+			"consensus votes when before joining consensus (disable when 0)")
 
 	// abci flags
 	cmd.Flags().String(

--- a/config/config.go
+++ b/config/config.go
@@ -827,6 +827,7 @@ type ConsensusConfig struct {
 	// Reactor sleep duration parameters
 	PeerGossipSleepDuration     time.Duration `mapstructure:"peer_gossip_sleep_duration"`
 	PeerQueryMaj23SleepDuration time.Duration `mapstructure:"peer_query_maj23_sleep_duration"`
+	DoubleSignCheckHeight       int64         `mapstructure:"double_sign_check_height"`
 }
 
 // DefaultConsensusConfig returns a default configuration for the consensus service
@@ -845,6 +846,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		CreateEmptyBlocksInterval:   0 * time.Second,
 		PeerGossipSleepDuration:     100 * time.Millisecond,
 		PeerQueryMaj23SleepDuration: 2000 * time.Millisecond,
+		DoubleSignCheckHeight:       int64(10),
 	}
 }
 
@@ -861,6 +863,7 @@ func TestConsensusConfig() *ConsensusConfig {
 	cfg.SkipTimeoutCommit = true
 	cfg.PeerGossipSleepDuration = 5 * time.Millisecond
 	cfg.PeerQueryMaj23SleepDuration = 250 * time.Millisecond
+	cfg.DoubleSignCheckHeight = int64(0) // disable when test
 	return cfg
 }
 
@@ -941,6 +944,9 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 	}
 	if cfg.PeerQueryMaj23SleepDuration < 0 {
 		return errors.New("peer_query_maj23_sleep_duration can't be negative")
+	}
+	if cfg.DoubleSignCheckHeight < 0 {
+		return errors.New("double_sign_check_height can't be negative")
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -164,6 +164,7 @@ func TestConsensusConfig_ValidateBasic(t *testing.T) {
 		"PeerGossipSleepDuration negative":     {func(c *ConsensusConfig) { c.PeerGossipSleepDuration = -1 }, true},
 		"PeerQueryMaj23SleepDuration":          {func(c *ConsensusConfig) { c.PeerQueryMaj23SleepDuration = time.Second }, false},
 		"PeerQueryMaj23SleepDuration negative": {func(c *ConsensusConfig) { c.PeerQueryMaj23SleepDuration = -1 }, true},
+		"DoubleSignCheckHeight negative":       {func(c *ConsensusConfig) { c.DoubleSignCheckHeight = -1 }, true},
 	}
 	for desc, tc := range testcases {
 		tc := tc // appease linter

--- a/config/toml.go
+++ b/config/toml.go
@@ -378,6 +378,13 @@ timeout_precommit = "{{ .Consensus.TimeoutPrecommit }}"
 timeout_precommit_delta = "{{ .Consensus.TimeoutPrecommitDelta }}"
 timeout_commit = "{{ .Consensus.TimeoutCommit }}"
 
+# How many blocks looks back to check existence of the node's consensus votes when before joining consensus
+# When the risk reduction method is on, restarting a validator node will panic
+# because the node itself voted on consensus with the same consensus key.
+# So, validators should stop the state machine, wait for some blocks, and then restart the state machine to avoid panic.
+# - 0 disable.
+double_sign_check_height = {{ .Consensus.DoubleSignCheckHeight }}
+
 # Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
 skip_timeout_commit = {{ .Consensus.SkipTimeoutCommit }}
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -36,6 +36,7 @@ var (
 	ErrInvalidProposalSignature = errors.New("error invalid proposal signature")
 	ErrInvalidProposalPOLRound  = errors.New("error invalid proposal POL round")
 	ErrAddingVote               = errors.New("error adding vote")
+	ErrDoubleSignProtection     = errors.New("double sign detected or restarted in DoubleSignCheckHeight")
 )
 
 //-----------------------------------------------------------------------------
@@ -354,6 +355,30 @@ func (cs *State) OnStart() error {
 		return err
 	}
 
+	// Double Signing Risk Reduction Logic
+	// triggered only when validator mode(existing privValidator) and DoubleSignCheckHeight set
+	if !(cs.privValidator == nil) && cs.config.DoubleSignCheckHeight > 0 && cs.Height > 0 {
+		valAddr, err := cs.privValidator.GetPubKey()
+		if err != nil {
+			return err
+		}
+		var doubleSignCheckHeight int64
+		if cs.config.DoubleSignCheckHeight > cs.Height {
+			doubleSignCheckHeight = cs.Height
+		} else {
+			doubleSignCheckHeight = cs.config.DoubleSignCheckHeight
+		}
+		for i := int64(1); doubleSignCheckHeight > i; i++ {
+			lastCommit := cs.blockStore.LoadSeenCommit(cs.Height - i)
+			if lastCommit != nil {
+				for _, s := range lastCommit.Signatures {
+					if s.BlockIDFlag == types.BlockIDFlagCommit && bytes.Equal(s.ValidatorAddress, valAddr.Address()) {
+						return ErrDoubleSignProtection
+					}
+				}
+			}
+		}
+	}
 	// now start the receiveRoutine
 	go cs.receiveRoutine(0)
 

--- a/docs/architecture/adr-051-double-signing-risk-reduction.md
+++ b/docs/architecture/adr-051-double-signing-risk-reduction.md
@@ -29,7 +29,7 @@ We would like to suggest a double signing risk reduction method.
     - We would like to suggest by introducing `double_sign_check_height` parameter in `config.toml` and cli, how many blocks state machine looks back to check votes
     - <span v-pre>`double_sign_check_height = {{ .Consensus.DoubleSignCheckHeight }}`</span> in `config.toml`
     - `tendermint node --double_sign_check_height` in cli
-    - State machine ignore checking procedure when `vote-check-height == 0`
+    - State machine ignore checking procedure when `double_sign_check_height == 0`
 
 ## Status
 

--- a/test/persist/test_failure_indices.sh
+++ b/test/persist/test_failure_indices.sh
@@ -9,7 +9,7 @@ tendermint init
 # use a unix socket so we can remove it
 RPC_ADDR="$(pwd)/rpc.sock"
 
-TM_CMD="tendermint node --log_level=debug --rpc.laddr=unix://$RPC_ADDR" # &> tendermint_${name}.log"
+TM_CMD="tendermint node --double_sign_check_height 0 --log_level=debug --rpc.laddr=unix://$RPC_ADDR" # &> tendermint_${name}.log"
 DUMMY_CMD="abci-cli kvstore --persist $TMHOME/kvstore" # &> kvstore_${name}.log"
 
 

--- a/test/persist/test_simple.sh
+++ b/test/persist/test_simple.sh
@@ -11,7 +11,7 @@ function start_procs(){
     echo "Starting persistent kvstore and tendermint"
     abci-cli kvstore --persist $TMHOME/kvstore &> "kvstore_${name}.log" &
     PID_DUMMY=$!
-    tendermint node &> tendermint_${name}.log &
+    tendermint node --double_sign_check_height 0 &> tendermint_${name}.log &
     PID_TENDERMINT=$!
     sleep 5
 }


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

- implementation spec of Double Signing Risk Reduction [ADR-51](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-051-double-signing-risk-reduction.md) by B-Harvest
- Add `DoubleSignCheckHeight` config variable to ConsensusConfig for "How many blocks looks back to check existence of the node's consensus votes when before joining consensus"
- Add `double_sign_check_height` to `config.toml` and `tendermint node` as flag for set `DoubleSignCheckHeight`
- Set default `double_sign_check_height` to `10`  ( it could be adjustable in this PR, disable when 0  )

Refs

- [ADR-51](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-051-double-signing-risk-reduction.md)
- [https://github.com/tendermint/tendermint/issues/4059](https://github.com/tendermint/tendermint/issues/4059)
- [https://github.com/tendermint/tendermint/pull/4262](https://github.com/tendermint/tendermint/pull/4262)

* [x] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG_PENDING.md
