### PR TITLE
Use Type() and Bytes() for ed25519 Equals()

### DIFF
--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -1,7 +1,6 @@
 package ed25519
 
 import (
-	"bytes"
 	"crypto/subtle"
 	"fmt"
 	"io"
@@ -85,15 +84,15 @@ func (privKey PrivKey) PubKey() crypto.PubKey {
 // Equals - you probably don't need to use this.
 // Runs in constant time based on length of the keys.
 func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
-	if otherEd, ok := other.(PrivKey); ok {
-		return subtle.ConstantTimeCompare(privKey[:], otherEd[:]) == 1
+	if privKey.Type() != other.Type() {
+		return false
 	}
 
-	return false
+	return subtle.ConstantTimeCompare(privKey.Bytes(), other.Bytes()) == 1
 }
 
 func (privKey PrivKey) Type() string {
-	return keyType
+	return PrivKeyName
 }
 
 // GenPrivKey generates a new ed25519 private key.
@@ -159,13 +158,13 @@ func (pubKey PubKey) String() string {
 }
 
 func (pubKey PubKey) Type() string {
-	return keyType
+	return PubKeyName
 }
 
 func (pubKey PubKey) Equals(other crypto.PubKey) bool {
-	if otherEd, ok := other.(PubKey); ok {
-		return bytes.Equal(pubKey[:], otherEd[:])
+	if pubKey.Type() != other.Type() {
+		return false
 	}
 
-	return false
+	return subtle.ConstantTimeCompare(pubKey.Bytes(), other.Bytes()) == 1
 }


### PR DESCRIPTION
## Description

_Please add a description of the changes that this PR introduces and the files that
are the most critical to review._ 

In the Cosmos SDK, we realized it was still necessary to add support ED25519 keys. Here is one potential solution to add compatibility between Tendermint's ED25519 keys, and the SDK's own (protobuf) ED25519 keys.

This is still a proof of concept, while we are exploring different possibilities, **please do not merge for now**.

ref: https://github.com/cosmos/cosmos-sdk/issues/6886#issuecomment-694710248

