### PR TITLE
docs: dont display duplicate 

### DIFF
--- a/docs/introduction/architecture.md
+++ b/docs/introduction/architecture.md
@@ -1,3 +1,6 @@
+---
+order: false
+---
 # Tendermint Architectural Overview
 
 


### PR DESCRIPTION
## Description

This PR makes Tendermint Architectural Overview not visible mainly because there are todos and it duplicates some information. 

Closes: #XXX

