### PR TITLE
evidence: backport evidence fixes regarding gossiping

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -31,3 +31,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [blockchain/v2] \#5530 Fix "processed height 4541 but expected height 4540" panic (@melekes)
 - [consensus/wal] Fix WAL autorepair by opening target WAL in read/write mode (@erikgrinaker)
 - [block] \#5567 Fix MaxCommitSigBytes (@cmwaters)
+- [evidence] \#5574 Fix bug where node sends committed evidence to peer (@cmwaters)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1871,10 +1871,13 @@ func (cs *State) tryAddVote(vote *types.Vote, peerID p2p.ID) (bool, error) {
 			} else {
 				timestamp = sm.MedianTime(cs.LastCommit.MakeCommit(), cs.LastValidators)
 			}
-			evidenceErr := cs.evpool.AddEvidenceFromConsensus(
-				types.NewDuplicateVoteEvidence(voteErr.VoteA, voteErr.VoteB), timestamp, cs.Validators)
+			evidence := types.NewDuplicateVoteEvidence(voteErr.VoteA, voteErr.VoteB)
+			evidenceErr := cs.evpool.AddEvidenceFromConsensus(evidence, timestamp, cs.Validators)
+
 			if evidenceErr != nil {
 				cs.Logger.Error("Failed to add evidence to the evidence pool", "err", evidenceErr)
+			} else {
+				cs.Logger.Debug("Added evidence to the evidence pool", "evidence", evidence)
 			}
 			return added, err
 		} else if err == types.ErrVoteNonDeterministicSignature {

--- a/evidence/pool.go
+++ b/evidence/pool.go
@@ -122,7 +122,8 @@ func (evpool *Pool) AddEvidence(ev types.Evidence) error {
 
 	// We have already verified this piece of evidence - no need to do it again
 	if evpool.isPending(ev) {
-		return errors.New("evidence already verified and added")
+		evpool.logger.Info("Evidence already pending, ignoring this one", "ev", ev)
+		return nil
 	}
 
 	// 1) Verify against state.
@@ -152,8 +153,10 @@ func (evpool *Pool) AddEvidenceFromConsensus(ev types.Evidence, time time.Time, 
 		totalPower int64
 	)
 
+	// we already have this evidence, log this but don't return an error.
 	if evpool.isPending(ev) {
-		return errors.New("evidence already verified and added") // we already have this evidence
+		evpool.logger.Info("Evidence already pending, ignoring this one", "ev", ev)
+		return nil
 	}
 
 	switch ev := ev.(type) {
@@ -175,7 +178,7 @@ func (evpool *Pool) AddEvidenceFromConsensus(ev types.Evidence, time time.Time, 
 	if err := evpool.addPendingEvidence(evInfo); err != nil {
 		return fmt.Errorf("can't add evidence to pending list: %w", err)
 	}
-
+	// add evidence to be gossiped with peers
 	evpool.evidenceList.PushBack(ev)
 
 	evpool.logger.Info("Verified new evidence of byzantine behavior", "evidence", ev)

--- a/evidence/reactor.go
+++ b/evidence/reactor.go
@@ -17,8 +17,13 @@ const (
 
 	maxMsgSize = 1048576 // 1MB TODO make it configurable
 
-	broadcastEvidenceIntervalS = 60  // broadcast uncommitted evidence this often
-	peerCatchupSleepIntervalMS = 100 // If peer is behind, sleep this amount
+	// broadcast all uncommitted evidence this often. This sets when the reactor
+	// goes back to the start of the list and begins sending the evidence again.
+	// Most evidence should be committed in the very next block that is why we wait
+	// just over the block production rate before sending evidence again.
+	broadcastEvidenceIntervalS = 10
+	// If a message fails wait this much before sending it again
+	peerRetryMessageIntervalMS = 100
 )
 
 // Reactor handles evpool evidence broadcasting amongst peers.
@@ -117,7 +122,7 @@ func (evR *Reactor) broadcastEvidenceRoutine(peer p2p.Peer) {
 		}
 
 		ev := next.Value.(types.Evidence)
-		evis, retry := evR.checkSendEvidenceMessage(peer, ev)
+		evis := evR.prepareEvidenceMessage(peer, ev)
 		if len(evis) > 0 {
 			msgBytes, err := encodeMsg(evis)
 			if err != nil {
@@ -125,12 +130,10 @@ func (evR *Reactor) broadcastEvidenceRoutine(peer p2p.Peer) {
 			}
 
 			success := peer.Send(EvidenceChannel, msgBytes)
-			retry = !success
-		}
-
-		if retry {
-			time.Sleep(peerCatchupSleepIntervalMS * time.Millisecond)
-			continue
+			if !success {
+				time.Sleep(peerRetryMessageIntervalMS * time.Millisecond)
+				continue
+			}
 		}
 
 		afterCh := time.After(time.Second * broadcastEvidenceIntervalS)
@@ -150,12 +153,12 @@ func (evR *Reactor) broadcastEvidenceRoutine(peer p2p.Peer) {
 	}
 }
 
-// Returns the message to send the peer, or nil if the evidence is invalid for the peer.
-// If message is nil, return true if we should sleep and try again.
-func (evR Reactor) checkSendEvidenceMessage(
+// Returns the message to send to the peer, or nil if the evidence is invalid for the peer.
+// If message is nil, we should sleep and try again.
+func (evR Reactor) prepareEvidenceMessage(
 	peer p2p.Peer,
 	ev types.Evidence,
-) (evis []types.Evidence, retry bool) {
+) (evis []types.Evidence) {
 
 	// make sure the peer is up to date
 	evHeight := ev.Height()
@@ -166,7 +169,7 @@ func (evR Reactor) checkSendEvidenceMessage(
 		// different every time due to us using a map. Sometimes other reactors
 		// will be initialized before the consensus reactor. We should wait a few
 		// milliseconds and retry.
-		return nil, true
+		return nil
 	}
 
 	// NOTE: We only send evidence to peers where
@@ -178,7 +181,7 @@ func (evR Reactor) checkSendEvidenceMessage(
 	)
 
 	if peerHeight <= evHeight { // peer is behind. sleep while he catches up
-		return nil, true
+		return nil
 	} else if ageNumBlocks > params.MaxAgeNumBlocks { // evidence is too old relative to the peer, skip
 
 		// NOTE: if evidence is too old for an honest peer, then we're behind and
@@ -192,11 +195,11 @@ func (evR Reactor) checkSendEvidenceMessage(
 			"peer", peer,
 		)
 
-		return nil, false
+		return nil
 	}
 
 	// send evidence
-	return []types.Evidence{ev}, false
+	return []types.Evidence{ev}
 }
 
 // PeerState describes the state of a peer.

--- a/evidence/reactor.go
+++ b/evidence/reactor.go
@@ -177,7 +177,7 @@ func (evR Reactor) checkSendEvidenceMessage(
 		ageNumBlocks = peerHeight - evHeight
 	)
 
-	if peerHeight < evHeight { // peer is behind. sleep while he catches up
+	if peerHeight <= evHeight { // peer is behind. sleep while he catches up
 		return nil, true
 	} else if ageNumBlocks > params.MaxAgeNumBlocks { // evidence is too old relative to the peer, skip
 

--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -215,7 +215,7 @@ func TestReactorSelectiveBroadcast(t *testing.T) {
 	evList := sendEvidence(t, pools[0], val, numEvidence)
 
 	// only ones less than the peers height should make it through
-	waitForEvidence(t, evList[:numEvidence/2], pools[1:2])
+	waitForEvidence(t, evList[:numEvidence/2-1], pools[1:2])
 
 	// peers should still be connected
 	peers := reactors[1].Switch.Peers().List()

--- a/evidence/verify.go
+++ b/evidence/verify.go
@@ -24,11 +24,6 @@ func (evpool *Pool) verify(evidence types.Evidence) (*info, error) {
 		ageNumBlocks   = height - evidence.Height()
 	)
 
-	// check that the evidence isn't already committed
-	if evpool.isCommitted(evidence) {
-		return nil, errors.New("evidence was already committed")
-	}
-
 	// verify the time of the evidence
 	blockMeta := evpool.blockStore.LoadBlockMeta(evidence.Height())
 	if blockMeta == nil {


### PR DESCRIPTION
## Description

Backports two commits related to evidence:

- evidence: don't gossip consensus evidence too soon (#5528)
- evidence: don't send committed evidence and ignore inbound evidence that is already committed (#5574)

