### PR TITLE
ci: fix net pipeline

### DIFF
--- a/.github/workflows/net.yml
+++ b/.github/workflows/net.yml
@@ -21,6 +21,7 @@ jobs:
       - name: 10 Blocks
         run: |
           set -x
+          docker run --rm -v "$PWD":/go/src/github.com/tendermint/tendermint -w /go/src/github.com/tendermint/tendermint golang make build-linux
           make localnet-start &
           ./scripts/localnet-blocks-test.sh 40 5 10 localhost
 

--- a/.github/workflows/net.yml
+++ b/.github/workflows/net.yml
@@ -3,10 +3,10 @@ name: Net
 # This workflow is run on every pull request, if a *{.go, .mod, .sum} file has been modified, and push to master and release/** branches
 on:
   pull_request:
-  # paths:
-  #   - "**.go"
-  #   - "**.mod"
-  #   - "**.sum"
+  paths:
+    - "**.go"
+    - "**.mod"
+    - "**.sum"
   push:
     branches:
       - master
@@ -15,7 +15,7 @@ on:
 jobs:
   net-short:
     runs-on: ubuntu-latest
-    timeout-minutes: 4
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - name: 10 Blocks

--- a/.github/workflows/net.yml
+++ b/.github/workflows/net.yml
@@ -3,10 +3,10 @@ name: Net
 # This workflow is run on every pull request, if a *{.go, .mod, .sum} file has been modified, and push to master and release/** branches
 on:
   pull_request:
-    paths:
-      - "**.go"
-      - "**.mod"
-      - "**.sum"
+  # paths:
+  #   - "**.go"
+  #   - "**.mod"
+  #   - "**.sum"
   push:
     branches:
       - master
@@ -21,7 +21,7 @@ jobs:
       - name: 10 Blocks
         run: |
           set -x
-          docker run --rm -v "$PWD":/go/src/github.com/tendermint/tendermint -w /go/src/github.com/tendermint/tendermint golang make build-linux
           make localnet-start &
           ./scripts/localnet-blocks-test.sh 40 5 10 localhost
+
 # Decide if we want to run longer lived testnets

--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -40,6 +40,8 @@ docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint node --proxy_app
 To run a 4-node network, see the `Makefile` in the root of [the repo](https://github.com/tendermint/tendermint/blob/master/Makefile) and run:
 
 ```sh
+make build-linux
+make build-docker-localnode
 make localnet-start
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ build_c-amazonlinux:
 .PHONY: build_c-amazonlinux
 
 # Run a 4-node testnet locally
-localnet-start: localnet-stop build-linux
+localnet-start: localnet-stop build-docker-localnode
 	@if ! [ -f build/node0/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/tendermint:Z tendermint/localnode testnet --config /etc/tendermint/config-template.toml --o . --starting-ip-address 192.167.10.2; fi
 	docker-compose up
 .PHONY: localnet-start


### PR DESCRIPTION
## Description

Ci handles localnet-start differently. To remedy the situation, reverting docker cmd updates is the short term situation. We will have to change a few things to make it work as we would like. 

Closes: #XXX

