### PR TITLE
CODEOWNERS: specify more precise codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,27 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
-# Everything goes through Bucky, Anton, Tess. For now.
-*       @ebuchman @melekes @tessr
+# Everything goes through the following "global owners" by default. 
+# Unless a later match takes precedence, these three will be
+# requested for review when someone opens a PR. 
+# Note that the last matching pattern takes precedence, so
+# global owners are only requested if there isn't a more specific
+# codeowner specified below. For this reason, the global codeowners 
+# are often repeated in package-level definitions.
+*       @ebuchman @erikgrinaker @melekes @tessr 
 
-# Precious documentation
-/docs/README.md  @zramsay
-/docs/DOCS_README.md  @zramsay
-/docs/.vuepress/  @zramsay
+# Overrides for tooling packages
+.circleci/ @marbar3778  @ebuchman @erikgrinaker @melekes @tessr 
+.github/ @marbar3778 @ebuchman @erikgrinaker @melekes @tessr 
+DOCKER/ @marbar3778 @ebuchman @erikgrinaker @melekes @tessr 
+
+# Overrides for core Tendermint packages 
+abci/  @marbar3778 @ebuchman @erikgrinaker @melekes @tessr 
+evidence/ @cmwaters @ebuchman @erikgrinaker @melekes @tessr
+light/ @cmwaters @melekes @ebuchman
+
+# Overrides for docs
+*.md @marbar3778 @ebuchman @erikgrinaker @melekes @tessr  
+docs/ @marbar3778 @ebuchman @erikgrinaker @melekes @tessr 
+
+
+


### PR DESCRIPTION
Per conversation in Slack, we'd like to experiment with a little more rigor before merging PRs. One thing we'll try is by actually utilizing Github's CODEOWNERS featuer. This PR serves as a proposal for changes to _who_ is responsible for _what_.

Note that we intend to eventually require sign-off from code owners on PRs before they're merged. But as a first step, we'll start by just designating code owners for various files and directories, and it will be up to PR authors to check that the expected code owners have been requested for review. 

A few notes on who is responsible for what:

* There are four global codeowners (@ebuchman, @erikgrinaker, @melekes and @tessr) who are the codeowners for any file/directory that isn't more precisely specified. 
* @marbar3778 is an additional codeowner for all docs and tooling-related directories, including all markdown files, as well as for the `abci` package.
* @cmwaters is an additional codeowner for the `evidence` and `light` packages. 
* I kept @ebuchman as a codeowner for everything because he's said in the past that this is how he manages his notification flow, and I don't see any reason to mess with that now.

I'd be happy to add more code owners (or reduce scope for any preexisting code owners) based on feedback and as the team evolves.

