### PR TITLE
evidence: fix usage of time field in abci evidence

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,3 +13,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 ### FEATURES:
 
 - [abci] [\#5174](https://github.com/tendermint/tendermint/pull/5174) Add amnesia evidence and remove mock and potential amnesia evidence from abci (@cmwaters)
+
+### BUG FIXES
+
+- [abci] [\#5170](https://github.com/tendermint/tendermint/pull/5170) change abci evidence time to the time the infraction happened not the time the evidence was committed on the block (@cmwaters)

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -351,8 +351,11 @@ message VoteInfo {
 
 message Evidence {
   string                    type      = 1;
+  // The offending validator
   Validator                 validator = 2 [(gogoproto.nullable) = false];
+  // The height when the offense occurred 
   int64                     height    = 3;
+  // The corresponding time where the offense occurred
   google.protobuf.Timestamp time      = 4 [
     (gogoproto.nullable) = false,
     (gogoproto.stdtime)  = true

--- a/state/execution.go
+++ b/state/execution.go
@@ -360,7 +360,7 @@ func getBeginBlockValidatorInfo(block *types.Block, stateDB dbm.DB) (abci.LastCo
 		if err != nil {
 			panic(err)
 		}
-		byzVals[i] = types.TM2PB.Evidence(ev, valset, block.Time)
+		byzVals[i] = types.TM2PB.Evidence(ev, valset)
 	}
 
 	return abci.LastCommitInfo{

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -140,10 +140,10 @@ func TestBeginBlockByzantineValidators(t *testing.T) {
 		expectedByzantineValidators []abci.Evidence
 	}{
 		{"none byzantine", []types.Evidence{}, []abci.Evidence{}},
-		{"one byzantine", []types.Evidence{ev1}, []abci.Evidence{types.TM2PB.Evidence(ev1, valSet, now)}},
+		{"one byzantine", []types.Evidence{ev1}, []abci.Evidence{types.TM2PB.Evidence(ev1, valSet)}},
 		{"multiple byzantine", []types.Evidence{ev1, ev2}, []abci.Evidence{
-			types.TM2PB.Evidence(ev1, valSet, now),
-			types.TM2PB.Evidence(ev2, valSet, now)}},
+			types.TM2PB.Evidence(ev1, valSet),
+			types.TM2PB.Evidence(ev2, valSet)}},
 	}
 
 	var (

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -3,7 +3,6 @@ package types
 import (
 	"fmt"
 	"reflect"
-	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
@@ -118,12 +117,12 @@ func (tm2pb) ConsensusParams(params *tmproto.ConsensusParams) *abci.ConsensusPar
 // ABCI Evidence includes information from the past that's not included in the evidence itself
 // so Evidence types stays compact.
 // XXX: panics on nil or unknown pubkey type
-func (tm2pb) Evidence(ev Evidence, valSet *ValidatorSet, evTime time.Time) abci.Evidence {
+func (tm2pb) Evidence(ev Evidence, valSet *ValidatorSet) abci.Evidence {
 	addr := ev.Address()
 	_, val := valSet.GetByAddress(addr)
 	if val == nil {
 		// should already have checked this
-		panic(val)
+		panic(fmt.Sprintf("validator in evidence is not in val set, val addr: %v", addr))
 	}
 
 	// set type
@@ -136,14 +135,14 @@ func (tm2pb) Evidence(ev Evidence, valSet *ValidatorSet, evTime time.Time) abci.
 	case *AmnesiaEvidence:
 		evType = ABCIEvidenceTypeAmnesia
 	default:
-		panic(fmt.Sprintf("Unknown evidence type: %v %v", ev, reflect.TypeOf(ev)))
+		panic(fmt.Sprintf("unknown evidence type: %v %v", ev, reflect.TypeOf(ev)))
 	}
 
 	return abci.Evidence{
 		Type:             evType,
 		Validator:        TM2PB.Validator(val),
 		Height:           ev.Height(),
-		Time:             evTime,
+		Time:             ev.Time(),
 		TotalVotingPower: valSet.TotalVotingPower(),
 	}
 }

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,7 +74,6 @@ func TestABCIEvidence(t *testing.T) {
 	abciEv := TM2PB.Evidence(
 		ev,
 		NewValidatorSet([]*Validator{NewValidator(pubKey, 10)}),
-		time.Now(),
 	)
 
 	assert.Equal(t, "duplicate/vote", abciEv.Type)


### PR DESCRIPTION
## Description

This PR fixes a bug where we were sending the time that evidence was committed to a block not the time that the actual infraction occurred to abci.

NOTE: This PR just addresses the issue of the wrong usage of time. There is a separate issue posted below which is that the evidence time (the time of infraction) itself is unreliably sourced from votes and should be changed to a more reliable source. This aims to be solved in a later PR

Addresses: https://github.com/tendermint/tendermint/issues/4150

