### PR TITLE
jsonrpc: change log to debug

### DIFF
--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -53,7 +53,7 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 
 		returns := rpcFunc.f.Call(args)
 
-		logger.Info("HTTPRestRPC", "method", r.URL.Path, "args", args, "returns", returns)
+		logger.Debug("HTTPRestRPC", "method", r.URL.Path, "args", args, "returns", returns)
 		result, err := unreflectResult(returns)
 		if err != nil {
 			WriteRPCResponseHTTP(w, types.RPCInternalError(dummyID, err))


### PR DESCRIPTION
## Description

this log message was marked as not useful and in the issue it was proposed to move it to debug. I am going with this path for now. After we have refactored the logger we shold go through the codebase in order to clean our log statements. 

Closes: #2101

