### PR TITLE
evidence: new evidence event subscription

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -101,6 +101,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [rpc] \#4979 Support EXISTS operator in `/tx_search` query (@melekes)
 - [rpc] \#5017 Add `/check_tx` endpoint to check transactions without executing them or adding them to the mempool (@melekes)
 - [statesync] Add state sync support, where a new node can be rapidly bootstrapped by fetching state snapshots from peers instead of replaying blocks. See the `[statesync]` config section.
+- [rpc] [\#5108](https://github.com/tendermint/tendermint/pull/5108) Subscribe using the websocket for new evidence events (@cmwaters)
 
 ### IMPROVEMENTS:
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -481,6 +481,15 @@ func fireEvents(
 		ResultEndBlock:   *abciResponses.EndBlock,
 	})
 
+	if len(block.Evidence.Evidence) != 0 {
+		for _, ev := range block.Evidence.Evidence {
+			eventBus.PublishEventNewEvidence(types.EventDataNewEvidence{
+				Evidence: ev,
+				Height:   block.Height,
+			})
+		}
+	}
+
 	for i, tx := range block.Data.Txs {
 		eventBus.PublishEventTx(types.EventDataTx{TxResult: abci.TxResult{
 			Height: block.Height,

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -156,6 +156,10 @@ func (b *EventBus) PublishEventNewBlockHeader(data EventDataNewBlockHeader) erro
 	return b.pubsub.PublishWithEvents(ctx, data, events)
 }
 
+func (b *EventBus) PublishEventNewEvidence(evidence EventDataNewEvidence) error {
+	return b.Publish(EventNewEvidence, evidence)
+}
+
 func (b *EventBus) PublishEventVote(data EventDataVote) error {
 	return b.Publish(EventVote, data)
 }
@@ -246,6 +250,10 @@ func (NopEventBus) PublishEventNewBlock(data EventDataNewBlock) error {
 }
 
 func (NopEventBus) PublishEventNewBlockHeader(data EventDataNewBlockHeader) error {
+	return nil
+}
+
+func (NopEventBus) PublishEventNewEvidence(evidence EventDataNewEvidence) error {
 	return nil
 }
 

--- a/types/events.go
+++ b/types/events.go
@@ -18,6 +18,7 @@ const (
 	// All of this data can be fetched through the rpc.
 	EventNewBlock            = "NewBlock"
 	EventNewBlockHeader      = "NewBlockHeader"
+	EventNewEvidence         = "NewEvidence"
 	EventTx                  = "Tx"
 	EventValidatorSetUpdates = "ValidatorSetUpdates"
 
@@ -49,6 +50,7 @@ type TMEventData interface {
 func init() {
 	tmjson.RegisterType(EventDataNewBlock{}, "tendermint/event/NewBlock")
 	tmjson.RegisterType(EventDataNewBlockHeader{}, "tendermint/event/NewBlockHeader")
+	tmjson.RegisterType(EventDataNewEvidence{}, "tendermint/event/NewEvidence")
 	tmjson.RegisterType(EventDataTx{}, "tendermint/event/Tx")
 	tmjson.RegisterType(EventDataRoundState{}, "tendermint/event/RoundState")
 	tmjson.RegisterType(EventDataNewRound{}, "tendermint/event/NewRound")
@@ -74,6 +76,12 @@ type EventDataNewBlockHeader struct {
 	NumTxs           int64                   `json:"num_txs"` // Number of txs in a block
 	ResultBeginBlock abci.ResponseBeginBlock `json:"result_begin_block"`
 	ResultEndBlock   abci.ResponseEndBlock   `json:"result_end_block"`
+}
+
+type EventDataNewEvidence struct {
+	Evidence Evidence `json:"evidence"`
+
+	Height int64 `json:"height"`
 }
 
 // All txs fire EventDataTx
@@ -139,6 +147,7 @@ var (
 	EventQueryLock                = QueryForEvent(EventLock)
 	EventQueryNewBlock            = QueryForEvent(EventNewBlock)
 	EventQueryNewBlockHeader      = QueryForEvent(EventNewBlockHeader)
+	EventQueryNewEvidence         = QueryForEvent(EventNewEvidence)
 	EventQueryNewRound            = QueryForEvent(EventNewRound)
 	EventQueryNewRoundStep        = QueryForEvent(EventNewRoundStep)
 	EventQueryPolka               = QueryForEvent(EventPolka)
@@ -164,6 +173,7 @@ func QueryForEvent(eventType string) tmpubsub.Query {
 type BlockEventPublisher interface {
 	PublishEventNewBlock(block EventDataNewBlock) error
 	PublishEventNewBlockHeader(header EventDataNewBlockHeader) error
+	PublishEventNewEvidence(evidence EventDataNewEvidence) error
 	PublishEventTx(EventDataTx) error
 	PublishEventValidatorSetUpdates(EventDataValidatorSetUpdates) error
 }

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -20,4 +20,8 @@ func TestQueryForEvent(t *testing.T) {
 		"tm.event='NewBlock'",
 		QueryForEvent(EventNewBlock).String(),
 	)
+	assert.Equal(t,
+		"tm.event='NewEvidence'",
+		QueryForEvent(EventNewEvidence).String(),
+	)
 }


### PR DESCRIPTION
Closes: #5092 

At the moment it is a simple query tm.event="NewEvidence" to get any new evidence. This is fired when a block is committed and there is evidence in the block. 

Made some unit tests - no full integration tests yet

The event also returns the height that the evidence was committed on the block. I thought this might be helpful but may not be necessary