### PR TITLE
blockchain: reuse channel variable

### DIFF
--- a/blockchain/util.go
+++ b/blockchain/util.go
@@ -1,0 +1,6 @@
+package blockchain
+
+const (
+	// BlockchainChannel is a channel for blocks and status updates (`BlockStore` height)
+	BlockchainChannel = byte(0x40)
+)

--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/tendermint/tendermint/behaviour"
 	bc "github.com/tendermint/tendermint/blockchain"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/p2p"
@@ -53,7 +52,6 @@ type BlockchainReactor struct {
 	blockExec *sm.BlockExecutor
 	store     *store.BlockStore
 	pool      *BlockPool
-	reporter  behaviour.Reporter
 	fastSync  bool
 
 	requestsCh <-chan BlockRequest

--- a/blockchain/v1/reactor.go
+++ b/blockchain/v1/reactor.go
@@ -16,8 +16,6 @@ import (
 )
 
 const (
-	// BlockchainChannel is a channel for blocks and status updates (`BlockStore` height)
-	BlockchainChannel = byte(0x40)
 	trySyncIntervalMS = 10
 	trySendIntervalMS = 10
 
@@ -164,7 +162,7 @@ func (bcR *BlockchainReactor) SwitchToFastSync(state sm.State) error {
 func (bcR *BlockchainReactor) GetChannels() []*p2p.ChannelDescriptor {
 	return []*p2p.ChannelDescriptor{
 		{
-			ID:                  BlockchainChannel,
+			ID:                  bc.BlockchainChannel,
 			Priority:            10,
 			SendQueueCapacity:   2000,
 			RecvBufferCapacity:  50 * 4096,
@@ -183,7 +181,7 @@ func (bcR *BlockchainReactor) AddPeer(peer p2p.Peer) {
 		bcR.Logger.Error("could not convert msg to protobuf", "err", err)
 		return
 	}
-	peer.Send(BlockchainChannel, msgBytes)
+	peer.Send(bc.BlockchainChannel, msgBytes)
 	// it's OK if send fails. will try later in poolRoutine
 
 	// peer is added to the pool once we receive the first
@@ -208,7 +206,7 @@ func (bcR *BlockchainReactor) sendBlockToPeer(msg *bcproto.BlockRequest,
 			bcR.Logger.Error("unable to marshal msg", "err", err)
 			return false
 		}
-		return src.TrySend(BlockchainChannel, msgBytes)
+		return src.TrySend(bc.BlockchainChannel, msgBytes)
 	}
 
 	bcR.Logger.Info("peer asking for a block we don't have", "src", src, "height", msg.Height)
@@ -218,7 +216,7 @@ func (bcR *BlockchainReactor) sendBlockToPeer(msg *bcproto.BlockRequest,
 		bcR.Logger.Error("unable to marshal msg", "err", err)
 		return false
 	}
-	return src.TrySend(BlockchainChannel, msgBytes)
+	return src.TrySend(bc.BlockchainChannel, msgBytes)
 }
 
 func (bcR *BlockchainReactor) sendStatusResponseToPeer(msg *bcproto.StatusRequest, src p2p.Peer) (queued bool) {
@@ -231,7 +229,7 @@ func (bcR *BlockchainReactor) sendStatusResponseToPeer(msg *bcproto.StatusReques
 		return false
 	}
 
-	return src.TrySend(BlockchainChannel, msgBytes)
+	return src.TrySend(bc.BlockchainChannel, msgBytes)
 }
 
 // RemovePeer implements Reactor by removing peer from the pool.
@@ -484,7 +482,7 @@ func (bcR *BlockchainReactor) sendStatusRequest() {
 	if err != nil {
 		panic(err)
 	}
-	bcR.Switch.Broadcast(BlockchainChannel, msgBytes)
+	bcR.Switch.Broadcast(bc.BlockchainChannel, msgBytes)
 }
 
 // Implements bcRNotifier
@@ -499,7 +497,7 @@ func (bcR *BlockchainReactor) sendBlockRequest(peerID p2p.ID, height int64) erro
 	if err != nil {
 		return err
 	}
-	queued := peer.TrySend(BlockchainChannel, msgBytes)
+	queued := peer.TrySend(bc.BlockchainChannel, msgBytes)
 	if !queued {
 		return errSendQueueFull
 	}

--- a/blockchain/v2/io.go
+++ b/blockchain/v2/io.go
@@ -31,11 +31,6 @@ func newSwitchIo(sw *p2p.Switch) *switchIO {
 	}
 }
 
-const (
-	// BlockchainChannel is a channel for blocks and status updates (`BlockStore` height)
-	BlockchainChannel = byte(0x40)
-)
-
 type consensusReactor interface {
 	// for when we switch from blockchain reactor and fast sync to
 	// the consensus machine
@@ -52,7 +47,7 @@ func (sio *switchIO) sendBlockRequest(peerID p2p.ID, height int64) error {
 		return err
 	}
 
-	queued := peer.TrySend(BlockchainChannel, msgBytes)
+	queued := peer.TrySend(bc.BlockchainChannel, msgBytes)
 	if !queued {
 		return fmt.Errorf("send queue full")
 	}
@@ -70,7 +65,7 @@ func (sio *switchIO) sendStatusResponse(base int64, height int64, peerID p2p.ID)
 		return err
 	}
 
-	if queued := peer.TrySend(BlockchainChannel, msgBytes); !queued {
+	if queued := peer.TrySend(bc.BlockchainChannel, msgBytes); !queued {
 		return fmt.Errorf("peer queue full")
 	}
 
@@ -95,7 +90,7 @@ func (sio *switchIO) sendBlockToPeer(block *types.Block, peerID p2p.ID) error {
 	if err != nil {
 		return err
 	}
-	if queued := peer.TrySend(BlockchainChannel, msgBytes); !queued {
+	if queued := peer.TrySend(bc.BlockchainChannel, msgBytes); !queued {
 		return fmt.Errorf("peer queue full")
 	}
 
@@ -112,7 +107,7 @@ func (sio *switchIO) sendBlockNotFound(height int64, peerID p2p.ID) error {
 		return err
 	}
 
-	if queued := peer.TrySend(BlockchainChannel, msgBytes); !queued {
+	if queued := peer.TrySend(bc.BlockchainChannel, msgBytes); !queued {
 		return fmt.Errorf("peer queue full")
 	}
 
@@ -134,7 +129,7 @@ func (sio *switchIO) broadcastStatusRequest() error {
 	}
 
 	// XXX: maybe we should use an io specific peer list here
-	sio.sw.Broadcast(BlockchainChannel, msgBytes)
+	sio.sw.Broadcast(bc.BlockchainChannel, msgBytes)
 
 	return nil
 }

--- a/blockchain/v2/reactor.go
+++ b/blockchain/v2/reactor.go
@@ -509,7 +509,7 @@ func (r *BlockchainReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 func (r *BlockchainReactor) GetChannels() []*p2p.ChannelDescriptor {
 	return []*p2p.ChannelDescriptor{
 		{
-			ID:                  BlockchainChannel,
+			ID:                  bc.BlockchainChannel,
 			Priority:            10,
 			SendQueueCapacity:   2000,
 			RecvBufferCapacity:  50 * 4096,

--- a/node/node.go
+++ b/node/node.go
@@ -1196,18 +1196,6 @@ func makeNodeInfo(
 		txIndexerStatus = "off"
 	}
 
-	var bcChannel byte
-	switch config.FastSync.Version {
-	case "v0":
-		bcChannel = bc.BlockchainChannel
-	case "v1":
-		bcChannel = bc.BlockchainChannel
-	case "v2":
-		bcChannel = bc.BlockchainChannel
-	default:
-		return nil, fmt.Errorf("unknown fastsync version %s", config.FastSync.Version)
-	}
-
 	nodeInfo := p2p.DefaultNodeInfo{
 		ProtocolVersion: p2p.NewProtocolVersion(
 			version.P2PProtocol, // global
@@ -1218,7 +1206,7 @@ func makeNodeInfo(
 		Network:       genDoc.ChainID,
 		Version:       version.TMCoreSemVer,
 		Channels: []byte{
-			bcChannel,
+			bc.BlockchainChannel,
 			cs.StateChannel, cs.DataChannel, cs.VoteChannel, cs.VoteSetBitsChannel,
 			mempl.MempoolChannel,
 			evidence.EvidenceChannel,

--- a/node/node.go
+++ b/node/node.go
@@ -18,6 +18,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
+	bc "github.com/tendermint/tendermint/blockchain"
 	bcv0 "github.com/tendermint/tendermint/blockchain/v0"
 	bcv1 "github.com/tendermint/tendermint/blockchain/v1"
 	bcv2 "github.com/tendermint/tendermint/blockchain/v2"
@@ -1198,11 +1199,11 @@ func makeNodeInfo(
 	var bcChannel byte
 	switch config.FastSync.Version {
 	case "v0":
-		bcChannel = bcv0.BlockchainChannel
+		bcChannel = bc.BlockchainChannel
 	case "v1":
-		bcChannel = bcv1.BlockchainChannel
+		bcChannel = bc.BlockchainChannel
 	case "v2":
-		bcChannel = bcv2.BlockchainChannel
+		bcChannel = bc.BlockchainChannel
 	default:
 		return nil, fmt.Errorf("unknown fastsync version %s", config.FastSync.Version)
 	}


### PR DESCRIPTION
## Description

This pr merges the blockchain channel variables. This is a minor change and more cosmetic than anything else. If people would like to leave it as is, we can.

not sure if this constitutes a changelog entry?

Closes: #XXX

