### PR TITLE
types: move `MakeBlock` to block.go

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -305,6 +305,25 @@ func MaxDataBytesNoEvidence(maxBytes int64, valsCount int) int64 {
 	return maxDataBytes
 }
 
+// MakeBlock returns a new block with an empty header, except what can be
+// computed from itself.
+// It populates the same set of fields validated by ValidateBasic.
+func MakeBlock(height int64, txs []Tx, lastCommit *Commit, evidence []Evidence) *Block {
+	block := &Block{
+		Header: Header{
+			Version: tmversion.Consensus{Block: version.BlockProtocol, App: 0},
+			Height:  height,
+		},
+		Data: Data{
+			Txs: txs,
+		},
+		Evidence:   EvidenceData{Evidence: evidence},
+		LastCommit: lastCommit,
+	}
+	block.fillHeader()
+	return block
+}
+
 //-----------------------------------------------------------------------------
 
 // Header defines the structure of a Tendermint block header.

--- a/types/test_util.go
+++ b/types/test_util.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
-	"github.com/tendermint/tendermint/version"
 )
 
 func MakeCommit(blockID BlockID, height int64, round int32,
@@ -79,23 +77,4 @@ func MakeVote(
 	vote.Signature = v.Signature
 
 	return vote, nil
-}
-
-// MakeBlock returns a new block with an empty header, except what can be
-// computed from itself.
-// It populates the same set of fields validated by ValidateBasic.
-func MakeBlock(height int64, txs []Tx, lastCommit *Commit, evidence []Evidence) *Block {
-	block := &Block{
-		Header: Header{
-			Version: tmversion.Consensus{Block: version.BlockProtocol, App: 0},
-			Height:  height,
-		},
-		Data: Data{
-			Txs: txs,
-		},
-		Evidence:   EvidenceData{Evidence: evidence},
-		LastCommit: lastCommit,
-	}
-	block.fillHeader()
-	return block
 }


### PR DESCRIPTION
## Description

MakeBlock was housed in the `test_util.go` file but used in the state package in a production path: https://github.com/tendermint/tendermint/blob/80b9eb8f0f7ee57753534b0ee14cbc22755669b5/state/state.go#L244, this pr moves the function out of test_utils into block.go. While an unneeded change it can cause confusion to why a test_util is used in production. 


Closes: #XXX

