### PR TITLE
bump go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Or [Blockchain](<https://en.wikipedia.org/wiki/Blockchain_(database)>), for shor
 
 [![version](https://img.shields.io/github/tag/tendermint/tendermint.svg)](https://github.com/tendermint/tendermint/releases/latest)
 [![API Reference](https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667)](https://pkg.go.dev/github.com/tendermint/tendermint)
-[![Go version](https://img.shields.io/badge/go-1.13-blue.svg)](https://github.com/moovweb/gvm)
+[![Go version](https://img.shields.io/badge/go-1.14-blue.svg)](https://github.com/moovweb/gvm)
 [![Discord chat](https://img.shields.io/discord/669268347736686612.svg)](https://discord.gg/AzefAFd)
 [![license](https://img.shields.io/github/license/tendermint/tendermint.svg)](https://github.com/tendermint/tendermint/blob/master/LICENSE)
 [![](https://tokei.rs/b1/github/tendermint/tendermint?category=lines)](https://github.com/tendermint/tendermint)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For examples of the kinds of bugs we're looking for, see [SECURITY.md](SECURITY.
 
 | Requirement | Notes            |
 | ----------- | ---------------- |
-| Go version  | Go1.13 or higher |
+| Go version  | Go1.14 or higher |
 
 ## Documentation
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,8 +29,8 @@ Vagrant.configure("2") do |config|
     usermod -a -G docker vagrant
 
     # install go
-    wget -q https://dl.google.com/go/go1.13.linux-amd64.tar.gz
-    tar -xvf go1.13.linux-amd64.tar.gz
+    wget -q https://dl.google.com/go/go1.14.linux-amd64.tar.gz
+    tar -xvf go1.14.linux-amd64.tar.gz
     mv go /usr/local
     rm -f go1.13.linux-amd64.tar.gz
 

--- a/docs/guides/go.md
+++ b/docs/guides/go.md
@@ -43,7 +43,7 @@ Verify that you have the latest version of Go installed:
 
 ```bash
 $ go version
-go version go1.13.1 darwin/amd64
+go version go1.14.x darwin/amd64
 ```
 
 Make sure you have `$GOPATH` environment variable set:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tendermint/tendermint
 
-go 1.13
+go 1.14
 
 require (
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.14
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \


### PR DESCRIPTION
## Description

since 0.34 is breaking we should bump the go version to 1.14

Closes: #XXX

