### PR TITLE
Update reactor.go

### DIFF
--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -128,9 +128,9 @@ func (bcR *BlockchainReactor) SwitchToFastSync(state sm.State) error {
 
 // OnStop implements service.Service.
 func (bcR *BlockchainReactor) OnStop() {
-        if bcR.fastSync {
+	if bcR.fastSync {
 		bcR.pool.Stop()
-        }
+	}
 }
 
 // GetChannels implements Reactor

--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -128,7 +128,9 @@ func (bcR *BlockchainReactor) SwitchToFastSync(state sm.State) error {
 
 // OnStop implements service.Service.
 func (bcR *BlockchainReactor) OnStop() {
-	bcR.pool.Stop()
+        if bcR.fastSync {
+		bcR.pool.Stop()
+        }
 }
 
 // GetChannels implements Reactor


### PR DESCRIPTION
check bcR.fastSync flag when "OnStop"

fix "service/service.go:161	Not stopping BlockPool -- have not been started yet	{"impl": "BlockPool"}" error when kill process

