### PR TITLE
crypto: consistent api across keys

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,7 +8,8 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - Go API
 
-    - [evidence] [\#5181](https://github.com/tendermint/tendermint/pull/5181) Phantom validator evidence was removed (also from abci) (@cmwaters)  
+    - [evidence] [\#5181](https://github.com/tendermint/tendermint/pull/5181) Phantom validator evidence was removed (also from abci) (@cmwaters) 
+    - [crypto] [] Change `GenPrivKeySecp256k1` to `GenPrivKeyFromSecret` to be consistent with other keys
 
 ### FEATURES:
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,7 +9,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - Go API
 
     - [evidence] [\#5181](https://github.com/tendermint/tendermint/pull/5181) Phantom validator evidence was removed (also from abci) (@cmwaters) 
-    - [crypto] [] Change `GenPrivKeySecp256k1` to `GenPrivKeyFromSecret` to be consistent with other keys
+    - [crypto] [\#5214] Change `GenPrivKeySecp256k1` to `GenPrivKeyFromSecret` to be consistent with other keys
 
 ### FEATURES:
 

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -79,7 +79,7 @@ func genPrivKey(rand io.Reader) PrivKey {
 
 var one = new(big.Int).SetInt64(1)
 
-// GenPrivKeySecp256k1 hashes the secret with SHA2, and uses
+// GenPrivKeyFromSecret hashes the secret with SHA2, and uses
 // that 32 byte output to create the private key.
 //
 // It makes sure the private key is a valid field element by setting:
@@ -89,7 +89,7 @@ var one = new(big.Int).SetInt64(1)
 //
 // NOTE: secret should be the output of a KDF like bcrypt,
 // if it's derived from user input.
-func GenPrivKeySecp256k1(secret []byte) PrivKey {
+func GenPrivKeyFromSecret(secret []byte) PrivKey {
 	secHash := sha256.Sum256(secret)
 	// to guarantee that we have a valid field element, we use the approach of:
 	// "Suite B Implementer’s Guide to FIPS 186-3", A.2.1

--- a/crypto/secp256k1/secp256k1_test.go
+++ b/crypto/secp256k1/secp256k1_test.go
@@ -84,7 +84,7 @@ func TestSecp256k1LoadPrivkeyAndSerializeIsIdentity(t *testing.T) {
 	}
 }
 
-func TestGenPrivKeySecp256k1(t *testing.T) {
+func TestGenPrivKeyFromSecret(t *testing.T) {
 	// curve oder N
 	N := underlyingSecp256k1.S256().N
 	tests := []struct {
@@ -104,7 +104,7 @@ func TestGenPrivKeySecp256k1(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotPrivKey := secp256k1.GenPrivKeySecp256k1(tt.secret)
+			gotPrivKey := secp256k1.GenPrivKeyFromSecret(tt.secret)
 			require.NotNil(t, gotPrivKey)
 			// interpret as a big.Int and make sure it is a valid field element:
 			fe := new(big.Int).SetBytes(gotPrivKey[:])


### PR DESCRIPTION
## Description

This Pr changes `GenPrivKeySecp256k1` to `GenPrivKeyFromSecret` to be consistent with the other keys. Also the previous name was not descriptive on what it did.

Closes: #XXX

