### PR TITLE
fix: private validator cache pubKey and reduce ping amount

### DIFF
--- a/privval/signer_client.go
+++ b/privval/signer_client.go
@@ -16,7 +16,6 @@ import (
 type SignerClient struct {
 	endpoint *SignerListenerEndpoint
 	chainID  string
-	pubKey crypto.PubKey
 }
 
 var _ types.PrivValidator = (*SignerClient)(nil)
@@ -73,11 +72,6 @@ func (sc *SignerClient) Ping() error {
 // returns an error if client is not able to provide the key
 func (sc *SignerClient) GetPubKey() (crypto.PubKey, error) {
 	sc.endpoint.Logger.Info("SignerClient: GetPubKey")
-	if sc.pubKey != nil {
-		sc.endpoint.Logger.Info("SignerClient: GetPubKey use cached key")
-		return sc.pubKey, nil
-	}
-
 	response, err := sc.endpoint.SendRequest(mustWrapMsg(&privvalproto.PubKeyRequest{ChainId: sc.chainID}))
 
 	if err != nil {
@@ -97,7 +91,6 @@ func (sc *SignerClient) GetPubKey() (crypto.PubKey, error) {
 		return nil, err
 	}
 
-	sc.pubKey = pk
 	return pk, nil
 }
 

--- a/privval/signer_listener_endpoint.go
+++ b/privval/signer_listener_endpoint.go
@@ -93,6 +93,8 @@ func (sl *SignerListenerEndpoint) SendRequest(request privvalproto.Message) (*pr
 		return nil, err
 	}
 
+	sl.Logger.Info("SignerListener: SendRequest sent")
+
 	err = sl.WriteMessage(request)
 	if err != nil {
 		return nil, err
@@ -102,6 +104,7 @@ func (sl *SignerListenerEndpoint) SendRequest(request privvalproto.Message) (*pr
 	if err != nil {
 		return nil, err
 	}
+	sl.Logger.Info("SignerListener: SendRequest got response")
 
 	return &res, nil
 }
@@ -117,11 +120,13 @@ func (sl *SignerListenerEndpoint) ensureConnection(maxWait time.Duration) error 
 	}
 
 	// block until connected or timeout
+	sl.Logger.Info("SignerListener: blocking for connection")
 	sl.triggerConnect()
 	err := sl.WaitConnection(sl.connectionAvailableCh, maxWait)
 	if err != nil {
 		return err
 	}
+	sl.Logger.Info("SignerListener: got connection")
 
 	return nil
 }
@@ -186,11 +191,17 @@ func (sl *SignerListenerEndpoint) pingLoop() {
 		select {
 		case <-sl.pingTimer.C:
 			{
+				sl.Logger.Info("SignerListener: PingLoop Active")
 				_, err := sl.SendRequest(mustWrapMsg(&privvalproto.PingRequest{}))
 				if err != nil {
 					sl.Logger.Error("SignerListener: Ping timeout")
 					sl.triggerReconnect()
+				} else {
+					sl.Logger.Info("SignerListener: PingLoop successes - sleeping")
+					// wait 1000 ms between each ping so we won't flood the connection
+					time.Sleep(1000 * time.Millisecond)
 				}
+
 			}
 		case <-sl.Quit():
 			return


### PR DESCRIPTION
## Description

Reduce network usage when using remote signer

- reduced the ping time to wait 1 second before each successful ping (I've tested it with up to 10 seconds interval and couldn't find any issues so this can be reduced even more)

- cached the pubKey and don't keep requesting it from the remote (pubKey was requested dozen of times on a single block)

- Added some logs so it will be easier to debug such issues

I only did this cahnge for the 0.33.x branch but I can backport it to 0.32.x so it can be used on gaia as well

Closes: #5550

