### PR TITLE
test: disable E2E misbehaviors due to bugs

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -41,8 +41,11 @@ var (
 		"restart":    0.1,
 	}
 	nodeMisbehaviors = weightedChoice{
-		misbehaviorOption{"double-prevote"}: 1,
-		misbehaviorOption{}:                 9,
+		// FIXME Disabled due to:
+		// https://github.com/tendermint/tendermint/issues/5554
+		// https://github.com/tendermint/tendermint/issues/5560
+		// misbehaviorOption{"double-prevote"}: 1,
+		misbehaviorOption{}: 9,
 	}
 )
 

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -36,7 +36,10 @@ seeds = ["seed01"]
 seeds = ["seed01"]
 snapshot_interval = 5
 perturb = ["disconnect"]
-misbehaviors = { 1012 = "double-prevote", 1018 = "double-prevote" }
+# FIXME Evidence handling causes panics and halts
+# https://github.com/tendermint/tendermint/issues/5554
+# https://github.com/tendermint/tendermint/issues/5560
+#misbehaviors = { 1012 = "double-prevote", 1018 = "double-prevote" }
 
 [node.validator02]
 seeds = ["seed02"]


### PR DESCRIPTION
Disables misbehaviors in E2E testnets due to failures caused by #5554 and #5560. Should be re-enabled once these are fixed.