### PR TITLE
version: bump version numbers

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const (
 	// Must be a string because scripts like dist.sh read this file.
 	// XXX: Don't change the name of this variable or you will break
 	// automation :)
-	TMCoreSemVer = "0.33.6"
+	TMCoreSemVer = "0.34.0"
 
 	// ABCISemVer is the semantic version of the ABCI library
 	ABCISemVer = "0.17.0"
@@ -31,9 +31,9 @@ const (
 var (
 	// P2PProtocol versions all p2p behaviour and msgs.
 	// This includes proposer selection.
-	P2PProtocol uint64 = 9
+	P2PProtocol uint64 = 8
 
 	// BlockProtocol versions all block data structures and processing.
 	// This includes validity of blocks and state updates.
-	BlockProtocol uint64 = 12
+	BlockProtocol uint64 = 11
 )


### PR DESCRIPTION
Bumps the Tendermint version to 0.34.0, and debumps the P2P and block protocol numbers since 0.33.6 has:

```go
    // P2PProtocol versions all p2p behaviour and msgs.
    // This includes proposer selection.
    P2PProtocol Protocol = 7 

    // BlockProtocol versions all block data structures and processing.
    // This includes validity of blocks and state updates.
    BlockProtocol Protocol = 10
```