### PR TITLE
ci: delay codecov notification 

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,8 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
+  notify:
+    after_n_builds: 4
 
   status:
     project:


### PR DESCRIPTION
## Description

Currently, for ci testing, we upload the code coverage reports individually across multiple machines. Once codecov receives one report it sends a notification in the form of a comment on the pull request. This comment does not contain the full report from all the tests therefore causing inaccurate reports. This PR aims at delaying the codecov notification till at least 4 reports have been uploaded, reducing noise.

Closes: #XXX

