### PR TITLE
linter: remove nolintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     # - whitespace
     # - wsl
     # - gocognit
-    - nolintlint
+    # - nolintlint
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     # - whitespace
     # - wsl
     # - gocognit
-    # - nolintlint
+    - nolintlint
 
 issues:
   exclude-rules:

--- a/abci/tests/test_app/main.go
+++ b/abci/tests/test_app/main.go
@@ -68,7 +68,7 @@ func testCounter() {
 	}()
 
 	if err := ensureABCIIsUp(abciType, maxABCIConnectTries); err != nil {
-		log.Fatalf("echo failed: %v", err) //nolint:gocritic
+		log.Fatalf("echo failed: %v", err)
 	}
 
 	client := startClient(abciType)

--- a/libs/rand/random.go
+++ b/libs/rand/random.go
@@ -48,7 +48,7 @@ func (r *Rand) init() {
 }
 
 func (r *Rand) reset(seed int64) {
-	r.rand = mrand.New(mrand.NewSource(seed)) // nolint:gosec // G404: Use of weak random number generator
+	r.rand = mrand.New(mrand.NewSource(seed))
 }
 
 //----------------------------------------

--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -171,6 +171,5 @@ func validateHeight(height int64) (*int64, error) {
 // exponential backoff (with jitter)
 // 0.5s -> 2s -> 4.5s -> 8s -> 12.5 with 1s variation
 func backoffTimeout(attempt uint16) time.Duration {
-	// nolint:gosec // G404: Use of weak random number generator
 	return time.Duration(500*attempt*attempt)*time.Millisecond + time.Duration(rand.Intn(1000))*time.Millisecond
 }

--- a/rpc/client/examples_test.go
+++ b/rpc/client/examples_test.go
@@ -22,7 +22,7 @@ func ExampleHTTP_simple() {
 	rpcAddr := rpctest.GetConfig().RPC.ListenAddress
 	c, err := rpchttp.New(rpcAddr, "/websocket")
 	if err != nil {
-		log.Fatal(err) //nolint:gocritic
+		log.Fatal(err)
 	}
 
 	// Create a transaction
@@ -98,7 +98,7 @@ func ExampleHTTP_batching() {
 		// Broadcast the transaction and wait for it to commit (rather use
 		// c.BroadcastTxSync though in production).
 		if _, err := batch.BroadcastTxCommit(context.Background(), tx); err != nil {
-			log.Fatal(err) //nolint:gocritic
+			log.Fatal(err)
 		}
 	}
 

--- a/scripts/wal2json/main.go
+++ b/scripts/wal2json/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		if err != nil {
 			fmt.Println("Failed to write message", err)
-			os.Exit(1) //nolint:gocritic
+			os.Exit(1)
 		}
 
 	}

--- a/statesync/snapshots.go
+++ b/statesync/snapshots.go
@@ -145,7 +145,7 @@ func (p *snapshotPool) GetPeer(snapshot *snapshot) p2p.Peer {
 	if len(peers) == 0 {
 		return nil
 	}
-	return peers[rand.Intn(len(peers))] // nolint:gosec // G404: Use of weak random number generator
+	return peers[rand.Intn(len(peers))]
 }
 
 // GetPeers returns the peers for a snapshot.

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -1,4 +1,3 @@
-//nolint: gosec
 package main
 
 import (

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -1,4 +1,3 @@
-//nolint: gosec
 package e2e
 
 import (


### PR DESCRIPTION
## Description

We're starting to stack up on nolintlint messages (for no lint comments on gosec and gocritic). Either we remove golintlint or the comments that ignore certain linting aspects. 

Closes: #XXX

