### PR TITLE
docs: make rfc section disppear

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -1,0 +1,7 @@
+---
+order: 1
+parent:
+  order: false
+---
+
+<!-- TODO: Add readme to RFC section -->


### PR DESCRIPTION
## Description

Hide the RFC section from the docs website. 

Closes: #XXX

