### PR TITLE
config: set statesync.rpc_servers when generating config file

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,7 +24,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [privval] `NewSignerDialerEndpoint` can now be given `SignerServiceEndpointOption` (@erikgrinaker)
 
-- [config] `statesync.rpc_servers` is now properly set when writing the configuration file (@erikgrinaker)
+- [config] \#5433 `statesync.rpc_servers` is now properly set when writing the configuration file (@erikgrinaker)
 
 ### BUG FIXES
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,5 +24,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [privval] `NewSignerDialerEndpoint` can now be given `SignerServiceEndpointOption` (@erikgrinaker)
 
+- [config] `statesync.rpc_servers` is now properly set when writing the configuration file (@erikgrinaker)
+
 ### BUG FIXES
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	tmos "github.com/tendermint/tendermint/libs/os"
@@ -17,7 +18,10 @@ var configTemplate *template.Template
 
 func init() {
 	var err error
-	if configTemplate, err = template.New("configFileTemplate").Parse(defaultConfigTemplate); err != nil {
+	tmpl := template.New("configFileTemplate").Funcs(template.FuncMap{
+		"StringsJoin": strings.Join,
+	})
+	if configTemplate, err = tmpl.Parse(defaultConfigTemplate); err != nil {
 		panic(err)
 	}
 }
@@ -350,7 +354,7 @@ enable = {{ .StateSync.Enable }}
 #
 # For Cosmos SDK-based chains, trust_period should usually be about 2/3 of the unbonding time (~2
 # weeks) during which they can be financially punished (slashed) for misbehavior.
-rpc_servers = ""
+rpc_servers = "{{ StringsJoin .StateSync.RPCServers "," }}"
 trust_height = {{ .StateSync.TrustHeight }}
 trust_hash = "{{ .StateSync.TrustHash }}"
 trust_period = "{{ .StateSync.TrustPeriod }}"


### PR DESCRIPTION
Required for #5291, to generate configuration files with state sync RPC servers.