### PR TITLE
blockchain: remove duplication of validate basic

### DIFF
--- a/blockchain/msgs.go
+++ b/blockchain/msgs.go
@@ -83,10 +83,8 @@ func ValidateMsg(pb proto.Message) error {
 			return errors.New("negative Height")
 		}
 	case *bcproto.BlockResponse:
-		_, err := types.BlockFromProto(msg.Block)
-		if err != nil {
-			return err
-		}
+		// validate basic is called later when converting from proto
+		return nil
 	case *bcproto.NoBlockResponse:
 		if msg.Height < 0 {
 			return errors.New("negative Height")

--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -227,6 +227,7 @@ func (bcR *BlockchainReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) 
 		bi, err := types.BlockFromProto(msg.Block)
 		if err != nil {
 			bcR.Logger.Error("Block content is invalid", "err", err)
+			bcR.Switch.StopPeerForError(src, err)
 			return
 		}
 		bcR.pool.AddBlock(src.ID(), bi, len(msgBytes))

--- a/blockchain/v1/reactor.go
+++ b/blockchain/v1/reactor.go
@@ -285,6 +285,7 @@ func (bcR *BlockchainReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) 
 		bi, err := types.BlockFromProto(msg.Block)
 		if err != nil {
 			bcR.Logger.Error("error transition block from protobuf", "err", err)
+			_ = bcR.swReporter.Report(behaviour.BadMessage(src.ID(), err.Error()))
 			return
 		}
 		msgForFSM := bcReactorMessage{

--- a/blockchain/v2/reactor.go
+++ b/blockchain/v2/reactor.go
@@ -469,6 +469,7 @@ func (r *BlockchainReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) {
 		bi, err := types.BlockFromProto(msg.Block)
 		if err != nil {
 			r.logger.Error("error transitioning block from protobuf", "err", err)
+			_ = r.reporter.Report(behaviour.BadMessage(src.ID(), err.Error()))
 			return
 		}
 		if r.events != nil {

--- a/blockchain/v2/scheduler.go
+++ b/blockchain/v2/scheduler.go
@@ -522,12 +522,6 @@ func (sc *scheduler) handleBlockResponse(event bcBlockResponse) (Event, error) {
 		return scPeerError{peerID: event.peerID, reason: err}, nil
 	}
 
-	err = event.block.ValidateBasic()
-	if err != nil {
-		_ = sc.removePeer(event.peerID)
-		return scPeerError{peerID: event.peerID, reason: err}, nil
-	}
-
 	err = sc.markReceived(event.peerID, event.block.Height, event.size, event.time)
 	if err != nil {
 		_ = sc.removePeer(event.peerID)

--- a/blockchain/v2/scheduler.go
+++ b/blockchain/v2/scheduler.go
@@ -522,6 +522,12 @@ func (sc *scheduler) handleBlockResponse(event bcBlockResponse) (Event, error) {
 		return scPeerError{peerID: event.peerID, reason: err}, nil
 	}
 
+	err = event.block.ValidateBasic()
+	if err != nil {
+		_ = sc.removePeer(event.peerID)
+		return scPeerError{peerID: event.peerID, reason: err}, nil
+	}
+
 	err = sc.markReceived(event.peerID, event.block.Height, event.size, event.time)
 	if err != nil {
 		_ = sc.removePeer(event.peerID)

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -661,6 +661,9 @@ func (vals *ValidatorSet) UpdateWithChangeSet(changes []*Validator) error {
 // with a bonus for including more than +2/3 of the signatures.
 func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID,
 	height int64, commit *Commit) error {
+	if commit == nil {
+		return errors.New("nil commit")
+	}
 
 	if vals.Size() != len(commit.Signatures) {
 		return NewErrInvalidCommitSignatures(vals.Size(), len(commit.Signatures))
@@ -773,9 +776,12 @@ func (vals *ValidatorSet) VerifyCommitLight(chainID string, blockID BlockID,
 // This method is primarily used by the light client and does not check all the
 // signatures.
 func (vals *ValidatorSet) VerifyCommitLightTrusting(chainID string, commit *Commit, trustLevel tmmath.Fraction) error {
-	// sanity check
+	// sanity checks
 	if trustLevel.Denominator == 0 {
 		return errors.New("trustLevel has zero Denominator")
+	}
+	if commit == nil {
+		return errors.New("nil commit")
 	}
 
 	var (

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -718,6 +718,9 @@ func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID,
 // signatures.
 func (vals *ValidatorSet) VerifyCommitLight(chainID string, blockID BlockID,
 	height int64, commit *Commit) error {
+	if commit == nil {
+		return errors.New("nil commit")
+	}
 
 	if vals.Size() != len(commit.Signatures) {
 		return NewErrInvalidCommitSignatures(vals.Size(), len(commit.Signatures))


### PR DESCRIPTION
## Description

When we run `BlockFromProto()` we also run validate basic on the converted block as part of the output. This is done twice: in `ValidateMsg` and when receiving `BlockResponse`. This PR removes the check in `ValidateMsg`.


