### PR TITLE
deps: bump tm-db to 0.6.0

### DIFF
--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -49,7 +49,10 @@ func saveState(state State) {
 	if err != nil {
 		panic(err)
 	}
-	state.db.Set(stateKey, stateBytes)
+	err = state.db.Set(stateKey, stateBytes)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func prefixKey(key []byte) []byte {
@@ -92,7 +95,10 @@ func (app *Application) DeliverTx(req types.RequestDeliverTx) types.ResponseDeli
 		key, value = req.Tx, req.Tx
 	}
 
-	app.state.db.Set(prefixKey(key), value)
+	err := app.state.db.Set(prefixKey(key), value)
+	if err != nil {
+		panic(err)
+	}
 	app.state.Size++
 
 	events := []types.Event{

--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -184,6 +184,9 @@ func (app *PersistentKVStoreApplication) Validators() (validators []types.Valida
 			validators = append(validators, *validator)
 		}
 	}
+	if err = itr.Error(); err != nil {
+		panic(err)
+	}
 	return
 }
 
@@ -254,7 +257,9 @@ func (app *PersistentKVStoreApplication) updateValidator(v types.ValidatorUpdate
 				Code: code.CodeTypeUnauthorized,
 				Log:  fmt.Sprintf("Cannot remove non-existent validator %s", pubStr)}
 		}
-		app.app.state.db.Delete(key)
+		if err = app.app.state.db.Delete(key); err != nil {
+			panic(err)
+		}
 		delete(app.valAddrToPubKeyMap, string(pubkey.Address()))
 	} else {
 		// add or update validator
@@ -264,7 +269,9 @@ func (app *PersistentKVStoreApplication) updateValidator(v types.ValidatorUpdate
 				Code: code.CodeTypeEncodingError,
 				Log:  fmt.Sprintf("Error encoding validator: %v", err)}
 		}
