### PR TITLE
mempool/reactor: fix reactor broadcast test

### DIFF
--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -76,6 +76,11 @@ func TestReactorNoBroadcastToSender(t *testing.T) {
 			}
 		}
 	}()
+	for _, r := range reactors {
+		for _, peer := range r.Switch.Peers().List() {
+			peer.Set(types.PeerStateKey, peerState{1})
+		}
+	}
 
 	const peerID = 1
 	checkTxs(t, reactors[0].mempool, numTxs, peerID)


### PR DESCRIPTION
## Description

found out this issue when trying to decouple mempool reactor with its
underlying clist implementation.

according to its comment, the test `TestReactorNoBroadcastToSender` is
intended to make sure that a peer shouldn't send tx back to its origin.
however, the current test forgot to init peer state key, thus the code
will get stuck at waiting for peer to catch up state *instead of* skipping
sending tx back, therefore the test passes by accident:

https://github.com/tendermint/tendermint/blob/b8d08b9ef448365695de19fea0156e1c8611ae7b/mempool/reactor.go#L216-L226

this PR fixes the issue by init peer state key.
