### PR TITLE
evidence: don't stop evidence verification if one fails

### DIFF
--- a/evidence/reactor.go
+++ b/evidence/reactor.go
@@ -75,13 +75,14 @@ func (evR *Reactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) {
 	for _, ev := range evis {
 		err := evR.evpool.AddEvidence(ev)
 		switch err.(type) {
-		case ErrInvalidEvidence:
-			evR.Logger.Error("Evidence is not valid", "evidence", evis, "err", err)
+		case *types.ErrEvidenceInvalid:
+			evR.Logger.Error(err.Error())
 			// punish peer
 			evR.Switch.StopPeerForError(src, err)
 			return
 		case nil:
 		default:
+			// continue to the next piece of evidence
 			evR.Logger.Error("Evidence has not been added", "evidence", evis, "err", err)
 		}
 	}

--- a/evidence/reactor.go
+++ b/evidence/reactor.go
@@ -83,7 +83,6 @@ func (evR *Reactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) {
 		case nil:
 		default:
 			evR.Logger.Error("Evidence has not been added", "evidence", evis, "err", err)
-			return
 		}
 	}
 }


### PR DESCRIPTION
## Description

Currently if adding evidence returns an error we log it and exit out of the Receive message in the evidence reactor. If the evidence sent was faulty we `StopPeerForError`, however, even for other errors like not having the block because we pruned, we still return an error and stop checking the rest of the evidence in the message. This PR changes that.

I've also replaced `ErrInvalidEvidence` because we already have a similar area used in the types package


