### PR TITLE
abci: fix abci evidence types

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,1 +1,9 @@
 ## v0.34.1
+
+Special thanks to external contributors on this release:
+
+Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermint).
+
+### FEATURES:
+
+- [abci] [\#5174](https://github.com/tendermint/tendermint/pull/5174) Add amnesia evidence and remove mock and potential amnesia evidence from abci (@cmwaters)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,14 @@
 This guide provides steps to be followed when you upgrade your applications to
 a newer version of Tendermint Core.
 
+## v0.34.1 
+
+### ABCI application changes
+
+A new form of evidence: amnesia evidence, has been added. Potential amnesia and
+mock evidence have been removed. Applications should be able to handle these
+evidence types.
+
 ## v0.34.0
 
 **This release is not compatible with previous blockchains** due to switching

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -16,10 +16,10 @@ import (
 // Use strings to distinguish types in ABCI messages
 
 const (
-	ABCIEvidenceTypeDuplicateVote    = "duplicate/vote"
-	ABCIEvidenceTypePhantom          = "phantom"
-	ABCIEvidenceTypeLunatic          = "lunatic"
-	ABCIEvidenceTypeAmnesia          = "amnesia"
+	ABCIEvidenceTypeDuplicateVote = "duplicate/vote"
+	ABCIEvidenceTypePhantom       = "phantom"
+	ABCIEvidenceTypeLunatic       = "lunatic"
+	ABCIEvidenceTypeAmnesia       = "amnesia"
 )
 
 const (

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -19,8 +19,7 @@ const (
 	ABCIEvidenceTypeDuplicateVote    = "duplicate/vote"
 	ABCIEvidenceTypePhantom          = "phantom"
 	ABCIEvidenceTypeLunatic          = "lunatic"
-	ABCIEvidenceTypePotentialAmnesia = "potential_amnesia"
-	ABCIEvidenceTypeMock             = "mock/evidence"
+	ABCIEvidenceTypeAmnesia          = "amnesia"
 )
 
 const (
@@ -137,8 +136,8 @@ func (tm2pb) Evidence(ev Evidence, valSet *ValidatorSet, evTime time.Time) abci.
 		evType = ABCIEvidenceTypePhantom
 	case *LunaticValidatorEvidence:
 		evType = ABCIEvidenceTypeLunatic
-	case *PotentialAmnesiaEvidence:
-		evType = ABCIEvidenceTypePotentialAmnesia
+	case *AmnesiaEvidence:
+		evType = ABCIEvidenceTypeAmnesia
 	default:
 		panic(fmt.Sprintf("Unknown evidence type: %v %v", ev, reflect.TypeOf(ev)))
 	}


### PR DESCRIPTION
## Description

Some of the evidence types weren't updated to match the changes. Such updates included:

- Removing mock evidence (we don't use that anymore)

- Adding amnesia evidence

- Removing potential amnesia evidence (this should never be committed on the chain) 

