### PR TITLE
metrics: switch from gauge to histogram

### DIFF
--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -43,7 +43,7 @@ type Metrics struct {
 	ByzantineValidatorsPower metrics.Gauge
 
 	// Time between this and the last block.
-	BlockIntervalSeconds metrics.Gauge
+	BlockIntervalSeconds metrics.Histogram
 
 	// Number of transactions.
 	NumTxs metrics.Gauge
@@ -138,7 +138,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "byzantine_validators_power",
 			Help:      "Total power of the byzantine validators.",
 		}, labels).With(labelsAndValues...),
-		BlockIntervalSeconds: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+		BlockIntervalSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "block_interval_seconds",
@@ -207,7 +207,7 @@ func NopMetrics() *Metrics {
 		ByzantineValidators:      discard.NewGauge(),
 		ByzantineValidatorsPower: discard.NewGauge(),
 
-		BlockIntervalSeconds: discard.NewGauge(),
+		BlockIntervalSeconds: discard.NewHistogram(),
 
 		NumTxs:          discard.NewGauge(),
 		BlockSizeBytes:  discard.NewGauge(),

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1655,7 +1655,7 @@ func (cs *State) recordMetrics(height int64, block *types.Block) {
 	if height > 1 {
 		lastBlockMeta := cs.blockStore.LoadBlockMeta(height - 1)
 		if lastBlockMeta != nil {
-			cs.metrics.BlockIntervalSeconds.Set(
+			cs.metrics.BlockIntervalSeconds.Observe(
 				block.Time.Sub(lastBlockMeta.Header.Time).Seconds(),
 			)
 		}


### PR DESCRIPTION
## Description

Part of the issue is to add metrics to the websocket connection. It seems this would require some moving around of things in the node pkg. I opted to not make this change now, and wait for when we do a node pkg refactor. 

If someone disagrees with this appraoch please let me know, I can attempt to get metrics into the rpc layer.

There is not a need to update documentation as it already states this metric is a histogram..

Closes: #1791

