### PR TITLE
ux: use docker to format proto files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+---
+Language: Proto
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 0
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+SpacesInSquareBrackets: true
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: check-breakage
-        run: make proto-check-breaking-ci
+        run: make proto-check-breaking

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: check-breakage
-        run: make proto-check-breaking
+        run: make proto-check-breaking-ci

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,5 @@
       "--proto_path=${workspaceRoot}/proto",
       "--proto_path=${workspaceRoot}/third_party/proto"
     ]
-  },
-  "clang-format.style": "{BasedOnStyle: Google, IndentWidth: 2, ColumnLimit: 0, AlignConsecutiveAssignments: true, AlignConsecutiveDeclarations: true, SpacesInSquareBrackets: true}",
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,11 @@ proto-lint:
 	@$(DOCKER_BUF) check lint --error-format=json
 .PHONY: proto-lint
 
+proto-format:
+	@echo "Formatting Protobuf files"
+	docker run -v $(shell pwd):/workspace --workdir /workspace tendermintdev/docker-build-proto find ./ -not -path "./third_party/*" -name *.proto -exec clang-format -i {} \;
+.PHONY: proto-format
+
 proto-check-breaking:
 	@$(DOCKER_BUF) check breaking --against-input .git#branch=master
 .PHONY: proto-check-breaking

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -334,9 +334,9 @@ message TxResult {
 
 // Validator
 message Validator {
-  bytes address = 1; // The first 20 bytes of SHA256(public key)
+  bytes address = 1;  // The first 20 bytes of SHA256(public key)
   // PubKey pub_key = 2 [(gogoproto.nullable)=false];
-  int64 power = 3; // The voting power
+  int64 power = 3;  // The voting power
 }
 
 // ValidatorUpdate
@@ -352,19 +352,19 @@ message VoteInfo {
 }
 
 enum EvidenceType {
-  UNKNOWN               = 0;
-  DUPLICATE_VOTE        = 1;
-  LIGHT_CLIENT_ATTACK   = 2;
+  UNKNOWN             = 0;
+  DUPLICATE_VOTE      = 1;
+  LIGHT_CLIENT_ATTACK = 2;
 }
 
 message Evidence {
-  EvidenceType              type      = 1;
+  EvidenceType type = 1;
   // The offending validator
-  Validator                 validator = 2 [(gogoproto.nullable) = false];
-  // The height when the offense occurred 
-  int64                     height    = 3;
+  Validator validator = 2 [(gogoproto.nullable) = false];
+  // The height when the offense occurred
+  int64 height = 3;
   // The corresponding time where the offense occurred
-  google.protobuf.Timestamp time      = 4 [
+  google.protobuf.Timestamp time = 4 [
     (gogoproto.nullable) = false,
     (gogoproto.stdtime)  = true
   ];

--- a/proto/tendermint/evidence/types.proto
+++ b/proto/tendermint/evidence/types.proto
@@ -13,8 +13,8 @@ message List {
 }
 
 message Info {
-  tendermint.types.Evidence           evidence = 1 [(gogoproto.nullable) = false];
-  google.protobuf.Timestamp           time = 2 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
-  repeated tendermint.types.Validator validators = 3;
+  tendermint.types.Evidence evidence                     = 1 [(gogoproto.nullable) = false];
+  google.protobuf.Timestamp time                         = 2 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  repeated tendermint.types.Validator validators         = 3;
   int64                               total_voting_power = 4;
 }

--- a/proto/tendermint/types/evidence.proto
+++ b/proto/tendermint/types/evidence.proto
@@ -14,14 +14,14 @@ message DuplicateVoteEvidence {
 }
 
 message LightClientAttackEvidence {
-  LightBlock                conflicting_block = 1;
-  int64                     common_height     = 2;
+  LightBlock conflicting_block = 1;
+  int64      common_height     = 2;
 }
 
 message Evidence {
   oneof sum {
-    DuplicateVoteEvidence     duplicate_vote_evidence       = 1;
-    LightClientAttackEvidence light_client_attack_evidence  = 2;
+    DuplicateVoteEvidence     duplicate_vote_evidence      = 1;
+    LightClientAttackEvidence light_client_attack_evidence = 2;
   }
 }
 

--- a/proto/tendermint/types/types.proto
+++ b/proto/tendermint/types/types.proto
@@ -26,13 +26,13 @@ enum SignedMsgType {
   option (gogoproto.goproto_enum_stringer) = true;
   option (gogoproto.goproto_enum_prefix)   = false;
 
-  SIGNED_MSG_TYPE_UNKNOWN   = 0 [(gogoproto.enumvalue_customname) = "UnknownType"];
+  SIGNED_MSG_TYPE_UNKNOWN = 0 [(gogoproto.enumvalue_customname) = "UnknownType"];
   // Votes
   SIGNED_MSG_TYPE_PREVOTE   = 1 [(gogoproto.enumvalue_customname) = "PrevoteType"];
   SIGNED_MSG_TYPE_PRECOMMIT = 2 [(gogoproto.enumvalue_customname) = "PrecommitType"];
 
   // Proposals
-  SIGNED_MSG_TYPE_PROPOSAL  = 32 [(gogoproto.enumvalue_customname) = "ProposalType"];
+  SIGNED_MSG_TYPE_PROPOSAL = 32 [(gogoproto.enumvalue_customname) = "ProposalType"];
 }
 
 // PartsetHeader
@@ -144,7 +144,7 @@ message SignedHeader {
 
 message LightBlock {
   SignedHeader                  signed_header = 1;
-  tendermint.types.ValidatorSet validator_set = 2; 
+  tendermint.types.ValidatorSet validator_set = 2;
 }
 
 message BlockMeta {


### PR DESCRIPTION
## Description

Add a cmd to docker image and use it to format our proto files. This avoids developers the need to install clang-format

Closes: #XXX

