### PR TITLE
test: enable restart/kill perturbations in E2E tests

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -36,9 +36,8 @@ var (
 	nodePerturbations     = probSetChoice{
 		"disconnect": 0.1,
 		"pause":      0.1,
-		// FIXME disabled due to https://github.com/tendermint/tendermint/issues/5422
-		// "kill":       0.1,
-		// "restart":    0.1,
+		"kill":       0.1,
+		"restart":    0.1,
 	}
 )
 

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -43,9 +43,7 @@ database = "boltdb"
 abci_protocol = "tcp"
 privval_protocol = "tcp"
 persist_interval = 0
-# FIXME The WAL gets corrupted when restarted
-# https://github.com/tendermint/tendermint/issues/5422
-#perturb = ["restart"]
+perturb = ["restart"]
 
 [node.validator03]
 seeds = ["seed01"]
@@ -54,9 +52,7 @@ abci_protocol = "grpc"
 privval_protocol = "unix"
 persist_interval = 3
 retain_blocks = 3
-# FIXME The WAL gets corrupted when killed
-# https://github.com/tendermint/tendermint/issues/5422
-#perturb = ["kill"]
+perturb = ["kill"]
 
 [node.validator04]
 persistent_peers = ["validator01"]
@@ -72,9 +68,7 @@ database = "cleveldb"
 fast_sync = "v0"
 abci_protocol = "grpc"
 privval_protocol = "tcp"
-# FIXME The WAL gets corrupted when killed
-# https://github.com/tendermint/tendermint/issues/5422
-#perturb = ["kill", "pause", "disconnect", "restart"]
+perturb = ["kill", "pause", "disconnect", "restart"]
 
 [node.full01]
 start_at = 1010
@@ -83,9 +77,7 @@ mode = "full"
 # https://github.com/tendermint/tendermint/issues/5444
 fast_sync = "v2"
 persistent_peers = ["validator01", "validator02", "validator03", "validator04", "validator05"]
-# FIXME The WAL gets corrupted when restarted
-# https://github.com/tendermint/tendermint/issues/5422
-#perturb = ["restart"]
+perturb = ["restart"]
 
 [node.full02]
 start_at = 1015
@@ -93,6 +85,4 @@ mode = "full"
 fast_sync = "v2"
 state_sync = true
 seeds = ["seed01"]
-# FIXME The WAL gets corrupted when restarted
-# https://github.com/tendermint/tendermint/issues/5422
-#perturb = ["restart"]
+perturb = ["restart"]


### PR DESCRIPTION
When #5536 lands we can re-enable restart/kill perturbations in E2E tests.