### PR TITLE
statesync: fix the validator set heights (again)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -42,8 +42,6 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [statesync] \#5302 Fix genesis state propagation to state sync routine (@erikgrinaker)
 
-- [statesync] \#5311 Fix validator set off-by-one causing consensus failures (@erikgrinaker)
-
 - [statesync] \#5320 Broadcast snapshot request to all pre-connected peers on start (@erikgrinaker)
 
 - [consensus] \#5329 Fix wrong proposer schedule for validators returned by `InitChain` (@erikgrinaker)


### PR DESCRIPTION
This reverts the "fix" in #5311, after the real fix #5328.