### PR TITLE
privval: allow passing options to NewSignerDialerEndpoint

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,5 +22,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### IMPROVEMENTS
 
+- [privval] `NewSignerDialerEndpoint` can now be given `SignerServiceEndpointOption` (@erikgrinaker)
+
 ### BUG FIXES
 

--- a/privval/signer_dialer_endpoint.go
+++ b/privval/signer_dialer_endpoint.go
@@ -48,12 +48,17 @@ type SignerDialerEndpoint struct {
 func NewSignerDialerEndpoint(
 	logger log.Logger,
 	dialer SocketDialer,
+	options ...SignerServiceEndpointOption,
 ) *SignerDialerEndpoint {
 
 	sd := &SignerDialerEndpoint{
 		dialer:         dialer,
 		retryWait:      defaultRetryWaitMilliseconds * time.Millisecond,
 		maxConnRetries: defaultMaxDialRetries,
+	}
+
+	for _, optionFunc := range options {
+		optionFunc(sd)
 	}
 
 	sd.BaseService = *service.NewBaseService(logger, "SignerDialerEndpoint", sd)


### PR DESCRIPTION
Required for #5291 to set timeouts for remote signers.