### PR TITLE
upgrading: state store change

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -138,7 +138,7 @@ A field `State.InitialHeight` has been added to record the initial chain height,
 (not `0`) if starting from height `1`. This can be configured via the genesis field
 `initial_height`.
 
-The state package has added a `Store` interface. The interface returns errors on all methods and can be used by calling `state.NewStore(dbm.DB)`.
+The state package has added a `Store` interface. All functions in [state/store.go](https://github.com/tendermint/tendermint/blob/56911ee35298191c95ef1c7d3d5ec508237aaff4/state/store.go#L42-L42) are now part of the interface. The interface returns errors on all methods and can be used by calling `state.NewStore(dbm.DB)`.
 
 ### Privval
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -138,6 +138,8 @@ A field `State.InitialHeight` has been added to record the initial chain height,
 (not `0`) if starting from height `1`. This can be configured via the genesis field
 `initial_height`.
 
+The state package has added a `Store` interface. The interface returns errors on all methods and can be used by calling `state.NewStore(dbm.DB)`.
+
 ### Privval
 
 All requests are now accompanied by the chainID from the network.


### PR DESCRIPTION

## Description

Adding a section explaining the state store interface change. I wasn't aware this was used externally. Our infamous API strikes again.


<img width="462" alt="Screen Shot 2020-09-16 at 2 57 12 PM" src="https://user-images.githubusercontent.com/24299864/93342053-2835fe80-f82f-11ea-9296-9484c2931d9a.png">

Closes: #XXX

