### PR TITLE
statesync: broadcast snapshot request to all peers on startup

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -40,4 +40,6 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [statesync] \#5311 Fix validator set off-by-one causing consensus failures (@erikgrinaker)
 
+- [statesync] \#5320 Broadcast snapshot request to all pre-connected peers on start (@erikgrinaker)
+
 - [light] [\#5307](https://github.com/tendermint/tendermint/pull/5307) Persist correct proposer priority in light client validator sets (@cmwaters)

--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -254,6 +254,10 @@ func (r *Reactor) Sync(stateProvider StateProvider) (sm.State, *types.Commit, er
 	r.syncer = newSyncer(r.Logger, r.conn, r.connQuery, stateProvider, r.tempDir)
 	r.mtx.Unlock()
 
+	// Request snapshots from all currently connected peers
+	r.Logger.Debug("Requesting snapshots from known peers")
+	r.Switch.Broadcast(SnapshotChannel, mustEncodeMsg(&ssproto.SnapshotsRequest{}))
+
 	state, commit, err := r.syncer.SyncAny(defaultDiscoveryTime)
 	r.mtx.Lock()
 	r.syncer = nil


### PR DESCRIPTION
On startup, the peer-to-peer stack may have peers connected before the state sync process begins, causing these to not trigger `AddPeer` events and thus not be used for snapshot discovery. Broadcasting a snapshot request to these explicitly makes sure we discover snapshots from existing peers as well.