### PR TITLE
docs: added further documentation to the subscribing to events page

### DIFF
--- a/docs/app-dev/subscribing-to-events-via-websocket.md
+++ b/docs/app-dev/subscribing-to-events-via-websocket.md
@@ -4,14 +4,21 @@ order: 5
 
 # Subscribing to events via Websocket
 
-Tendermint emits different events, to which you can subscribe via
+Tendermint emits different events, to which you can subscribe to via
 [Websocket](https://en.wikipedia.org/wiki/WebSocket). This can be useful
-for third-party applications (for analysis) or inspecting state.
+for third-party applications (for analysis) or for inspecting state.
 
 [List of events](https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants)
 
-You can subscribe to any of the events above by calling `subscribe` RPC
-method via Websocket.
+To open a websocket connection with a node, you can use a cli tool such as 
+[wscat](https://github.com/websockets/wscat) and run:
+
+```
+wscat ws://127.0.0.1:26657/websocket
+```
+
+You can then subscribe to any of the events above by calling the `subscribe` RPC
+method via Websocket along with a valid query.
 
 ```
 {

--- a/docs/app-dev/subscribing-to-events-via-websocket.md
+++ b/docs/app-dev/subscribing-to-events-via-websocket.md
@@ -4,20 +4,20 @@ order: 5
 
 # Subscribing to events via Websocket
 
-Tendermint emits different events, to which you can subscribe to via
+Tendermint emits different events, which you can subscribe to via
 [Websocket](https://en.wikipedia.org/wiki/WebSocket). This can be useful
 for third-party applications (for analysis) or for inspecting state.
 
 [List of events](https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants)
 
-To open a websocket connection with a node, you can use a cli tool such as 
+To connect to a node via websocket from the CLI, you can use a tool such as
 [wscat](https://github.com/websockets/wscat) and run:
 
 ```
 wscat ws://127.0.0.1:26657/websocket
 ```
 
-You can then subscribe to any of the events above by calling the `subscribe` RPC
+You can subscribe to any of the events above by calling the `subscribe` RPC
 method via Websocket along with a valid query.
 
 ```


### PR DESCRIPTION
## Description

Whilst traipsing around the websocket side of tendermint to try setup an event I felt that this page could include a little more detail into how to set up a websocket connection and subscribe to messages. (Some of this information is duplicated here: https://docs.tendermint.com/master/rpc/)

Also I noticed that we provide a link to all the events that someone can subscribe to but just for the ValidatorSetUpdates do we provide more info - I was wondering if we should do the same for the others? 


