### PR TITLE
tx: reduce function to one parameter

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -526,7 +526,7 @@ func (mem *CListMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
 		memTx := e.Value.(*mempoolTx)
 
-		dataSize := types.ComputeProtoSizeForTxs(txs, memTx.tx)
+		dataSize := types.ComputeProtoSizeForTxs(append(txs, memTx.tx))
 
 		// Check total size requirement
 		if maxBytes > -1 && dataSize > maxBytes {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -105,7 +105,7 @@ type TxInfo struct {
 // PreCheckMaxBytes checks that the size of the transaction is smaller or equal to the expected maxBytes.
 func PreCheckMaxBytes(maxBytes int64) PreCheckFunc {
 	return func(tx types.Tx) error {
-		txSize := types.ComputeProtoSizeForTx(tx)
+		txSize := types.ComputeProtoSizeForTxs([]types.Tx{tx})
 
 		if txSize > maxBytes {
 			return fmt.Errorf("tx size is too big: %d, max: %d",

--- a/types/tx.go
+++ b/types/tx.go
@@ -140,20 +140,8 @@ func TxProofFromProto(pb tmproto.TxProof) (TxProof, error) {
 
 // ComputeProtoOverheadForTxs wraps the transactions in tmproto.Data{} and calculates the size.
 // https://developers.google.com/protocol-buffers/docs/encoding
-func ComputeProtoSizeForTxs(txs []Tx, tx Tx) int64 {
-	tt := make(Txs, len(txs)+1)
-
-	tt = append(tt, txs...)
-	tt = append(tt, tx)
-	data := Data{Txs: tt}
+func ComputeProtoSizeForTxs(txs []Tx) int64 {
+	data := Data{Txs: txs}
 	pdData := data.ToProto()
 	return int64(pdData.Size())
-}
-
-// ComputeProtoSizeForTx wraps the transaction in tmproto.Data{} and calculates the size.
-// https://developers.google.com/protocol-buffers/docs/encoding
-func ComputeProtoSizeForTx(tx Tx) int64 {
-	pbdata := tmproto.Data{Txs: [][]byte{tx}}
-
-	return int64(pbdata.Size())
 }

--- a/types/tx.go
+++ b/types/tx.go
@@ -138,7 +138,7 @@ func TxProofFromProto(pb tmproto.TxProof) (TxProof, error) {
 	return pbtp, nil
 }
 
-// ComputeProtoOverheadForTxs wraps the transactions in tmproto.Data{} and calculates the size.
+// ComputeProtoSizeForTxs wraps the transactions in tmproto.Data{} and calculates the size.
 // https://developers.google.com/protocol-buffers/docs/encoding
 func ComputeProtoSizeForTxs(txs []Tx) int64 {
 	data := Data{Txs: txs}


### PR DESCRIPTION
## Description

- use append within function parameter instead of passing two parameters

Closes: #XXX

