### PR TITLE
consensus: don't check InitChain app hash vs genesis app hash, replace it

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,9 +6,6 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### BREAKING CHANGES
 
-- ABCI
-    - [\#5227](https://github.com/tendermint/tendermint/pull/5227) Added `ResponseInitChain.app_hash` which must match genesis app hash and is recorded in genesis block (@erikgrinaker)
-
 - Blockchain Protocol
     - [\#5193](https://github.com/tendermint/tendermint/pull/5193) Header hashes are no longer empty for empty inputs, notably `DataHash`, `EvidenceHash`, and `LastResultsHash` (@erikgrinaker)
 
@@ -16,14 +13,15 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
     - [evidence] [\#5181](https://github.com/tendermint/tendermint/pull/5181) Phantom validator evidence was removed (also from abci) (@cmwaters)  
     - [merkle] [\#5193](https://github.com/tendermint/tendermint/pull/5193) `HashFromByteSlices` and `ProofsFromByteSlices` now return a hash for empty inputs, following RFC6962 (@erikgrinaker)
     - [crypto] [\#5214] Change `GenPrivKeySecp256k1` to `GenPrivKeyFromSecret` to be consistent with other keys
-    - [state] [\#5191](https://github.com/tendermint/tendermint/pull/5191/files) Add `State.InitialHeight` field to record initial block height, must be `1` (not `0`) to start from 1 (@erikgrinaker)
+    - [state] [\#5191](https://github.com/tendermint/tendermint/pull/5191) Add `State.InitialHeight` field to record initial block height, must be `1` (not `0`) to start from 1 (@erikgrinaker)
     - [state] `LoadStateFromDBOrGenesisFile()` and `LoadStateFromDBOrGenesisDoc()` no longer saves the state in the database if not found, the genesis state is simply returned (@erikgrinaker)
 
 ### FEATURES:
 
 - [abci] [\#5174](https://github.com/tendermint/tendermint/pull/5174) Add amnesia evidence and remove mock and potential amnesia evidence from abci (@cmwaters)
-- [abci] [\#5191](https://github.com/tendermint/tendermint/pull/5191/files) Add `InitChain.InitialHeight` field giving the initial block height (@erikgrinaker)
-- [genesis] [\#5191](https://github.com/tendermint/tendermint/pull/5191/files) Add `initial_height` field to specify the initial chain height (defaults to `1`) (@erikgrinaker)
+- [abci] [\#5191](https://github.com/tendermint/tendermint/pull/5191) Add `InitChain.InitialHeight` field giving the initial block height (@erikgrinaker)
+- [abci] [\#5227](https://github.com/tendermint/tendermint/pull/5227) Add `ResponseInitChain.app_hash` which is recorded in genesis block (@erikgrinaker)
+- [genesis] [\#5191](https://github.com/tendermint/tendermint/pull/5191) Add `initial_height` field to specify the initial chain height (defaults to `1`) (@erikgrinaker)
 - [db] Add support for `badgerdb` database backend (@erikgrinaker)
 
 ### IMPROVEMENTS:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,9 +26,6 @@ if you want to learn more & support it (with cosmos-sdk you get it
  automatically). If you don't want to support it, just leave these methods
  empty.
 
- `ResponseInitChain.app_hash` has been added, which must match the genesis app
- hash and is recorded in the genesis block.
-
 `KV.Pair` has been replaced with `abci.EventAttribute`. `EventAttribute.Index`
 field allows ABCI applications to dictate which events should be indexed.
 

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -323,15 +323,15 @@ func (h *Handshaker) ReplayBlocks(
 			return nil, err
 		}
 
-		if !bytes.Equal(res.AppHash, h.genDoc.AppHash) {
-			return nil, fmt.Errorf(
-				"app hash from InitChain does not match genesis, got %X expected %X",
-				res.AppHash, h.genDoc.AppHash)
-		}
 		appHash = res.AppHash
 
 		if stateBlockHeight == 0 { //we only update state when we are in initial state
-			state.AppHash = res.AppHash
+			// If the app did not return an app hash, we keep the one set from the genesis doc in
+			// the state. We don't set appHash since we don't want the genesis doc app hash
+			// recorded in the genesis block. We should probably just remove GenesisDoc.AppHash.
+			if len(res.AppHash) > 0 {
+				state.AppHash = res.AppHash
+			}
 			// If the app returned validators or consensus params, update the state.
 			if len(res.Validators) > 0 {
 				vals, err := types.PB2TM.ValidatorUpdates(res.Validators)


### PR DESCRIPTION
Followup from #5227. Instead of checking `ResponseInitChain.app_hash` against the genesis doc app hash, we instead replace it. We should probably remove the genesis doc app hash completely, and rely solely on the one from `InitChain`, I'll open a separate issue to discuss this.