### PR TITLE
tests: use github.sha in binary cache key

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
         if: "env.GIT_DIFF != ''"
+      # Cache binaries for use by other jobs
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-${{ github.sha }}-tm-binary
+        if: "env.GIT_DIFF != ''"
 
   test_abci_apps:
     runs-on: ubuntu-latest
@@ -69,6 +75,11 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+        if: "env.GIT_DIFF != ''"
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-${{ github.sha }}-tm-binary
         if: "env.GIT_DIFF != ''"
       - name: test_abci_apps
         run: abci/tests/test_app/test.sh
@@ -99,6 +110,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
         if: "env.GIT_DIFF != ''"
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-${{ github.sha }}-tm-binary
+        if: "env.GIT_DIFF != ''"
       - run: abci/tests/test_cli/test.sh
         shell: bash
         if: "env.GIT_DIFF != ''"
@@ -126,6 +142,11 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+        if: "env.GIT_DIFF != ''"
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-${{ github.sha }}-tm-binary
         if: "env.GIT_DIFF != ''"
       - name: test_apps
         run: test/app/test.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,12 +45,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
         if: "env.GIT_DIFF != ''"
-      # Cache bin
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/bin
-          key: ${{ runner.os }}-${{ github.head_ref }}-tm-binary
-        if: "env.GIT_DIFF != ''"
 
   test_abci_apps:
     runs-on: ubuntu-latest
@@ -75,11 +69,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-        if: "env.GIT_DIFF != ''"
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/bin
-          key: ${{ runner.os }}-${{ github.head_ref }}-tm-binary
         if: "env.GIT_DIFF != ''"
       - name: test_abci_apps
         run: abci/tests/test_app/test.sh
@@ -110,11 +99,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
         if: "env.GIT_DIFF != ''"
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/bin
-          key: ${{ runner.os }}-${{ github.head_ref }}-tm-binary
-        if: "env.GIT_DIFF != ''"
       - run: abci/tests/test_cli/test.sh
         shell: bash
         if: "env.GIT_DIFF != ''"
@@ -142,11 +126,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-        if: "env.GIT_DIFF != ''"
-      - uses: actions/cache@v1
-        with:
-          path: ~/go/bin
-          key: ${{ runner.os }}-${{ github.head_ref }}-tm-binary
         if: "env.GIT_DIFF != ''"
       - name: test_apps
         run: test/app/test.sh

--- a/store/store.go
+++ b/store/store.go
@@ -14,7 +14,6 @@ import (
 )
 
 /*
-
 BlockStore is a simple low level store for blocks.
 
 There are three types of information stored:

--- a/store/store.go
+++ b/store/store.go
@@ -14,6 +14,7 @@ import (
 )
 
 /*
+
 BlockStore is a simple low level store for blocks.
 
 There are three types of information stored:


### PR DESCRIPTION
The binaries are cached using `github.head_ref` as a key; this is e.g. the branch name, so the binary will be built on the first run and then the cached version reused for all subsequent builds. This broke tests on e.g. #5058 since the cached binary has a bug that was fixed in a later commit, but the cached version used for tests still had the bug. Changing to `github.sha` makes sure the cache is only valid for the current commit.