### PR TITLE
libs/rand: fix "out-of-memory" error on unexpected argument

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,4 +19,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [evidence] [\#5170](https://github.com/tendermint/tendermint/pull/5170) change abci evidence time to the time the infraction happened not the time the evidence was committed on the block (@cmwaters)
 - [node] Don't attempt fast sync when the ABCI application specifies ourself as the only validator via `InitChain` (@erikgrinaker)
-- [rand] [\#5215](https://github.com/tendermint/tendermint/pull/5215) Fix out-of-memory error on unexpected argument of Str() (@SadPencil)
+- [libs/rand] [\#5215](https://github.com/tendermint/tendermint/pull/5215) Fix out-of-memory error on unexpected argument of Str() (@SadPencil)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,3 +19,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [evidence] [\#5170](https://github.com/tendermint/tendermint/pull/5170) change abci evidence time to the time the infraction happened not the time the evidence was committed on the block (@cmwaters)
 - [node] Don't attempt fast sync when the ABCI application specifies ourself as the only validator via `InitChain` (@erikgrinaker)
+- [rand] [\#5215](https://github.com/tendermint/tendermint/pull/5215) Fix out-of-memory error on unexpected argument of Str() (@SadPencil)

--- a/libs/rand/random.go
+++ b/libs/rand/random.go
@@ -149,6 +149,10 @@ func (r *Rand) Seed(seed int64) {
 
 // Str constructs a random alphanumeric string of given length.
 func (r *Rand) Str(length int) string {
+	if length <= 0 {
+		return ""
+	}
+
 	chars := []byte{}
 MAIN_LOOP:
 	for {


### PR DESCRIPTION
## Description

changes `Str()` in `libs/rand/random.go` file.

If someone invoke this method with an unexpected argument, e.g. `rand.Str(0)`, an out of memory error occurs.

It takes me hours to finally figure it out, because I write this line in my program:
```
str := rand.Str(rand.Intn(32768))
```

After this pull request, if the argument is less or equals to 0, an empty string will be returned, instead of an out-of-memory error.

