### PR TITLE
cli: light home dir should default to where the full node default is

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,21 @@ see our recent paper, "[The latest gossip on BFT consensus](https://arxiv.org/ab
 
 ## Releases
 
-Note: Please, do not depend on master as your production branch, use [releases](https://github.com/tendermint/tendermint/releases) instead.
+Please do not depend on master as your production branch. Use [releases](https://github.com/tendermint/tendermint/releases) instead.
 
 Tendermint is being used in production in both private and public environments,
 most notably the blockchains of the [Cosmos Network](https://cosmos.network/).
 However, we are still making breaking changes to the protocol and the APIs and have not yet released v1.0.
 See below for more details about [versioning](#versioning).
 
-In any case, if you intend to run Tendermint in production,
-please [contact us](mailto:hello@interchain.berlin) and [join the chat](https://discord.gg/AzefAFd).
+In any case, if you intend to run Tendermint in production, we're happy to help. You can
+contact us [over email](mailto:hello@interchain.berlin) or [join the chat](https://discord.gg/AzefAFd).
 
 ## Security
 
 To report a security vulnerability, see our [bug bounty
-program](https://hackerone.com/tendermint)
-
-For examples of the kinds of bugs we're looking for, see [SECURITY.md](SECURITY.md)
+program](https://hackerone.com/tendermint). 
+For examples of the kinds of bugs we're looking for, see [our security policy](SECURITY.md)
 
 ## Minimum requirements
 
@@ -57,13 +56,13 @@ Complete documentation can be found on the [website](https://docs.tendermint.com
 
 ### Install
 
-See the [install instructions](/docs/introduction/install.md)
+See the [install instructions](/docs/introduction/install.md).
 
 ### Quick Start
 
 - [Single node](/docs/introduction/quick-start.md)
 - [Local cluster using docker-compose](/docs/networks/docker-compose.md)
-- [Remote cluster using terraform and ansible](/docs/networks/terraform-and-ansible.md)
+- [Remote cluster using Terraform and Ansible](/docs/networks/terraform-and-ansible.md)
 - [Join the Cosmos testnet](https://cosmos.network/testnet)
 
 ## Contributing
@@ -71,12 +70,9 @@ See the [install instructions](/docs/introduction/install.md)
 Please abide by the [Code of Conduct](CODE_OF_CONDUCT.md) in all interactions.
 
 Before contributing to the project, please take a look at the [contributing guidelines](CONTRIBUTING.md)
-and the [style guide](STYLE_GUIDE.md).
-
-To get more active, Join the wider community at [Discord](https://discord.gg/AzefAFd) or jump onto the [Forum](https://forum.cosmos.network/).
-
-Learn more by reading the code and the
-[specifications](https://github.com/tendermint/spec) or watch the [Developer Sessions](/docs/DEV_SESSIONS.md) and read up on the
+and the [style guide](STYLE_GUIDE.md). You may also find it helpful to read the
+[specifications](https://github.com/tendermint/spec), watch the [Developer Sessions](/docs/DEV_SESSIONS.md), 
+and familiarize yourself with our
 [Architectural Decision Records](https://github.com/tendermint/tendermint/tree/master/docs/architecture).
 
 ## Versioning
@@ -89,7 +85,7 @@ According to SemVer, anything in the public API can change at any time before ve
 To provide some stability to Tendermint users in these 0.X.X days, the MINOR version is used
 to signal breaking changes across a subset of the total public API. This subset includes all
 interfaces exposed to other processes (cli, rpc, p2p, etc.), but does not
-include the in-process Go APIs.
+include the Go APIs.
 
 That said, breaking changes in the following packages will be documented in the
 CHANGELOG even if they don't lead to MINOR version bumps:
@@ -114,20 +110,15 @@ CHANGELOG even if they don't lead to MINOR version bumps:
 - rpc/client
 - types
 
-Exported objects in these packages that are not covered by the versioning scheme
-are explicitly marked by `// UNSTABLE` in their go doc comment and may change at any
-time without notice. Functions, types, and values in any other package may also change at any time.
-
 ### Upgrades
 
 In an effort to avoid accumulating technical debt prior to 1.0.0,
 we do not guarantee that breaking changes (ie. bumps in the MINOR version)
 will work with existing Tendermint blockchains. In these cases you will
 have to start a new blockchain, or write something custom to get the old
-data into the new chain.
+data into the new chain. However, any bump in the PATCH version should be 
+compatible with existing blockchain histories.
 
-However, any bump in the PATCH version should be compatible with existing histories
-(if not please open an [issue](https://github.com/tendermint/tendermint/issues)).
 
 For more information on upgrading, see [UPGRADING.md](./UPGRADING.md).
 
@@ -150,14 +141,8 @@ hosted at: <https://docs.tendermint.com/master/>
 
 ### Tools
 
-Benchmarking is provided by `tm-load-test`.
-The code for `tm-load-test` can be found [here](https://github.com/informalsystems/tm-load-test) this binary needs to be built separately.
-Additional documentation is found [here](/docs/tools).
-
-### Sub-projects
-
-- [IAVL](http://github.com/tendermint/iavl), Merkleized IAVL+ Tree implementation
-- [Tm-db](http://github.com/tendermint/tm-db), Data Base abstractions to be used in applications.
+Benchmarking is provided by [`tm-load-test`](https://github.com/informalsystems/tm-load-test).
+Additional tooling can be found in [/docs/tools](/docs/tools).
 
 ### Applications
 

--- a/cmd/tendermint/commands/debug/debug.go
+++ b/cmd/tendermint/commands/debug/debug.go
@@ -33,7 +33,7 @@ func init() {
 		&nodeRPCAddr,
 		flagNodeRPCAddr,
 		"tcp://localhost:26657",
-		"The Tendermint node's RPC address (<host>:<port>)",
+		"the Tendermint node's RPC address (<host>:<port>)",
 	)
 
 	DebugCmd.AddCommand(killCmd)

--- a/cmd/tendermint/commands/debug/dump.go
+++ b/cmd/tendermint/commands/debug/dump.go
@@ -32,14 +32,14 @@ func init() {
 		&frequency,
 		flagFrequency,
 		30,
-		"The frequency (seconds) in which to poll, aggregate and dump Tendermint debug data",
+		"the frequency (seconds) in which to poll, aggregate and dump Tendermint debug data",
 	)
 
 	dumpCmd.Flags().StringVar(
 		&profAddr,
 		flagProfAddr,
 		"",
-		"The profiling server address (<host>:<port>)",
+		"the profiling server address (<host>:<port>)",
 	)
 }
 

--- a/cmd/tendermint/commands/lite.go
+++ b/cmd/tendermint/commands/lite.go
@@ -74,7 +74,8 @@ func init() {
 		"connect to a Tendermint node at this address")
 	LightCmd.Flags().StringVarP(&witnessAddrsJoined, "witnesses", "w", "",
 		"tendermint nodes to cross-check the primary node, comma-separated")
-	LightCmd.Flags().StringVar(&home, "home-dir", os.ExpandEnv(filepath.Join("$HOME", ".tendermint-light")), "specify the home directory")
+	LightCmd.Flags().StringVar(&home, "home-dir", os.ExpandEnv(filepath.Join("$HOME", ".tendermint-light")),
+		"specify the home directory")
 	LightCmd.Flags().IntVar(
 		&maxOpenConnections,
 		"max-open-connections",

--- a/cmd/tendermint/commands/lite.go
+++ b/cmd/tendermint/commands/lite.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -68,27 +69,27 @@ var (
 
 func init() {
 	LightCmd.Flags().StringVar(&listenAddr, "laddr", "tcp://localhost:8888",
-		"Serve the proxy on the given address")
+		"serve the proxy on the given address")
 	LightCmd.Flags().StringVarP(&primaryAddr, "primary", "p", "",
-		"Connect to a Tendermint node at this address")
+		"connect to a Tendermint node at this address")
 	LightCmd.Flags().StringVarP(&witnessAddrsJoined, "witnesses", "w", "",
-		"Tendermint nodes to cross-check the primary node, comma-separated")
-	LightCmd.Flags().StringVar(&home, "home-dir", ".tendermint-light", "Specify the home directory")
+		"tendermint nodes to cross-check the primary node, comma-separated")
+	LightCmd.Flags().StringVar(&home, "home-dir", os.ExpandEnv(filepath.Join("$HOME", ".tendermint-light")), "specify the home directory")
 	LightCmd.Flags().IntVar(
 		&maxOpenConnections,
 		"max-open-connections",
 		900,
-		"Maximum number of simultaneous connections (including WebSocket).")
+		"maximum number of simultaneous connections (including WebSocket).")
 	LightCmd.Flags().DurationVar(&trustingPeriod, "trusting-period", 168*time.Hour,
-		"Trusting period that headers can be verified within. Should be significantly less than the unbonding period")
+		"trusting period that headers can be verified within. Should be significantly less than the unbonding period")
 	LightCmd.Flags().Int64Var(&trustedHeight, "height", 1, "Trusted header's height")
 	LightCmd.Flags().BytesHexVar(&trustedHash, "hash", []byte{}, "Trusted header's hash")
 	LightCmd.Flags().BoolVar(&verbose, "verbose", false, "Verbose output")
 	LightCmd.Flags().StringVar(&trustLevelStr, "trust-level", "1/3",
-		"Trust level. Must be between 1/3 and 3/3",
+		"trust level. Must be between 1/3 and 3/3",
 	)
 	LightCmd.Flags().BoolVar(&sequential, "sequential", false,
-		"Sequential Verification. Verify all headers sequentially as opposed to using skipping verification",
+		"sequential verification. Verify all headers sequentially as opposed to using skipping verification",
 	)
 }
 

--- a/cmd/tendermint/commands/reset_priv_validator.go
+++ b/cmd/tendermint/commands/reset_priv_validator.go
@@ -21,7 +21,7 @@ var ResetAllCmd = &cobra.Command{
 var keepAddrBook bool
 
 func init() {
-	ResetAllCmd.Flags().BoolVar(&keepAddrBook, "keep-addr-book", false, "Keep the address book intact")
+	ResetAllCmd.Flags().BoolVar(&keepAddrBook, "keep-addr-book", false, "keep the address book intact")
 }
 
 // ResetPrivValidatorCmd resets the private validator files.

--- a/cmd/tendermint/commands/root.go
+++ b/cmd/tendermint/commands/root.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func registerFlagsRootCmd(cmd *cobra.Command) {
-	cmd.PersistentFlags().String("log_level", config.LogLevel, "Log level")
+	cmd.PersistentFlags().String("log_level", config.LogLevel, "log level")
 }
 
 // ParseConfig retrieves the default environment configuration,

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -22,34 +22,34 @@ var (
 // These are exposed for convenience of commands embedding a tendermint node
 func AddNodeFlags(cmd *cobra.Command) {
 	// bind flags
-	cmd.Flags().String("moniker", config.Moniker, "Node Name")
+	cmd.Flags().String("moniker", config.Moniker, "node name")
 
 	// priv val flags
 	cmd.Flags().String(
 		"priv_validator_laddr",
 		config.PrivValidatorListenAddr,
-		"Socket address to listen on for connections from external priv_validator process")
+		"socket address to listen on for connections from external priv_validator process")
 
 	// node flags
-	cmd.Flags().Bool("fast_sync", config.FastSyncMode, "Fast blockchain syncing")
+	cmd.Flags().Bool("fast_sync", config.FastSyncMode, "fast blockchain syncing")
 	cmd.Flags().BytesHexVar(
 		&genesisHash,
 		"genesis_hash",
 		[]byte{},
-		"Optional SHA-256 hash of the genesis file")
+		"optional SHA-256 hash of the genesis file")
 	cmd.Flags().Int64("consensus.double_sign_check_height", config.Consensus.DoubleSignCheckHeight,
-		"How many blocks to look back to check existence of the node's "+
+		"how many blocks to look back to check existence of the node's "+
 			"consensus votes before joining consensus")
 
 	// abci flags
 	cmd.Flags().String(
 		"proxy_app",
 		config.ProxyApp,
-		"Proxy app address, or one of: 'kvstore',"+
+		"proxy app address, or one of: 'kvstore',"+
 			" 'persistent_kvstore',"+
 			" 'counter',"+
 			" 'counter_serial' or 'noop' for local testing.")
-	cmd.Flags().String("abci", config.ABCI, "Specify abci transport (socket | grpc)")
+	cmd.Flags().String("abci", config.ABCI, "specify abci transport (socket | grpc)")
 
 	// rpc flags
 	cmd.Flags().String("rpc.laddr", config.RPC.ListenAddress, "RPC listen address. Port required")
@@ -57,42 +57,42 @@ func AddNodeFlags(cmd *cobra.Command) {
 		"rpc.grpc_laddr",
 		config.RPC.GRPCListenAddress,
 		"GRPC listen address (BroadcastTx only). Port required")
-	cmd.Flags().Bool("rpc.unsafe", config.RPC.Unsafe, "Enabled unsafe rpc methods")
+	cmd.Flags().Bool("rpc.unsafe", config.RPC.Unsafe, "enabled unsafe rpc methods")
 	cmd.Flags().String("rpc.pprof_laddr", config.RPC.PprofListenAddress, "pprof listen address (https://golang.org/pkg/net/http/pprof)")
 
 	// p2p flags
 	cmd.Flags().String(
 		"p2p.laddr",
 		config.P2P.ListenAddress,
-		"Node listen address. (0.0.0.0:0 means any interface, any port)")
-	cmd.Flags().String("p2p.seeds", config.P2P.Seeds, "Comma-delimited ID@host:port seed nodes")
-	cmd.Flags().String("p2p.persistent_peers", config.P2P.PersistentPeers, "Comma-delimited ID@host:port persistent peers")
+		"node listen address. (0.0.0.0:0 means any interface, any port)")
+	cmd.Flags().String("p2p.seeds", config.P2P.Seeds, "comma-delimited ID@host:port seed nodes")
+	cmd.Flags().String("p2p.persistent_peers", config.P2P.PersistentPeers, "comma-delimited ID@host:port persistent peers")
 	cmd.Flags().String("p2p.unconditional_peer_ids",
-		config.P2P.UnconditionalPeerIDs, "Comma-delimited IDs of unconditional peers")
-	cmd.Flags().Bool("p2p.upnp", config.P2P.UPNP, "Enable/disable UPNP port forwarding")
-	cmd.Flags().Bool("p2p.pex", config.P2P.PexReactor, "Enable/disable Peer-Exchange")
-	cmd.Flags().Bool("p2p.seed_mode", config.P2P.SeedMode, "Enable/disable seed mode")
-	cmd.Flags().String("p2p.private_peer_ids", config.P2P.PrivatePeerIDs, "Comma-delimited private peer IDs")
+		config.P2P.UnconditionalPeerIDs, "comma-delimited IDs of unconditional peers")
+	cmd.Flags().Bool("p2p.upnp", config.P2P.UPNP, "enable/disable UPNP port forwarding")
+	cmd.Flags().Bool("p2p.pex", config.P2P.PexReactor, "enable/disable Peer-Exchange")
+	cmd.Flags().Bool("p2p.seed_mode", config.P2P.SeedMode, "enable/disable seed mode")
+	cmd.Flags().String("p2p.private_peer_ids", config.P2P.PrivatePeerIDs, "comma-delimited private peer IDs")
 
 	// consensus flags
 	cmd.Flags().Bool(
 		"consensus.create_empty_blocks",
 		config.Consensus.CreateEmptyBlocks,
-		"Set this to false to only produce blocks when there are txs or when the AppHash changes")
+		"set this to false to only produce blocks when there are txs or when the AppHash changes")
 	cmd.Flags().String(
 		"consensus.create_empty_blocks_interval",
 		config.Consensus.CreateEmptyBlocksInterval.String(),
-		"The possible interval between empty blocks")
+		"the possible interval between empty blocks")
 
 	// db flags
 	cmd.Flags().String(
 		"db_backend",
 		config.DBBackend,
-		"Database backend: goleveldb | cleveldb | boltdb | rocksdb | badgerdb")
+		"database backend: goleveldb | cleveldb | boltdb | rocksdb | badgerdb")
 	cmd.Flags().String(
 		"db_dir",
 		config.DBPath,
-		"Database directory")
+		"database directory")
 }
 
 // NewRunNodeCmd returns the command that allows the CLI to start a node.

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -42,38 +42,38 @@ const (
 
 func init() {
 	TestnetFilesCmd.Flags().IntVar(&nValidators, "v", 4,
-		"Number of validators to initialize the testnet with")
+		"number of validators to initialize the testnet with")
 	TestnetFilesCmd.Flags().StringVar(&configFile, "config", "",
-		"Config file to use (note some options may be overwritten)")
+		"config file to use (note some options may be overwritten)")
 	TestnetFilesCmd.Flags().IntVar(&nNonValidators, "n", 0,
-		"Number of non-validators to initialize the testnet with")
+		"number of non-validators to initialize the testnet with")
 	TestnetFilesCmd.Flags().StringVar(&outputDir, "o", "./mytestnet",
-		"Directory to store initialization data for the testnet")
+		"directory to store initialization data for the testnet")
 	TestnetFilesCmd.Flags().StringVar(&nodeDirPrefix, "node-dir-prefix", "node",
-		"Prefix the directory name for each node with (node results in node0, node1, ...)")
+		"prefix the directory name for each node with (node results in node0, node1, ...)")
 	TestnetFilesCmd.Flags().Int64Var(&initialHeight, "initial-height", 0,
-		"Initial height of the first block")
+		"initial height of the first block")
 
 	TestnetFilesCmd.Flags().BoolVar(&populatePersistentPeers, "populate-persistent-peers", true,
-		"Update config of each node with the list of persistent peers build using either"+
+		"update config of each node with the list of persistent peers build using either"+
 			" hostname-prefix or"+
 			" starting-ip-address")
 	TestnetFilesCmd.Flags().StringVar(&hostnamePrefix, "hostname-prefix", "node",
-		"Hostname prefix (\"node\" results in persistent peers list ID0@node0:26656, ID1@node1:26656, ...)")
+		"hostname prefix (\"node\" results in persistent peers list ID0@node0:26656, ID1@node1:26656, ...)")
 	TestnetFilesCmd.Flags().StringVar(&hostnameSuffix, "hostname-suffix", "",
-		"Hostname suffix ("+
+		"hostname suffix ("+
 			"\".xyz.com\""+
 			" results in persistent peers list ID0@node0.xyz.com:26656, ID1@node1.xyz.com:26656, ...)")
 	TestnetFilesCmd.Flags().StringVar(&startingIPAddress, "starting-ip-address", "",
-		"Starting IP address ("+
+		"starting IP address ("+
 			"\"192.168.0.1\""+
 			" results in persistent peers list ID0@192.168.0.1:26656, ID1@192.168.0.2:26656, ...)")
 	TestnetFilesCmd.Flags().StringArrayVar(&hostnames, "hostname", []string{},
-		"Manually override all hostnames of validators and non-validators (use --hostname multiple times for multiple hosts)")
+		"manually override all hostnames of validators and non-validators (use --hostname multiple times for multiple hosts)")
 	TestnetFilesCmd.Flags().IntVar(&p2pPort, "p2p-port", 26656,
 		"P2P Port")
 	TestnetFilesCmd.Flags().BoolVar(&randomMonikers, "random-monikers", false,
-		"Randomize the moniker for each generated node")
+		"randomize the moniker for each generated node")
 }
 
 // TestnetFilesCmd allows initialisation of files for a Tendermint testnet.

--- a/light/detector.go
+++ b/light/detector.go
@@ -35,7 +35,7 @@ func (c *Client) detectDivergence(ctx context.Context, primaryTrace []*types.Lig
 		lastVerifiedHeader = primaryTrace[len(primaryTrace)-1].SignedHeader
 		witnessesToRemove  = make([]int, 0)
 	)
-	c.logger.Info("Running detector against trace", "endBlockHeight", lastVerifiedHeader.Height,
+	c.logger.Debug("Running detector against trace", "endBlockHeight", lastVerifiedHeader.Height,
 		"endBlockHash", lastVerifiedHeader.Hash, "length", len(primaryTrace))
 
 	c.providerMutex.Lock()
@@ -178,7 +178,7 @@ func (c *Client) compareNewHeaderWithWitness(ctx context.Context, errc chan erro
 		errc <- errConflictingHeaders{Block: lightBlock, WitnessIndex: witnessIndex}
 	}
 
-	c.logger.Info("Matching header received by witness", "height", h.Height, "witness", witnessIndex)
+	c.logger.Debug("Matching header received by witness", "height", h.Height, "witness", witnessIndex)
 	errc <- nil
 }
 


### PR DESCRIPTION
## Description

Minor PR made whilst testing light client. Home directory of the light client is set relative to where the cmd was done whereas the tendermint node cmd uses an absolute home path so made this the same with the light client. In addition, made all the flag descriptions lower-case and lowered the log level of some of the light client calls which were unnecessary.


