### PR TITLE
blockchain/v1: add noBlockResponse handling  (#5401)

### DIFF
--- a/blockchain/v1/reactor.go
+++ b/blockchain/v1/reactor.go
@@ -298,6 +298,16 @@ func (bcR *BlockchainReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) 
 		}
 		bcR.Logger.Info("Received", "src", src, "height", bi.Height)
 		bcR.messagesForFSMCh <- msgForFSM
+	case *bcproto.NoBlockResponse:
+		msgForFSM := bcReactorMessage{
+			event: noBlockResponseEv,
+			data: bReactorEventData{
+				peerID: src.ID(),
+				height: msg.Height,
+			},
+		}
+		bcR.Logger.Debug("Peer does not have requested block", "peer", src, "height", msg.Height)
+		bcR.messagesForFSMCh <- msgForFSM
 
 	case *bcproto.StatusResponse:
 		// Got a peer status. Unverified.

--- a/blockchain/v1/reactor_fsm.go
+++ b/blockchain/v1/reactor_fsm.go
@@ -74,6 +74,7 @@ const (
 	startFSMEv = iota + 1
 	statusResponseEv
 	blockResponseEv
+	noBlockResponseEv
 	processedBlockEv
 	makeRequestsEv
 	stopFSMEv
@@ -94,6 +95,9 @@ func (msg *bcReactorMessage) String() string {
 	case blockResponseEv:
 		dataStr = fmt.Sprintf("peer=%v block.height=%v length=%v",
 			msg.data.peerID, msg.data.block.Height, msg.data.length)
+	case noBlockResponseEv:
+		dataStr = fmt.Sprintf("peer=%v requested height=%v",
+			msg.data.peerID, msg.data.height)
 	case processedBlockEv:
 		dataStr = fmt.Sprintf("error=%v", msg.data.err)
 	case makeRequestsEv:
@@ -119,6 +123,8 @@ func (ev bReactorEvent) String() string {
 		return "statusResponseEv"
 	case blockResponseEv:
 		return "blockResponseEv"
+	case noBlockResponseEv:
+		return "noBlockResponseEv"
 	case processedBlockEv:
 		return "processedBlockEv"
 	case makeRequestsEv:
@@ -269,7 +275,10 @@ func init() {
 					return waitForPeer, err
 				}
 				return waitForBlock, err
+			case noBlockResponseEv:
+				fsm.logger.Error("peer does not have requested block", "peer", data.peerID)
 
+				return waitForBlock, nil
 			case processedBlockEv:
 				if data.err != nil {
 					first, second, _ := fsm.pool.FirstTwoBlocksAndPeers()

--- a/blockchain/v1/reactor_fsm_test.go
+++ b/blockchain/v1/reactor_fsm_test.go
@@ -822,7 +822,7 @@ const (
 	maxRequestsPerPeerTest      = 20
 	maxTotalPendingRequestsTest = 600
 	maxNumPeersTest             = 1000
-	maxNumBlocksInChainTest     = 10000 //should be smaller than 9999999
+	maxNumBlocksInChainTest     = 10000 // should be smaller than 9999999
 )
 
 func makeCorrectTransitionSequenceWithRandomParameters() testFields {


### PR DESCRIPTION
## Description

Add simple `NoBlockResponse` handling to blockchain reactor v1. I tested before and after with erik's e2e testing and was not able to reproduce the inability to sync after the changes were applied

Closes: #5394

Backport of #5401.