-		app.app.state.db.Set(key, value.Bytes())
+		if err = app.app.state.db.Set(key, value.Bytes()); err != nil {
+			panic(err)
+		}
 		app.valAddrToPubKeyMap[string(pubkey.Address())] = v.PubKey
 	}
 

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -276,11 +276,17 @@ func (pb *playback) replayConsoleLoop() int {
 func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusConfig) *State {
 	dbType := dbm.BackendType(config.DBBackend)
 	// Get BlockStore
-	blockStoreDB := dbm.NewDB("blockstore", dbType, config.DBDir())
+	blockStoreDB, err := dbm.NewDB("blockstore", dbType, config.DBDir())
+	if err != nil {
+		tmos.Exit(err.Error())
+	}
 	blockStore := store.NewBlockStore(blockStoreDB)
 
 	// Get State
-	stateDB := dbm.NewDB("state", dbType, config.DBDir())
+	stateDB, err := dbm.NewDB("state", dbType, config.DBDir())
+	if err != nil {
+		tmos.Exit(err.Error())
+	}
 	gdoc, err := sm.MakeGenesisDocFromFile(config.GenesisFile())
 	if err != nil {
 		tmos.Exit(err.Error())

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1
-	github.com/tendermint/tm-db v0.5.1
+	github.com/tendermint/tm-db v0.6.0
 	golang.org/x/crypto v0.0.0-20200406173513-056763e48d71
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	google.golang.org/grpc v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,6 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.3.0 h1:miYCvYqFXtl/J9FIy8eNpBfYthAEFg+Ys0XyUVEcDsc=
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
-github.com/prometheus/client_golang v1.7.0 h1:wCi7urQOGBsYcQROHqpUUX4ct84xp40t9R9JX0FuA/U=
-github.com/prometheus/client_golang v1.7.0/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=
@@ -442,8 +440,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
@@ -452,8 +448,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d h1:gZZadD8H+fF+
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzHWCjJB1zZfXPIAaDpzXIEJ0eS6B5Ok=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
-github.com/tendermint/tm-db v0.5.1 h1:H9HDq8UEA7Eeg13kdYckkgwwkQLBnJGgX4PgLJRhieY=
-github.com/tendermint/tm-db v0.5.1/go.mod h1:g92zWjHpCYlEvQXvy9M168Su8V1IBEeawpXVVBaK4f4=
+github.com/tendermint/tm-db v0.6.0 h1:Us30k7H1UDcdqoSPhmP8ztAW/SWV6c6OfsfeCiboTC4=
+github.com/tendermint/tm-db v0.6.0/go.mod h1:xj3AWJ08kBDlCHKijnhJ7mTcDMOikT1r8Poxy2pJn7Q=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -464,6 +460,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
+go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738 h1:VcrIfasaLFkyjk6KNlXQSzO+B0fZcnECiDrKJsfxka0=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
@@ -531,8 +529,6 @@ golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
-golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 h1:fHDIZ2oxGnUZRN6WgWFCbYBjH9uqVPRCUVUDhs0wnbA=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
@@ -570,6 +566,7 @@ golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f h1:68K/z8GLUxV76xGSqwTWw2gyk/jwn79LUL43rES2g8o=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
@@ -645,10 +642,6 @@ google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.28.0 h1:bO/TA4OxCOummhSf10siHuG7vJOiwh7SpRpFZDkOgl4=
-google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
-google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
-google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0 h1:M5a8xTlYTxwMn5ZFkwhRabsygDY5G8TYLyQDBxJNAxE=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/light/store/db/db.go
+++ b/light/store/db/db.go
@@ -283,7 +283,7 @@ func (s *dbs) Prune(size uint16) error {
 		append(s.shKey(1<<63-1), byte(0x00)),
 	)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer itr.Close()
 
@@ -296,10 +296,10 @@ func (s *dbs) Prune(size uint16) error {
 		_, height, ok := parseShKey(key)
 		if ok {
 			if err = b.Delete(s.shKey(height)); err != nil {
-				panic(err)
+				return err
 			}
 			if err = b.Delete(s.vsKey(height)); err != nil {
-				panic(err)
+				return err
 			}
 		}
 		itr.Next()

--- a/node/node.go
+++ b/node/node.go
@@ -64,7 +64,7 @@ type DBProvider func(*DBContext) (dbm.DB, error)
 // specified in the ctx.Config.
 func DefaultDBProvider(ctx *DBContext) (dbm.DB, error) {
 	dbType := dbm.BackendType(ctx.Config.DBBackend)
-	return dbm.NewDB(ctx.ID, dbType, ctx.Config.DBDir()), nil
+	return dbm.NewDB(ctx.ID, dbType, ctx.Config.DBDir())
 }
 
 // GenesisDocProvider returns a GenesisDoc.

--- a/p2p/trust/store_test.go
+++ b/p2p/trust/store_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/libs/log"
@@ -17,12 +18,11 @@ import (
 
 func TestTrustMetricStoreSaveLoad(t *testing.T) {
 	dir, err := ioutil.TempDir("", "trust_test")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	defer os.Remove(dir)
 
-	historyDB := dbm.NewDB("trusthistory", "goleveldb", dir)
+	historyDB, err := dbm.NewDB("trusthistory", "goleveldb", dir)
+	require.NoError(t, err)
 
 	// 0 peers saved
 	store := NewTrustMetricStore(historyDB, DefaultConfig())
@@ -79,7 +79,8 @@ func TestTrustMetricStoreSaveLoad(t *testing.T) {
 }
 
 func TestTrustMetricStoreConfig(t *testing.T) {
-	historyDB := dbm.NewDB("", "memdb", "")
+	historyDB, err := dbm.NewDB("", "memdb", "")
+	require.NoError(t, err)
 
 	config := MetricConfig{
 		ProportionalWeight: 0.5,
@@ -101,7 +102,8 @@ func TestTrustMetricStoreConfig(t *testing.T) {
 }
 
 func TestTrustMetricStoreLookup(t *testing.T) {
-	historyDB := dbm.NewDB("", "memdb", "")
+	historyDB, err := dbm.NewDB("", "memdb", "")
+	require.NoError(t, err)
 
 	store := NewTrustMetricStore(historyDB, DefaultConfig())
 	store.SetLogger(log.TestingLogger())
@@ -121,7 +123,8 @@ func TestTrustMetricStoreLookup(t *testing.T) {
 }
 
 func TestTrustMetricStorePeerScore(t *testing.T) {
-	historyDB := dbm.NewDB("", "memdb", "")
+	historyDB, err := dbm.NewDB("", "memdb", "")
+	require.NoError(t, err)
 
 	store := NewTrustMetricStore(historyDB, DefaultConfig())
 	store.SetLogger(log.TestingLogger())

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -28,7 +28,8 @@ import (
 func setupTestCase(t *testing.T) (func(t *testing.T), dbm.DB, sm.State) {
 	config := cfg.ResetTestRoot("state_")
 	dbType := dbm.BackendType(config.DBBackend)
-	stateDB := dbm.NewDB("state", dbType, config.DBDir())
+	stateDB, err := dbm.NewDB("state", dbType, config.DBDir())
+	require.NoError(t, err)
 	state, err := sm.LoadStateFromDBOrGenesisFile(stateDB, config.GenesisFile())
 	assert.NoError(t, err, "expected no error on LoadStateFromDBOrGenesisFile")
 

--- a/state/store.go
+++ b/state/store.go
@@ -205,10 +205,16 @@ func PruneStates(db dbm.DB, from int64, to int64) error {
 				if err != nil {
 					return err
 				}
-				batch.Set(calcValidatorsKey(h), bz)
+				err = batch.Set(calcValidatorsKey(h), bz)
+				if err != nil {
+					return err
+				}
 			}
 		} else {
-			batch.Delete(calcValidatorsKey(h))
+			err = batch.Delete(calcValidatorsKey(h))
+			if err != nil {
+				return err
+			}
 		}
 
 		if keepParams[h] {
@@ -223,13 +229,22 @@ func PruneStates(db dbm.DB, from int64, to int64) error {
 				if err != nil {
 					return err
 				}
-				batch.Set(calcConsensusParamsKey(h), bz)
+				err = batch.Set(calcConsensusParamsKey(h), bz)
+				if err != nil {
+					return err
+				}
 			}
 		} else {
-			batch.Delete(calcConsensusParamsKey(h))
+			err = batch.Delete(calcConsensusParamsKey(h))
+			if err != nil {
+				return err
+			}
 		}
 
-		batch.Delete(calcABCIResponsesKey(h))
+		err = batch.Delete(calcABCIResponsesKey(h))
+		if err != nil {
+			return err
+		}
 		pruned++
 
 		// avoid batches growing too large by flushing to database regularly
@@ -332,7 +347,10 @@ func SaveABCIResponses(db dbm.DB, height int64, abciResponses *tmstate.ABCIRespo
 	if err != nil {
 		panic(err)
 	}
-	db.SetSync(calcABCIResponsesKey(height), bz)
+	err = db.SetSync(calcABCIResponsesKey(height), bz)
+	if err != nil {
+		panic(err)
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -434,7 +452,10 @@ func saveValidatorsInfo(db dbm.DB, height, lastHeightChanged int64, valSet *type
 		panic(err)
 	}
 
-	db.Set(calcValidatorsKey(height), bz)
+	err = db.Set(calcValidatorsKey(height), bz)
+	if err != nil {
+		panic(err)
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -505,5 +526,8 @@ func saveConsensusParamsInfo(db dbm.DB, nextHeight, changeHeight int64, params t
 		panic(err)
 	}
 
-	db.Set(calcConsensusParamsKey(nextHeight), bz)
+	err = db.Set(calcConsensusParamsKey(nextHeight), bz)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -50,7 +50,8 @@ func BenchmarkLoadValidators(b *testing.B) {
 	config := cfg.ResetTestRoot("state_")
 	defer os.RemoveAll(config.RootDir)
 	dbType := dbm.BackendType(config.DBBackend)
-	stateDB := dbm.NewDB("state", dbType, config.DBDir())
+	stateDB, err := dbm.NewDB("state", dbType, config.DBDir())
+	require.NoError(b, err)
 	state, err := sm.LoadStateFromDBOrGenesisFile(stateDB, config.GenesisFile())
 	if err != nil {
 		b.Fatal(err)

--- a/state/tx_filter_test.go
+++ b/state/tx_filter_test.go
@@ -31,7 +31,8 @@ func TestTxFilter(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		stateDB := dbm.NewDB("state", "memdb", os.TempDir())
+		stateDB, err := dbm.NewDB("state", "memdb", os.TempDir())
+		require.NoError(t, err)
 		state, err := sm.LoadStateFromDBOrGenesisDoc(stateDB, genDoc)
 		require.NoError(t, err)
 

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -117,7 +117,7 @@ func (txi *TxIndex) Index(result *abci.TxResult) error {
 	return nil
 }
 
-func (txi *TxIndex) indexEvents(result *abci.TxResult, hash []byte, store dbm.SetDeleter) error {
+func (txi *TxIndex) indexEvents(result *abci.TxResult, hash []byte, store dbm.Batch) error {
 	for _, event := range result.Result.Events {
 		// only index events with a non-empty type
 		if len(event.Type) == 0 {

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -72,21 +72,29 @@ func (txi *TxIndex) AddBatch(b *txindex.Batch) error {
 		hash := types.Tx(result.Tx).Hash()
 
 		// index tx by events
-		txi.indexEvents(result, hash, storeBatch)
+		err := txi.indexEvents(result, hash, storeBatch)
+		if err != nil {
+			return err
+		}
 
 		// index by height (always)
-		storeBatch.Set(keyForHeight(result), hash)
+		err = storeBatch.Set(keyForHeight(result), hash)
+		if err != nil {
+			return err
+		}
 
 		rawBytes, err := proto.Marshal(result)
 		if err != nil {
 			return err
 		}
 		// index by hash (always)
-		storeBatch.Set(hash, rawBytes)
+		err = storeBatch.Set(hash, rawBytes)
+		if err != nil {
+			return err
+		}
 	}
 
-	storeBatch.WriteSync()
-	return nil
+	return storeBatch.WriteSync()
 }
 
 // Index indexes a single transaction using the given list of events. Each key
@@ -100,21 +108,28 @@ func (txi *TxIndex) Index(result *abci.TxResult) error {
 	hash := types.Tx(result.Tx).Hash()
 
 	// index tx by events
-	txi.indexEvents(result, hash, b)
+	err := txi.indexEvents(result, hash, b)
+	if err != nil {
+		return err
+	}
 
 	// index by height (always)
-	b.Set(keyForHeight(result), hash)
+	err = b.Set(keyForHeight(result), hash)
+	if err != nil {
+		return err
+	}
 
 	rawBytes, err := proto.Marshal(result)
 	if err != nil {
 		return err
 	}
 	// index by hash (always)
-	b.Set(hash, rawBytes)
+	err = b.Set(hash, rawBytes)
+	if err != nil {
+		return err
+	}
 
-	b.WriteSync()
-
-	return nil
+	return b.WriteSync()
 }
 
 func (txi *TxIndex) indexEvents(result *abci.TxResult, hash []byte, store dbm.Batch) error {
@@ -132,7 +147,10 @@ func (txi *TxIndex) indexEvents(result *abci.TxResult, hash []byte, store dbm.Ba
 			// index if `index: true` is set
 			compositeTag := fmt.Sprintf("%s.%s", event.Type, string(attr.Key))
 			if attr.GetIndex() {
-				store.Set(keyForEvent(compositeTag, attr.Value, result), hash)
+				err := store.Set(keyForEvent(compositeTag, attr.Value, result), hash)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -326,12 +326,11 @@ func txResultWithEvents(events []abci.Event) *abci.TxResult {
 
 func benchmarkTxIndex(txsCount int64, b *testing.B) {
 	dir, err := ioutil.TempDir("", "tx_index_db")
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.NoError(b, err)
 	defer os.RemoveAll(dir) // nolint: errcheck
 
-	store := db.NewDB("tx_index", "goleveldb", dir)
+	store, err := db.NewDB("tx_index", "goleveldb", dir)
+	require.NoError(b, err)
 	indexer := NewTxIndex(store)
 
 	batch := txindex.NewBatch(txsCount)

--- a/store/store.go
+++ b/store/store.go
@@ -366,13 +366,8 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 	}
 	bs.mtx.Unlock()
 
-	// Save new BlockStoreState descriptor
+	// Save new BlockStoreState descriptor. This also flushes the database.
 	bs.saveState()
-
-	// Flush
-	if err := bs.db.SetSync(nil, nil); err != nil {
-		panic(err)
-	}
 }
 
 func (bs *BlockStore) saveBlockPart(height int64, index int, part *types.Part) {

--- a/store/store.go
+++ b/store/store.go
@@ -265,12 +265,22 @@ func (bs *BlockStore) PruneBlocks(height int64) (uint64, error) {
 		if meta == nil { // assume already deleted
 			continue
 		}
-		batch.Delete(calcBlockMetaKey(h))
-		batch.Delete(calcBlockHashKey(meta.BlockID.Hash))
-		batch.Delete(calcBlockCommitKey(h))
-		batch.Delete(calcSeenCommitKey(h))
+		if err := batch.Delete(calcBlockMetaKey(h)); err != nil {
+			return 0, err
+		}
+		if err := batch.Delete(calcBlockHashKey(meta.BlockID.Hash)); err != nil {
+			return 0, err
+		}
+		if err := batch.Delete(calcBlockCommitKey(h)); err != nil {
+			return 0, err
+		}
+		if err := batch.Delete(calcSeenCommitKey(h)); err != nil {
+			return 0, err
+		}
 		for p := 0; p < int(meta.BlockID.PartSetHeader.Total); p++ {
-			batch.Delete(calcBlockPartKey(h, p))
+			if err := batch.Delete(calcBlockPartKey(h, p)); err != nil {
+				return 0, err
+			}
 		}
 		pruned++
 
@@ -320,8 +330,12 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 		panic("nil blockmeta")
 	}
 	metaBytes := mustEncode(pbm)
-	bs.db.Set(calcBlockMetaKey(height), metaBytes)
-	bs.db.Set(calcBlockHashKey(hash), []byte(fmt.Sprintf("%d", height)))
+	if err := bs.db.Set(calcBlockMetaKey(height), metaBytes); err != nil {
+		panic(err)
+	}
+	if err := bs.db.Set(calcBlockHashKey(hash), []byte(fmt.Sprintf("%d", height))); err != nil {
+		panic(err)
+	}
 
 	// Save block parts
 	for i := 0; i < int(blockParts.Total()); i++ {
@@ -332,13 +346,17 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 	// Save block commit (duplicate and separate from the Block)
 	pbc := block.LastCommit.ToProto()
 	blockCommitBytes := mustEncode(pbc)
-	bs.db.Set(calcBlockCommitKey(height-1), blockCommitBytes)
+	if err := bs.db.Set(calcBlockCommitKey(height-1), blockCommitBytes); err != nil {
+		panic(err)
+	}
 
 	// Save seen commit (seen +2/3 precommits for block)
 	// NOTE: we can delete this at a later height
 	pbsc := seenCommit.ToProto()
 	seenCommitBytes := mustEncode(pbsc)
-	bs.db.Set(calcSeenCommitKey(height), seenCommitBytes)
+	if err := bs.db.Set(calcSeenCommitKey(height), seenCommitBytes); err != nil {
+		panic(err)
+	}
 
 	// Done!
 	bs.mtx.Lock()
@@ -352,7 +370,9 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 	bs.saveState()
 
 	// Flush
-	bs.db.SetSync(nil, nil)
+	if err := bs.db.SetSync(nil, nil); err != nil {
+		panic(err)
+	}
 }
 
 func (bs *BlockStore) saveBlockPart(height int64, index int, part *types.Part) {
@@ -361,7 +381,9 @@ func (bs *BlockStore) saveBlockPart(height int64, index int, part *types.Part) {
 		panic(fmt.Errorf("unable to make part into proto: %w", err))
 	}
 	partBytes := mustEncode(pbp)
-	bs.db.Set(calcBlockPartKey(height, index), partBytes)
+	if err := bs.db.Set(calcBlockPartKey(height, index), partBytes); err != nil {
+		panic(err)
+	}
 }
 
 func (bs *BlockStore) saveState() {
@@ -416,7 +438,9 @@ func SaveBlockStoreState(bsj *tmstore.BlockStoreState, db dbm.DB) {
 	if err != nil {
 		panic(fmt.Sprintf("Could not marshal state bytes: %v", err))
 	}
-	db.SetSync(blockStoreKey, bytes)
+	if err := db.SetSync(blockStoreKey, bytes); err != nil {
+		panic(err)
+	}
 }
 
 // LoadBlockStoreState returns the BlockStoreState as loaded from disk.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -119,10 +119,10 @@ func TestNewBlockStore(t *testing.T) {
 		assert.Contains(t, fmt.Sprintf("%#v", panicErr), tt.wantErr, "#%d data: %q", i, tt.data)
 	}
 
-	err = db.Set(blockStoreKey, nil)
+	err = db.Set(blockStoreKey, []byte{})
 	require.NoError(t, err)
 	bs = NewBlockStore(db)
-	assert.Equal(t, bs.Height(), int64(0), "expecting nil bytes to be unmarshaled alright")
+	assert.Equal(t, bs.Height(), int64(0), "expecting empty bytes to be unmarshaled alright")
 }
 
 func freshBlockStore() (*BlockStore, dbm.DB) {


### PR DESCRIPTION
Noticed while working on this that we've disabled the `errcheck` lint, which made it hard to find and fix all the instances since enabling it threw a ton of unrelated warnings. Maybe we should enable it and clean up the code base?