### PR TITLE
docs: fix sidebar versions

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -25,8 +25,47 @@ module.exports = {
       banner: false,
     },
     sidebar: {
-      auto: true,
+      auto: false,
       nav: [
+        {
+          children: [
+            {
+              title: "Introduction",
+              path: "/introduction",
+              directory: true,
+            },
+            {
+              title: "Guides",
+              path: "/tutorials",
+              directory: true,
+            },
+            {
+              title: "Apps",
+              path: "/app-dev",
+              directory: true,
+            },
+            {
+              title: "Tendermint Core",
+              path: "/tendermint-core",
+              directory: true,
+            },
+            {
+              title: "Networks",
+              path: "/networks",
+              directory: true,
+            },
+            {
+              title: "Tools",
+              path: "/tools",
+              directory: true,
+            },
+            {
+              title: "Tendermint Spec",
+              path: "/spec",
+              directory: true,
+            },
+          ]
+        },
         {
           title: 'Resources',
           children: [
@@ -39,16 +78,15 @@ module.exports = {
               path: 'https://docs.tendermint.com/master/rpc/',
               static: true
             },
-            // TODO: remove once https://github.com/cosmos/vuepress-theme-cosmos/issues/91 is closed
             {
               title: 'Version 0.32',
-              path: '/v0.32',
-              static: true
+              path: '/0.32',
+              directory: true,
             },
             {
               title: 'Version 0.33',
-              path: '/v0.33',
-              static: true
+              path: '/0.33',
+              directory: true,
             },
           ]
         }
@@ -138,7 +176,7 @@ module.exports = {
           children: [
             {
               title: 'Contributing to the docs',
-              url: 'https://github.com/tendermint/tendermint'
+              url: 'https://github.com/tendermint/tendermint/blob/master/docs/DOCS_README.md'
             },
             {
               title: 'Source code on GitHub',

--- a/docs/post.sh
+++ b/docs/post.sh
@@ -2,3 +2,6 @@
 
 rm -rf ./.vuepress/public/rpc
 rm -rf ./spec
+
+rm -rf ./0.32
+rm -rf ./0.33

--- a/docs/pre.sh
+++ b/docs/pre.sh
@@ -1,4 +1,29 @@
 #!/bin/bash
 
 cp -a ../rpc/openapi/ .vuepress/public/rpc/
-git clone https://github.com/tendermint/spec.git specRepo && cp -r specRepo/spec . && rm -rf specRepo
+
+git clone https://github.com/tendermint/spec.git specRepo
+cp -r specRepo/spec .
+rm -rf specRepo
+
+mkdir 0.32
+git clone -b v0.32.0  --depth 1  https://github.com/tendermint/tendermint.git 32Repo
+cp -r 32Repo/docs 0.32
+rm -rf 32Repo
+rm -rf 0.32/docs/DOCS_README.md
+rm -rf 0.32/docs/README.md
+cd 0.32/docs
+mv * ../
+rm -rf 0.32/docs
+
+cd ../..
+
+mkdir 0.33
+git clone -b v0.33.0  --depth 1  https://github.com/tendermint/tendermint.git 33Repo
+cp -r 33Repo/docs 0.33
+rm -rf 33Repo
+rm -rf 0.33/docs/DOCS_README.md
+rm -rf 0.33/docs/README.md
+cd 0.33/docs
+mv * ../
+rm -rf 0.33/docs


### PR DESCRIPTION
## Description

Preview: https://tendermint-docs-staging.netlify.app

~~Version 0.32 and 0.33 are not working on the production (https://docs.tendermint.com) because there are no 0.32 and 0.33 directories in the /docs.~~

- ~~Clone 0.32 and 0.33 to the docs dir~~
- ~~Add the versioned content during pre-build, same as [Tendermint Spec folder](https://github.com/tendermint/tendermint/pull/5409/files#diff-7f9e27b746ff0d5617dfd375180ad77cR5)~~
- ~~Set sidebar auto false~~
- ~~So sidebar won't automatically include the versions in the primary sidebar~~

Related: https://github.com/tendermint/tendermint/pull/5241

## Update

- [x] Fix console/build errors in [`v0.33`](https://github.com/tendermint/tendermint/pull/5424) branch
- [x] Check https://docs.staging-tendermint.com
- [x] Close this PR