### PR TITLE
statesync: fix valset off-by-one causing consensus failures

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,4 +23,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [statesync] \#5302 Fix genesis state propagation to state sync routine (@erikgrinaker)
 
-- [statesync] Fix validator set off-by-one causing consensus failures (@erikgrinaker)
+- [statesync] \#5311 Fix validator set off-by-one causing consensus failures (@erikgrinaker)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,3 +22,5 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [blockchain] \#5249 Fix fast sync halt with initial height > 1 (@erikgrinaker)
 
 - [statesync] \#5302 Fix genesis state propagation to state sync routine (@erikgrinaker)
+
+- [statesync] Fix validator set off-by-one causing consensus failures (@erikgrinaker)

--- a/statesync/stateprovider.go
+++ b/statesync/stateprovider.go
@@ -120,9 +120,8 @@ func (s *lightClientStateProvider) State(height uint64) (sm.State, error) {
 		state.InitialHeight = 1
 	}
 
-	// We need to verify up until h+2, to get the validator set. This also prefetches the headers
-	// for h and h+1 in the typical case where the trusted header is after the snapshot height.
-	_, err := s.lc.VerifyHeaderAtHeight(int64(height+2), time.Now())
+	// We need to verify the previous block to get the validator set.
+	_, err := s.lc.VerifyHeaderAtHeight(int64(height-1), time.Now())
 	if err != nil {
 		return sm.State{}, err
 	}
@@ -140,15 +139,15 @@ func (s *lightClientStateProvider) State(height uint64) (sm.State, error) {
 	state.AppHash = nextHeader.AppHash
 	state.LastResultsHash = nextHeader.LastResultsHash
 
-	state.LastValidators, _, err = s.lc.TrustedValidatorSet(int64(height))
+	state.LastValidators, _, err = s.lc.TrustedValidatorSet(int64(height - 1))
 	if err != nil {
 		return sm.State{}, err
 	}
-	state.Validators, _, err = s.lc.TrustedValidatorSet(int64(height + 1))
+	state.Validators, _, err = s.lc.TrustedValidatorSet(int64(height))
 	if err != nil {
 		return sm.State{}, err
 	}
-	state.NextValidators, _, err = s.lc.TrustedValidatorSet(int64(height + 2))
+	state.NextValidators, _, err = s.lc.TrustedValidatorSet(int64(height + 1))
 	if err != nil {
 		return sm.State{}, err
 	}


### PR DESCRIPTION
Fixes #5295. Requires #5307 as well.