### PR TITLE
abci: fix socket client error for state sync responses

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -51,4 +51,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [store] \#5382 Fix race conditions when loading/saving/pruning blocks (@erikgrinaker)
 - [light] [\#5307](https://github.com/tendermint/tendermint/pull/5307) Persist correct proposer priority in light client validator sets (@cmwaters)
 - [docker] \#5385 Fix incorrect `time_iota_ms` default setting causing block timestamp drift (@erikgrinaker)
-- [abci] Fix socket client error for state sync responses (@erikgrinaker)
+- [abci] \#5395 Fix socket client error for state sync responses (@erikgrinaker)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -51,3 +51,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [store] \#5382 Fix race conditions when loading/saving/pruning blocks (@erikgrinaker)
 - [light] [\#5307](https://github.com/tendermint/tendermint/pull/5307) Persist correct proposer priority in light client validator sets (@cmwaters)
 - [docker] \#5385 Fix incorrect `time_iota_ms` default setting causing block timestamp drift (@erikgrinaker)
+- [abci] Fix socket client error for state sync responses (@erikgrinaker)

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -486,6 +486,14 @@ func resMatchesReq(req *types.Request, res *types.Response) (ok bool) {
 		_, ok = res.Value.(*types.Response_BeginBlock)
 	case *types.Request_EndBlock:
 		_, ok = res.Value.(*types.Response_EndBlock)
+	case *types.Request_ApplySnapshotChunk:
+		_, ok = res.Value.(*types.Response_ApplySnapshotChunk)
+	case *types.Request_LoadSnapshotChunk:
+		_, ok = res.Value.(*types.Response_LoadSnapshotChunk)
+	case *types.Request_ListSnapshots:
+		_, ok = res.Value.(*types.Response_ListSnapshots)
+	case *types.Request_OfferSnapshot:
+		_, ok = res.Value.(*types.Response_OfferSnapshot)
 	}
 	return ok
 }


### PR DESCRIPTION
This caused the node to crash whenever any state sync-related request was called via the ABCI UNIX socket client.