### PR TITLE
fix max commit sig size

### DIFF
--- a/state/tx_filter_test.go
+++ b/state/tx_filter_test.go
@@ -25,8 +25,8 @@ func TestTxFilter(t *testing.T) {
 		tx    types.Tx
 		isErr bool
 	}{
-		{types.Tx(tmrand.Bytes(2187)), false},
-		{types.Tx(tmrand.Bytes(2188)), true},
+		{types.Tx(tmrand.Bytes(2155)), false},
+		{types.Tx(tmrand.Bytes(2156)), true},
 		{types.Tx(tmrand.Bytes(3000)), true},
 	}
 

--- a/types/block.go
+++ b/types/block.go
@@ -24,6 +24,8 @@ import (
 
 const (
 	// MaxHeaderBytes is a maximum header size.
+	// NOTE: Because app hash can be of arbitrary size, the header is therefore not
+	// capped in size and thus this number should be seen as a soft max
 	MaxHeaderBytes int64 = 626
 
 	// MaxOverheadForBlock - maximum overhead to encode a block (up to
@@ -573,9 +575,9 @@ const (
 const (
 	// Max size of commit without any commitSigs -> 82 for BlockID, 8 for Height, 4 for Round.
 	MaxCommitOverheadBytes int64 = 94
-	// Commit sig size is made up of 32 bytes for the signature, 20 bytes for the address,
+	// Commit sig size is made up of 64 bytes for the signature, 20 bytes for the address,
 	// 1 byte for the flag and 14 bytes for the timestamp
-	MaxCommitSigBytes int64 = 77
+	MaxCommitSigBytes int64 = 109
 )
 
 // CommitSig is a part of the Vote included in a Commit.

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -269,15 +269,13 @@ func TestCommitValidateBasic(t *testing.T) {
 }
 
 func TestMaxCommitSigBytes(t *testing.T) {
-	// time is varint encoded so need to pick the max.
-	// year int, month Month, day, hour, min, sec, nsec int, loc *Location
 	timestamp := time.Date(math.MaxInt64, 0, 0, 0, 0, 0, math.MaxInt64, time.UTC)
 
 	cs := &CommitSig{
 		BlockIDFlag:      BlockIDFlagNil,
 		ValidatorAddress: crypto.AddressHash([]byte("validator_address")),
 		Timestamp:        timestamp,
-		Signature:        tmhash.Sum([]byte("signature")),
+		Signature:        crypto.CRandBytes(MaxSignatureSize),
 	}
 
 	pb := cs.ToProto()
@@ -286,14 +284,20 @@ func TestMaxCommitSigBytes(t *testing.T) {
 }
 
 func TestMaxCommitBytes(t *testing.T) {
+	// time is varint encoded so need to pick the max.
+	// year int, month Month, day, hour, min, sec, nsec int, loc *Location
 	timestamp := time.Date(math.MaxInt64, 0, 0, 0, 0, 0, math.MaxInt64, time.UTC)
 
 	cs := CommitSig{
 		BlockIDFlag:      BlockIDFlagNil,
 		ValidatorAddress: crypto.AddressHash([]byte("validator_address")),
 		Timestamp:        timestamp,
-		Signature:        tmhash.Sum([]byte("signature")),
+		Signature:        crypto.CRandBytes(MaxSignatureSize),
 	}
+
+	pbSig := cs.ToProto()
+
+	assert.EqualValues(t, MaxCommitSigBytes, pbSig.Size())
 
 	// check size with a single commit
 	commit := &Commit{
@@ -474,9 +478,11 @@ func TestBlockMaxDataBytes(t *testing.T) {
 	}{
 		0: {-10, 1, 0, true, 0},
 		1: {10, 1, 0, true, 0},
-		2: {809, 1, 0, true, 0},
-		3: {810, 1, 0, false, 0},
-		4: {811, 1, 0, false, 1},
+		2: {841, 1, 0, true, 0},
+		3: {842, 1, 0, false, 0},
+		4: {843, 1, 0, false, 1},
+		5: {954, 2, 0, false, 1},
+		6: {1053, 2, 100, false, 0},
 	}
 
 	for i, tc := range testCases {
@@ -503,9 +509,9 @@ func TestBlockMaxDataBytesNoEvidence(t *testing.T) {
 	}{
 		0: {-10, 1, true, 0},
 		1: {10, 1, true, 0},
-		2: {809, 1, true, 0},
-		3: {810, 1, false, 0},
-		4: {811, 1, false, 1},
+		2: {841, 1, true, 0},
+		3: {842, 1, false, 0},
+		4: {843, 1, false, 1},
 	}
 
 	for i, tc := range testCases {

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -268,21 +268,6 @@ func TestCommitValidateBasic(t *testing.T) {
 	}
 }
 
-func TestMaxCommitSigBytes(t *testing.T) {
-	timestamp := time.Date(math.MaxInt64, 0, 0, 0, 0, 0, math.MaxInt64, time.UTC)
-
-	cs := &CommitSig{
-		BlockIDFlag:      BlockIDFlagNil,
-		ValidatorAddress: crypto.AddressHash([]byte("validator_address")),
-		Timestamp:        timestamp,
-		Signature:        crypto.CRandBytes(MaxSignatureSize),
-	}
-
-	pb := cs.ToProto()
-
-	assert.EqualValues(t, MaxCommitSigBytes, pb.Size())
-}
-
 func TestMaxCommitBytes(t *testing.T) {
 	// time is varint encoded so need to pick the max.
 	// year int, month Month, day, hour, min, sec, nsec int, loc *Location
@@ -296,7 +281,7 @@ func TestMaxCommitBytes(t *testing.T) {
 	}
 
 	pbSig := cs.ToProto()
-
+	// test that a single commit sig doesn't exceed max commit sig bytes
 	assert.EqualValues(t, MaxCommitSigBytes, pbSig.Size())
 
 	// check size with a single commit


### PR DESCRIPTION
## Description

MaxCommitSigSize should be 109 bytes instead of 77 (Signature is 64 instead of 32)

will back port this also into rc-6

Closes: #5564

