### PR TITLE
fix RPC blockresults reutrn

### DIFF
--- a/crypto/encoding/codec.go
+++ b/crypto/encoding/codec.go
@@ -5,8 +5,14 @@ import (
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/libs/json"
 	pc "github.com/tendermint/tendermint/proto/tendermint/crypto"
 )
+
+func init() {
+	json.RegisterType((*pc.PublicKey)(nil), "tendermint.crypto.PublicKey")
+	json.RegisterType((*pc.PublicKey_Ed25519)(nil), "tendermint.crypto.PublicKey_Ed25519")
+}
 
 // PubKeyToProto takes crypto.PubKey and transforms it to a protobuf Pubkey
 func PubKeyToProto(k crypto.PubKey) (pc.PublicKey, error) {


### PR DESCRIPTION
## Description

In blocks_results we use the proto definition of abciResponses: https://github.com/tendermint/tendermint/blob/2672b91ab099b8b02f3afabae4a0a745acd93c3f/rpc/core/blocks.go#L152-L155, this leads to the use of the proto definition of the pubkey which is an interface in go (oneof). The interface must be registered with the JSON encoder to have it work correctly.

A clearer divide between proto types and native types is needed.

Closes: #XXX

