### PR TITLE
config: add state sync discovery_time setting

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -41,6 +41,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [blockchain] \#5278 Verify only +2/3 of the signatures in a block when fast syncing. (@marbar3778)
 - [rpc] \#5293 `/dial_peers` has added `private` and `unconditional` as parameters. (@marbar3778)
 - [types] \#5340 Add check in `Header.ValidateBasic()` for block protocol version (@marbar3778)
+- [statesync] \#5399 Add `discovery_time` configuration setting, and reduce default to 15s. (@erikgrinaker)
 
 ## BUG FIXES
 

--- a/config/config.go
+++ b/config/config.go
@@ -726,12 +726,13 @@ func (cfg *MempoolConfig) ValidateBasic() error {
 
 // StateSyncConfig defines the configuration for the Tendermint state sync service
 type StateSyncConfig struct {
-	Enable      bool          `mapstructure:"enable"`
-	TempDir     string        `mapstructure:"temp_dir"`
-	RPCServers  []string      `mapstructure:"rpc_servers"`
-	TrustPeriod time.Duration `mapstructure:"trust_period"`
-	TrustHeight int64         `mapstructure:"trust_height"`
-	TrustHash   string        `mapstructure:"trust_hash"`
+	Enable        bool          `mapstructure:"enable"`
+	TempDir       string        `mapstructure:"temp_dir"`
+	RPCServers    []string      `mapstructure:"rpc_servers"`
+	TrustPeriod   time.Duration `mapstructure:"trust_period"`
+	TrustHeight   int64         `mapstructure:"trust_height"`
+	TrustHash     string        `mapstructure:"trust_hash"`
+	DiscoveryTime time.Duration `mapstructure:"discovery_time"`
 }
 
 func (cfg *StateSyncConfig) TrustHashBytes() []byte {
@@ -746,7 +747,8 @@ func (cfg *StateSyncConfig) TrustHashBytes() []byte {
 // DefaultStateSyncConfig returns a default configuration for the state sync service
 func DefaultStateSyncConfig() *StateSyncConfig {
 	return &StateSyncConfig{
-		TrustPeriod: 168 * time.Hour,
+		TrustPeriod:   168 * time.Hour,
+		DiscoveryTime: 15 * time.Second,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -355,6 +355,9 @@ trust_height = {{ .StateSync.TrustHeight }}
 trust_hash = "{{ .StateSync.TrustHash }}"
 trust_period = "{{ .StateSync.TrustPeriod }}"
 
+# Time to spend discovering snapshots before initiating a restore.
+discovery_time = "{{ .StateSync.DiscoveryTime }}"
+
 # Temporary directory for state sync snapshot chunks, defaults to the OS tempdir (typically /tmp).
 # Will create a new, randomly named directory within, and remove it when done.
 temp_dir = "{{ .StateSync.TempDir }}"

--- a/node/node.go
+++ b/node/node.go
@@ -580,7 +580,7 @@ func startStateSync(ssR *statesync.Reactor, bcR fastSyncReactor, conR *cs.Reacto
 	}
 
 	go func() {
-		state, commit, err := ssR.Sync(stateProvider)
+		state, commit, err := ssR.Sync(stateProvider, config.DiscoveryTime)
 		if err != nil {
 			ssR.Logger.Error("State sync failed", "err", err)
 			return

--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -3,6 +3,7 @@ package statesync
 import (
 	"errors"
 	"sort"
+	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmsync "github.com/tendermint/tendermint/libs/sync"
@@ -245,7 +246,7 @@ func (r *Reactor) recentSnapshots(n uint32) ([]*snapshot, error) {
 
 // Sync runs a state sync, returning the new state and last commit at the snapshot height.
 // The caller must store the state and commit in the state database and block store.
-func (r *Reactor) Sync(stateProvider StateProvider) (sm.State, *types.Commit, error) {
+func (r *Reactor) Sync(stateProvider StateProvider, discoveryTime time.Duration) (sm.State, *types.Commit, error) {
 	r.mtx.Lock()
 	if r.syncer != nil {
 		r.mtx.Unlock()
@@ -258,7 +259,7 @@ func (r *Reactor) Sync(stateProvider StateProvider) (sm.State, *types.Commit, er
 	r.Logger.Debug("Requesting snapshots from known peers")
 	r.Switch.Broadcast(SnapshotChannel, mustEncodeMsg(&ssproto.SnapshotsRequest{}))
 
-	state, commit, err := r.syncer.SyncAny(defaultDiscoveryTime)
+	state, commit, err := r.syncer.SyncAny(discoveryTime)
 	r.mtx.Lock()
 	r.syncer = nil
 	r.mtx.Unlock()

--- a/statesync/syncer.go
+++ b/statesync/syncer.go
@@ -18,8 +18,6 @@ import (
 )
 
 const (
-	// defaultDiscoveryTime is the time to spend discovering snapshots.
-	defaultDiscoveryTime = 20 * time.Second
 	// chunkFetchers is the number of concurrent chunk fetchers to run.
 	chunkFetchers = 4
 	// chunkTimeout is the timeout while waiting for the next chunk from the chunk queue.


### PR DESCRIPTION
Reduces the state sync discovery time from 20 to 15 seconds, and makes it configurable.

