### PR TITLE
docs: set master as default version

### DIFF
--- a/docs/versions
+++ b/docs/versions
@@ -1,3 +1,3 @@
-master                  master
 v0.32                   v0.32
 cyrus/0.33-version      v0.33
+master                  master


### PR DESCRIPTION
## Description

This PR changes the order of docs versions in order to have master as the default version.

Closes: #5472

