### PR TITLE
state: don't save genesis state in database when loaded

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
     - [merkle] [\#5193](https://github.com/tendermint/tendermint/pull/5193) `HashFromByteSlices` and `ProofsFromByteSlices` now return a hash for empty inputs, following RFC6962 (@erikgrinaker)
     - [crypto] [\#5214] Change `GenPrivKeySecp256k1` to `GenPrivKeyFromSecret` to be consistent with other keys
     - [state] [\#5191](https://github.com/tendermint/tendermint/pull/5191/files) Add `State.InitialHeight` field to record initial block height, must be `1` (not `0`) to start from 1 (@erikgrinaker)
+    - [state] `LoadStateFromDBOrGenesisFile()` and `LoadStateFromDBOrGenesisDoc()` no longer saves the state in the database if not found, the genesis state is simply returned (@erikgrinaker)
 
 ### FEATURES:
 

--- a/node/node.go
+++ b/node/node.go
@@ -1255,9 +1255,8 @@ var (
 )
 
 // LoadStateFromDBOrGenesisDocProvider attempts to load the state from the
-// database, or creates one using the given genesisDocProvider and persists the
-// result to the database. On success this also returns the genesis doc loaded
-// through the given provider.
+// database, or creates one using the given genesisDocProvider. On success this also
+// returns the genesis doc loaded through the given provider.
 func LoadStateFromDBOrGenesisDocProvider(
 	stateDB dbm.DB,
 	genesisDocProvider GenesisDocProvider,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -32,6 +32,7 @@ func setupTestCase(t *testing.T) (func(t *testing.T), dbm.DB, sm.State) {
 	require.NoError(t, err)
 	state, err := sm.LoadStateFromDBOrGenesisFile(stateDB, config.GenesisFile())
 	assert.NoError(t, err, "expected no error on LoadStateFromDBOrGenesisFile")
+	sm.SaveState(stateDB, state)
 
 	tearDown := func(t *testing.T) { os.RemoveAll(config.RootDir) }
 

--- a/state/store.go
+++ b/state/store.go
@@ -37,8 +37,7 @@ func calcABCIResponsesKey(height int64) []byte {
 }
 
 // LoadStateFromDBOrGenesisFile loads the most recent state from the database,
-// or creates a new one from the given genesisFilePath and persists the result
-// to the database.
+// or creates a new one from the given genesisFilePath.
 func LoadStateFromDBOrGenesisFile(stateDB dbm.DB, genesisFilePath string) (State, error) {
 	state := LoadState(stateDB)
 	if state.IsEmpty() {
@@ -47,15 +46,13 @@ func LoadStateFromDBOrGenesisFile(stateDB dbm.DB, genesisFilePath string) (State
 		if err != nil {
 			return state, err
 		}
-		SaveState(stateDB, state)
 	}
 
 	return state, nil
 }
 
 // LoadStateFromDBOrGenesisDoc loads the most recent state from the database,
-// or creates a new one from the given genesisDoc and persists the result
-// to the database.
+// or creates a new one from the given genesisDoc.
 func LoadStateFromDBOrGenesisDoc(stateDB dbm.DB, genesisDoc *types.GenesisDoc) (State, error) {
 	state := LoadState(stateDB)
 
@@ -65,7 +62,6 @@ func LoadStateFromDBOrGenesisDoc(stateDB dbm.DB, genesisDoc *types.GenesisDoc) (
 		if err != nil {
 			return state, err
 		}
-		SaveState(stateDB, state)
 	}
 
 	return state, nil


### PR DESCRIPTION
Fixes #5138. I don't have a strong opinion on this, but find it sort of odd that `Load` functions actually save as well.