### PR TITLE
light: new mbt test fixtures

### DIFF
--- a/light/mbt/json/MC100_2_faulty_TestFailure.json
+++ b/light/mbt/json/MC100_2_faulty_TestFailure.json
@@ -1,0 +1,3411 @@
+{
+  "description": "MC100_2_faulty_TestFailure.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "043E6934A5E887D08CE06A090F61F0EDA9A7A74F36DAF4F2A0D3EF8735A0E74F",
+        "next_validators_hash": "8D0DDFC3F6A87AD152D9E7BCFDD3A25DB0A5BAFA4231786B2D302F4513656175",
+        "consensus_hash": "043E6934A5E887D08CE06A090F61F0EDA9A7A74F36DAF4F2A0D3EF8735A0E74F",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "E868910597CA7E9C3695CA2C2A7751C4E6DC2D1CC663DF566BB4A7B79FFC740F",
+          "part_set_header": {
+            "total": 1,
+            "hash": "E868910597CA7E9C3695CA2C2A7751C4E6DC2D1CC663DF566BB4A7B79FFC740F"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "AEfG6lOyQvYkoP6tYXCr8io3Io58etLWElvAz0N5r19oF24uB9hs4Il4RkvrUZ80zG+p/WKRhEK6uaPPteILBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "04CA9AA40B76FF67B56D5A9285CB9AE5ED2F3247",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "bp3whc+Pyvj/n5nUWn2Sw/5WPAbUDLibbfb2WCHwU8pnOwtqfW8d+JqlCw8naLAhhbGvVANG9wwEneMHl77PDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "050E6732CEC76C71C0CF6784EB4A4E2CEE8C23B0",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "oY5oYkGiZ2Ix3ZonOoaU37PhaacwHA6/v5KzVIevK4hLlrMnTKT6V8J2vhedypH4U4gvI6XITb/4B4LmyqY6Dw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ET/pnZ9K/bNaIOPsWu3bvtydSy9koxAwHpKyKyAEodFwB5tg8ilLTOl9uA9I9QDNPpL057Vb0mvZsNM7yTj+Cw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "0C7A21D9023613B0F814882F40694D07FB508388",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "jVpThdMIBi+SzNFTi6FlhG/uxuMhbnwNtfmqgeKc56zXTIWZQDhBAVU80cL7da/XGhaQmqpO0kQAtdb6wgyQCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "VIjbq9eMZSnYtb8QXEDKjZMbnsYwXl/VYKc5On+kQXe4uRLalUIRQ3Wcfpn+38hzIO2PnSr4R4ND1IGjF5InBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "239D1ACB182F9EC413D6AD8BED3A13447318B95F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "V+Tr6dT3SBJrtJ0W8/sn01/TwOdm4FHQyuEZL8BT+ydEm32USo/bYLIQwyWrOm3xiFKGZHGcQ4c0QaxLn3W0AA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "23A53F06EAAF2B827B9AF8B6866DEAADE5A5CAA3",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "OgDWN51bLgUsvVGu8YN/0tv4P11EZfcuKfwkPh9DiHrGyyxxtL3ncvD2Je3H/6AjyJov10bpTc1ltFHKXtixDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "26E91E700545D79E8A18092C393DB76294DF393A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Y+fXb6fvIEVUZ+1qHhBSSKM2oVzty3KQp1FS7oVZwK8esKBznS3L+7tP+dcuPuoCC7JmPPkbgyULqSkMtzqJBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "NdlwqLwes7ybIK5s3Sx5WxjuL731jXkbwRaGApkKd+iRAo8hCkf54MWWt70D7ai1FqBxMQfjsYjIxBQWueygDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "sl4y0OHl9ZaF7Da0B15YwNSneqdTJ5srzqnXWoZVNMuhNf6KdYuTky+WJTULgokp5RR0oEIEUr38yEqFtiMSBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "31580E874C4F84AA5EB5F986FA70B74F8D1865BE",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "1aDqUxtisDGP/30eSFaqWTtsOIdqmWGYpHt3Qih+tQ2XBUXw8OU5ilnFzDppDtC4Sow7rJ6bLw3X/yHEipRkDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "319549CEC8B9DADB70C7E8DBBC8FE5D550398506",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "HyCZ5odq0/Cxn7PVF0Ww9GoelzeHM9PP1RskBrNaBE6WSwhCAnlD5nglE7PEYSbRtcY+ovlDnOGtm1aZE83VCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "361491162A6178776B903E57AB7C4D909394B4B4",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "XRg2yJm9pFUHKlHh7itFDTPne/Ew7t6w58dvP++TkT4tKDfKFLaLcnZV0JsHx84rvlZpT9rtg5ln5kSlB7uRCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "fcaVVdL6F8Za3FCeTPMlzl9Ql55AQOSzwf6Rl1p/t5A1vXIcxBwgwmoumPVDbMXuj0TspWbLfxfgLADRNqytDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "umqPn6ra7mdizUnYJ1zpofwPJtsOeXi9iifyWp+RjlgxY7JfgzlKYuMmR/tLsI3WO1n68PeRw9bc0G8mXa9SBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3C733B78F612FB791744711958D8BC4A3D1B54BF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Id+aCSLwHwzCYHLLxjz4S8L07osuGDflCiy+DuQilgBvXep3Tl8+9jJYjwcYyQcJn6zPo7HFjuIrGptBDEUgDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Qu1h1TILFFDLfQVCHj736m36EQ30SeYm6uNYpZmj6Bpe1JJwb8nqSKYRPAJuR5YQ5F7uhQRWK5HPdiQXiD4NAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3D7E3723C921B1D35B52921B8511142BF5976863",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "twIxgwcMcGNtNXffkECqiCtwpd2FIo5SuLC4qrtzYfJoQxT74cAN7sJRQ0B/Xdz5tI14rdV6q6enjjnYoaXkDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "400C0199DEC08A2DBFDF5D081AC15FD6685E8870",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "p6LU9RmLZAmd+nfJyDZAeFb3uHirjx7O7tWwU4kawDXdaa3nMnEmc8ZXyQdyHa9zIcixodRbCPpCn7Cxb7YZAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "416A8E60A478C20CEB021A84425D8B457558D4E9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "RJ+4xFqybZ6FfXv49amSwvqiLR5czwpqkkYvRCCroTtzTeEpfWcrOdaxbDy6RjUC2/NSpt/g6CzTQ9vtULrmCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "42D162EDB46B7C1FEA616810A7617A6369958ADE",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "6oLVTsYHzQBKK59ik0iHAEbMcW7byHnIl8udUGK88aBwuFMQhxq2ngpJGD3J5EYVODw3XsbuLVFTdsS3E57gCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ae4aCRHuDIipH3VU8JbL3/Mctedfk6UuY+JKGQ/xkKfHkF19U7tLTCw/RajySRqmASo/Qq72kUPYBwRBZ+4/Bg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "k2HLwlTWcA8+T4bJIesrLHqXI3W1+Q8UVF3522CrEL4v5BNIp+S1LuCX1hkH8lVQf0s+82ofq3WkiwCXRzizAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "AD6XauvRZausNxBJkE1HEfQIm1+6lXP6RIaT0XIs8wQePvQumWCq1frEDaP4xoEXaDqLk/d9JYL0HvjVueBCCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "55027F5FDE2DFC9F1C956D4700A0E60E47BC8126",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "GvTClZ3wxTZGnhMHUwvPCJftzxTOy5Ul7usqyuAhfl8jTFWHAbEeRd8aHynxhoRgm1ZmWHf/zKNz0Jl1G2sHAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5AE3C3EDDD4C4F12E0A45618C9A7EE302BF0C466",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "qCUqzJ+p+N085Pj71qCXlocRLHG81OVhiLjtRptzvYWOvcdW6XymnKndd56Or4/EhIrieMufd3fYsKIa8RgsCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "GjvfRum9DzS3h7eEw7zVhXiRSo4W3Cvp2iDLAfTD5rg6JY0YhPyulTX5lNn/rbVniA0J5SOQBBGqeq255RTzAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "627231A077D55F34733997ECD928CE2C511F126C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "jJ6C8fVOLKvrAl0n4dgFDc2cRpwXrGrdcR4jDu1/Qzhii/7I1CipIL4uNcL7oT7xDK9+4Rn6Q9/XFzYJKhXpDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "62B738D2DFB76A0938F116B001D4AD686B75F700",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "PzYPzQObK/DSB7/SBOca1MRDROtP/KxSneC1HCq/f7EiPxkJ50z9UiwfCHuDGhy3VaRcWqLP1mkA+v89tREiCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "635206EBFDCCCE8AE040DE2FF07F1508929F3ED7",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "qJ2nLmIFBfDEJldLv4pDRARJO/t0EBHwb7kwxI/HscFFgTyU0vePTHNo5dE6/d7hIdgRfyJF7OLhjnsVMtPfBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "9FGTJcxYtXUOJ4ExWAlea3uTrG9DcHZ3WRb6JyCbkYyK4dDVInmxVlvoXOJRR1j36fFyTxXclUlxt5g16zy4BA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "bLtc2Hl58VuKV3WhkaIA4/OceCyZWXDf7AlhDN5oknbmEOgSWJCfT/3QzweZebnqPhbRF0+OlgvtKib59z/uBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6D4B3D65AD9A81CD7AE83EA598B6FD2818F7F6D1",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "6Rx3/eGo5fdlQyF2mtwmN6sRGvcehlcSCOrB7WwV6PhLSH3gXAABFAvYjouVokdDbWpdcnXVfi7Uakxms7mJCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6DC5F977934E65C23231DDC30BF273F22FF5454E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "6nqYWyVRRbHDY41gcRIT2Q7Gffru1tnFrVPlEqh6MQgoU6gyayPMih7I33QfuWoPWtZs0y6+NxI/1NRbr/nFBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "lFH7lVen1ibOio7WqMwH6kOa1T17r62+7ZneTzYJP0F17BUFUjCp2T0KDWFShyMb0ilaOn7KsmJl54riQ4NjDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "aVg2uX3IzWtGLbY5H8pFj/yxKn/914HUjz3uxtocV7EFI8c18+pekqOcFu7HTAgZn2ydwIqF9EY2kj7Mlj5xAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "74830E4D56CD8E0ECC47E508CBA279042A3882C9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Tqbz7r5P0GFGsQKmjTz1hU4x6zGrYrRcsVbw4EHXmC+q/jVWS1lHqqRLMv602i8rPo/j7tBC8YQh14U6SddXDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "74C2BE39F07B51E72003D4C437535A797D2774BA",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "JWTdqiMOMp7izh0wWkDr4YG70cD4+ZHjSvZblMp9j+ir51Bv8WgfHS+sUT72XBcH/zN0ArPpfnq4QtYPVbSPBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "766BE28A48C243E4F9AC3FA6B5505B6208EF4494",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "t4WxYKuYPcEd3KEmepTz3A2E1/76m4q2jAOuJ1uZSojcQ8gDWWyEfSAmQsNR3rqrRLYhhlelUtWfzBOpJkeSAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "i1Ck+idTzFRCsTydd2NzJLdqclaLygyn/oFuHo3nBGsG+Q8xXE1YvoZOD9CdPL7lWr/emODMTI/HVvVWz/wtCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7D5B8447A0C1D5E85E095C885947C4EF180BA676",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "72EOS6JGo+8zSHaFSktIwW8LNs5+oYMMD2aliHas+DkzNeQJPpIC2MULyJ1EhnTlfxcwz+rjoX4AJ+cjQZRECg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "umhw9rfkUmhMUmqwR+5T06JYhwyJbeGcJfeaAF2ytJhPTSk/MCg8tNHPHJ93VXCXUOeFEdNnit7cUUWYWuqxAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "2IcFdRqsOsXAI+pjLEdVRuKwGf2uJqv6pNHAX2WfLHY1jLVlGC0Q4waH5rNf3HK0b0xCgxxRl/YxAWcBrwJtDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "oI/ApSNDtF6ylK5Wtldxn8OzBlitwa0jAPsQ8hDwDtt5Z02KRGjRc+H4nozf7gfJr5YSaj0iJ68HxhEQllwuCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "TUaW8rM7Sw1c/Q2qPRaL7pDFNZTqNR3KgKsdfcaL4uA06vRWGF9i8naW6nxCOSH8xciNhZfJbTy3vKptLujdBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "822D9296BE1DAF413AB15B489C002F4CEAD426D7",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "aMqBFSuath/NYPFaK83XZ93Xf5LYYwL1X5lWUjwJcc7mErYB9zdArEbINaQR2CgohcFSfD3MpRpd9Cym9VRnAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "82FB9EE4538CEAA9C808E862C8D47D36C143E0DB",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "eePQ/bp2PvOA2DVYXFriMAysBymx5hIjCx62JKQQPiiuqDl7hsPQDkvMzLfC4jct/9xStG5AALz0tTes5+7LCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8301D560188D8CA97B5D373B6423292FA7A1C414",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ULwIAyWD5zzMD3xRKZOg6SccU+YazMIayaWqoEMKfEawfa3PDpUPVyyAAp+Jae1KDZWfp0mYC21KAvsjvROnAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "890C8588FAE1C90E164BFF1917A3EC93FF7AE8EF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Wd1a2kgtOr3OIYkzhW0popgboDTehnocG6rbTs0C5qH6LH04mh4QvvAnQuyaawhdAzU+agIZ6/EwyqFMJSgfAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ks08YHhScMqk28BrzS5emzSdAw202HuIMUWHJIL2DaQ+UER6WLmd9X7CwjcDXhyjLEek5JdvVpUoVEWpSMkpBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8A0B5C8CE8B72985C325F02B580C4DBFC527EB9C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "kgrUPz5aGwa4r4C8yMNybV3NEHgf6BBD1c2KsWXtzbd2bIgk6R9b+1McCjey1KpZgZLEsDzfTy9j8OI0Fu9RAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8B730D99A94FEA0729980BDBB4585DC2B7E932D3",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "5LjLdS2bNnSfXgcT2iufwk4hOnYR5iHcIrhVWLOGuH8A/eTD6f3ya4E6F7X66/ecoXAH+s+S7rHAZKGxKrklBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "fSNgZOXAhZyop7hBCp69Pzdoot7IXBhYebN0RlVUPwjiZCePpx30S/w6kKnoHUuoZMxAMdwQ/pdV/9MUH7OXBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "GKaC31qEtDPi6iQ4IXHqxW6XJs5kFS7+yNJMVmZ/mgihlvlx8bLoFrDg2rQdAsAxSa59eLrLTL61XkkkvZrwDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "92932AD7E082B90296C192F3113710CD6F99432E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "B5MiWW15DPsWMbnlrfea6Yt7QgLtIJcfVPvCmJkloIxxSvJGUeZNSc4z47cZknTDtLXFTg6pIAFfFkPn5FzPBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "93597B2726E0FDD812E38163799427FA2FF684A8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "avgSHew1r00n6GMdLljcIFqQ2LWAJQhUGJkoSi8DD7/01qaH0u/jNTSoaEESRKIduahWUA2usQMQQPs2mRTgCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "9562DE62254FB0C58E70196412E5F3C9D30B80AA",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "DSxnaPudASvrqyQs7k96gspKeCBjsRbkW4xnine8l0b3Un3/cfRmiG8AW5S89Y31854N/6nbaTof1oFbBDt/AQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "9SYFXk21r4W5rRPnBbCR+oLJejW5lvuZwXWohsHSYXWx21YQGBhXM4SHnyRHGffWxfbab51I1LHhzvXiemUTBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "9AE69E7D6961BB4CDAA74F99BB45A9EE25B02288",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "rHfxARciKr+c7ISW6fZkBb05ANpmd0fw8IvQj7C5O8d+NcQOOaFggmcYP/CvLG0txE+mAdFFDpzkkycSdotSAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "kLqhgf8Obx9f1bckRKBzcfElJJDu0/oRIJdsBAucPB+Hvo6FZ4HK4x1SriZ0odXQqxhcdxYmu8GBjg9n7JcEAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "PiwFPnRxysSoZagumwbqQSK1lLJvvmCDs0GFVW9Hh8ksYESJKFoylxxTpkHBR9p3lFOR8kPBUig9vdlt1hpUCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "vtD7SLA8Pwfk1jW3Hz3EKdtqnZDGrefGVHnOtCbt90rX6sfZgU84edOwZpLuxO0vp1SQIXZb8/aFTdaiwk7rCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "VF7XtjnH4I5TbBUKIi1ZFUQhkk2oi6dDxrHC7M0JALwBMj3wvmJdKf0Q7lVFQt5j7zle6V3zmnYrvrHouD3JCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A67BF23C710F87B158BC3369684A3033D3C8112E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "qV82bxhd0i1jODjZCf+HTN1BA3FP9qsNFLFbHrjzLpacUXiM/FQDZk8jVuZpEqoX/GNH1Ln7dZvBAaCrJg8nCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "T4eMUmE0eRLGoRZO6WYBcWdFhx001x9idQuB3BiVg6vtbPIS9QVhNil4lFzcAk4ICoAeewPGXPsxFR0aQB2UBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "VzsT68NkvmowVchf5ewgblM24RqEHUGwkWAcaI/v7K7ZFruumA66TJpUmxpf9/wlS6CUThJBRN4hY7J/5KMbBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "g5w+pjWldzbElz/Mv2dWbS1aqS7gJa3Tp7woqxgsLtvfDFrf5HtvdEthUBlPHbD2iMWMIbb9jJhyAMA7afdlAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "AFBD6E8C17284683A951FB263DDCB856AB61A176",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "LCwgU8Hi3x5mkHMP4pjLLqgO5vSPsUkwduRETgJkgV1mG65UgWAz99+AJoQ/oY0zuNJEjxXT1SwA4sb4AYv9AA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B058604741DFB193660713A02366D5A6CF1EF016",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "OYluwvCsCZ7IPi+WiljYXqOorFZVCyO1pijQjPvTv3lzo28OPc08U5SPhzDt3Op5sIBGbDU5p7BtwY9+TXC4Ag=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "d+J5GW2KtglgtrWW57vXDef+cySfG0mCHe9Zp6Jhi95Ie3IA6yD8FZ7J2eSVlcG5OEmoS4EIvwDIAy+DFYNtBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "LKPyWsQbIHGUKVAJroWf3YQpxVXTQvzGLmUWaq9vNisry0OZKHIlTXDoPQzFqqiVOCDEcTMZDuYvNjuIRow+Aw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B99E8C85A4BB4886BA6E3043B3A7553A481FB9C0",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "HZ7Jrd3tcMSJvM2yFsQOUXstK9w8IgCwohbj/M9pXySUzU7LYTumbNeyu0r4WN/iHrbTZCUBU1Rip7+34DHQCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "9AN3BF0ekfPsMVToBqHaomB2u3DY4jHUEW2aVGlR0ssGfYirolaxdzIVIfWhzUsO2jLWLJ82BeXiQe3tZdUcAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C1A12367BC4BD69AF83B436A15D33703F381375E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "6z5I0EUZY9hU3bK9NH4bGM2/JjaxK9ci+zFg8cyvz9MnSJP58Q1QvgSowKpk7YuIWgVACmqU12Ecukg1rMRhAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C453130417F90DCAE44D28978DE1FB987507E6E1",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "PYsLEDYaHKXset6HQCbESRzhblaGDgfggX58v4BKRqadUrXhXwNoGS2UebMZQEEDjsshScM01rnpLbP1pavLCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "k2nGyqF8RJ0U8BYux4HoUGW+kJmZ+zPZVWT/Gc/NOc/O1xltxD7mmiGYqKFj58Jlo/eBavg85qpihCh/uFgkCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C56B6E67680CEB8BF11B0B5FCAE3987EB930188E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "hF6IdjEVI+K6nsQwOvJuudVblvzrgN04GxMlZ93t+OYs6aTNnTJ5L+nh+n/G+wln1MkbtjJ43vUGB2G/ixnaAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "2W+HeDDKkERi8UGKSyqtcrrBFN9kNMtezdZRNWCkxi7MuD7kJgLNVx/dRokvJDK1GoQ2Ot+X1DrOpyIyu9OfAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "CA6211FB7B017D171FB7C5E46269AB49C9A1A135",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "0EZbWofEnILrFosBj/54CmbfmUxI/nzni5bG1YymJj+1V06mc4VmF0GVmp5laCIulKR+3OjVqsBuxXZWK+IXCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Tu5RKvLOdhojBBAF/RZKsgZU1LMqGyjpDaL/n2fmp7c/L7aQtuSphh6SeFw6TDegEouKtlb4Flm4jntqPVDMDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ENi7/72ACMzdbnM51dmeVul3S0OYO5Xb0KLYpYjaceEbqHzw/ecFViIuTipG6E2I27YjyriGFiE+/BTU6ImzAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D361FCD15625DF4EA62DB0021C8D67C6083C8735",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "fdI0ueJyp1BV0ZbuWtkmhOr3XdFhfUAZB75uVfD0FJuxaMHBpVHlHlf7jO/XqRJCpaBmSYFFmr+3PUNjwWVCBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "E3kqRYaiaVDZrJUuSnC3cGSbQ5Z061c3ACTZyiyvJ4N+J+mBKrK3ALoU+ILDOpL3wlvL6NBFhpK7eGHg7B2aBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D447195654516BE994064E03868856302AEAF1D1",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "D5FdavHMELMS/nogYrqBACoz7Tg2F0LMBgX4XhZfi+Z1Yo9dtJrsWdPiQ9QpkXujEE6aRHQ8XOStr0/cQe4oAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D6BAFC0943840D65A80FCABC03BED8BE3FA7A8D3",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "9AougG+qBIKfmOr/bttj43aP34femOfHiaND4tf20EkxQtPUG1OCSZUT2jhSCoBDdV1ZLYBvIqiRQDaJonzJBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "qFDjWjGQLG1P2qvYY+0+xei2zd1kqGPvXwlO3XRNKCyvtKlnutgUX0lEAOiQR42XygnpM3gsSBQ5IyulkPTRAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAA78817A47B08F3022C756FA3BDE8E3CE14F761",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "7Nj2WsFiU2oo174HtU2THr6cykdbadzce8f1pDfSOJISI19+SdZNryQ08vc7AcVzcPKg+0WLkSmiZPPobBZTAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "YfGxVWZEp3uPmGXQgCVUIgvavForqHivaxg9Z/BQJAyQiXYRyNf8Ci9uNf12xrzj3bUWQEwaZgwA7sy06KtQCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EB8F0269F7A03728DD8D57D1484545B68DA6697C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "h9wYO7IJ/mRzOptvjd9ZyoqDlawlxGMFJbEdUoGc5NOd/oMQykn1FyOy8dybdw3SxdQTZAqCuMkhLZIr2ZqVCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EBBE61282EC27BF8D06D96C2992040450DD2C1B6",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "wUHGQDxqPvd9+x+okyOJYTb+JKBMYl6Dffk81zljMnDeJXsk6Qm0s8FstjN6iHWKi4ywdXJ3tjTTikmoCRdRCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "ED245292B061110D52CFD7AE6D02919E6C3480F7",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "hwqw4NmrpMuYzQ+PxDQ0M9w9nHpfpnZ+WCbitatxbAA83Li1zeMs21lBdLoq7nVHcobo2uLqLgfQmkstCItfAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EED08060959B8BC09DF99BB8A51A08C8D6F1663D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "N8Y5Td68aWqCyQqxe49YyODVmKhjT//Iy24r1TvtE89YW5zacyxAQcrISnH0nGasmzeLzYQLwYkGIQScCMgQCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "gb9zJphB3aQlZAKXIvLWHXWOgk6vev4kv9KM+aBMP9G+/Bi6WBDoyYHi3E40dBp7UtYEY4bwzZz35e/ERA4KCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EFE8CD307C19FE1E9C437B59A0066EDD97F45E9D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "8npQxVB63TI2jxvEu+XrUk26VO7aqO8HAtvpLvtqYbA7MAJcJq1d/Tw77mbOdEPXJW0C6h6PKaenAfHSyHWZDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F08432D4BD305E8D18FBA52D3B1D351C486B9217",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "6lsaYwbWKkzF/WtUsB1FYzJpu4aufRBYA8cyD3Ts0a0ipLFuQOtqZ8r41wu4i1HFZJoVNNaRXCS9uWv8ZreODw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F1DA81336F50B87982CF10581D308080031406C6",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "XH/UuK7bQIa3J4wKq5oxxD221ZJxei1O2RtRTUXfnvjA/bsmwQhwuUbgaUjRekM4lNAJFU1b98WM0HKrM5MZDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "vGsa4WpM4TQmqHuJAtyRyP7bpjTPyRmt9E2o+gk0PgouhhmUX0JRXkFvxTO3Pfk2hZEoStGcCNbjtikRbk2SCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "P3WlIVRiHtJrfroheVitLGCmUQBEMbWvOXXnpI/RV/fe/DpjzOC9kmn+2yIzf+d9bG8D1Ys4L4L8JeqrY0aZBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "FFF869AF4555A83882CE6697720536EF9759CF69",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "qgoINNna7jjX2IXrKTnGyF94y9Qxg+NOdCPjWFcMHao07uSS11Q21/AVDUNUwOWldMWGAr1L17j0mTP4fgHOBQ=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Kam3xVXv675BD8rZmi4Zs5jdR4+8I8i8ZEZU0gs9Bp4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "04CA9AA40B76FF67B56D5A9285CB9AE5ED2F3247",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "/hFZhF/r5QiEeRGVjMZhG0sO0SeqlURltv8wMjkmOG4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "050E6732CEC76C71C0CF6784EB4A4E2CEE8C23B0",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "b7OxLS/2TcshawP8QjsCuyxOUe9d3566aFczz61UZNc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "0C7A21D9023613B0F814882F40694D07FB508388",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "yVRzgrYNJ4G1uy85dJseiG2K9/ofD/6kObbAfvK1E5I="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "239D1ACB182F9EC413D6AD8BED3A13447318B95F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ELiW5vI49RoPS71qjid0QFJM8CZpmLnW7qkmN8lQU8g="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "23A53F06EAAF2B827B9AF8B6866DEAADE5A5CAA3",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "WPAEO3zKMIbXTkPCa/Wg+s/eR7w6Wea1a6Xuzk1RTag="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "26E91E700545D79E8A18092C393DB76294DF393A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "F8xDDGP4gRkFMeuIlULpbOP6aGPdTe5gZT7kCCnAQIY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "fWMaYDTFwdDo7SVw9hBIraX2GVqvzKhNKEUkr/2ZnEc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Uq1fQj/TXkpg+zP37a//6YC04vQHWraWfYSg88fMHxw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "31580E874C4F84AA5EB5F986FA70B74F8D1865BE",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "scpN1hLNChIB1QuRHojxUwl59cPP2KpwzilLU10JViM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "319549CEC8B9DADB70C7E8DBBC8FE5D550398506",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "iPt9P7DZ9EUBhWssBSvr/qYatOs08WwLCZbfeuW5hds="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "361491162A6178776B903E57AB7C4D909394B4B4",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "QlwrDiydr8tfRonzwMnML1JYtWUHQZiG6aqhWsXRriA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "etUp4mnEHDdNnJSwu5KW8EMXYt7n94iYZm+y7xa9ym8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "R1rD/692T348fL4cA0mvvbK9aANwT0vBNAT5B9+p+rw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "3C733B78F612FB791744711958D8BC4A3D1B54BF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "dul9CqXgrwNXGlWp4ya6mulGjKJok/Q2RYqITOGgYro="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Spb0BakJqr3uNaAEqdaGbv77bQEwym0/6cl/tnCdkGM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "3D7E3723C921B1D35B52921B8511142BF5976863",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "vfycl3VTi9VKc+Fytp4pvbp0+xZKEUTufet65El49EA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "400C0199DEC08A2DBFDF5D081AC15FD6685E8870",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "y+sL3o3wbcoAx67HqR8BNzJVokJrYGI5pflGS8GMSv0="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "416A8E60A478C20CEB021A84425D8B457558D4E9",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6P6otvJpi36GOMprEbFwzth4AjleE/ThQMksZ2Wgh3k="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "JqkfZ01ZvkPHj9ohj0F2Saa5t6KIX5uq1bhHS7YAyxk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "M5rP8lPaJdES+Bd4oWI/va2sRUvbJiYINzOpUdiuO8Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "mGpmR8PNc6w2cUzPwAQhkSadkyGOuKMl68Nji5E3h5o="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "55027F5FDE2DFC9F1C956D4700A0E60E47BC8126",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "zfSXZ7DLwIeRwhbsE/Pr7cSaQZTmySpuXmGEnNRUZpc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5AE3C3EDDD4C4F12E0A45618C9A7EE302BF0C466",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ZVXL7nJ5h9ZrCc6K3ZMgqR7HhT36DroxaBN7/kRHRx4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "627231A077D55F34733997ECD928CE2C511F126C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "UaISVfdgdm5p0+bwCbeatoNYfJP6LzW5k4DoL8++t4U="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "62B738D2DFB76A0938F116B001D4AD686B75F700",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "bgZ8KLzPd4mI0aDX5aRLG7piFzEt59yzsq3djHZMV1s="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "635206EBFDCCCE8AE040DE2FF07F1508929F3ED7",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VcBAfhXKgDF4pSdLRo3dWX1v+q8PSRMTXKNrU9QPQC4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GR4akX9jBcU4iFUBqB3NGwD3CuSTGPHiaWofAhCjCiE="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6D4B3D65AD9A81CD7AE83EA598B6FD2818F7F6D1",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "dHIiP4b5najkXBsEsplzaD8hQubhKlOrUEVOZ+NY+8A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6DC5F977934E65C23231DDC30BF273F22FF5454E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "RQYSRBpF1ESzlpakxi9woi1sM2EiMYBxsf88soDQrKg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "r7QqYEO8hh6xOwJMpsH+gYer+oOcuP/UQyG7NNsLLHk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "74830E4D56CD8E0ECC47E508CBA279042A3882C9",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KzE4Qyz7He+wo2wMepqCgTD4n10WA1Xafryn9Xgt6I0="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "74C2BE39F07B51E72003D4C437535A797D2774BA",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "qThLDyok7ht1m6Qj9sMPFfOvXQUIbnJ5PSmBxdnG0Rc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "766BE28A48C243E4F9AC3FA6B5505B6208EF4494",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "PeiNyRBUZ/qNnGl11xmW6b/Ejxq+9hfXdXPBewEzjqo="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Pfy3anXtYHMFjDLvM+5jJN3iS5Ypz9NMJ1KTNVjfJ7I="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "7D5B8447A0C1D5E85E095C885947C4EF180BA676",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "f6tNu5SZs7uu6h6e6g+ymxhOmJM09hbiT4mcoopbMx8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "JgRep5bgxhsdM6EVAEzE/cEaxMsdR6/VtG24KHgHDyc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "UGBPzd5VtGwtUkXOkCgJuzUO6s7Zk0RGKCo/Csdlqf4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "2ekMO1AKawC1gbXty/y6KBVpUfC9RcKyf3sR0ZK7UR8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "822D9296BE1DAF413AB15B489C002F4CEAD426D7",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "InuzWLzsYP/6DLHQbmiYe0rtduz2xktozH2FmOKQsZc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "82FB9EE4538CEAA9C808E862C8D47D36C143E0DB",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "QOPk17DOenwtH6MoTdxaW1/+ZUJw8r4QjevWGDpBi1k="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8301D560188D8CA97B5D373B6423292FA7A1C414",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "CQgaHk/wmnmnhWq8+vP2baKD2qUhYvNpFfRliGunlJg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "890C8588FAE1C90E164BFF1917A3EC93FF7AE8EF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "espgSJouSR/5l7I0UHcZqkUgByHgtt4yFAYzNbw4UVg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8A0B5C8CE8B72985C325F02B580C4DBFC527EB9C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "OBRlQyOtvKRxxxIF+7gsbA/5d4gI0aVdV+8Qzd42KuQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8B730D99A94FEA0729980BDBB4585DC2B7E932D3",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "E2+EA4BJea4XtU/Aahf4t8TpJG2FmJ0yIEP8dpDAABQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "92932AD7E082B90296C192F3113710CD6F99432E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GJlkT7S82nRWW34K5ax6ZCW9EV2nt1E/PF1P5LQgJdg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "93597B2726E0FDD812E38163799427FA2FF684A8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "8nCk/jO6oTXElCrzQ4YOdQkE6Rxj2AHMf9qxMPItnwQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "9562DE62254FB0C58E70196412E5F3C9D30B80AA",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "s8MeP7HuqZOi9/wCl1Su1+R/kmhSvWx0BQiXog6CM8A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "UseUFPt/FyVO1D19U7tHq4/CAsW/JxWOeTbw/ZftxMM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "9AE69E7D6961BB4CDAA74F99BB45A9EE25B02288",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "PbgEtU7KS/td42OxA7Aq7C49zcWVgbG7+pn5mjRBrqA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Hm8gqT6zv3BHDTjlY1nLMK2U4gte/cducumkYBgvXig="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "z7XkAAZ+x6klleinW1VTrsMLnAwNF9LHBFprFx1E4bA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "uEXsZIGASOuKR3SQn2cakTAkulEbm2kElVjj50W2oJw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A67BF23C710F87B158BC3369684A3033D3C8112E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "E3+y8GQu99AUysuGJfmtQxKYWRp7lvMPUoH67bt9k+8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ZHfThztGFsj0VfR6xV1r5ZA09Q6/+np9oYXs8CWY4F8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "L7pTIdyDJ9DHXRXMGcDeLxQ7KUP3AKiPpggq385vkrA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6lcuin9eD6uwAu9qjsoRjtd+uCtVUZbn//5UqLng9mI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "AFBD6E8C17284683A951FB263DDCB856AB61A176",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "0b2pdpqDMNKqBqZUpwLNqh6s/hblF4PaXJQLO1XZIs0="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "B058604741DFB193660713A02366D5A6CF1EF016",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "uktjN/4JpMiNcfX4GYir212W5zPhi4LVM+28oObD4ac="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "8f/zBc9sYTK1e73NefD07XG1gA/fqVsf8CZ5EyualYk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Ct8qHvpO82bPqzj2YxHkFgE+fmxVF0q7fTuvXzsK6Cw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "B99E8C85A4BB4886BA6E3043B3A7553A481FB9C0",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "9D+mHClSgLhk5LVobp4HPZi5N3+SUrzFKBd9Fz86Ml4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ZDJSsUONDbWTaQATQjuhqxsQFTnSyzSburJRflWe6ro="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C1A12367BC4BD69AF83B436A15D33703F381375E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "QoUOhrmZjUftNo5mXv8nIlT+QXIN3tDR3XOb2phGa0I="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C453130417F90DCAE44D28978DE1FB987507E6E1",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Cyw/3K8X71s0tFS0kFJb1HxaDdqcfodHQD4HXZ1p/rQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C56B6E67680CEB8BF11B0B5FCAE3987EB930188E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "DU+N0lyWiAJ3aUbKUz5q/LOQUDIPTunXAcK78TVKlpk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "55KLg7eVl0IyiFhu7r38WGQizm6hglE4rsAo68dGK28="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "CA6211FB7B017D171FB7C5E46269AB49C9A1A135",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Y9W7N4IeYcWu6yvh9XKzt2cHsI/QOAMEQgDhQG79yxQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "QEsifvLPeeGUsnI5MjI+gOXd2aU+NOqCwE6+Cs/LQRQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "xzIY0miEtnX/3fduBl9vYN2iDEmt7HIGK3Qb0bywdbU="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D361FCD15625DF4EA62DB0021C8D67C6083C8735",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "7Zs1DiFznmkmW6Yh0lh1nT2fRdcrm+2rFwUillbFS+w="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D447195654516BE994064E03868856302AEAF1D1",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D6BAFC0943840D65A80FCABC03BED8BE3FA7A8D3",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ze+xQF2/qcTtY9cje/r150eNoXCs4B1Vacf3TPcwquE="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "K+cn+8TPKo7d9dNhdj999tu1T108JCxecojB0pkssl0="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAA78817A47B08F3022C756FA3BDE8E3CE14F761",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "9fJlZL8iH/1ysAI/r+2cSqXOT67uknmJKnfIIaShLww="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EB8F0269F7A03728DD8D57D1484545B68DA6697C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "7wsvbzutFAAQReO+Jq7L4Drc37uLg6IKafptL9ofTOg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EBBE61282EC27BF8D06D96C2992040450DD2C1B6",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "9nbajKrFkiIL/zv6tNIC2ZVcFQOJDcYa4jOSzpw6qX8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "ED245292B061110D52CFD7AE6D02919E6C3480F7",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "O7sRf+YCASDFbn5BaxMC+DcoblK00JYTs8oE5uFMnLA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EED08060959B8BC09DF99BB8A51A08C8D6F1663D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "qBJDd/Wkt0KQfBUw4+wsWIpaqpSiUAQjGsTKfoz8IF4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "CkWTr7zqfXcDHuTn961EfHkJv82Ql1oibFWbfROfbCc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EFE8CD307C19FE1E9C437B59A0066EDD97F45E9D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Ov8G5YKHc1hjCBM/HT5k+MswEwXf+UZfP33bKi1prO8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "F08432D4BD305E8D18FBA52D3B1D351C486B9217",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "T66D+MDA5XJsSmlca6yAEADfkNnERoNTzWdQ/q5y/Cw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "F1DA81336F50B87982CF10581D308080031406C6",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "TCNu3Qckfx5+zXKvDTIHAFd/FZgbk013UFYIZqWl7w8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "F4d36ebIiyCzz/pk4sGrxYnls8XuzOfMRh/lF2LTdA4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "wqp6kT/3DEZ81E8BAdD802/NccJcCyBWBVrah3EOTFk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "FFF869AF4555A83882CE6697720536EF9759CF69",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "bZexjZwa8waNh2TSQjSenvvyjtNS0j98rRHUKdsvRxY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:23:55.160336583Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "8D0DDFC3F6A87AD152D9E7BCFDD3A25DB0A5BAFA4231786B2D302F4513656175",
+            "next_validators_hash": "ACB51CB30CCC545745BA88A2F683DBB0844E03559BB4EACEBEE24D2CBBCEED2E",
+            "consensus_hash": "8D0DDFC3F6A87AD152D9E7BCFDD3A25DB0A5BAFA4231786B2D302F4513656175",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "B2F6854D5B4CF1FA12A6BFCB61AD4F4FA8FB5FFF44866964BF768BC579F53094",
+              "part_set_header": {
+                "total": 1,
+                "hash": "B2F6854D5B4CF1FA12A6BFCB61AD4F4FA8FB5FFF44866964BF768BC579F53094"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "BXrCREgCjWEuAHZE1Kvb23lio8tElEhLG5/Qf/5RJfA//ZND2WVsBxiHTFY+lymJ+Pi0772PNbei3cj1s7RpCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "04CA9AA40B76FF67B56D5A9285CB9AE5ED2F3247",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "xsi5QF0bSnPm26NhUzbudFzcwcTubugxCTrJ7nFl+Q/y0916BUzHKalSTLemUv5/UYw2lpcqHqFW9Jqywo0VCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "050E6732CEC76C71C0CF6784EB4A4E2CEE8C23B0",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "eKWZOBa7XiWt8hPPun9AwBJI9UoWFJ/VRXoSwe0z+7FU9AH3RQCzcc599XEAKg3LFAOpXcuin8v7cJCNahBWCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "My6T6286KLoYa3kXU93af6QjOacQuerURMGAEnp2VUyX6gRNZkkNKDI0A4ndhTmbFUpP2ZsxaM4mmR8mIrnBAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "0C7A21D9023613B0F814882F40694D07FB508388",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "KynA29HyiU7x2BY8iVqK7KucNmE19wYzotb/PAg3SxYUh8Swn1G8sx+WKqzUWtMaNBvPlbn4jxL2rMd9c9nLCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "VL73QDHTbnI9eJNgZYa2NXXv0EUqwG+kqwXStJsnlsxr87CXOpX+WI/kU9tmYMrsTDfZ2T7ps3oucl4BtQ0YAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "239D1ACB182F9EC413D6AD8BED3A13447318B95F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "LysRW53Fqbk5s6Gkl6Ev+wNBOpCbCuOsoGnDfMGKaBvcVSKa6isy80A5BtdMtJO3Uze5LTCiLd2DqHYpcGW5Aw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "23A53F06EAAF2B827B9AF8B6866DEAADE5A5CAA3",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "64jaS+/fpipjE+ncDezVUBBYO+JMypppisSvZKNDrf3YyGV5kAk0ww3CMDXAJvLuIbE74PHglUfJYDg0jDXLAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "26E91E700545D79E8A18092C393DB76294DF393A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "2+LpEW8B/6JtX5r8EG61AnQeJGyahpsWFv2H0BYHWnkQoay/auNVmowgfuHYBHrflHuRUTRxkNaaopLfXMz+AA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "Ael9t/CHxJqWHMVmYmXzyNSm3JGTzpvKYHOnDTG7vR6ubfiROUntE3qO/AzFnAWfhJfrMunl9Ooo3CCI20uSAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "T2zqIn3qRs1lqQuId1769x61wdSn1yYjaT4CNmcskXifHcoSl0avjTnCcfvhN9LPY27X4Be5yTF6N+bFIbxMAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "31580E874C4F84AA5EB5F986FA70B74F8D1865BE",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "HznxJEkrR+SZOO1v52vGOodS6y1ASpV/pSYBQiWQTvkmqAsgcspmvMTkVwGGJa2is2PPpszUlaF/YgyuAESZCg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "319549CEC8B9DADB70C7E8DBBC8FE5D550398506",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "z5xLRMYF+8YcBnYJncTERAUAnnSHKJeKzOQV/or3V7TetRGFOWqntnQ+gzYn/3SdLfFLItddemv08TPU2TU+DA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "361491162A6178776B903E57AB7C4D909394B4B4",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "xzkHQpTiKFfEN8HqvHO1gP2FN07ffqWGUwFsU7XsOlF7yvyugtUXBMDNtYyOgYYw7IuFfdE3IiY61LDjWFBXAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "DRrRQfbefxnBWYK9YFKM22F9cO3iTDI/BR8bAloSpu9qguCfSazrF+DFGjjVvXj2uNSbq1B20AKvn1aRpZnRAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "XVCiRp0GxBAVgdm+RjpUjeVGgy71btxEmBkqP7Emd9nTFldL3EfCy5zyYrDLAG+kBhlsMXKxlVyvU34CzNbfAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "3C733B78F612FB791744711958D8BC4A3D1B54BF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "oagER+P/zX44sg9QqmArMJgOx1dCqe8P61wJPhRRtWblQ++okDTp9A0oMGcyyP6Wu5xrRcWj9tJ5p0ZvhphTAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "ux76FlCfnyBGrfykjy6KLE9sQZSvipO9/JETU+GJr09hmrVNngoSAC9fbFuCTCGWqYUReIb2lK6yjxSva02kCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "3D7E3723C921B1D35B52921B8511142BF5976863",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "P6aLRhym4TBlBlmZuQuro4hacMatCvOIO7kRkSIbZWkWv+wjsb6ip+hGfYo0epqJWB8h7i85wtspGk8KoeHbCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "400C0199DEC08A2DBFDF5D081AC15FD6685E8870",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "8dv+Dj+19Tp7NnJy78qA1lOxAsSodCxdz7pxA5KvnHJOLZiQDP4+i99yG6ky4RGwYP/WoxqXJPE702nBvNWbCg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "416A8E60A478C20CEB021A84425D8B457558D4E9",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "IpsnA4741Kg4G1fU2Tob52IFWEPABk7Qjsjs4K8FtdWyx87YGq8X4vGRiLO9oDJtvqvGHXWd1YdWKE/MccHNDQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "42D162EDB46B7C1FEA616810A7617A6369958ADE",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "iVfgRkl0F/cx0Vjxu8zFTGJavYW30VL3GLV25A8txCGYGlIAZBT6CQ/8sKeFpE8DTiau0OxqM50O8qXzajMMDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "GFw8tpDmP7ff/+buHiZTeD+KVhIYZaTtmqN14KWyobA+JcnG3tNo5vBa7wlHgPVFCzhyu8jOGBWfR9L1UeOOCQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "qZXSNh7EUlEN8jmUZE46aP9T+S/QPV5I6F9CJSuD4WgPoDCloTe27GTJgVTyBWquP1PA/Hve4snM8flWumeUBg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "55027F5FDE2DFC9F1C956D4700A0E60E47BC8126",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "UUcweiQdXkn4IBDGLH9zkWFvekN8WP0unuQ0va0hz7AFeMN1ALgoTOtPoVZqeqe7fSRx/qrptgZb5+mtvxsYBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "5AE3C3EDDD4C4F12E0A45618C9A7EE302BF0C466",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "8Z71Rw+R3ak3BAEKlF30qZfrfm5vWyDXqpSH+WV9i1mdMcuxNSpAQ6EdjdND8Hwg5oZvkHDbaQg83TzlXmSnDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "s49y6an1GDLO2raldfLEsYSdiAZzx5Z4fanrxQpMYc28iyU+/hJBTInuAQX24wxlH1+McGE2athvUQUMK1gDDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "627231A077D55F34733997ECD928CE2C511F126C",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "OeLjErOhOAcJmHa4k9WnBFPj6B6sBKi2fwN3I8ruJjGut1EGgK+75jVLQZJmXWlDttByAEUUXetIJM7x+xGXDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "62B738D2DFB76A0938F116B001D4AD686B75F700",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "SJLxEo0EV+hOwTmrJ7EsZcHgE/bkORlHVYwQqu+DDSAVe+JdxFEjupdpkz7ZnOgy0bk/ZGBr9rIICs1kKow4Aw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "635206EBFDCCCE8AE040DE2FF07F1508929F3ED7",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "V0Ky0VMfjCDc0nRVF5LKCsyHsKmwLcNW+z2JKU1jeJMx4kquZv87S8zn4W2SsjyFhXgDZHvhB+ykUy+ESk2DBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "R0nOsNrLdS/upl/+5Iba9OHAwRtsgv445VJGZZiKnLHRFBgz7Ol/yOL7Ljc8oDkOE9WqhwrhNFJY1pn2f823Dg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "afTEZLosjOuGErFt2rpvlRzD80O0StBPOe59G+Goq0lU8FP/BFCICY6xWu/jzA0QWG7rgtAElPK4FP0pXoguAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6D4B3D65AD9A81CD7AE83EA598B6FD2818F7F6D1",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "XnHStM09O+H8irbchRetkrAtY79Ln5Elj8r/p7RdyjDuNm0VEus9afcabzzBQ+cqKw33xMWJSpTsDUfI2ELjCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6DC5F977934E65C23231DDC30BF273F22FF5454E",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "TeA75zv8Dxxf3+zm4W2gTAsm7eKUaht4Y+y8hJPzpaKTyr2r+qdiKkP/MLyl8vdN3lnGuObjmw3fYDAPm8G7AQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "ZM3LwXpBLNlHPKRJdM0FsEKu0+DdjfJ1S31ysKK1ZI6p142NHR4tBdBoFMX/jqbsZH1G4mZG6UrAUZU1JalxDQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "eJ0gYT3LT8Sy0NNo5Bgntl4P6537gVTLx6o8CxA7vf6K/vXTBVp651owe/rqWvHH0RUoCWWLn+FFFPOWqDgsDw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "74830E4D56CD8E0ECC47E508CBA279042A3882C9",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "8tax06m3Ewcnf56WO0dttkNDE6yZm773oSDKCo4mT0NGMFygHUMcoX3vaKd5jEsM9d9TTRQF4YoF7JBLUecXBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "74C2BE39F07B51E72003D4C437535A797D2774BA",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "MVwkwXSPVHtKS6MLyBM6jIJq6af5ryrJOQApZgSgfNlEKKI3IMJPhoT+vGCFbSMjttmM8ThQHC/hjwcTQ5wfDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "766BE28A48C243E4F9AC3FA6B5505B6208EF4494",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "yTah+MCJRSLLHLXkNZy12mdQQra2HqiPaD7k42W1+1Po96pf0ZKDAWA2nXLwi3RMVdSP+tD1SuhS32qaqn6FCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "koxe3GfDOOO9DiT/5hajiaPct12CxqUEefM61oK7R2CU+puuhy/OF45IQoBoTQpsiq6ec6E1A1cE9XcybYE8Cw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "7D5B8447A0C1D5E85E095C885947C4EF180BA676",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "RIAAVtsebgbUkZSqG7l7x4A0BFhqGupCatUHqeVGPAzZovpq8nBlHZzYA3Dw4yffA+7eeV1Bv8qhY+LJ/tGdBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "0fEM1NxHV7mNsO1JyB/mTyl6mIc95KJBju50fWIsQPM5AFIhEwcNMitla1W/kt4MFiQbMcUj6MbOCpsAiJbVCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "hcDhwXhwBQHD2/yv/KA7G3Y/ESFfrwcHhlmVZ6weZ2o5iEyirDLRiYmvH1z2b6ihWkLeEOrn85w/cpWn2GmCBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "AT6VR7HTzYTGnGPFIcGUcPnFIa5b5NfO6E5VlLOdL3YVZAMFRrdmICtpt5tK4Lamo+p8WeteUZhHzKur+7FWAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "D/Y+MoXuG/AGZQJtGvUYPQqj3ulhE6DRRvv29Q5cR0MURWcEG58GeoSeLLRo7Vf8lZaJYRPCLtqYd0AOh7uBDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "822D9296BE1DAF413AB15B489C002F4CEAD426D7",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "LZBVBAU37WQJQzoBFNHjAOje9I0+SX4Hexkv+Vk09QRUcUJVNzQw+Kqi95BdKzD12lqxv5pevgtALqTHBrBtCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "82FB9EE4538CEAA9C808E862C8D47D36C143E0DB",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "BJi/IaY4/TTRTQPlr08x8k+yvKHOP52dDoOaGPfHE2EGfa47bZeAKfjzvJ+KdTDgmDKmhFrCTpQQ9g+nfLOhAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8301D560188D8CA97B5D373B6423292FA7A1C414",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "toM4MeSyswxVrOQhg7lW23T+lBRt1A9kaAocYzcAYRyqlHslh8hNhRF8n7ueSzmJZPTNy2TZbVgMowOkx4u6CQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "890C8588FAE1C90E164BFF1917A3EC93FF7AE8EF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "N6h7pr1KlDdCAu6ED4lsQCH203NOjibtPjqR9T3J2C2IGzq9dyNk/JAtu+wOx8RBr194DzErEXVXSMvYoptzBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "rAkCcR6pymVnKqzvCFEFPQry9quZDvcFWiedzqjuMG2SeohYaLknEy0Qx4d6aEWQnDLYSh9GX651OILoQlizBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8A0B5C8CE8B72985C325F02B580C4DBFC527EB9C",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "fjhbijdhA4QM6TuEwAUgHmcOx79dJfCLnzsWBVWVfJ92643Zv0Z/IFLFXq94Zt55WmQmnIXCsXZFj4yK4XX+Cw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8B730D99A94FEA0729980BDBB4585DC2B7E932D3",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "1g2zkgzsBNOeUzaLh2KGOL4hAZyXX7QPa+nWARs+/GQEjKNXYXdjZTWO0nByQ0jOtvkmPOr2LMRZUBioYJQqDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "AMr69zVUaQjv9r+V90ioND3G4VAOapaJS8B1S44b7wmk74iiBLJ/zM1FifDBM2mHVyHUk8JSR9Rgzptf6mfrBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "LyokpTmJZPNHvBxXrwuz5N88/EcPq4wsyNvlSW0FHIT590dZb/MrfqEhAX8uLC2TgsBNCv9Mtlo1bJYMfWROBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "92932AD7E082B90296C192F3113710CD6F99432E",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "7z12x0DGqKJU61zsyDJe/tiV8IIEdcYb2ZZOQBzkLrZGLawwIE1/z22ltvWEzpVO19OWh5nw7wElSFV4/woWAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "93597B2726E0FDD812E38163799427FA2FF684A8",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "AmO5qOw3mDppyRWF1hf44+OdxqZHI9rB1sqmQ7IBHN1T7rggBER7swC94DFw7KndTWaNeRzstMVvNDwr3/qDBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "9562DE62254FB0C58E70196412E5F3C9D30B80AA",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "bbCeCojrFDMr+HGZxhg+zzC9uq9YIDt/uxGZgysU980sfRT6/cFlmZgYCprxJRH8+L9Pe8aTQmmRcd84gP0PBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "eZG595TDpRz9TlE42oHRR8HMohqCYIpHhqIyiCL8BURk6AzybQJTeDkH43omxMZprBSq8XzbSjicogMBbc+9AA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "9AE69E7D6961BB4CDAA74F99BB45A9EE25B02288",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "SpFQjWgvzrhxK5V7a8++Uyq/G/3qVpFJuaG3A9OoYesGbDzQRLg+DWU7JB60AMIG6buGhoOv7GaNFIbnaz9TDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "rtv8xnYT7BQNFaowW6tr+HkjIYhl0oiI/+auGLBB4giYUOjlYymX82CJkB8hhCOXRaLXw6MIk7ewQbtRd0+sDQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "EvHb40keibaNGVsSICdeSFeoj+/6M3RGj20HFjz1hvDXsxK2ADx5PAAHvzxBLuhccTXaUonmDqqQhQIZYidsDQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "aFOfAZzg30TG40fS4L0rf6XiZyc8dDClhqzguUj1YtxCUs48yZ9heK0L8a9CXBDpCyU1p9I1ZtHqLtAaCKhGAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "YUpt1UPYmnTkKoGLSBeWlp105Jb+pgHQegOgvj4q02BJ5tOJir9ovCLbhQ2D7Fy6lZZ6g0WGce+PFezqlCkDBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A67BF23C710F87B158BC3369684A3033D3C8112E",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "czS6AeZ83nEaBXX9hdeBz/08X2/gXVwMpl7hptWPWBjCx5K4DknWVU+jbyGmxoTZH7W7ARMDA1k4242PCGY6BA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "5RtCg4EQhvh8BsPbM0GJowOPghs3LJGy8Eu9Z2caQY8AzR+oa1HxMpqBdmBIQzMOALELtdPaViPYaoJL0S0WBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "BBH2ICzqkRsUblPT8znJyx7CifjVGR1MKv09C1mIPMEvV+/OsPmywVJyewj7AyY1+mCxCBy16hDJhf8Dn11bAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "Up7b4fwJ135rjfCYcgGzbxKnP/V90AyyV1B9PhJKetZfZKrMnAphqc4t4QWVbViAwmpwppuS4URyblvCqNcCAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "AFBD6E8C17284683A951FB263DDCB856AB61A176",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "B8usMB4a+WYCwCphOki6nMj1O1hFZhrqh9zb2/+VH5r9CUbXI5jSe2xSOuZwG9Ga3RGS27Fce48pfIX4RH5ICw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "B058604741DFB193660713A02366D5A6CF1EF016",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "xDk1XmK/i45ixSp1kpxhd+cZ7RaZf0L4Txtl+O4yC8aO1KNV2LmYAUPb6pk01tebq3gVMaZTdnhFxCeafS5pAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "toiYw1hTQbIwmKy6y00087UsP3cGcQm+QgiUu2xx3iKR7fDlTA8E2MSunWKH5VJrPD4RxpskZKASyfC797gRCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "JZqZwrvtXJZZoLUNqxhI0Vqe0f7urzlCtDWeZtLpzdv5lnL4IKzmVzAbMbJjbuZta08dtexVmY8ms2JalBarAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "B99E8C85A4BB4886BA6E3043B3A7553A481FB9C0",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "cZFySn63dp4u2xu6a06yQOEg4yfwjVKvXmm7VLzN3NWOGMcdqw0LU2sm/YHZ8+O9q8YE8Ii4sy9ASTjFQr90Cw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C1A12367BC4BD69AF83B436A15D33703F381375E",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "LnuOWuu3mltaat+At0wUmy8WDOjY0thYT3GcexW/FkYUxyWkfZBvKDWR2/+bBtGRnMPviA6QONhRiNyuaXHPDQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C453130417F90DCAE44D28978DE1FB987507E6E1",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "rCmlApnvyoHDuSjp3iQFAR57qRlanqKDA05wDSQaBKos1CK1yV4xtZDUFx6BuymLKx/j0Iw/07/Bn0SFVt+WCQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "sssyQQe5QUCe7xkVrrqA65Xvzgq4VDkwpp4JPaZzPovvdxuR8EjvEByxSKUZtmtUZvrLyAaYUFgoih2igNqsBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C56B6E67680CEB8BF11B0B5FCAE3987EB930188E",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "yIukecEFVWgV5wU8JKDa8+ryLqHe+ZWsl6BkQzcAFxNTbiF9zssVfb5a086A+w4sb81HRBq0BADj0MTFxEWPBg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "CA6211FB7B017D171FB7C5E46269AB49C9A1A135",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "0gB6yNpzzX1mmnQBIUUgTktFhpWEJO1GG+3IMp9m6VpNeFPBo2xPFcnIlMqDeyAdhjonvXotBlOI8MZ9b790DA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "IRgfWR1zSuotmvvflIz2zHt7B7iriF6xkHsrvJ4KdjfDD0dH1GeFxP6RX/nYBv3rFbE4hYiBA6ua90xSbrABCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "B8I92+vp1XSsA4r2KBcztoQgd7ofDcOyHxRoIaEBgDGtGQns8jPyee9zWycOUkaMHEgJHG4wT/M6dQmlw94ZDw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D361FCD15625DF4EA62DB0021C8D67C6083C8735",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "/ZEIwQbowmk9Yh+a44ysUD4od6Ssks+6QXdgOoIcxEHpyZBYoVNsxvO+7wDLLU4925m+ZrliAhig6WVeF22cAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "kS0fk12xos5uM3v1c59GbCv2JTyBhrWfDtRnFnI/nxzIHPNv6zAjKa6ajsgSfLvA1F6Z5qjbXAhBxVsPVgSLAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D447195654516BE994064E03868856302AEAF1D1",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "UwahTdGceXCFHD7w/ZlFZDAUuiG/rrhJA0773LPafnBqAGPMRYHZR9O5kaadQAEglB62Yfz5YqtbvvW6dZzgAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D6BAFC0943840D65A80FCABC03BED8BE3FA7A8D3",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "MMB+WmCp2d0WRpAs3C3JAfDVncQIV52sv/b/FNQRu3lGOm0MH3hu/8GuV5FVDBg0LzS1Mt1BsJHhq2/L2MeTDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "suqkI46F1GxOB81qbcdhw1i54YEzl4xWoyKAf+WNJ9OEXY8lzdKv6d6Avfl1RFvnaSw97HcbY8iFfxHXNiaXAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAA78817A47B08F3022C756FA3BDE8E3CE14F761",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "wl4x942xQEURLdqnfU35hOY+bEBw/aJnuF92zUxgFJbPvnH6XjIvnpNIs3T74oETkLFtYTfg1nGue0/UYhUHBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "6nxbd5hf/YlF7eX4W2YuppYEDpWNqWHZFnCHUPPf9qBqOUJBHr/3O/doD4bu1YIToZEpJTtC/vR/39tprD9yBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EB8F0269F7A03728DD8D57D1484545B68DA6697C",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "y4vU2M/GpzJzpRxQD/hYrm4pH+g56AetmKbTK29uCBADBXXfSOIzzSS4VnYflRV22akeTU4wTMZBoiUDlH0iAA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "ED245292B061110D52CFD7AE6D02919E6C3480F7",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "OEoqQa0+Qlv2OMMxx0u6jGVUZy6tiYfFg0xXAkoeB6ZCUGaNoo8eQaDuoUF1NVddG9J6yWwhcqp3WLhfYz5zAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EED08060959B8BC09DF99BB8A51A08C8D6F1663D",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "71kN3LX/eQk5Imj0QbjAR+PGqIOwkEhgTAwSP9a3zvsVgUHuwKprWY1o2npif/ww4h7iUP1e5BQWNA7Mhbo5CA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "Tzs4qCydtYcATcTLEXCdvZbhEvmwND4C97tzvDet4I4F/pbECDRI9MymTjzganpFHaW3uEYYv5NNtC1yPlrZAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EFE8CD307C19FE1E9C437B59A0066EDD97F45E9D",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "2MO/zyJzQCcTWO8pgVmpJ9OGIHaKSy6rKFBuaBTfdKU5RuiBGRYDUQEOxvRjjaPGtKySj3uP0mODJizyCXbsDw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "F08432D4BD305E8D18FBA52D3B1D351C486B9217",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "L81elSPk10G6HyVnBQretW4QkzuaEeZVh8Db1WwSVMju1xzzI996qctHPxSjrIJVoqOXm93d0VOvCEcwc1+5BA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "F1DA81336F50B87982CF10581D308080031406C6",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "IX+iYg5Kg9D0Pag4bVIbK4NPV81UaFK9lJ61JX2IcHF9SixNGVA0JXkGLuiMZkhzBi0rIfxpYUtO8VRocXyjAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "vq0xO2Vqsqjwk8qpNdtztfVOi6h/Y2zGrv3XFy7yZShcRVeRgDA/k+vNXDeWShzwJF+crQ6/vDBRk744InHaBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "H1i8/t1F/3rWsbr8yhKDcswVKEbo2vN5pZ3ECSh+IoGCk3JRbvQ9prqqHPFQgSGyy/b0AIqKjbHswdE2oPLxDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "FFF869AF4555A83882CE6697720536EF9759CF69",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "z85chRDHppBT8rj+eEqddIbsfVCIk0tdAbaO/9ZFzy3tpFzMge4SfM+1hhmRRDafdM7KUFPQ9T05hRq/yrGPDw=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Kam3xVXv675BD8rZmi4Zs5jdR4+8I8i8ZEZU0gs9Bp4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "04CA9AA40B76FF67B56D5A9285CB9AE5ED2F3247",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "/hFZhF/r5QiEeRGVjMZhG0sO0SeqlURltv8wMjkmOG4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "050E6732CEC76C71C0CF6784EB4A4E2CEE8C23B0",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "b7OxLS/2TcshawP8QjsCuyxOUe9d3566aFczz61UZNc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "0C7A21D9023613B0F814882F40694D07FB508388",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "yVRzgrYNJ4G1uy85dJseiG2K9/ofD/6kObbAfvK1E5I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "239D1ACB182F9EC413D6AD8BED3A13447318B95F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ELiW5vI49RoPS71qjid0QFJM8CZpmLnW7qkmN8lQU8g="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "23A53F06EAAF2B827B9AF8B6866DEAADE5A5CAA3",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "WPAEO3zKMIbXTkPCa/Wg+s/eR7w6Wea1a6Xuzk1RTag="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "26E91E700545D79E8A18092C393DB76294DF393A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F8xDDGP4gRkFMeuIlULpbOP6aGPdTe5gZT7kCCnAQIY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "fWMaYDTFwdDo7SVw9hBIraX2GVqvzKhNKEUkr/2ZnEc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Uq1fQj/TXkpg+zP37a//6YC04vQHWraWfYSg88fMHxw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "31580E874C4F84AA5EB5F986FA70B74F8D1865BE",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "scpN1hLNChIB1QuRHojxUwl59cPP2KpwzilLU10JViM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "319549CEC8B9DADB70C7E8DBBC8FE5D550398506",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "iPt9P7DZ9EUBhWssBSvr/qYatOs08WwLCZbfeuW5hds="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "361491162A6178776B903E57AB7C4D909394B4B4",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QlwrDiydr8tfRonzwMnML1JYtWUHQZiG6aqhWsXRriA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "etUp4mnEHDdNnJSwu5KW8EMXYt7n94iYZm+y7xa9ym8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "R1rD/692T348fL4cA0mvvbK9aANwT0vBNAT5B9+p+rw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3C733B78F612FB791744711958D8BC4A3D1B54BF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "dul9CqXgrwNXGlWp4ya6mulGjKJok/Q2RYqITOGgYro="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Spb0BakJqr3uNaAEqdaGbv77bQEwym0/6cl/tnCdkGM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3D7E3723C921B1D35B52921B8511142BF5976863",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "vfycl3VTi9VKc+Fytp4pvbp0+xZKEUTufet65El49EA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "400C0199DEC08A2DBFDF5D081AC15FD6685E8870",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "y+sL3o3wbcoAx67HqR8BNzJVokJrYGI5pflGS8GMSv0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "416A8E60A478C20CEB021A84425D8B457558D4E9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6P6otvJpi36GOMprEbFwzth4AjleE/ThQMksZ2Wgh3k="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "JqkfZ01ZvkPHj9ohj0F2Saa5t6KIX5uq1bhHS7YAyxk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "M5rP8lPaJdES+Bd4oWI/va2sRUvbJiYINzOpUdiuO8Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "mGpmR8PNc6w2cUzPwAQhkSadkyGOuKMl68Nji5E3h5o="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "55027F5FDE2DFC9F1C956D4700A0E60E47BC8126",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "zfSXZ7DLwIeRwhbsE/Pr7cSaQZTmySpuXmGEnNRUZpc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5AE3C3EDDD4C4F12E0A45618C9A7EE302BF0C466",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZVXL7nJ5h9ZrCc6K3ZMgqR7HhT36DroxaBN7/kRHRx4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "627231A077D55F34733997ECD928CE2C511F126C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UaISVfdgdm5p0+bwCbeatoNYfJP6LzW5k4DoL8++t4U="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "62B738D2DFB76A0938F116B001D4AD686B75F700",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "bgZ8KLzPd4mI0aDX5aRLG7piFzEt59yzsq3djHZMV1s="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "635206EBFDCCCE8AE040DE2FF07F1508929F3ED7",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VcBAfhXKgDF4pSdLRo3dWX1v+q8PSRMTXKNrU9QPQC4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GR4akX9jBcU4iFUBqB3NGwD3CuSTGPHiaWofAhCjCiE="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6D4B3D65AD9A81CD7AE83EA598B6FD2818F7F6D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "dHIiP4b5najkXBsEsplzaD8hQubhKlOrUEVOZ+NY+8A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6DC5F977934E65C23231DDC30BF273F22FF5454E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "RQYSRBpF1ESzlpakxi9woi1sM2EiMYBxsf88soDQrKg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "r7QqYEO8hh6xOwJMpsH+gYer+oOcuP/UQyG7NNsLLHk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "74830E4D56CD8E0ECC47E508CBA279042A3882C9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KzE4Qyz7He+wo2wMepqCgTD4n10WA1Xafryn9Xgt6I0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "74C2BE39F07B51E72003D4C437535A797D2774BA",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "qThLDyok7ht1m6Qj9sMPFfOvXQUIbnJ5PSmBxdnG0Rc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "766BE28A48C243E4F9AC3FA6B5505B6208EF4494",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "PeiNyRBUZ/qNnGl11xmW6b/Ejxq+9hfXdXPBewEzjqo="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Pfy3anXtYHMFjDLvM+5jJN3iS5Ypz9NMJ1KTNVjfJ7I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7D5B8447A0C1D5E85E095C885947C4EF180BA676",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "f6tNu5SZs7uu6h6e6g+ymxhOmJM09hbiT4mcoopbMx8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "JgRep5bgxhsdM6EVAEzE/cEaxMsdR6/VtG24KHgHDyc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UGBPzd5VtGwtUkXOkCgJuzUO6s7Zk0RGKCo/Csdlqf4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "2ekMO1AKawC1gbXty/y6KBVpUfC9RcKyf3sR0ZK7UR8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "822D9296BE1DAF413AB15B489C002F4CEAD426D7",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "InuzWLzsYP/6DLHQbmiYe0rtduz2xktozH2FmOKQsZc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "82FB9EE4538CEAA9C808E862C8D47D36C143E0DB",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QOPk17DOenwtH6MoTdxaW1/+ZUJw8r4QjevWGDpBi1k="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8301D560188D8CA97B5D373B6423292FA7A1C414",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "CQgaHk/wmnmnhWq8+vP2baKD2qUhYvNpFfRliGunlJg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "890C8588FAE1C90E164BFF1917A3EC93FF7AE8EF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "espgSJouSR/5l7I0UHcZqkUgByHgtt4yFAYzNbw4UVg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8A0B5C8CE8B72985C325F02B580C4DBFC527EB9C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "OBRlQyOtvKRxxxIF+7gsbA/5d4gI0aVdV+8Qzd42KuQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8B730D99A94FEA0729980BDBB4585DC2B7E932D3",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "E2+EA4BJea4XtU/Aahf4t8TpJG2FmJ0yIEP8dpDAABQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "92932AD7E082B90296C192F3113710CD6F99432E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GJlkT7S82nRWW34K5ax6ZCW9EV2nt1E/PF1P5LQgJdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "93597B2726E0FDD812E38163799427FA2FF684A8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "8nCk/jO6oTXElCrzQ4YOdQkE6Rxj2AHMf9qxMPItnwQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "9562DE62254FB0C58E70196412E5F3C9D30B80AA",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "s8MeP7HuqZOi9/wCl1Su1+R/kmhSvWx0BQiXog6CM8A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UseUFPt/FyVO1D19U7tHq4/CAsW/JxWOeTbw/ZftxMM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "9AE69E7D6961BB4CDAA74F99BB45A9EE25B02288",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "PbgEtU7KS/td42OxA7Aq7C49zcWVgbG7+pn5mjRBrqA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Hm8gqT6zv3BHDTjlY1nLMK2U4gte/cducumkYBgvXig="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "z7XkAAZ+x6klleinW1VTrsMLnAwNF9LHBFprFx1E4bA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "uEXsZIGASOuKR3SQn2cakTAkulEbm2kElVjj50W2oJw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A67BF23C710F87B158BC3369684A3033D3C8112E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "E3+y8GQu99AUysuGJfmtQxKYWRp7lvMPUoH67bt9k+8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZHfThztGFsj0VfR6xV1r5ZA09Q6/+np9oYXs8CWY4F8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "L7pTIdyDJ9DHXRXMGcDeLxQ7KUP3AKiPpggq385vkrA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6lcuin9eD6uwAu9qjsoRjtd+uCtVUZbn//5UqLng9mI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AFBD6E8C17284683A951FB263DDCB856AB61A176",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "0b2pdpqDMNKqBqZUpwLNqh6s/hblF4PaXJQLO1XZIs0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B058604741DFB193660713A02366D5A6CF1EF016",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "uktjN/4JpMiNcfX4GYir212W5zPhi4LVM+28oObD4ac="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "8f/zBc9sYTK1e73NefD07XG1gA/fqVsf8CZ5EyualYk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Ct8qHvpO82bPqzj2YxHkFgE+fmxVF0q7fTuvXzsK6Cw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B99E8C85A4BB4886BA6E3043B3A7553A481FB9C0",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "9D+mHClSgLhk5LVobp4HPZi5N3+SUrzFKBd9Fz86Ml4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZDJSsUONDbWTaQATQjuhqxsQFTnSyzSburJRflWe6ro="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C1A12367BC4BD69AF83B436A15D33703F381375E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QoUOhrmZjUftNo5mXv8nIlT+QXIN3tDR3XOb2phGa0I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C453130417F90DCAE44D28978DE1FB987507E6E1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Cyw/3K8X71s0tFS0kFJb1HxaDdqcfodHQD4HXZ1p/rQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C56B6E67680CEB8BF11B0B5FCAE3987EB930188E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "DU+N0lyWiAJ3aUbKUz5q/LOQUDIPTunXAcK78TVKlpk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "55KLg7eVl0IyiFhu7r38WGQizm6hglE4rsAo68dGK28="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "CA6211FB7B017D171FB7C5E46269AB49C9A1A135",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Y9W7N4IeYcWu6yvh9XKzt2cHsI/QOAMEQgDhQG79yxQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QEsifvLPeeGUsnI5MjI+gOXd2aU+NOqCwE6+Cs/LQRQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "xzIY0miEtnX/3fduBl9vYN2iDEmt7HIGK3Qb0bywdbU="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D361FCD15625DF4EA62DB0021C8D67C6083C8735",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "7Zs1DiFznmkmW6Yh0lh1nT2fRdcrm+2rFwUillbFS+w="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D447195654516BE994064E03868856302AEAF1D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D6BAFC0943840D65A80FCABC03BED8BE3FA7A8D3",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ze+xQF2/qcTtY9cje/r150eNoXCs4B1Vacf3TPcwquE="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "K+cn+8TPKo7d9dNhdj999tu1T108JCxecojB0pkssl0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAA78817A47B08F3022C756FA3BDE8E3CE14F761",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "9fJlZL8iH/1ysAI/r+2cSqXOT67uknmJKnfIIaShLww="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EB8F0269F7A03728DD8D57D1484545B68DA6697C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "7wsvbzutFAAQReO+Jq7L4Drc37uLg6IKafptL9ofTOg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EBBE61282EC27BF8D06D96C2992040450DD2C1B6",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "9nbajKrFkiIL/zv6tNIC2ZVcFQOJDcYa4jOSzpw6qX8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "ED245292B061110D52CFD7AE6D02919E6C3480F7",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "O7sRf+YCASDFbn5BaxMC+DcoblK00JYTs8oE5uFMnLA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EED08060959B8BC09DF99BB8A51A08C8D6F1663D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "qBJDd/Wkt0KQfBUw4+wsWIpaqpSiUAQjGsTKfoz8IF4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "CkWTr7zqfXcDHuTn961EfHkJv82Ql1oibFWbfROfbCc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EFE8CD307C19FE1E9C437B59A0066EDD97F45E9D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Ov8G5YKHc1hjCBM/HT5k+MswEwXf+UZfP33bKi1prO8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F08432D4BD305E8D18FBA52D3B1D351C486B9217",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "T66D+MDA5XJsSmlca6yAEADfkNnERoNTzWdQ/q5y/Cw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F1DA81336F50B87982CF10581D308080031406C6",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "TCNu3Qckfx5+zXKvDTIHAFd/FZgbk013UFYIZqWl7w8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F4d36ebIiyCzz/pk4sGrxYnls8XuzOfMRh/lF2LTdA4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "wqp6kT/3DEZ81E8BAdD802/NccJcCyBWBVrah3EOTFk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "FFF869AF4555A83882CE6697720536EF9759CF69",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "bZexjZwa8waNh2TSQjSenvvyjtNS0j98rRHUKdsvRxY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Kam3xVXv675BD8rZmi4Zs5jdR4+8I8i8ZEZU0gs9Bp4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "04CA9AA40B76FF67B56D5A9285CB9AE5ED2F3247",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "/hFZhF/r5QiEeRGVjMZhG0sO0SeqlURltv8wMjkmOG4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "050E6732CEC76C71C0CF6784EB4A4E2CEE8C23B0",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "b7OxLS/2TcshawP8QjsCuyxOUe9d3566aFczz61UZNc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "0C7A21D9023613B0F814882F40694D07FB508388",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "yVRzgrYNJ4G1uy85dJseiG2K9/ofD/6kObbAfvK1E5I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "239D1ACB182F9EC413D6AD8BED3A13447318B95F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ELiW5vI49RoPS71qjid0QFJM8CZpmLnW7qkmN8lQU8g="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3D7E3723C921B1D35B52921B8511142BF5976863",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "vfycl3VTi9VKc+Fytp4pvbp0+xZKEUTufet65El49EA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "JqkfZ01ZvkPHj9ohj0F2Saa5t6KIX5uq1bhHS7YAyxk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "M5rP8lPaJdES+Bd4oWI/va2sRUvbJiYINzOpUdiuO8Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GR4akX9jBcU4iFUBqB3NGwD3CuSTGPHiaWofAhCjCiE="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6D4B3D65AD9A81CD7AE83EA598B6FD2818F7F6D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "dHIiP4b5najkXBsEsplzaD8hQubhKlOrUEVOZ+NY+8A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6DC5F977934E65C23231DDC30BF273F22FF5454E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "RQYSRBpF1ESzlpakxi9woi1sM2EiMYBxsf88soDQrKg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "766BE28A48C243E4F9AC3FA6B5505B6208EF4494",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "PeiNyRBUZ/qNnGl11xmW6b/Ejxq+9hfXdXPBewEzjqo="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7D5B8447A0C1D5E85E095C885947C4EF180BA676",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "f6tNu5SZs7uu6h6e6g+ymxhOmJM09hbiT4mcoopbMx8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UGBPzd5VtGwtUkXOkCgJuzUO6s7Zk0RGKCo/Csdlqf4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "2ekMO1AKawC1gbXty/y6KBVpUfC9RcKyf3sR0ZK7UR8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8301D560188D8CA97B5D373B6423292FA7A1C414",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "CQgaHk/wmnmnhWq8+vP2baKD2qUhYvNpFfRliGunlJg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8B730D99A94FEA0729980BDBB4585DC2B7E932D3",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "E2+EA4BJea4XtU/Aahf4t8TpJG2FmJ0yIEP8dpDAABQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "93597B2726E0FDD812E38163799427FA2FF684A8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "8nCk/jO6oTXElCrzQ4YOdQkE6Rxj2AHMf9qxMPItnwQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Hm8gqT6zv3BHDTjlY1nLMK2U4gte/cducumkYBgvXig="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZHfThztGFsj0VfR6xV1r5ZA09Q6/+np9oYXs8CWY4F8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6lcuin9eD6uwAu9qjsoRjtd+uCtVUZbn//5UqLng9mI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B058604741DFB193660713A02366D5A6CF1EF016",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "uktjN/4JpMiNcfX4GYir212W5zPhi4LVM+28oObD4ac="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "8f/zBc9sYTK1e73NefD07XG1gA/fqVsf8CZ5EyualYk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZDJSsUONDbWTaQATQjuhqxsQFTnSyzSburJRflWe6ro="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QEsifvLPeeGUsnI5MjI+gOXd2aU+NOqCwE6+Cs/LQRQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D447195654516BE994064E03868856302AEAF1D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D6BAFC0943840D65A80FCABC03BED8BE3FA7A8D3",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ze+xQF2/qcTtY9cje/r150eNoXCs4B1Vacf3TPcwquE="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "K+cn+8TPKo7d9dNhdj999tu1T108JCxecojB0pkssl0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "CkWTr7zqfXcDHuTn961EfHkJv82Ql1oibFWbfROfbCc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F08432D4BD305E8D18FBA52D3B1D351C486B9217",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "T66D+MDA5XJsSmlca6yAEADfkNnERoNTzWdQ/q5y/Cw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "FFF869AF4555A83882CE6697720536EF9759CF69",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "bZexjZwa8waNh2TSQjSenvvyjtNS0j98rRHUKdsvRxY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:22Z",
+      "verdict": "INVALID"
+    }
+  ]
+}

--- a/light/mbt/json/MC100_2_faulty_TestSuccess.json
+++ b/light/mbt/json/MC100_2_faulty_TestSuccess.json
@@ -1,0 +1,3168 @@
+{
+  "description": "MC100_2_faulty_TestSuccess.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "043E6934A5E887D08CE06A090F61F0EDA9A7A74F36DAF4F2A0D3EF8735A0E74F",
+        "next_validators_hash": "B036DEA89C5504F98793EE843E01A5A4FF2DD4A7E32E8F10C9122E5476BB206A",
+        "consensus_hash": "043E6934A5E887D08CE06A090F61F0EDA9A7A74F36DAF4F2A0D3EF8735A0E74F",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "4AD2DC11CFE50F3758ED8B2BDD4236C0EA3936B88C04EA989E407C90F2086207",
+          "part_set_header": {
+            "total": 1,
+            "hash": "4AD2DC11CFE50F3758ED8B2BDD4236C0EA3936B88C04EA989E407C90F2086207"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "8nGVogFxe2r87eUrMGRQttTU0tWVUCbL0uodWGhoW6y61WCiy25EW0fLKJFZ4q2Myx8Dfuk9I0fT5u1AQez3CQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "04CA9AA40B76FF67B56D5A9285CB9AE5ED2F3247",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "NtLTh9zK4krQ7/fJEEvfjy756NTcN2jB0DIVMyaPSqLlTUVYWLpBiAGGrM6/BQN9p6RkVOvdKz8t5OnqaYgKDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "050E6732CEC76C71C0CF6784EB4A4E2CEE8C23B0",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "yUshrRarJAM0HNmOAeJUoqg5xFEYtobZh1FTkIR6NQVS2ZvBL0x2qiHN8wxfl6fFJvEIXYtv8Of6ijlHz1bbDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "I65HNOcORilyZ4zfkBf78afrd8fBVbIOICuDKwX8hD/QkPgoJFXz5qHadQaJei+hJKA4qsY/eFutzXbb4T1eAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "0C7A21D9023613B0F814882F40694D07FB508388",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "wo+QEt3vdtDZhxBY96hRe7Ue9HLGNF04TloO5Hdbiqh7SGgv8yO3hO9t2pWZOeMWiNyMe109+L5P4VVsjYSSCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "0xE9W+4oxHNqFycI/+efIcklRz0U3Q8VcDGYiFCoZIHRjg6aMz7DFpR9laSy+QKaw4xq3Evppa46WGHNC47zDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "239D1ACB182F9EC413D6AD8BED3A13447318B95F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Tig9HsKJm85sUhcqghEs+DR1OR3hJhlYX4wsghwWzm24GEJaae8F5vW6qzv6as/gpmShTP/qLbSPqSvG+aoWCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "23A53F06EAAF2B827B9AF8B6866DEAADE5A5CAA3",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "8uIzjGM0WyTfwKniGcB/wCkJsZHH8rxeP9sCdBZ3mtWQo5XYLCggRdSgQRR3LvVT5ZXyMheNacz+00xEw08gAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "26E91E700545D79E8A18092C393DB76294DF393A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "svpNoJV5AlYanRV3+R7ngV+S/86Ebc9Bxx+tleDdr8x+BKYlZrto/or6WWcNsu2ZF/DtfXB5vNLA7drTy7l2Aw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "/Ou4WMsQKW0wLHv7sf3PP53qnt5fPvwwclq1u8SPMPDRNbo6H2lzEy14odLC/GYRu1yeBi2gqH1QbZ9AXi6RBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "cTPURTF1JINIC7WTDXA6/V24VYPpNM1GkqJLLZ9WFqbuz91/d6c3P35VeCpsH4qqTA0j/w7AcTSw+mYn+JYKCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "31580E874C4F84AA5EB5F986FA70B74F8D1865BE",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "aWAfPDrJJ7Q5XLYl08qAGeW/eqiq5OpThKeNH48CTyVlDyipnspVie43Kc6heb/bS6tfEOGYErBDLDX4zhLmAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "319549CEC8B9DADB70C7E8DBBC8FE5D550398506",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "p34OgWrLDL5P+X4RCcBm6T/BVpIV6YLhFFQRrNr+XENv5EvMmAyh50stWKWLD2msCDLKNWciaPfqbS0mkrm0CQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "361491162A6178776B903E57AB7C4D909394B4B4",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "M/WZHlZVYIoiFwNdDlzehWZP3xz28AREWRcfJJdFUBBaweknFHWu+Qh19Ux/C4vzMVu8cxYjmg3o9dzaBzsVAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "f7b1jQQclakoMvHW/QEgF6iNHZTezqtj84k+XdikH6dTFM5LFx+ZIT4mwHcc0ZDDZbKgIrURaBZYaw658EU4Bw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "76Jt2CfodH93efwocAw/ppKwqMxS8hvdLAHBEtYwPNdvt+3yLfQO8dK5XBDEogEO8vZg3WkRD4YbFdRLmmeADg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3C733B78F612FB791744711958D8BC4A3D1B54BF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "6C8itHcLxS82pm1S3E7aexnLdf51TIBYuaGrhmgX3qceBqabTwYR2httzWJ/W5oYyIPIJeC98DchYcfSQvQ8AA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "eKW+ZAbEtxtC2ocoUL85IaI+/ZwYYpEnxcqSrDlR1hEq+cCwzz9A8bqakYnzA35qaSw176NK9tU/X96OuwBNCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3D7E3723C921B1D35B52921B8511142BF5976863",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "8dMAxdK9z8LdymRHUmReenM69umt/Rd7oab2lRicaZbLhoWObVEx8myhj5sHevHM6qxKol9CLKNGxq04kds2BQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "400C0199DEC08A2DBFDF5D081AC15FD6685E8870",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "55cAaQQFIdfaKLv/mWXWhYfbXB+9wt50IMlP6mvC4p8efRchgaQ8zI6Eeee5Fl/Co8Fvm0FV+8RoRF8pt5xQDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "416A8E60A478C20CEB021A84425D8B457558D4E9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "YbscLqVkoxetsepmOZTg0THK8ITRYOt5/NXVY+ZorYZL/Sa0vGFA/nzxYafxwv0ie9v73iwmlWginndzLhTcCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "42D162EDB46B7C1FEA616810A7617A6369958ADE",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "so94nifep3dwp73Dcbf4Gjuk29fxajOQaGzj63WfWY+k2tUDfQs8VQmvk5NqGUU9fn9ioBzoz7yEQkdK91+4Ag=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "M/ZzJTu5X50e0ywdslTMqQIcPItwTbURy9Vf9Codnq1Bl31nCAV0nMWdW9H5aCWuOyxKkHhl5cjCjSqtcGf+Bw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ptNbWiy76gS725QCvUYC5TWf9b8HBplvToeMDLjn5IbZtl8jU71Fo7A0FWeksOb82bI4pwe7j17mczq/9hlFDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "SpyXl8uYJfH269eT4fJGdZPs/W1+eRV4hzL7rWQFbhiZSmcefMG6hMYu+TosET7A7bHDT5sGCkG980qbdNreCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "55027F5FDE2DFC9F1C956D4700A0E60E47BC8126",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "OFxkuIA7KVukV76xYgIEp/UfaWzJoLRNZ/ckOu03nw8c08YYJjowYY/bcLeiEIdzYVwwhzM/XR50i8S41AXKBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5AE3C3EDDD4C4F12E0A45618C9A7EE302BF0C466",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "n2DVpa4OKa3HfR5EC4HarBEm4rvMUaeVN/CLroYAsgoHBywOMiQdOBnGDzCZfmH+PTWEBKV9uBi9fDwtEX3ZDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "YBcnLtf+xp18mJXkAFLxNt5rEkTMySGj9VyqIiGeH1X9NTihrGDOpg/6yFd7Awt8/1jo9KzhBoIO8cf8IYCIAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "627231A077D55F34733997ECD928CE2C511F126C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "PrVQx5KXF5rKy+QeV/buBuJNekAdbtuU5coHSOGTfQogtplTsGURJ3mtoOplkzYJfcrOZTZ6TmjK7NnQ04guDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "62B738D2DFB76A0938F116B001D4AD686B75F700",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "BRNvM9TMTs/51UpJOBc8IVvpEkHIH3Q78s3doEHJCU8AHIK73tcN44c61w63RdbXx2aKWV5oz74pFgkko7+fBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "635206EBFDCCCE8AE040DE2FF07F1508929F3ED7",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "HJKFyJNQ8UwA7YVTf6dzmg5WuWos3eRHT6tAmjvb6FSsh2L2aXmyPuM0DFN1iF+C1W1THjA8LpMIAIV34IJODA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "glFq88/aReXd881mkQ7m2ygmSd56DTfBEkfqc3p3mj5m6MVW/o3cLVpyMByRFDIqLCoYuxm1F9Eq4R6PHa8XCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "qPVxsGfj5C7K+tczvZAtYm4hqbiC2Myh2lc41pNPNDqhexhczYmy6S1GpEobRhzQQpfXoD2G2XxzLsgAL2y/CA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6D4B3D65AD9A81CD7AE83EA598B6FD2818F7F6D1",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "c8UYSF99f52jQNog2y7Dbe7MIvWpoRClhABjuXtPB7P55qAKbmQ8uQGO6p7H54v+oW9g11B7HQKu57cLiTGODw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6DC5F977934E65C23231DDC30BF273F22FF5454E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ka++yamXsukq9a1ztH8S+n3FtoT2QJ3GYEPIEP7Wlj0nlAoCzRxvanOS5zQ8biO8NOOsMVZ78O+juBS076xaBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "J4Jqvv6K7suRW6PzqfXxKRZN2kkkWT01MOyT8C4mxmbpXZuk6iVBKMZxHuslvCkSUbVNgHS6RkUVxtVLoZdtCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "MOjqrl+EMdC6xfGW3uc5Kd6cDYHMwBdpltF6JVODjaokbrs/ocidc92RPQOyQDdSs8TgyXDYNODYMY90INaMDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "74830E4D56CD8E0ECC47E508CBA279042A3882C9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Rwaqh1wkbEUe6JGi/UN9pJEM1RqhzrZyEif60MGuTMQxCQgVCIHN4oQCU/GUuAPepPhEnmH1By1NGA8g47/VDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "74C2BE39F07B51E72003D4C437535A797D2774BA",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "H5MHSr0Kj4DYDFfFNTm7sEtkgMtHdAh0zeiPzGcbM4F8ks8TOW0hXW1u+DhHeybu2WiqpQNNwOlF/FUs6UMxAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "766BE28A48C243E4F9AC3FA6B5505B6208EF4494",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "IBqSGf+PUdAHIsvXhoyvcYHd6+toUK4gaZ+xLMVziZ8ZQ0W1I7XZYKHvRaSHiZNox6jH7oZdNpfjLjLAW4zrBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Y8gKtrREuXcrWiL/svp5OMlyZXfKdgHrC0JjyzUHELOWhoHsjD8a5pvGc5h6P7aiDtR8Z+abOjg/jqtKyZbhCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7D5B8447A0C1D5E85E095C885947C4EF180BA676",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "UbnaHoJnrOeIaJcZ7zHPeXuHuMjRwh6F8o4c9w2gTO15PHHdcp+Garvhvpb1j5KpZnN9HLhEp5dNKT1LIlIYAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "WZSvpzkyzAnyLDGPOLtozbJhid9eDLGnUnRA1Nx/ecr3FwhT2lQ5QzqjFbMV5DrewSDE15vSKgKSYQPX+vGzCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ruJ7w+MhzDuDa4/ZpDvp9m47zIckCN0IBviZ5ZySjxt26FlBQHyWeYQMl/kUZx6wFats9I2l+Vv9JTycl6Q5Dg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "OZBPUOKPH17+MElNMnuzdIUbp+gOqTpxO5PbtgBZsAHvr5pkbc7VU4+vAw1BK68LXSGN759spdNXNmuDjb8VCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "19PAh3ZTulrL6FWFkEFZ9yycEazKVRSvjpefK1hq/jjvERIxUpNCSDrLmVEYpMXc1Z1SGdRpyTy+PvH6YS6eCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "822D9296BE1DAF413AB15B489C002F4CEAD426D7",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Rxx9GPQKHvFh1mRgC14FitWtQaeZ2uXCTfvOozFmxMKPZRFZYxzOCBwT84rOMGVpHonUY46m6XLSyKKGgdBABw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "82FB9EE4538CEAA9C808E862C8D47D36C143E0DB",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "nNVt7WTE30eZcTufy0QhPYA1M7CzR7+9uf6WZ+BTJR9UyXnekYx5GtTwd6Ll7KGxMsplAPFwEEFufnakhyENCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8301D560188D8CA97B5D373B6423292FA7A1C414",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "sd8+lRBA5hyEppjrYIVY9r1ZVMgrpdSq3kuvsK3CIVrAQsXI9fhVT7dtEc7RRXk9UfQDaFzKhQFF3vVJ0k9lCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "890C8588FAE1C90E164BFF1917A3EC93FF7AE8EF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "EJkBqyge4jpEo6gll1qrXWZLwo7evVYGWyqDlaWnmaXWXLa1fBz4WGyezQD0cGlAAiC2h/Vu6pmN6d6pP3elCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "YDGnu3cYpN98XyJYqS3fJzKcgUlBJk4agDY7OJKaZY6zHv/kfcycRd12xQ0vOQGN2qGErSdSwe5h4kW4I3VGAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8A0B5C8CE8B72985C325F02B580C4DBFC527EB9C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "U4O8clIiaQlFmIqGXpDBTDDD7hmrUxFWR1H35KLZL/mEqv9srfHHhSkb4HfUzDMM+dr26XsNP00+WKnMHSqeAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8B730D99A94FEA0729980BDBB4585DC2B7E932D3",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "zAIAV91n/NNkSD3l0zP7wBCv+hCyRgwnRXib47xM8RSRM7BZryCC2q+2A627n7mJvUF5NrkXgLM5NHw9/n1EAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "COYAzX/AoLbuBec90/Nv6zlSOtYNa8CxcO5T3JPNXWmbcerQHVnvW/LCVpichj5ilIDv0GtlkatYxxVgOOPOCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "tEbI4HHc5FzFjI2ykKQO2z0nQ+GxB8jqSbzuE97F+0M6zqkSirQyKACymgI5pmoSoK1igRVriewmSCYrKbIHCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "92932AD7E082B90296C192F3113710CD6F99432E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "EKKQpnXW92j6pZwhyAzY6j6w/DLAFA2eZSWnwtsHC5VP8usV8TNokzwUSp3B8ZyG1GClCxkLxNxiKDYGq40fDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "93597B2726E0FDD812E38163799427FA2FF684A8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "3Fx3MwoDm4UAV+1mkRLVxPwgscylCxg8wnKu266dAADQePSxuAhfcgCxkcs90k0IOz69JHvUKDg5BEMqtOjpBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "9562DE62254FB0C58E70196412E5F3C9D30B80AA",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "C6P3foS5y2zFyGJadsUYuvvKdpy/YdyNURPxeO3mERTp1eu8wAF7owMuwEjSYiv1lWf1omuYGH6mJy+Wfp4rDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "tQYRXAcW136ehV/golD7r/dYGN+bZh/bEea9lExbO/WdXaYUE9BsK4QBYXI5Iqn9LqQb4gCJ9s4Ws/wIEhqcCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "9AE69E7D6961BB4CDAA74F99BB45A9EE25B02288",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "osMnm/6v6PQYG6jw9iNNG0+RpDJfiil/nra7e00lLB3HqCTXeKpZXcrE7aqBI/8AUUvatgI6fJWWRJnYViK2Dg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "RM2aobvxwY4D+cJOJ7Dvzoz/R35FtvnvSGgd9StzdfnCVp5nmk9V8+PTuqgQAmX+Q/a/GV1hXG6ojtLWc0ytCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "TmGzc6dJmr9jsbp5ivLih2rc9nX4FUqn/HLwumGALMu9AD+E64gmKEcC4J84brcyJntyJ5u+85zzlBvE7LCcDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "pMaEQucpz4w9/a2mjjC7KQsUmsXxXsRrxsKYkKP+zSI2UyMHML2D7R9Y4whIqFsF3qKm6rMZAxi3uAjjnhoiBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "rben19x5Y86abArEPOjploknpYEjWvSLCPC/g3K9++CW2ox8X7Kmwc3eC5vbcayaBEo6IO4k8vsUqBkxFcWFDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A67BF23C710F87B158BC3369684A3033D3C8112E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "1gp51EF/4xx77MLLC92LIoCfEPihMTNGOpz/hlrOH6qGm/o/ReJAZ5xQnYToqO6LfspS1esVl/XIDCMzwYGFDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ajjpHw+c4XZo2NAFbi7BYphUYFEoJedqEeDBGHeM5He+C1T5YnoWYsoGXEwyQoWxYAaRTzfAuyLWuNGdasouAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "JAJlqKpsU8tEu9s+UGOq+N+97pd7KrB9LfYolJRgXgibjiTkIQ9YfAJsZoS9JK0O3PBd05a9MkFYTRTolTkPCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "VWJ8ajhk7e9/tzb9znyj7mm8tWR+YR4LB4oPpW3TvZ8mwhZVyDfDlFyVZBjct78KSPqTTH/wot4YYFsaT2xgBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "AFBD6E8C17284683A951FB263DDCB856AB61A176",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "oKAydVPS4wwnvaBip5FB5D089RTyXhpFYZEoXycjCoPFA9mdhKLNnOSxlu82C1mhuAc2gUjDYVyJCvpHBntvBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B058604741DFB193660713A02366D5A6CF1EF016",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "RpTSt8/kt17kGud1lB3311cWgnSybLI4JFQNxdOEQ0ufKsy3OBlbCMrMj8pt+fxly0Bg8yoabx/Z/5M2d/7hBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "AY0GbmQnTzE+h1MhFwGDifjInuXM+llTNi2CXcHsZ+EVqUsCVeF/wJ2st+y6c2qeRLois83ZzHfXc0WzzhyRCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "WLHbbMRrzF4GYkVnqXi6jFG1PBBVG1oVIPJ2tOfTx0EvpBBWXprP95rjQoTEIo1LiRJz0ELXUARZqURtFMn6Bw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B99E8C85A4BB4886BA6E3043B3A7553A481FB9C0",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "sstTex79uTsOY86c5S7PzIuoCP12jhz1vuFUMT7Kw6G+PP6PBE7h0ecZamKc67orJp76DejmERqhsOGYHj5cDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Du1gUDzqYzmPjqMIVWy7sGZOHPMGDvri/kJVpk7oDUBm9Dzs1987VLyENXHPoWwh+7YvhV0RuIYd47t4DfZMBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C1A12367BC4BD69AF83B436A15D33703F381375E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "mfexPvVkVCzlNnNpV9l+4qpM3ItpkQA9bZ8CAdWPLNn/XnEt4DeFcSy4sh2BYCa+PJQbSDqW7+M5PxMKQKAwCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C453130417F90DCAE44D28978DE1FB987507E6E1",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "luRYGR8uCrKcP575dVMF8/YcV+YOMf+5veS45cQVR02kfw7Ru9E91xAlxqNFbJgJeYqHTcHN0+rFbOqAwpSQDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "0Vmc6IFK6+yrnANjgAVmhnzc0Jwk/vwuvFbP4Xg9n5jlMDhncRFtlQFFfA2dP+4ORbZ+jIiOvoWVq0qTcLnqCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C56B6E67680CEB8BF11B0B5FCAE3987EB930188E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "m19XLQYQjFXEykkEewS9jN0HoMbDsNA+L65vgJ02UixwVRXqbB7/YnDWrEZNir26jqmvaE5JRbLpAV7J38/sAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ZJKGx5V5XiOWlpJhAETXlntvP687DP9d8U+2pmRQ7c+ugGHk2rorSih6YgA+Y7p6NS/7EBVGRxNFZW8F51BQAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "CA6211FB7B017D171FB7C5E46269AB49C9A1A135",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "6e4qrmh1LZ3UC9cMc0MQsvO0namsvj174t7wU7xq0i0iDs38W0AlYT4Z/EAD23JnsiYCu2IlKKXdT16g85ypCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "MSbuUc0bBOlkjR2bEhFzvg3295Bt+ztMQDjsvk2eJ2l6AvRc32u4d9RxDK8jZ5WM8RYM+Mzw7DIAI80tryO/AA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "mjE4v98BcNPP+a6OMoHFIsP+01ivOjfZfWwp5OFJ5uITF7cAcbMts/XkP/ccBDrr8WNes8mNuiZA2AdbKDRPBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D361FCD15625DF4EA62DB0021C8D67C6083C8735",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "SsF5I0fAgHVJMXQq7NmhllXtVuJhsikUQ1gO09Ms1xmDSBQ+XnTa4vaKYcf5oyx7gSUG/JTCoOGaXqE70UcIBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "X99d3W4lJjLZ0g/ZFNbGnO8+D4bwvXjtBQfFcS1Lld+wPDGZpKYlnEr45Ep9+LeNZIB02DsnRLPdADfHasaEAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D447195654516BE994064E03868856302AEAF1D1",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "3FKy+QjtqgtI620X4OheaXKnd5Zg892Ri0a1I+E53ApxviUkYG2o5oghw0+4YC9erxcGmX7OJezysqM5yPzACw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D6BAFC0943840D65A80FCABC03BED8BE3FA7A8D3",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "UFpzyePGQgQWqT00n+4U7nPChLQ/6XpzxoNk2z5YOYUMprCT1oK5kNXIvfxk46gusUOrfqRjrBL2aopHCIAlDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "h8H9iRGna2l39qkcUOy30hIpBb6aQFUbWtUlyRUSvxwBhkEYTck7XdQWdVZ7cGBCZ8evMp2YZjKJ4uGk7GRUBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAA78817A47B08F3022C756FA3BDE8E3CE14F761",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "8E2CghjAX1yz09unlL8zU9VHKaayKC6GnKJyJV00A+4ZywHcvsB4W+STkU01Gnl/LefQnBSwHZGQcAOh51dtAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "llgiUWreS26air06LDnc4hQ6hnq+VGtSAauCn+CKlvkAbDSDIUSbBNHT3c8NNegVC8IjBPNxk27ZsJlR2X4CAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EB8F0269F7A03728DD8D57D1484545B68DA6697C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "FfDaN42q9YH/59HFHRmaPXljR0/yzl55x/oO27GrJfvkpMRinXDJSoZM+hygg8xL2TGqQmtjb0NLWnWW1qwxDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EBBE61282EC27BF8D06D96C2992040450DD2C1B6",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "KYXR/AgoTVCWEHaMdNj47DC7oe6pJURIFTSNetQYX1l+4eKcF+IWBrClOL5bHGOi36PbHbPuOY84mPzm54FKBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "ED245292B061110D52CFD7AE6D02919E6C3480F7",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "mduabsPKWSkpqV0iLj/G7fhDY0RK7TZRUX/GfIH9j9/byKesu+9cdJbf/MoQzNxtwPDbT3rY79NBnyRhLn+BAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EED08060959B8BC09DF99BB8A51A08C8D6F1663D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "UADeQKXNql4G2x6u4UX7p8LFCEw9Wxs60GiDTA1MhCntl/b8qN3xkvG3GJNxXKapIQJamIU70BLMafBdjalyAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "mSqZZXbVt8qAjRypuRgbjQSAFeZ4smt7d2KcBFYOp2WHHGiXxu4G3ecsZlfyUkYGtA0wKpYGrzhPewI/QMoLDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EFE8CD307C19FE1E9C437B59A0066EDD97F45E9D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "WtRhnP/Z7/FxX8B0EBTFNcQ3kCBMTq9exoOqRgBYtbpcCVzXVFpYafkoX7SCKtJA6JF/u41dFZvUJfTPGdHyDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F08432D4BD305E8D18FBA52D3B1D351C486B9217",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "z1lDWfEmyTjsQRYAhbsQmL/oEGlW0ebKlzRLJIIFfQhMDZPBmnMA1bDvmLBsFpImPLMHksYd7xuHDv0xHY8qDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F1DA81336F50B87982CF10581D308080031406C6",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "jHDjJIBu9DcpldCCJhR//BulEoba0ZBlrXq9DCvUkBO+e3835BXPyMaYS+LQ6eQAGth4CziWs1RODzr9gK90AQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "5MO2Fl7g51USI+qRr7yGfKCKVfyYDcsMhxK4UvSHDn5JzW5n//Vw5bgO0AK6BqdwjXVRMlPPr6+OnPgL6tvgCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "sqBEU4zILwSDA0ygByq6lJPS/7nQkmqeVgg/OkuvJZBAaq2bHm2gry+Sh2KmsMD8srngU7+IvMzWmOtXIu85CA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "FFF869AF4555A83882CE6697720536EF9759CF69",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "lGEngsY0iCmkrIs6exiwCL7yk0LsMF3/KDbDd04NeZXOJ27/xNaKex+I6W4RSwEZfxFHH0Vaya+kk98JMb5jAA=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Kam3xVXv675BD8rZmi4Zs5jdR4+8I8i8ZEZU0gs9Bp4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "04CA9AA40B76FF67B56D5A9285CB9AE5ED2F3247",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "/hFZhF/r5QiEeRGVjMZhG0sO0SeqlURltv8wMjkmOG4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "050E6732CEC76C71C0CF6784EB4A4E2CEE8C23B0",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "b7OxLS/2TcshawP8QjsCuyxOUe9d3566aFczz61UZNc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "0C7A21D9023613B0F814882F40694D07FB508388",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "yVRzgrYNJ4G1uy85dJseiG2K9/ofD/6kObbAfvK1E5I="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "239D1ACB182F9EC413D6AD8BED3A13447318B95F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ELiW5vI49RoPS71qjid0QFJM8CZpmLnW7qkmN8lQU8g="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "23A53F06EAAF2B827B9AF8B6866DEAADE5A5CAA3",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "WPAEO3zKMIbXTkPCa/Wg+s/eR7w6Wea1a6Xuzk1RTag="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "26E91E700545D79E8A18092C393DB76294DF393A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "F8xDDGP4gRkFMeuIlULpbOP6aGPdTe5gZT7kCCnAQIY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "fWMaYDTFwdDo7SVw9hBIraX2GVqvzKhNKEUkr/2ZnEc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Uq1fQj/TXkpg+zP37a//6YC04vQHWraWfYSg88fMHxw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "31580E874C4F84AA5EB5F986FA70B74F8D1865BE",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "scpN1hLNChIB1QuRHojxUwl59cPP2KpwzilLU10JViM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "etUp4mnEHDdNnJSwu5KW8EMXYt7n94iYZm+y7xa9ym8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "R1rD/692T348fL4cA0mvvbK9aANwT0vBNAT5B9+p+rw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "3C733B78F612FB791744711958D8BC4A3D1B54BF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "dul9CqXgrwNXGlWp4ya6mulGjKJok/Q2RYqITOGgYro="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Spb0BakJqr3uNaAEqdaGbv77bQEwym0/6cl/tnCdkGM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "400C0199DEC08A2DBFDF5D081AC15FD6685E8870",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "y+sL3o3wbcoAx67HqR8BNzJVokJrYGI5pflGS8GMSv0="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "416A8E60A478C20CEB021A84425D8B457558D4E9",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6P6otvJpi36GOMprEbFwzth4AjleE/ThQMksZ2Wgh3k="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "42D162EDB46B7C1FEA616810A7617A6369958ADE",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "U4HzaR1kBj9HGcZU1I3rIZMwMoikUmYQyIMZktuBOF0="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "JqkfZ01ZvkPHj9ohj0F2Saa5t6KIX5uq1bhHS7YAyxk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "mGpmR8PNc6w2cUzPwAQhkSadkyGOuKMl68Nji5E3h5o="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5AE3C3EDDD4C4F12E0A45618C9A7EE302BF0C466",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ZVXL7nJ5h9ZrCc6K3ZMgqR7HhT36DroxaBN7/kRHRx4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "627231A077D55F34733997ECD928CE2C511F126C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "UaISVfdgdm5p0+bwCbeatoNYfJP6LzW5k4DoL8++t4U="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "62B738D2DFB76A0938F116B001D4AD686B75F700",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "bgZ8KLzPd4mI0aDX5aRLG7piFzEt59yzsq3djHZMV1s="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "635206EBFDCCCE8AE040DE2FF07F1508929F3ED7",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VcBAfhXKgDF4pSdLRo3dWX1v+q8PSRMTXKNrU9QPQC4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GR4akX9jBcU4iFUBqB3NGwD3CuSTGPHiaWofAhCjCiE="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6D4B3D65AD9A81CD7AE83EA598B6FD2818F7F6D1",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "dHIiP4b5najkXBsEsplzaD8hQubhKlOrUEVOZ+NY+8A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6DC5F977934E65C23231DDC30BF273F22FF5454E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "RQYSRBpF1ESzlpakxi9woi1sM2EiMYBxsf88soDQrKg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "r7QqYEO8hh6xOwJMpsH+gYer+oOcuP/UQyG7NNsLLHk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "74C2BE39F07B51E72003D4C437535A797D2774BA",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "qThLDyok7ht1m6Qj9sMPFfOvXQUIbnJ5PSmBxdnG0Rc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "766BE28A48C243E4F9AC3FA6B5505B6208EF4494",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "PeiNyRBUZ/qNnGl11xmW6b/Ejxq+9hfXdXPBewEzjqo="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Pfy3anXtYHMFjDLvM+5jJN3iS5Ypz9NMJ1KTNVjfJ7I="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "7D5B8447A0C1D5E85E095C885947C4EF180BA676",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "f6tNu5SZs7uu6h6e6g+ymxhOmJM09hbiT4mcoopbMx8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "JgRep5bgxhsdM6EVAEzE/cEaxMsdR6/VtG24KHgHDyc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "UGBPzd5VtGwtUkXOkCgJuzUO6s7Zk0RGKCo/Csdlqf4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "2ekMO1AKawC1gbXty/y6KBVpUfC9RcKyf3sR0ZK7UR8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "822D9296BE1DAF413AB15B489C002F4CEAD426D7",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "InuzWLzsYP/6DLHQbmiYe0rtduz2xktozH2FmOKQsZc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "82FB9EE4538CEAA9C808E862C8D47D36C143E0DB",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "QOPk17DOenwtH6MoTdxaW1/+ZUJw8r4QjevWGDpBi1k="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8301D560188D8CA97B5D373B6423292FA7A1C414",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "CQgaHk/wmnmnhWq8+vP2baKD2qUhYvNpFfRliGunlJg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "890C8588FAE1C90E164BFF1917A3EC93FF7AE8EF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "espgSJouSR/5l7I0UHcZqkUgByHgtt4yFAYzNbw4UVg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8A0B5C8CE8B72985C325F02B580C4DBFC527EB9C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "OBRlQyOtvKRxxxIF+7gsbA/5d4gI0aVdV+8Qzd42KuQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8B730D99A94FEA0729980BDBB4585DC2B7E932D3",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "E2+EA4BJea4XtU/Aahf4t8TpJG2FmJ0yIEP8dpDAABQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "92932AD7E082B90296C192F3113710CD6F99432E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GJlkT7S82nRWW34K5ax6ZCW9EV2nt1E/PF1P5LQgJdg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "93597B2726E0FDD812E38163799427FA2FF684A8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "8nCk/jO6oTXElCrzQ4YOdQkE6Rxj2AHMf9qxMPItnwQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "9562DE62254FB0C58E70196412E5F3C9D30B80AA",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "s8MeP7HuqZOi9/wCl1Su1+R/kmhSvWx0BQiXog6CM8A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "UseUFPt/FyVO1D19U7tHq4/CAsW/JxWOeTbw/ZftxMM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "9AE69E7D6961BB4CDAA74F99BB45A9EE25B02288",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "PbgEtU7KS/td42OxA7Aq7C49zcWVgbG7+pn5mjRBrqA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Hm8gqT6zv3BHDTjlY1nLMK2U4gte/cducumkYBgvXig="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "z7XkAAZ+x6klleinW1VTrsMLnAwNF9LHBFprFx1E4bA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "uEXsZIGASOuKR3SQn2cakTAkulEbm2kElVjj50W2oJw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A67BF23C710F87B158BC3369684A3033D3C8112E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "E3+y8GQu99AUysuGJfmtQxKYWRp7lvMPUoH67bt9k+8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ZHfThztGFsj0VfR6xV1r5ZA09Q6/+np9oYXs8CWY4F8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6lcuin9eD6uwAu9qjsoRjtd+uCtVUZbn//5UqLng9mI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "AFBD6E8C17284683A951FB263DDCB856AB61A176",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "0b2pdpqDMNKqBqZUpwLNqh6s/hblF4PaXJQLO1XZIs0="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "B058604741DFB193660713A02366D5A6CF1EF016",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "uktjN/4JpMiNcfX4GYir212W5zPhi4LVM+28oObD4ac="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "8f/zBc9sYTK1e73NefD07XG1gA/fqVsf8CZ5EyualYk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Ct8qHvpO82bPqzj2YxHkFgE+fmxVF0q7fTuvXzsK6Cw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "B99E8C85A4BB4886BA6E3043B3A7553A481FB9C0",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "9D+mHClSgLhk5LVobp4HPZi5N3+SUrzFKBd9Fz86Ml4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ZDJSsUONDbWTaQATQjuhqxsQFTnSyzSburJRflWe6ro="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C1A12367BC4BD69AF83B436A15D33703F381375E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "QoUOhrmZjUftNo5mXv8nIlT+QXIN3tDR3XOb2phGa0I="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C453130417F90DCAE44D28978DE1FB987507E6E1",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Cyw/3K8X71s0tFS0kFJb1HxaDdqcfodHQD4HXZ1p/rQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C56B6E67680CEB8BF11B0B5FCAE3987EB930188E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "DU+N0lyWiAJ3aUbKUz5q/LOQUDIPTunXAcK78TVKlpk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "55KLg7eVl0IyiFhu7r38WGQizm6hglE4rsAo68dGK28="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "CA6211FB7B017D171FB7C5E46269AB49C9A1A135",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Y9W7N4IeYcWu6yvh9XKzt2cHsI/QOAMEQgDhQG79yxQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "QEsifvLPeeGUsnI5MjI+gOXd2aU+NOqCwE6+Cs/LQRQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "xzIY0miEtnX/3fduBl9vYN2iDEmt7HIGK3Qb0bywdbU="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D361FCD15625DF4EA62DB0021C8D67C6083C8735",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "7Zs1DiFznmkmW6Yh0lh1nT2fRdcrm+2rFwUillbFS+w="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D447195654516BE994064E03868856302AEAF1D1",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D6BAFC0943840D65A80FCABC03BED8BE3FA7A8D3",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ze+xQF2/qcTtY9cje/r150eNoXCs4B1Vacf3TPcwquE="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "K+cn+8TPKo7d9dNhdj999tu1T108JCxecojB0pkssl0="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAA78817A47B08F3022C756FA3BDE8E3CE14F761",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "9fJlZL8iH/1ysAI/r+2cSqXOT67uknmJKnfIIaShLww="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EB8F0269F7A03728DD8D57D1484545B68DA6697C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "7wsvbzutFAAQReO+Jq7L4Drc37uLg6IKafptL9ofTOg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "ED245292B061110D52CFD7AE6D02919E6C3480F7",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "O7sRf+YCASDFbn5BaxMC+DcoblK00JYTs8oE5uFMnLA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EED08060959B8BC09DF99BB8A51A08C8D6F1663D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "qBJDd/Wkt0KQfBUw4+wsWIpaqpSiUAQjGsTKfoz8IF4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "CkWTr7zqfXcDHuTn961EfHkJv82Ql1oibFWbfROfbCc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EFE8CD307C19FE1E9C437B59A0066EDD97F45E9D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Ov8G5YKHc1hjCBM/HT5k+MswEwXf+UZfP33bKi1prO8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "F08432D4BD305E8D18FBA52D3B1D351C486B9217",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "T66D+MDA5XJsSmlca6yAEADfkNnERoNTzWdQ/q5y/Cw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "F1DA81336F50B87982CF10581D308080031406C6",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "TCNu3Qckfx5+zXKvDTIHAFd/FZgbk013UFYIZqWl7w8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "F4d36ebIiyCzz/pk4sGrxYnls8XuzOfMRh/lF2LTdA4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "wqp6kT/3DEZ81E8BAdD802/NccJcCyBWBVrah3EOTFk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:19:37.160336557Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "B036DEA89C5504F98793EE843E01A5A4FF2DD4A7E32E8F10C9122E5476BB206A",
+            "next_validators_hash": "8FC5FF2AC111E2EE4A162F23CE65C4CB4857B595E189D319DC8F3E598E8104C1",
+            "consensus_hash": "B036DEA89C5504F98793EE843E01A5A4FF2DD4A7E32E8F10C9122E5476BB206A",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "CA8BB09C8ABA4F2253237DA4780938C0D890DF8B1498B57BB5CA6B2D2338F21D",
+              "part_set_header": {
+                "total": 1,
+                "hash": "CA8BB09C8ABA4F2253237DA4780938C0D890DF8B1498B57BB5CA6B2D2338F21D"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "NW0ZkSiYH+jXx1w9se5U8lO0xqvAdBR+gGpX4jOvOwgDhPh6WbKirlYmBPoln5gEgvgW/m+HxN9wbRM8C43WAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "04CA9AA40B76FF67B56D5A9285CB9AE5ED2F3247",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "dRIbx8ufMOFzCuxIVFelQzF5u4ZF6dXs/Ae2Kqj7TRMsYhcmF0mT+pybkBsbinWFKHF8VRrlrOLMHZ7sibvWBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "050E6732CEC76C71C0CF6784EB4A4E2CEE8C23B0",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "V9AF2zTkGJf9CYPmtpYAnUEO8+l7fE6lQdMY/x5oLDyyWptm+bzF0+65r9QDbsCKvlmRZY6rghadPW5n0yHJAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "0C7A21D9023613B0F814882F40694D07FB508388",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "6u+X8aTojQ1awvGd6qbp5O/gDpzsXK9ACHaRccvGaie50Hwpw0C3+mIBQ6l3XcTAa9c1pbZi0woSHBoNizqpAg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "23A53F06EAAF2B827B9AF8B6866DEAADE5A5CAA3",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "paUWWSK/jkBxqmKcAeWowlL33ua+t8OQAbAMe2R+v/GHpgzj8R8mVA+NZ9vJgOykq/dyi7Qf1+CkgYfPjOtSCw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "0TYos4xmH5tBqYdihCUQVXAdAw6FZKMVCoYNYdEzBrtErW+c+o0MM2ei5yyH3vIE6n1Gt9DK5mZmcgqzeY0yBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "aCeqfjtDkKCMTVk6QNU8gN2EXcV7nxYYOlwerT7PQrdy+UOkStzrmD9SQ76WkkZbTjq4Kb3XQpDvAUynOIOSDw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "31580E874C4F84AA5EB5F986FA70B74F8D1865BE",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "L8vDSwFm2G+kId0IdtDrNxzsOplWidn+KTxqaPahJ7Kw3cKCa4NyVMObPiAav8umpHm9Gqvb4tkPJkgJQL3vBw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "KcIV3ZPInzL4+AXJ9YDFwIsF4JPM44kS8QgmGyFS30hM74/pTitL9DiN01l+iZgiFRfAfChDms1mp/ADaNZUCQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "3C733B78F612FB791744711958D8BC4A3D1B54BF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "X2GUNCMKw0E2nd/R22+dafRKQVkFzYGlWEts7lMeXMnzXbOKhrq7lMdA9rMGH7sCaeXbqHYNCKnddTWDH/cdCQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "416A8E60A478C20CEB021A84425D8B457558D4E9",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "ontaNTVsr9Hwwgqn4ncJTF43WIACask5rDtsdeGKzB30brkAHAuHI87hVp2rbFX1jFCCLlUcIKgAxDgINTa5Dg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "42D162EDB46B7C1FEA616810A7617A6369958ADE",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "/cXRcThIqmYFpBQSbydbV+lxSQ6FnhwdZ/lbIXrRoFFrL66EXB4dRS4z8vbYsl0EFQrvRJvBLMbQXk2guZ9iBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "WXOAFkKfVF5SK7zkwCP4Q/yZjKOn1lkAvzmWqAtqKv7i0V8b0TqtKE22PrlagwZDkDa7iuBNfwXCXtdtUQY4BA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "DKLWhpepPikalY6cXm+Z8Rm/U9ivs2lUdz8krJy0luPI5Z3WEY0c3vq6ql4zYBvSvQUYShMasHwvBHtcdp1dBQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "627231A077D55F34733997ECD928CE2C511F126C",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "fCF7LWEMnbvuraU6ajnmE2JmCpidbRgshPW/9QRR6R8ngEidbR+bMmcCoxnrlX45CzC7Mnqyk6v5qO+ZA8uSDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "62B738D2DFB76A0938F116B001D4AD686B75F700",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "ldqOEHvw0L+tbspNVRlBlwQnga52ChsdDur4yVNsyoH6TmQxImzUvbbnytAPHZpiDaQqRCZGDZJnLCdNh1exDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "635206EBFDCCCE8AE040DE2FF07F1508929F3ED7",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "1HEb2/8Jrp4ZG8c6k3YlGw9lSpwbKQ/BT4mPqzALdhL9iMZWyRBZNsfCwabdCW6fMkdSmPUqWUqC1/WYI3SRCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "nCM4uoTc81ww4U2fFmzHGmtIP0h4eKVdBj/BgyU8lBezdS6bGHPBtGgoQVW0wzkJy3YknUnbvFVE5o0rT0DvCg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6D4B3D65AD9A81CD7AE83EA598B6FD2818F7F6D1",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "UteqGbUJU8S7+35QTvlx0t6Wa+TVjOL6NqjuBFwcRgn/gyQQq+kJAKmBMvyMoE6VGpBFIIEWlDVP2nvT+kEyBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6DC5F977934E65C23231DDC30BF273F22FF5454E",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "/h35zR+qbhIYbKNa9xCbwDC/660fk3l0nyrUCyHE1qWEU/P5lPm4t71gD6KLqW6sJhnX+SO7Juu9rSujfneBBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "u/aKgmUTatvY7bliFPZvYMLJDS0SZuGuYxMTKFu3Z11YCH1TC24OXoVK+kwTDZU+S/7wWjhjHlVfs/hnr4FFDg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "74C2BE39F07B51E72003D4C437535A797D2774BA",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "xhOutaPhLhEW8iHR1RpbcGGdxFSpQVgcdG0cn8tDuxUgkP8N77royenaHhyyJloNBl3S/m0xAvenvYrHOoVyDQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "766BE28A48C243E4F9AC3FA6B5505B6208EF4494",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "gMtbhle+UROtLRALWZZgEnaUlo+VjMbUApyzfahZ0thIrFDT5PnoYdWqgWnGjQGniIN9S3/FGHeK36VPZr47DQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "p7HTQ3qMsoaCD0vl/W763vgaFd6Xq2kLgCpS9VNcYfd7d0ECHY8IBCRLkXR5XTQx7ZLOtQf8mALGnNy/xO2YBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "7D5B8447A0C1D5E85E095C885947C4EF180BA676",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "GNtmoMYar/NPQwyOCrQJjLunQHhRTsctUqtZOzv4R9dkrW+J7QQJETtoBSbG8+yt49eqzm00+K1eolmOd0dVCg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "10WzANo8xXA0nKPqaAxSaPbOSth8xv03+H3aEwbvd30h9GXRNqLRGoeZZXjRHeRaOOyjpMTULw/FLxQWetT8CQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "5AL98tdjY11LQzJ2QeUbGkI6Bta/fhkN5YVAfYSNwURgFUuUKFxLCpFI4Wc2BvI8ME1/U8jIFi8I2n/b3HMaCg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "82FB9EE4538CEAA9C808E862C8D47D36C143E0DB",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "pPYmElxGXj/nWUOTsAFlorlZeoGjCbTAn7apFD6G/OShl6bdTgis3f50iwyLYOUpMp0zpoPbhvHVkKm3nrtEBg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "CYLFdoC6A6Bqk9svl9P2hMq4eEZ99R0kQBnmYjtVaJPPwIyK7bZrtWamwFvNjeugtigNlKenzS3rxiY2LuqTCg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8A0B5C8CE8B72985C325F02B580C4DBFC527EB9C",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "wlrjtJUOo0AC6j8yRJBDfU3Nssg5ui4/MFNs3SBvRA9edyGelTVVX23N3KwfwkzjeKWTnd0VW7+633b/286DDw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "tEnboKqFDAuBoAgCYVXP98L7OWK3zxgemZT2Yedjk2vPbde+yci6nbszhf8gmw6wzCBP/wM+Nv0Xz699ODNkBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "nizEIKBr+uKjL7pYNQohj3A3xHQ8wIWsuDI3RfVICcMAV3qj9QbPvafcXqdaLZmKfjClyM0yAqag/aSSHm8jCA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "5na/C1rsu0jkW/bmOjqK5qrQZdGh36u2XBcY1hYkph/nwW48IJOgPvwX+YtK9c29QL5hV4Ba0apcF2rndn7eBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "9AE69E7D6961BB4CDAA74F99BB45A9EE25B02288",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "hGCXXn6i/pLmJSoh+nglpHzA7zs7fWm2XSLL7PeOdEGPfvgHXlgGhiETfRpjC4+wxOJzjpWSqGJmeLnj8G19Dg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "8T+8nOHcbeeLaNgEF3fTkDZDmnsrhdhSt2i44LGKTekttC1OcY1i5iRQYkF36ZyLOka2/7L66IXds4Vp8/ZQBg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "pEB880UYj9wsyjXLs7i07zfw6AeQQOms+UGEd1vHc7bTtbB+oZyiZOx4G3ZNYh27AwbZhf0PmF9Lye6G2e+rDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "L1RAle0Dop+rE5UJwmrRGgBDEh2qfTqawjFxps+lRMevEHTWHNaebVSbN6S5HXDEVTuRBvNwBC2DmzW9V250CA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A67BF23C710F87B158BC3369684A3033D3C8112E",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "Ce2K3sJOAvHNTpLJ0Dh2pRLnNjOka1Wt9z4zzsPiNrC8Ki2TQQHtDSwNUi2KGWX++0a8GMCowRaZykf6lXxhAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "znCxUqa1xMKT6MQqhQ2ptJXFslJVoWpuH4LAl5xF0QoAmWTUJhwvHHLYOqfMxw60kZ1fcqAHAxTs5+so04ykCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "FrulJP9Om91kDT2kyvpzbTw+8oetbJnOrnus1Tp8novhKBu9EmOCKg2uSD+UvpkvnG5ScSZwGKOfT3apUjvOBA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "B058604741DFB193660713A02366D5A6CF1EF016",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "biQKMuoRYpeyEOft0zCgeRpZqrIOaRgtyiO1yu8+i3WuJ1a4uONUg+81EIXWOzjC583Mxk8JiSYkGMzgThP5BA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "zl0xMIAvwL4UhHex4DVqzQOo0nFEeFqFOMhCLVk4nzWf/xy7S53IWHe/5tAKaK/mQDCzo+dt0dUOZHonaNLyDQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "B99E8C85A4BB4886BA6E3043B3A7553A481FB9C0",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "VAV5vNxCh6OKHXbdNGLCKfnI5CDVzR/C2SIhbY2oYAzoYM1rOD+mqAwYac14MHbdtrXZBZTTZN6fpLYV2WL+DQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "1wcDM60tK/tmOEWXke86Ki1WWU1yvqVCgJS7Z8OUrbMGHAOfIDZyhVjRD/nGEW+N6CC5eud3Qaiae6p0ivdMBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C1A12367BC4BD69AF83B436A15D33703F381375E",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "YUPzxfyybyIGAqv/IbD4bC590eDwcXmhtwaqFezPQlRSiRqfu3kA0oNQEFICIPbOTwe90pjL1H+klAM4ROjGCQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C56B6E67680CEB8BF11B0B5FCAE3987EB930188E",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "bHDkXVKkIG+lRSA0XN01XlcI1nbv6jdJ3LocMRaNRhDpLo/X0/fcQvzudQfbFCYfkr5ksDuGpC7bFyFRfOjFBg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "xU3U1Q4wjjAGJJ5WtsC7WbjWk52KVZe+a2Z54/CNDYfuPp2we5tHz5TZCF21ZywmFu3ZadWEdIDvMaosy2thAQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D361FCD15625DF4EA62DB0021C8D67C6083C8735",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "Bcy3zUvKEm+gJrDejbP+TOSuFyBfFl73WimWIQUtzLTeQIO8dtqk3zvB0nAy5BCRCLVWLJQ4CKBIy+71Ak3UDg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D447195654516BE994064E03868856302AEAF1D1",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "XxEpZp+veJP1xULZTqmIBi7EWumQbjInuYKOUThZXpR3PS9h5lVEU3H3s3SOTYJzi9jEIzoXuRFYqwq4crhNAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D6BAFC0943840D65A80FCABC03BED8BE3FA7A8D3",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "/uTgOUTE+gDsEQndDA192nVZirvItMnjFJ0F/IB28JUFiCiIEUB+KQY9ZSqCXYbjqNHLmT97CXLY22fLbREvBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "vgj9651x3mMiwV0dfHWJWq2y79BgiNV7DUNvhlcITX2ugmiZnC2ybu3pnmSGZ44ow5DRxXAMNclALdlv/rmVCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAA78817A47B08F3022C756FA3BDE8E3CE14F761",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "0ckeSCEn/OI3JIfnjGCzrMXVc9DSbjXfUYJ4Us/HHeQgl5XonpYK3F26vDVX7llxN93rYqQXE1djME+DC5qcDw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "fgTuT6VtOfbVTwesJ2u05itfx6Z+KXNOKnCe2WexpnlrCMX0wGmxXj1tU3OTicNmP4fWDNHkyPRy5EvcB0ljCg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EED08060959B8BC09DF99BB8A51A08C8D6F1663D",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "nVgPMI5vEoUQ4ryiYU5e2VWf2JL3yrSXNtOpzyy6DAZqcclnuUtosg+0fPdBMzcDn+1ue/26xkhaeOLZyL54CA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "0QcogFrNByv3nZeaxkmHEGlgkKW6su/GsiY+EJ+zmKBuLHUv+6hs7AXwn7DQnc4I7U6SJBV7Jn6As8fDR9KvBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EFE8CD307C19FE1E9C437B59A0066EDD97F45E9D",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "oBuZ+pKeylG3xgLD3NXvnW3XwZgzVLDSqDSbsbgmKEACYBVqJMOfECriYOp2WCsUL40jErogkIoRDB3UFLInCQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "F08432D4BD305E8D18FBA52D3B1D351C486B9217",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "HBZWHA0hElna7TWOjwynBRJlZu4LkkDiyprRYSyb7FJR0zIFDGOMUf32WRlGUxW6JWAK5fL64SZAG7sGcqkuDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "F1DA81336F50B87982CF10581D308080031406C6",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "6FreIDt/X+jw/5cJBIqiH+a1Ll5FlG+qWhNZwk8l77mdF5PZVU/h5BNsL5HsZ1tk7kbxvDmm6X0g52QkYAVLAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "tRaMOz5gZJiUT7L4Fm5cg8Lx/u7Pn5Bo7zrxragwQX6gi4Z/tvaJdpsCH6IQj245oJF69/+0KSzKMM6UH55BDg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "01343237335CCFAD102B8BD435D49D3A7E73A0A1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Kam3xVXv675BD8rZmi4Zs5jdR4+8I8i8ZEZU0gs9Bp4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "04CA9AA40B76FF67B56D5A9285CB9AE5ED2F3247",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "/hFZhF/r5QiEeRGVjMZhG0sO0SeqlURltv8wMjkmOG4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "050E6732CEC76C71C0CF6784EB4A4E2CEE8C23B0",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "b7OxLS/2TcshawP8QjsCuyxOUe9d3566aFczz61UZNc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "0C7A21D9023613B0F814882F40694D07FB508388",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "yVRzgrYNJ4G1uy85dJseiG2K9/ofD/6kObbAfvK1E5I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "239D1ACB182F9EC413D6AD8BED3A13447318B95F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ELiW5vI49RoPS71qjid0QFJM8CZpmLnW7qkmN8lQU8g="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "23A53F06EAAF2B827B9AF8B6866DEAADE5A5CAA3",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "WPAEO3zKMIbXTkPCa/Wg+s/eR7w6Wea1a6Xuzk1RTag="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "26E91E700545D79E8A18092C393DB76294DF393A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F8xDDGP4gRkFMeuIlULpbOP6aGPdTe5gZT7kCCnAQIY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "fWMaYDTFwdDo7SVw9hBIraX2GVqvzKhNKEUkr/2ZnEc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Uq1fQj/TXkpg+zP37a//6YC04vQHWraWfYSg88fMHxw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "31580E874C4F84AA5EB5F986FA70B74F8D1865BE",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "scpN1hLNChIB1QuRHojxUwl59cPP2KpwzilLU10JViM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "etUp4mnEHDdNnJSwu5KW8EMXYt7n94iYZm+y7xa9ym8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "R1rD/692T348fL4cA0mvvbK9aANwT0vBNAT5B9+p+rw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3C733B78F612FB791744711958D8BC4A3D1B54BF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "dul9CqXgrwNXGlWp4ya6mulGjKJok/Q2RYqITOGgYro="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Spb0BakJqr3uNaAEqdaGbv77bQEwym0/6cl/tnCdkGM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "400C0199DEC08A2DBFDF5D081AC15FD6685E8870",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "y+sL3o3wbcoAx67HqR8BNzJVokJrYGI5pflGS8GMSv0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "416A8E60A478C20CEB021A84425D8B457558D4E9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6P6otvJpi36GOMprEbFwzth4AjleE/ThQMksZ2Wgh3k="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "42D162EDB46B7C1FEA616810A7617A6369958ADE",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "U4HzaR1kBj9HGcZU1I3rIZMwMoikUmYQyIMZktuBOF0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "JqkfZ01ZvkPHj9ohj0F2Saa5t6KIX5uq1bhHS7YAyxk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "mGpmR8PNc6w2cUzPwAQhkSadkyGOuKMl68Nji5E3h5o="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5AE3C3EDDD4C4F12E0A45618C9A7EE302BF0C466",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZVXL7nJ5h9ZrCc6K3ZMgqR7HhT36DroxaBN7/kRHRx4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "627231A077D55F34733997ECD928CE2C511F126C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UaISVfdgdm5p0+bwCbeatoNYfJP6LzW5k4DoL8++t4U="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "62B738D2DFB76A0938F116B001D4AD686B75F700",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "bgZ8KLzPd4mI0aDX5aRLG7piFzEt59yzsq3djHZMV1s="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "635206EBFDCCCE8AE040DE2FF07F1508929F3ED7",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VcBAfhXKgDF4pSdLRo3dWX1v+q8PSRMTXKNrU9QPQC4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GR4akX9jBcU4iFUBqB3NGwD3CuSTGPHiaWofAhCjCiE="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6D4B3D65AD9A81CD7AE83EA598B6FD2818F7F6D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "dHIiP4b5najkXBsEsplzaD8hQubhKlOrUEVOZ+NY+8A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6DC5F977934E65C23231DDC30BF273F22FF5454E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "RQYSRBpF1ESzlpakxi9woi1sM2EiMYBxsf88soDQrKg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "r7QqYEO8hh6xOwJMpsH+gYer+oOcuP/UQyG7NNsLLHk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "74C2BE39F07B51E72003D4C437535A797D2774BA",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "qThLDyok7ht1m6Qj9sMPFfOvXQUIbnJ5PSmBxdnG0Rc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "766BE28A48C243E4F9AC3FA6B5505B6208EF4494",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "PeiNyRBUZ/qNnGl11xmW6b/Ejxq+9hfXdXPBewEzjqo="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Pfy3anXtYHMFjDLvM+5jJN3iS5Ypz9NMJ1KTNVjfJ7I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7D5B8447A0C1D5E85E095C885947C4EF180BA676",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "f6tNu5SZs7uu6h6e6g+ymxhOmJM09hbiT4mcoopbMx8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "JgRep5bgxhsdM6EVAEzE/cEaxMsdR6/VtG24KHgHDyc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UGBPzd5VtGwtUkXOkCgJuzUO6s7Zk0RGKCo/Csdlqf4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "2ekMO1AKawC1gbXty/y6KBVpUfC9RcKyf3sR0ZK7UR8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "822D9296BE1DAF413AB15B489C002F4CEAD426D7",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "InuzWLzsYP/6DLHQbmiYe0rtduz2xktozH2FmOKQsZc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "82FB9EE4538CEAA9C808E862C8D47D36C143E0DB",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QOPk17DOenwtH6MoTdxaW1/+ZUJw8r4QjevWGDpBi1k="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8301D560188D8CA97B5D373B6423292FA7A1C414",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "CQgaHk/wmnmnhWq8+vP2baKD2qUhYvNpFfRliGunlJg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "890C8588FAE1C90E164BFF1917A3EC93FF7AE8EF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "espgSJouSR/5l7I0UHcZqkUgByHgtt4yFAYzNbw4UVg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8A0B5C8CE8B72985C325F02B580C4DBFC527EB9C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "OBRlQyOtvKRxxxIF+7gsbA/5d4gI0aVdV+8Qzd42KuQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8B730D99A94FEA0729980BDBB4585DC2B7E932D3",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "E2+EA4BJea4XtU/Aahf4t8TpJG2FmJ0yIEP8dpDAABQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "92932AD7E082B90296C192F3113710CD6F99432E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GJlkT7S82nRWW34K5ax6ZCW9EV2nt1E/PF1P5LQgJdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "93597B2726E0FDD812E38163799427FA2FF684A8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "8nCk/jO6oTXElCrzQ4YOdQkE6Rxj2AHMf9qxMPItnwQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "9562DE62254FB0C58E70196412E5F3C9D30B80AA",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "s8MeP7HuqZOi9/wCl1Su1+R/kmhSvWx0BQiXog6CM8A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UseUFPt/FyVO1D19U7tHq4/CAsW/JxWOeTbw/ZftxMM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "9AE69E7D6961BB4CDAA74F99BB45A9EE25B02288",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "PbgEtU7KS/td42OxA7Aq7C49zcWVgbG7+pn5mjRBrqA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Hm8gqT6zv3BHDTjlY1nLMK2U4gte/cducumkYBgvXig="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "z7XkAAZ+x6klleinW1VTrsMLnAwNF9LHBFprFx1E4bA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "uEXsZIGASOuKR3SQn2cakTAkulEbm2kElVjj50W2oJw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A67BF23C710F87B158BC3369684A3033D3C8112E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "E3+y8GQu99AUysuGJfmtQxKYWRp7lvMPUoH67bt9k+8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZHfThztGFsj0VfR6xV1r5ZA09Q6/+np9oYXs8CWY4F8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6lcuin9eD6uwAu9qjsoRjtd+uCtVUZbn//5UqLng9mI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AFBD6E8C17284683A951FB263DDCB856AB61A176",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "0b2pdpqDMNKqBqZUpwLNqh6s/hblF4PaXJQLO1XZIs0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B058604741DFB193660713A02366D5A6CF1EF016",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "uktjN/4JpMiNcfX4GYir212W5zPhi4LVM+28oObD4ac="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "8f/zBc9sYTK1e73NefD07XG1gA/fqVsf8CZ5EyualYk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Ct8qHvpO82bPqzj2YxHkFgE+fmxVF0q7fTuvXzsK6Cw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B99E8C85A4BB4886BA6E3043B3A7553A481FB9C0",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "9D+mHClSgLhk5LVobp4HPZi5N3+SUrzFKBd9Fz86Ml4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZDJSsUONDbWTaQATQjuhqxsQFTnSyzSburJRflWe6ro="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C1A12367BC4BD69AF83B436A15D33703F381375E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QoUOhrmZjUftNo5mXv8nIlT+QXIN3tDR3XOb2phGa0I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C453130417F90DCAE44D28978DE1FB987507E6E1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Cyw/3K8X71s0tFS0kFJb1HxaDdqcfodHQD4HXZ1p/rQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C56B6E67680CEB8BF11B0B5FCAE3987EB930188E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "DU+N0lyWiAJ3aUbKUz5q/LOQUDIPTunXAcK78TVKlpk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "55KLg7eVl0IyiFhu7r38WGQizm6hglE4rsAo68dGK28="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "CA6211FB7B017D171FB7C5E46269AB49C9A1A135",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Y9W7N4IeYcWu6yvh9XKzt2cHsI/QOAMEQgDhQG79yxQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QEsifvLPeeGUsnI5MjI+gOXd2aU+NOqCwE6+Cs/LQRQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "xzIY0miEtnX/3fduBl9vYN2iDEmt7HIGK3Qb0bywdbU="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D361FCD15625DF4EA62DB0021C8D67C6083C8735",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "7Zs1DiFznmkmW6Yh0lh1nT2fRdcrm+2rFwUillbFS+w="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D447195654516BE994064E03868856302AEAF1D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D6BAFC0943840D65A80FCABC03BED8BE3FA7A8D3",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ze+xQF2/qcTtY9cje/r150eNoXCs4B1Vacf3TPcwquE="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "K+cn+8TPKo7d9dNhdj999tu1T108JCxecojB0pkssl0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAA78817A47B08F3022C756FA3BDE8E3CE14F761",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "9fJlZL8iH/1ysAI/r+2cSqXOT67uknmJKnfIIaShLww="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EB8F0269F7A03728DD8D57D1484545B68DA6697C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "7wsvbzutFAAQReO+Jq7L4Drc37uLg6IKafptL9ofTOg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "ED245292B061110D52CFD7AE6D02919E6C3480F7",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "O7sRf+YCASDFbn5BaxMC+DcoblK00JYTs8oE5uFMnLA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EED08060959B8BC09DF99BB8A51A08C8D6F1663D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "qBJDd/Wkt0KQfBUw4+wsWIpaqpSiUAQjGsTKfoz8IF4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "CkWTr7zqfXcDHuTn961EfHkJv82Ql1oibFWbfROfbCc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EFE8CD307C19FE1E9C437B59A0066EDD97F45E9D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Ov8G5YKHc1hjCBM/HT5k+MswEwXf+UZfP33bKi1prO8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F08432D4BD305E8D18FBA52D3B1D351C486B9217",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "T66D+MDA5XJsSmlca6yAEADfkNnERoNTzWdQ/q5y/Cw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F1DA81336F50B87982CF10581D308080031406C6",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "TCNu3Qckfx5+zXKvDTIHAFd/FZgbk013UFYIZqWl7w8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F4d36ebIiyCzz/pk4sGrxYnls8XuzOfMRh/lF2LTdA4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "wqp6kT/3DEZ81E8BAdD802/NccJcCyBWBVrah3EOTFk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "04CA9AA40B76FF67B56D5A9285CB9AE5ED2F3247",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "/hFZhF/r5QiEeRGVjMZhG0sO0SeqlURltv8wMjkmOG4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "050E6732CEC76C71C0CF6784EB4A4E2CEE8C23B0",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "b7OxLS/2TcshawP8QjsCuyxOUe9d3566aFczz61UZNc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "0C7A21D9023613B0F814882F40694D07FB508388",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "yVRzgrYNJ4G1uy85dJseiG2K9/ofD/6kObbAfvK1E5I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "26E91E700545D79E8A18092C393DB76294DF393A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F8xDDGP4gRkFMeuIlULpbOP6aGPdTe5gZT7kCCnAQIY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "fWMaYDTFwdDo7SVw9hBIraX2GVqvzKhNKEUkr/2ZnEc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "319549CEC8B9DADB70C7E8DBBC8FE5D550398506",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "iPt9P7DZ9EUBhWssBSvr/qYatOs08WwLCZbfeuW5hds="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "361491162A6178776B903E57AB7C4D909394B4B4",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QlwrDiydr8tfRonzwMnML1JYtWUHQZiG6aqhWsXRriA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3C733B78F612FB791744711958D8BC4A3D1B54BF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "dul9CqXgrwNXGlWp4ya6mulGjKJok/Q2RYqITOGgYro="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Spb0BakJqr3uNaAEqdaGbv77bQEwym0/6cl/tnCdkGM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "42D162EDB46B7C1FEA616810A7617A6369958ADE",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "U4HzaR1kBj9HGcZU1I3rIZMwMoikUmYQyIMZktuBOF0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "mGpmR8PNc6w2cUzPwAQhkSadkyGOuKMl68Nji5E3h5o="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "55027F5FDE2DFC9F1C956D4700A0E60E47BC8126",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "zfSXZ7DLwIeRwhbsE/Pr7cSaQZTmySpuXmGEnNRUZpc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5AE3C3EDDD4C4F12E0A45618C9A7EE302BF0C466",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZVXL7nJ5h9ZrCc6K3ZMgqR7HhT36DroxaBN7/kRHRx4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "627231A077D55F34733997ECD928CE2C511F126C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UaISVfdgdm5p0+bwCbeatoNYfJP6LzW5k4DoL8++t4U="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GR4akX9jBcU4iFUBqB3NGwD3CuSTGPHiaWofAhCjCiE="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6D4B3D65AD9A81CD7AE83EA598B6FD2818F7F6D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "dHIiP4b5najkXBsEsplzaD8hQubhKlOrUEVOZ+NY+8A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6DC5F977934E65C23231DDC30BF273F22FF5454E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "RQYSRBpF1ESzlpakxi9woi1sM2EiMYBxsf88soDQrKg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "r7QqYEO8hh6xOwJMpsH+gYer+oOcuP/UQyG7NNsLLHk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "74830E4D56CD8E0ECC47E508CBA279042A3882C9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KzE4Qyz7He+wo2wMepqCgTD4n10WA1Xafryn9Xgt6I0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "766BE28A48C243E4F9AC3FA6B5505B6208EF4494",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "PeiNyRBUZ/qNnGl11xmW6b/Ejxq+9hfXdXPBewEzjqo="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7D5B8447A0C1D5E85E095C885947C4EF180BA676",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "f6tNu5SZs7uu6h6e6g+ymxhOmJM09hbiT4mcoopbMx8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "82FB9EE4538CEAA9C808E862C8D47D36C143E0DB",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QOPk17DOenwtH6MoTdxaW1/+ZUJw8r4QjevWGDpBi1k="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "9562DE62254FB0C58E70196412E5F3C9D30B80AA",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "s8MeP7HuqZOi9/wCl1Su1+R/kmhSvWx0BQiXog6CM8A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Hm8gqT6zv3BHDTjlY1nLMK2U4gte/cducumkYBgvXig="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A67BF23C710F87B158BC3369684A3033D3C8112E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "E3+y8GQu99AUysuGJfmtQxKYWRp7lvMPUoH67bt9k+8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "L7pTIdyDJ9DHXRXMGcDeLxQ7KUP3AKiPpggq385vkrA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6lcuin9eD6uwAu9qjsoRjtd+uCtVUZbn//5UqLng9mI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B058604741DFB193660713A02366D5A6CF1EF016",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "uktjN/4JpMiNcfX4GYir212W5zPhi4LVM+28oObD4ac="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Ct8qHvpO82bPqzj2YxHkFgE+fmxVF0q7fTuvXzsK6Cw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B99E8C85A4BB4886BA6E3043B3A7553A481FB9C0",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "9D+mHClSgLhk5LVobp4HPZi5N3+SUrzFKBd9Fz86Ml4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZDJSsUONDbWTaQATQjuhqxsQFTnSyzSburJRflWe6ro="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C56B6E67680CEB8BF11B0B5FCAE3987EB930188E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "DU+N0lyWiAJ3aUbKUz5q/LOQUDIPTunXAcK78TVKlpk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D361FCD15625DF4EA62DB0021C8D67C6083C8735",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "7Zs1DiFznmkmW6Yh0lh1nT2fRdcrm+2rFwUillbFS+w="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAA78817A47B08F3022C756FA3BDE8E3CE14F761",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "9fJlZL8iH/1ysAI/r+2cSqXOT67uknmJKnfIIaShLww="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "ED245292B061110D52CFD7AE6D02919E6C3480F7",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "O7sRf+YCASDFbn5BaxMC+DcoblK00JYTs8oE5uFMnLA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F4d36ebIiyCzz/pk4sGrxYnls8XuzOfMRh/lF2LTdA4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:03Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestEmptyCommitEmptyValset.json
+++ b/light/mbt/json/MC10_3_faulty_TestEmptyCommitEmptyValset.json
@@ -1,0 +1,244 @@
+{
+  "description": "MC10_3_faulty_TestEmptyCommitEmptyValset.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "1CC9D76BC9218657FC828C192735EF77D57FEDC3AE44564FBF5270EF850E5587",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "3F61F463C3805570F650F8DB6293F13C45BE8968A743E73667B7C2F0E1390946",
+          "part_set_header": {
+            "total": 1,
+            "hash": "3F61F463C3805570F650F8DB6293F13C45BE8968A743E73667B7C2F0E1390946"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "uRQU9xiERwW/GxPRdtGUU6fsqDNkabOwr9LMhoN382IRjqvZqaRabGsT8KE0GHuMKG3CU4kEd63uSYDRKIMNAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "PbFSoDq2NLwU9mw/6yPCAkridZY3Vc/ZqSs0EJedSVLV4z1dXPMv6Ti2xEIHFaw4wd/Ib99mxYuyKHq9BNrKAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Oie1C472sqdBV7E6H4kkdDlns7Jjv1lC1ZBYU23BB5I01UicLeHbYTahk6sDKRcIhv6B4QUnjM+GdzKKwKM7DQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "gXXNRaogcREHOnK/hx9tMHzkjIbxpu6Ze3ziBtNPqX1Vl4aftl0Pzr8HfLvBxrteXg6oZiIk/U59164cNsRfDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "KeMLt8mzlHeiKfMUFzS9E/b1VzQ1W1/IRnMydc5NFuHbgDLkKLXkjvoeN/HOwTDJm9FNGFmcXOICOJ9LesepCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "6c55sAQxgWmdOnX7WI6eHzwPfOA53fmxHAnRmAfrtJxnhpTnCwClMxFaFgNlnO6toq2V0szdRnW4o5ko5Zt2Cw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "sxFIdEW1z7hhQcahZF++sXRi/q4LDxceUgdY6O8k3JsUzJloguSGcTPcprvk/7iMZQiiMjVpNllRVEdDvbCQBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "lZpjwVoK6Y73IQaOw54FswsHrsZcNM1DF2dfV0rEzPWNp0rj0WczAqcQenehvfmVlOluYDNoy98zgZBf5y6aAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "6vmYywv5b5Jf8UzZeG1gfVxkkY2MOs6OOlbVQhKfgkCur0S6YMf5zkDoZIW2YTmPogv4/jvadcWJZlXUva2hDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "LQbEoBnwc0cjtd+h+FLyI6ekgfSboO2WhWMBfDWI4ESw3DGNHPDIIFIH2e9ledSC6ZtNrz/hHUD9L3sk/h/XAg=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T12:32:19.160336993Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "next_validators_hash": "95772270EA1287FB89A1CE77D2BB2D07283DBEF31D1D63688DF46D92901CDD92",
+            "consensus_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "730D3D6B2E9F4F0F23879458F2D02E0004F0F241"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "C70E1C5EC220068CFF5AAA898E0AEC46602F290696397FBEAD38895F0FEF544F",
+              "part_set_header": {
+                "total": 1,
+                "hash": "C70E1C5EC220068CFF5AAA898E0AEC46602F290696397FBEAD38895F0FEF544F"
+              }
+            },
+            "signatures": []
+          }
+        },
+        "validator_set": {
+          "validators": []
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:04Z",
+      "verdict": "INVALID"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestEmptyCommitNonEmptyValset.json
+++ b/light/mbt/json/MC10_3_faulty_TestEmptyCommitNonEmptyValset.json
@@ -1,0 +1,261 @@
+{
+  "description": "MC10_3_faulty_TestEmptyCommitNonEmptyValset.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "60CC60FD2230D2CC9A7BB634E71FD57E60E75EDB39D57091CA335224DA8A1312",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "8FB94C801AC29675AE9C8CB3CF2ACD0DB04CF2E874AF0F8C558CD9183B148B51",
+          "part_set_header": {
+            "total": 1,
+            "hash": "8FB94C801AC29675AE9C8CB3CF2ACD0DB04CF2E874AF0F8C558CD9183B148B51"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "gCLvZvr+xtKj9b9cV4+SwNfBXmQiSgQn8xeNikcyN3O8om7KGKixBsipjkUiKRTVvtN6bDwRyXLz4k3WaTVlDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "NPayC4uu69D7hRN/XkP+S2mc0Rwtl7iuAmJ+xDNGtDtDvdq9VfmigTiKgxk/DgYUa8cLLltOdIGCPzSECEKbDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "p1/t4flarfZMeLgzz62dtop/4nUMnDJ5kz4zmAAXVD4I2S90UCW1QTE9+E/c3gSaVFC0stTfntyO7+v4C/ZpBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "WkVxx05PvFPx3rSGQRGHJB5qAgUCXsB4atCb9nRrtaJ2A2fekkIXePNJcOJd/hok1Ri200Cp5rQG1xezskn5CQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "MrMZj6XoebqOZZFHrKvtHt8Zd/4gTgzJt61GjUCArMsRj4/B12jq/BhTbJvFinQa9NmDeY0/9eEPuXwSK9w5CQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "WC3ATJs+m3mUO96V24kWc9+d8+rSr1s2vjHI58X0yxgY+JIL31KtihGF+OedXovVvyV8kPeDfRiuJuE9D2jWAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "oY3A7hJ87SxfQSKCwd1+VoIK6BUpeSfvEkJegMggVmcY5VOz+MN/zTgVDmMjWfRJ/v8bax2qsm7RuX2nBz9fCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "eGO0PPSYcyZviH8qGO/pDvvtMgmH1KWKwJ8wjYS/YyN1Hy5X81pKNvnpmV1V0Erq0KcHMHitkRTLreZ+L4nCCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "XhPZWaV9JlFiq4gxh4gJGI/9XEd7mHhSHYUUO6+w4BTVLFedUM2kMbZogbrHLOATMDkjdA0OyT3gi2Ip7AReDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "WKlM0i+9qQIi2/fEkdtTLb+JCfyvpPh1EGm7U+wt6BSiMdDJlQ+NiPOlSnhTmwzni9VOToncK6IjofklcLVnBA=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T12:32:27.160336994Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "next_validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
+            "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "127C94EA2F77949C022CC78D867091AC0D9DAFC0D1BF3957A591B8D9EB9EE41F",
+              "part_set_header": {
+                "total": 1,
+                "hash": "127C94EA2F77949C022CC78D867091AC0D9DAFC0D1BF3957A591B8D9EB9EE41F"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "INVALID"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestFailure.json
+++ b/light/mbt/json/MC10_3_faulty_TestFailure.json
@@ -1,0 +1,324 @@
+{
+  "description": "MC10_3_faulty_TestFailure.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "F70BFBF4EF69378EE647A415B16F45DAA2A807C21E035FDFC1DAF6EE1E3FAF57",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "F8680C7F437694D2C2CC79F90F01D336CCDC9599084EB99559FDBBE1CB8EC3F0",
+          "part_set_header": {
+            "total": 1,
+            "hash": "F8680C7F437694D2C2CC79F90F01D336CCDC9599084EB99559FDBBE1CB8EC3F0"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "fxJFNZ6vNIYD80OcX6S8b+aXN4YYBh7O8ZCeuQRc06Hwa4JJ8hG1eDumdzKpuBliZKeCZ8R5MzAXtXkdnbGABw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "n6N42VKlhMg5eU+AmMByZQ6RqYCFl4k0dYXnP8oYkSmT6t8PVWl29V0R1xpeVR3iIOHmleOP7aV/6vxRrI/FAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "x5E1FcMv7UQ91DFBuEs1tDLEqYzRhXMBmKROGqRursuiMHynHbIGi0tPdkkZN6Y+PG8HKtznVrdj/TN1KHJaCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "a1hoKKStU10K2oJXP4qu8Y2hPhUFkjyMZAdpom7dGo9+dzbh4N/FG/tS66IjeGbanZdsirt3NT1b+7swNoQWCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "CU/5QeJO+HFZBHj/CbZhskqbxrvbEXBQeU8n1cocw1EjeDsYD5MERFmOSJNjyaGYE5Wp6tGC6sUCrMEVMhROAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "O+5ncXwd7/+auW0ihlitIeIeb2BwvYPGL53Phpy+4FHHm7axmifvyELP2zG6HGErLCWe9Sujk/9RIWd0hP8iCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "5fS6QJlX8UU9qkg4p8YAh9c0q+4GVWYcYEN/EDaexeS2XJpiT8PaKw4Sj2Z+8ndvXuoy/MXkSZZYiwIKqZE1Dw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "bm1ph1QAyyArkT5qrs8fSMyscg2OZHImw8GvUqjNKfd2Tev5tl1lV3GjoiMpH/0AKb29bgsshUMv061OdkfvCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "tViuBVrkCXJA44tGXlfrbLTI++Jh1bJDx0kWiEbz85QJ4JhNQzdGF/bIAnPD/O91Srl4o1N3wybmGTtyTrRIBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ckfq6olzasiqdcV+jCp3n/hbMibQ9oJH9nKCHlVVz1qjjV0dUDipLEGkniEPcEAII35So6uZ6tVsiUtqbdLgDg=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:12:53.160336517Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "4",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "997BBC494E4BD76CABDD1CB5D4E2C16ACE26FBF3BD0231377E642CB0452D1803",
+            "next_validators_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "consensus_hash": "997BBC494E4BD76CABDD1CB5D4E2C16ACE26FBF3BD0231377E642CB0452D1803",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "4",
+            "round": 1,
+            "block_id": {
+              "hash": "520B771A9B4FB790793CDD059E62775D6329F96F4EF50CFE11EA6F4BC6415C61",
+              "part_set_header": {
+                "total": 1,
+                "hash": "520B771A9B4FB790793CDD059E62775D6329F96F4EF50CFE11EA6F4BC6415C61"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "0wXMmjYiTyZ4ckkpITP+luBd5qlYMZLmBaVKagTy52us38UaOfLGvwEQx1PdWg/8cbYT22XYoMTELGNc6qZoDA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "gT7nQrpeqd1N4cjDb+YBbZUtL+ipkWkzQFjvKymZ0AI6EEvBVAhfxOyYWiCrbcfo2EX+VUV6KLksZ2Avb2wBBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "jyEMHmj1AN09Td3rk5MuRDUmZdgIE9xWod+tvyAcnPi50oMjuQB7+zHlg7Gfw9s6M5cGmSLju66a/VD69bnlAg=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": []
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:04Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "next_validators_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "consensus_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "730D3D6B2E9F4F0F23879458F2D02E0004F0F241"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "10CD40B969B2C302A2B9286045FC4799F07B2CC00985E94DA383111AF70C7FB3",
+              "part_set_header": {
+                "total": 1,
+                "hash": "10CD40B969B2C302A2B9286045FC4799F07B2CC00985E94DA383111AF70C7FB3"
+              }
+            },
+            "signatures": []
+          }
+        },
+        "validator_set": {
+          "validators": []
+        },
+        "next_validator_set": {
+          "validators": []
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:22Z",
+      "verdict": "INVALID"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestHalfValsetChanges.json
+++ b/light/mbt/json/MC10_3_faulty_TestHalfValsetChanges.json
@@ -1,0 +1,442 @@
+{
+  "description": "MC10_3_faulty_TestHalfValsetChanges.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "C914525C286C94B98E3147913C096DB7316F2463BE3224E9CF395C79A3DA8AC6",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "CE90937477841CB6A728011A8BD1D79065B71A299C1A25A4AD53AB4D5DB69371",
+          "part_set_header": {
+            "total": 1,
+            "hash": "CE90937477841CB6A728011A8BD1D79065B71A299C1A25A4AD53AB4D5DB69371"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "BMi22IMjqsAnWVGoCu4nVS9rPrLehEO5nR70u4F1zWZBk99kkkcE4IoKlmGzsZ0gDRz3Dt31KMWQiFGTZ8ZZDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "KlxqCjMczeeUtzgGVwBCZWO4BMse6eLRlDIu2RCDegYmWBtLq3fCTYX7LyERN6+JvpbaK6oBXhLh32wbjLeDBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "icHST4J+GTTTT2jVdM+rMabnjxg1hOcJexSOa5H1ZRyeo14we4Od6W2PRuBItWaaDg/ynrM/dWw4YvIM4HT5DQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ZFveW72lGwHAaAQZkYrHXnGeDwQktTaErMdUwz4vBmEzkRwaRH+plsa+nJz8Q37Nm3ll+l7NYctNUo/IbcMZCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "VZ1cF99COolSUQ8uTfsdrajinto4nQqdR/J4e5zHVsSMd+oi85mTusuDjIYq16s6ArcKAyA8U1oicjXtPS1gDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "K4FunOFI0kbIFoxrkB180UK4rBUeTPQHf7z9X22LT45pKSji8YToEmJm3Fhqe9CG5FmJb3iO9VG9HamrInn/CQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "0rkvaUvcfY3SyIlNbiBMyJPVao7Mv4DRE0sHuFSok1jmrM/tcFohHTIFYM+xOQ+9qw+HICrKaBtU9QjiJfhtAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "2eKgj0Y7/eAlFoJFZk/r59/0UaNtOkJ6AlJS64ghNnEUdTS76cZfSVdH1SR+U09ITReDEUsJNUdW/SNaURVfDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "CNfcML0KzLUviRdDLb3nyLkwM2QusajbenShRSZ+j2zCMCuIrzXoRbXXWwWxjtlAD8NRzlKrNR1yL1E7NcqeAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "EDTPo4pRxeTAXkVQ3E9wuoO/89JadRaBc/Ke6V3aynWctNpuVwHOWfflhcYmrS/LDzog+cXfVT2utaXPe4P+Bw=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:13:27.160336520Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "2FB19D6A832F3544C7D5B0D95179935E02194014EA0156835B5E58C32C00CE92",
+            "next_validators_hash": "7F0348DBF21442AD4C85345E09A5A4E16C58F2A06E10CBB69F51453349E9A719",
+            "consensus_hash": "2FB19D6A832F3544C7D5B0D95179935E02194014EA0156835B5E58C32C00CE92",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "622D056238788AD94EEE0DBE5A776DE2E89AA2EDF4E674314FE6E69078B90B74",
+              "part_set_header": {
+                "total": 1,
+                "hash": "622D056238788AD94EEE0DBE5A776DE2E89AA2EDF4E674314FE6E69078B90B74"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "R13jTG5qsGKUlqbrd9yoInEiooAXv3UBoslBPhOWFCEku8M7SSty903oD5WwjlXFUeEZEY1OAUiVtDuUgpFwDQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "+OmY1WjkV6MGJ0fKLeYA4mBAHMNbJgxsf6W8bS8k/8okgl+Hx4qksIDXNZ49mlbmkKJt7salsEu3nZBuQk5yAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "FoPqvVajAlNMGhwnK40tmN+SGF517V98TxPupQNOG9s9ELlOyEkJdIUNG/eb1WszAlGhfP7hLAVcN2UqPyFJBA=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:18Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "C914525C286C94B98E3147913C096DB7316F2463BE3224E9CF395C79A3DA8AC6",
+            "next_validators_hash": "2FB19D6A832F3544C7D5B0D95179935E02194014EA0156835B5E58C32C00CE92",
+            "consensus_hash": "C914525C286C94B98E3147913C096DB7316F2463BE3224E9CF395C79A3DA8AC6",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "4E1DFB69AE7302EB635D104B2445782D3E6C23D41A9A3996CF7976FBEFCBBB9D",
+              "part_set_header": {
+                "total": 1,
+                "hash": "4E1DFB69AE7302EB635D104B2445782D3E6C23D41A9A3996CF7976FBEFCBBB9D"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "q3ZPOGahW2bAh2vc52bcFgE0UB/14wA5TiHMkbyLqMyjeEqNUkEyS2DXs0lcluidi3VOGcOmixwriilggdbAAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "LWlfirsyf/zDjD+5P0qzgnAHA0wTe7/Ph8p1bp7ZBAcE8klI13yj8DW9dP0LcSmVEwtZ4rAG4NttMQKg6teIBw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "xsac9VuJOCDnEfNQtytFYrX9fLTtrtLezXBbhm1OwtIhgY+55i+zv404OYbzD4IVa+4YEpmb2iO81RlAZl6CCw=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestHalfValsetChangesVerdictNotEnoughTrust.json
+++ b/light/mbt/json/MC10_3_faulty_TestHalfValsetChangesVerdictNotEnoughTrust.json
@@ -1,0 +1,442 @@
+{
+  "description": "MC10_3_faulty_TestHalfValsetChangesVerdictNotEnoughTrust.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "E0A40D70E6B3C80BDAAA44C82C0228726EC5B523DBB153CAF54209A3EA55A2E8",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "EF3299E493CA5765692B74E6E4A35CC6EB29AE29D406B92B2D22B94516628A6F",
+          "part_set_header": {
+            "total": 1,
+            "hash": "EF3299E493CA5765692B74E6E4A35CC6EB29AE29D406B92B2D22B94516628A6F"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "j/MZkzIIJI35C0y9CleM6JZdqP7JwhKQhq6xz++m7aFLjHbuigBgITK+xpZC4JYSsNv4RM7xyNJIysqJMcPEAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "+I7bQSiWOlrY6yQd7VWCAzxu/TfPg6pNK6v3yJcgdjIXvsUYcI4Kz86Ic+F0EPTPtxsN+rGhpBfF2jXdP+YXAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "IXBq17bCJR3FljpSIW1a9aKiTp0RcjHv5cvNRNn4Cno4EQ5qxX64C0Pq1eS2kqeZevOdAtnaHwdLcKd7hYVlDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "jxOxTqp1iSnZ3nAUHvMzNFl4u+EXEKw+r6cPl96tKmu7d5Y67uuwhxNZZmj98yNwMOKfO4OEW2W9mb2UXNlPBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "isSfAKtDTmFFVxaOSbBzlYUyjL7aZNhKdaEwq2MSk8bGb1HN7Jbetvo8uUyzcAuTyw1pgchuYbpHcfGvLKrMAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "En3Pb5YiHxrfcYQqBru6p7uZenIsS/CQMCXRHJW6o+US3U9b/txWFr+Izto0UhcQufL9SDoLxL6Nr7eq0nFmBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "IpxGcodnhQf5B/nxOrNO7EOd/OvzckDx92a9A7fRKMQZuhtrYj3QVG9Oqh3KRL3lTNMMi/7XavxZZycyh9Q5Dw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "MnQ0e/9iY+LuNJuIvM8fQNa0kIDjdRzTCnIJ0wFHU+KR2rsz/+y60JM5EbtYSg02tUM7RK5/U3G0/4cII80eCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "+3oo629ivu2KZRuO76azTUHlpygu1EFvbmsqfPz8d2q0ujNZHAmK8fgSHdvv7FrkwSA0GG/swolnWKB8DuqjDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "59cRQX1Rmwgo0Yl1OcmiMGEDlgWvS59JPuLs8JSSk+YkPM7L6H7qaEHgjssHOsc2XYQg+FN6PfqwY7qsq633Dw=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:13:46.160336522Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "4",
+            "time": "1970-01-01T00:00:04Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "AE143E2B5E5C3A76D4CCFC3C5F0D3E440EA91781800E00811FEDB2BB0F85F5C5",
+            "next_validators_hash": "2741031AA03B47590836834106A5C0F29F0504A26D27504E17FEF676BCA0318D",
+            "consensus_hash": "AE143E2B5E5C3A76D4CCFC3C5F0D3E440EA91781800E00811FEDB2BB0F85F5C5",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "4",
+            "round": 1,
+            "block_id": {
+              "hash": "14916605BF267C9724786B9ABB065F20AA77FC10B4198E15D07B9E0B25ADCF29",
+              "part_set_header": {
+                "total": 1,
+                "hash": "14916605BF267C9724786B9ABB065F20AA77FC10B4198E15D07B9E0B25ADCF29"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "FmM9ckf3g7Glgz/tVZXlWtaTYsp7rVmX5t0Q4BjuL+34StbJumdkFlXaVpuxg3pmeQFT71cbyd14YgFklb2KBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "IR9KMMnuRSnyeg6x85PKjb+aqB00dyItRI5Y8DlXy9LebRB61LafuyLVrHVn37GITe/R6rLBxTaXp7iKqp+UBQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "3B81KI+Pnj6dQWBQ9lG+03CLJ+lZIGC/XRF0jNTjqF3t8CUUg/5xaQ2PZjYGfYCyt9572l88iR9jU43MBuBmDA=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "E0A40D70E6B3C80BDAAA44C82C0228726EC5B523DBB153CAF54209A3EA55A2E8",
+            "next_validators_hash": "C085B600FAB4C6B7013BA12E680A05CC06B5EF61D59835EF255B58814D6473E5",
+            "consensus_hash": "E0A40D70E6B3C80BDAAA44C82C0228726EC5B523DBB153CAF54209A3EA55A2E8",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "9B59EED30247228E9995B692B1819FB3AB5D40DA9073E10C6DDA960C988858DA",
+              "part_set_header": {
+                "total": 1,
+                "hash": "9B59EED30247228E9995B692B1819FB3AB5D40DA9073E10C6DDA960C988858DA"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "HzY3fW1pV0amkw35e/N3fNzJtdAQ3G90o48q9nwO+crd2HNW3sw4pTXKXJxKrAuYDQ3PWIy5th6ZJicxPu/DAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "LCpJXcmNyt1PlJNPca9c4ua/NLbYfyt9lNMpWH2oNH5zHmYXd/6E6TOdQiZt0UXOYy9+eK+QblJtICBwAXsrBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "MzBmKP/g7BwMNWaqhmWdv4yHpQga0IIPKycTzhrTgO/00SQIjOo6l6uSb6iNdu+UDbiBY76UPnEGu/0jZ9IFDw=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestHalfValsetChangesVerdictSuccess.json
+++ b/light/mbt/json/MC10_3_faulty_TestHalfValsetChangesVerdictSuccess.json
@@ -1,0 +1,487 @@
+{
+  "description": "MC10_3_faulty_TestHalfValsetChangesVerdictSuccess.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "801A0D7BA1E5A4F90B2FFD494006593528A9F2DEA45279290CFF7AE6685C37D2",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "EAEACED40A68DEC5CA1724184231D3A4BEB094AF8CD5EAE47ADD63D52299A1F4",
+          "part_set_header": {
+            "total": 1,
+            "hash": "EAEACED40A68DEC5CA1724184231D3A4BEB094AF8CD5EAE47ADD63D52299A1F4"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "5p1NuTqen3iKt2VTVv/VVOcyyyN9AA+9W/FouL5Ngoi+DL0UK0FdoggyEUafr9HDpjCFKmr9Im17MJtIqtHRAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "R481Eol1g5+ltSHTWXz3bnmpmtY5SEPHkLc8JK1+qZ8Mz7vLb4K8qWq3hyinuKVOFFb/fNYd3Y/9nnUJoHCKCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "oMRqzNgptUitBqdSQCVppfmfO5D4nWDCF1dEKmY6ONcHM5J2ouwFAgEFPis9NURbf699YDMd0wXXGyIktpVwCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "VcUAeDxWHSHiuPNIRC2BJp9jW8AFZfwhdcZn7iSJzWbLuOX5GYhtDj0f7PpSeHxnmnN7fz6E2OZpEfyrWfJXBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "+xTtN0svwzE/DZI63BWkFyVcUYb1hA6/ON4GGSkPXL1LpASPC4CrCGQUWzPL5TPT8K9ZOoBiaXqYDM9Nfrm5AQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "eQbGE3lV3kJbDtC+j9WXBPZhj5LWChNd0sSsNaJhcZR5L5YXnuUVAUTzb99gr5fX46VGA00+Vk4c1o6MzwtZCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "fET2+y2cFcpbipTTvnRCrGWIfeYPh6D29tpHe8wDA48BPCQELOL9ShIc8igfnwqgx8h2G81UKvBiYso1WoKTDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "xBy93AP+AsCe7hir8HbojJumugdAdv6YjO7TUpdpHBmDnBWRg+3j1wPI70QIaPMWQ2X1CqJH9HgOY7q5dHBFDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "y2xHVmrp1mwTeANzk76dUyoLYdgaBttsMCBJv61UhZTrAjoXm/5+tXaOuPh0KNjX3ezSdomKB6rlRuPsNZSbDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "86NljfEVP12UlnJJGvlE5FGu1Nk3T1ppRIBgIJLhWCLOB19D+IHDgeLPxmECSN3LT/CSSJX31yjXGxDKtVeGDg=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:13:36.160336521Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "CF937D0398D1A6B407CAD163AEE635AECB87BAF88E3C272C143F718518A69200",
+            "next_validators_hash": "E0E707BA58E0983A36D8894E135BA85F25036C98B57A0E3F94A329A06D853C6A",
+            "consensus_hash": "CF937D0398D1A6B407CAD163AEE635AECB87BAF88E3C272C143F718518A69200",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "F84E163C878FF02264EC1DCD8FE05A84C9F56A875DBCC88BA71EE3C385D91175",
+              "part_set_header": {
+                "total": 1,
+                "hash": "F84E163C878FF02264EC1DCD8FE05A84C9F56A875DBCC88BA71EE3C385D91175"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "sBRs7zT0EgI/1Uc6dZrkXSb1BB/YCbr2ThXl5oeWBa7Px0QL9RlrnTjh1SjuxNXS5Jxmv9s5HMFOKhfONL+ACA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "28MJUyVV5YzpBYnHNALECvQMVjUu1P1EK5SrGIhXuOmikmVilzSHOoaxUmxhEMK3L5/sax8rMBfiyzJDjONaCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "xKcqIJ4eZuII6Ckh8178t/cOAYxGQq/VPxdhqlRmVYxS19D7l4bdNhPJIbfvfZdf6gCAqaaQp+yhww4/nce5Ag=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "oM3QFnVc0JpcLB32uB4Am3jNHQXLIL8ZFermL0v+QqQuXCn09KJRASB4cvG0Sq+sQzQo87JOxe2tBVodFc+wCA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:04Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "801A0D7BA1E5A4F90B2FFD494006593528A9F2DEA45279290CFF7AE6685C37D2",
+            "next_validators_hash": "CF937D0398D1A6B407CAD163AEE635AECB87BAF88E3C272C143F718518A69200",
+            "consensus_hash": "801A0D7BA1E5A4F90B2FFD494006593528A9F2DEA45279290CFF7AE6685C37D2",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "A68D54E22BDBC8C49E16D9470A4947CAA031DA7D9D411076E10E84F13DCB2F6C",
+              "part_set_header": {
+                "total": 1,
+                "hash": "A68D54E22BDBC8C49E16D9470A4947CAA031DA7D9D411076E10E84F13DCB2F6C"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "06Y3EPCK19yL4ToPLtKozystTl6fWZmbljcD49B6HD0JfVS+omsl2dtbDdX9MJ1slquWTJ923VhPbi2koBcVCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "9PpfY9+QF6++C/8Rvvr0VqoMa91sr1WDy2kTjVNoNVMgik7ujha/szRno/fGjc4FpcFrVPxEiKVgnY6v39SCAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "gJHwwllrunwG7RXk8xd27ZnNyP9CdEGgPw6hT0BhsYZu0Rdvsj5AtGMWRJyUs1JfjkMs/rqGwFYUdnmUzoMIDw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "Lmgl2bcHucxAhyEcEgWAqkTt1Vh2A8PWGh1QbRxzl+26P7sNNCsXqPca0q/w6feR5RLogD2bIYgPlWTpDVtaDw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "BOChXPtkncxDtMHxXDnIeFQuRm2FujUkYyEGYYAgDYvdigjOZWCMQF948Tty8UgPuheE+sZWZeDfIEbvBcIVCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "k0sjNkA42aRLhn1/N8QseL0p9mFLCgMvy+qe2utkjG4DY9P1MjTLxGqZvmZ3w2jGCkdxs5ZaY266FivM52caDQ=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:05Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestHeaderFromFuture.json
+++ b/light/mbt/json/MC10_3_faulty_TestHeaderFromFuture.json
@@ -1,0 +1,375 @@
+{
+  "description": "MC10_3_faulty_TestHeaderFromFuture.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "D62D06AD898E176C59375D9B0A9962A436BCCC1FDDBAB1B964E1A0079B50EDEE",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "FA349EF4668AA0BB571D2BC7AC2F216C56A47667B415097A81107A63C817A2C1",
+          "part_set_header": {
+            "total": 1,
+            "hash": "FA349EF4668AA0BB571D2BC7AC2F216C56A47667B415097A81107A63C817A2C1"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "yg+BYVV9MqRoA9ekPX8uF7GAWyFo+hz7ggVuM2yQFq/n2lbnhR5wHhp/oU1F2YycuKy3/h2ZiCsqgHv+EBQ7CQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "9ExfQ16FK37QABYtyaZb7typ/49k+RNhVcoT4AcfYgAwC/EybT1pdkJF5kudoETj8rKG9OHpnE5BvQRHMbbEBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "MK55kxJ3PLMnqrhEuRYogLkOhJsd0iY4B/NpYCBVSyKuapxQL83o2VED9KAMzc7enE7/rGuj3AK+CcAEmJiICg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "NqqKOdbUelFGUzckALLTOgSBrcqQ4JOOa/FO0etG0StRKNlNZ0GKc1qPASVbei/qkDAo6gMppDWUx0fl5NW6AQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "pM2eaozQy/QUd4Q+mVAqMyqrvLpKuCoIeMVvY8lhmSydGtCpaSXuNWDu1Oj6cWUPiwdmmKSul7wgAN8qq15ZDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "PAyA11pFaBjqHWuqEvl/8MaQMq/LHvXcoNC+ndLg+Vtq7fzyUPThAqqEI4zIhSo64J2G3TApq95vbQpxNqQSBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "uPzjIQ0y2bBGxGUDqE1B24DxXytEY+WYcQt6VXohQOTGRh8TRe+Ikp/R5U0bUmuUqXQufRh5jklX9iQ2CnUsDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "R6e76wlfuIGuolr9C/wmuIEGYQUkxlgPjoCvRDGJIsJtZauLpl1Ru4kK1gbGgIK14KcJOiJiVALksESUs6VxDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "4ydelTWPLyNnDO5I3vmD0WQA+GxqbJCk53SpWclpECmy87W23pofIIFzfZaPxqbcDdr4tZmhFsGkVUhzOU12Bw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "+HalZD1hQv1WEQsUuZF8WdNYcUtGaDLfRopevQEh/x+Jw7HB7t4qg+vNnrUVh6HNx8kGnyLVVZBaIPqpq1L0AQ=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:13:10.160336519Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "1",
+            "time": "1970-01-01T00:00:05Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "CE1991C55056200682FA6D37B05813AF74E49A981A06AFA22BBAF55FC49709D5",
+            "next_validators_hash": "ABE95A93AF2C6F9D5F9734403F01BB340338CD1B09453682155A5FDBA581B8EE",
+            "consensus_hash": "CE1991C55056200682FA6D37B05813AF74E49A981A06AFA22BBAF55FC49709D5",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "1",
+            "round": 1,
+            "block_id": {
+              "hash": "C75E819252A6F4BA260CC4CE10DE965BFD8A8D15D407D9463BDD59BA6D65F2BE",
+              "part_set_header": {
+                "total": 1,
+                "hash": "C75E819252A6F4BA260CC4CE10DE965BFD8A8D15D407D9463BDD59BA6D65F2BE"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:04Z",
+      "verdict": "INVALID"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestLessThanThirdValsetChanges.json
+++ b/light/mbt/json/MC10_3_faulty_TestLessThanThirdValsetChanges.json
@@ -1,0 +1,577 @@
+{
+  "description": "MC10_3_faulty_TestLessThanThirdValsetChanges.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "C533F19C1F4CDFBA94F5087EC273082DBC18B232C279E746F6237FCF3F015A6C",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "34F30059E11F8EA2B218776902DF2037969245088281EB005EF9E122CD39A157",
+          "part_set_header": {
+            "total": 1,
+            "hash": "34F30059E11F8EA2B218776902DF2037969245088281EB005EF9E122CD39A157"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "oBlkCOHo6Yi0+vZV1ztLFATCRSZf/w9AZCrrvVP0pvtgaLD207K8yeCDzqmHKkssPxQ2fKAKt9elqg5oJesiCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "+ypM7qfx+kB+O6VsazoSxFg9lAt3xbNZcGTEfrEou03m3WK07Q66Id3omUHmEr9jCQcKa9eWX5G4l6M+TGoHBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "FZvqIw0FtRUJ/pdjssJLJQvjTvhLgV5C8noV/sJcwVcBwvBdR/NZLZLJzQYclE4ld40f9Ip4gxKPfn6UvcoxDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "mh8a6u3VwMI6oo0fydO1hs7wrdOcws8Jh84PZ+1UcLRnFwV+tnEht1KebPkwM0ukzxFFBBhKbAnWM1vjSwl5Bg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "8uL0VZGLi4Da+Sj3YJT5V3NbIsVUs6+F/DgbMFs2hCe4bTLY746krpB9Lg1EVaktDk8vt2mZIo5oETWVlUkkBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "d1ev1JjtaPr7vxuGJZYTcioPS4NPi65XTG6XOmDve1vws+twUOFrJfYjjuFoRrzvIvbQQxQUUXrlXO2bujpwAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "vHGGEJl+Py3fOyOvYFMoQgyJa/tiHtXo54gskHlK8twWaaUH5JseyFfHFTVHWkIFF/7PNXCMCUv0bi2keMy6DQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "VVDZI0aBtkYUsJrXbXWEUU45dieSOOPkap9Xj5TfkJFV3FJDl3qfulo0TgQ6CQ5UvHJidqpPCrXdrUrmXZp9Dg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "94gK/StxfWHZijvMzq974pvk4UA9kBtlOI3EWuICMi74QN/ctvfcxqczxggkoOiRlPLr4v60dePeRtfANOgpBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "4bXjmzlJYp7cjMDBy5TjkQITCvSXmkp5bglgSDFp9wVpkwXnv3n1fmx28HvfB6bWfUH8zRyGFqG5eJUX9SDNDg=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:14:22.160336526Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "2752CC163C7325973743F17757B7148F91AB734A71028C7EEA195D67BD63F5BE",
+            "next_validators_hash": "34B44D075E334D244C00BEB423B9F7AE4FABCF785F93657B280CDB6EA3C8A971",
+            "consensus_hash": "2752CC163C7325973743F17757B7148F91AB734A71028C7EEA195D67BD63F5BE",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "766DBC66FAC5BAE5B4CFB3CFC48474F3A734E2A8BD06DA3E74BF2630556003E8",
+              "part_set_header": {
+                "total": 1,
+                "hash": "766DBC66FAC5BAE5B4CFB3CFC48474F3A734E2A8BD06DA3E74BF2630556003E8"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "clztV8cPrhZ5hp+yAAD292iEZjKdETzwFhfa8WpWqWCg7Jw+/uBhoxM6XMOLF+ZZkCVjidnr4dyXQttwgDu3BQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "AkmBtX8ICRHYThOWRMyEfWvdNK+HGFuszLPhlMcQK1Yw8ZzjhTQuhv+9M4ZHenBliBumeoUCZ3HS+WsvxMiJAg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "lrThNgN8zzZEDAUoDK4g4uhART4yq8Pv2BSTdQ6QkCrjaBgsPmH30AG3zSB2WFFPASEvHmDXDgx2JAwgjTgICQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "S+IqMBYgjoAUxat+rYPv4UTVH0IIO5GsfAb0/H0n0gRWIR4pP5YG8hV8LCx2r1dEKZ8cR8RH94MdLs0+eUUwBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "ZGiB3UHBHH12sSWJeuCggzSy2DaGfLz9ECa3KhUOtNdO8yk7Hk9F/JuTmSh4+wENB3gOGlA0youYs/pfjpq4BQ=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "C533F19C1F4CDFBA94F5087EC273082DBC18B232C279E746F6237FCF3F015A6C",
+            "next_validators_hash": "2752CC163C7325973743F17757B7148F91AB734A71028C7EEA195D67BD63F5BE",
+            "consensus_hash": "C533F19C1F4CDFBA94F5087EC273082DBC18B232C279E746F6237FCF3F015A6C",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "654339A4F6697BE6765A0B4A580F5D7B79719791E94A03A7016AD28597BE8471",
+              "part_set_header": {
+                "total": 1,
+                "hash": "654339A4F6697BE6765A0B4A580F5D7B79719791E94A03A7016AD28597BE8471"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "MR7/SrqmTX58rkVpH9U16Q31R5nm0RYpdqO8B/lwdOxsn9cR/5vJ/fodLqZFsBN0iOUZsHSLLfeCTcvcSsD/AQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "miWvQajvn9Yg5EZi8AUUlGfEZwx9psZH1Va8J0ips6RDModSPYkmMqdJJ6D/jJ63P4aTgLfAuZJwktf+mKrpAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "5KqKEtsduuUs9NyoCyyeMTYq+c2RQoJOd7oG3q53WpGPDli3DdZgLoQPS1ASbQco8WUkGb9QWV629DEOnw/7AA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "/nhiNjZjSDRBJIszooZlyF9z4l1PDBdIsPwfIcFj5t6tV6juxO8a192rqrNCeXlPmLKiGk69Jt8V7brn1mf7DA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "bTtKlpS1df1sHScEhlQx/jxve/FHd+H9EK0OmGmoPP3vPbXMZf0hwjhKbot4tR3cUfzANCLg70BMDRL+hjAKBg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestLessThanTwoThirdsCommit.json
+++ b/light/mbt/json/MC10_3_faulty_TestLessThanTwoThirdsCommit.json
@@ -1,0 +1,336 @@
+{
+  "description": "MC10_3_faulty_TestLessThanTwoThirdsCommit.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "B393E67B3629ADE8917A38FCC2246F9B43B4A783C4257F841577C9ACA47427F8",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "AF3C23C1B57741569A7AAFCC0A05EFFF44F1AA1308D87A12790002B8534BC00D",
+          "part_set_header": {
+            "total": 1,
+            "hash": "AF3C23C1B57741569A7AAFCC0A05EFFF44F1AA1308D87A12790002B8534BC00D"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "XNSSZjCdIklCiu+QjWQR3jQCdh4fAoA43V/giv2tKcJV8XLPdA/g1rQAm0a+OpEOiDAHzV7UMpcLEo2UocvUDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "f9+j1mIVi+X6vKMGbOXsN8pnsLn/JCymemM+dNRy/8uYZALWq2a7g4QTl5UZSrFgdMzZBNrLKW6V9EVZTiuoDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "7/rOrFJOr/5ElV6AG7XHJZQUQxAhMdDrh8bHvjwRn6cO5XjMCAAja1dAQTj06+OTy2z09UPknSN7AIkElI85Bg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "oUe9pj5HfbD4Rsw7xHQmWnWKOBt742ubfzzPjHdS2lrcVDSveIB6CRJ/ZW33rND4aGEE2t+zWQx2419vBQkVBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Ynge8IFqWh0FpA8z5uAqz5N6aaDPZswiqGtei/bW+/JNYOxWvrBxxei+EWkmp1KMsI0f8gAoUUKGylFOCVDWAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "2GnhTj8W1K5++ZPcDPiOQRD/lYUYLhMm5jWMx4fXYThV/hGSq6hnGEjXbpy6i9fV1dd/qJrJmlYbfLJ4UquZAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "I+5cK9jl6YpDwvcpUAqwEzRmrbG0jWgjhhKQcHsuxT+Ba5SSibd1a8Ibmk7axpUSRkRoBBEXF2wzbm/oEZXcDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Daga4n8t2jpH4BPSZs/+RfRERCU94ZAjG5cADatbsSmob56At3PvpTzVXViEuVFv3Yrt6qZTNazJItqw+EXLAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "tF6xv5OAn3CXiGVJJK+vc6ITtXJ5Md/p6NegsaKrZsFzQw4nJR8hyuPuhcdV2DAmthQMtItqgQVphC6ox5Y1Cg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "LsROmXZ0nboHSvOoDvrLMHgLbPz4+7jTnoqCUuqYPl639i0YJ8+TpAJc4fXqyxx0OEuW9zyl8KqQrc80pK3CAQ=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-23T09:11:54.160344431Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "39DBA2010F7E16CC79EBAD61892C1B479DC95B9C904814E0A7C67756765EADA7",
+            "next_validators_hash": "1CB94A57700B9A345230CAB9790F23C89346BD49F6E4984F980D2BEB6A8B3BA3",
+            "consensus_hash": "39DBA2010F7E16CC79EBAD61892C1B479DC95B9C904814E0A7C67756765EADA7",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "52D96B0FEE6E1E7D12FE104A343CFCB2C1D68896CE11959B7F5A5C5CCC95FF50",
+              "part_set_header": {
+                "total": 1,
+                "hash": "52D96B0FEE6E1E7D12FE104A343CFCB2C1D68896CE11959B7F5A5C5CCC95FF50"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "qyHyFfWaX7UIXElUTTojX5iukawcU07CblL+mbk75Kh3aEIMQ85FY68fmGr9h18+Hb5gLVOrlRmxCDYcUuiwAg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "xCOFm5ZfBwPZMyO6jO7Owv6lPylQhXKb0QPIR3oY4DUZPbQbiqvIrC1ttjc5Fyxywe2xxkt7/mdpgyszWfxeDw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "3jsiMUSBbx7OlCKPydgTadaJeeq2ugvNq4xy2732QdADScMY5Ho9vpCDm/q9Ad20jjNa2fRwm9GGeyAje6h3AA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "INVALID"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestLessThanTwoThirdsSign.json
+++ b/light/mbt/json/MC10_3_faulty_TestLessThanTwoThirdsSign.json
@@ -1,0 +1,334 @@
+{
+  "description": "MC10_3_faulty_TestLessThanTwoThirdsSign.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "02158955D6D6E3E29CE8E67487829E8019FEB601861A8B621D6AE3F8A709C44D",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "BAFA5821E2B5AEE05231E7559F26474389D4AB0ED1EB0638003378F7CC457F0B",
+          "part_set_header": {
+            "total": 1,
+            "hash": "BAFA5821E2B5AEE05231E7559F26474389D4AB0ED1EB0638003378F7CC457F0B"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "LZlABwW3ncMmz7w7JQt4hBVyx+QENeumlmZbykCGwbdyBpQBmegpM9vO0WC4M5wqpPi/86s386u3KAUk9ecbBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "AbPMa+gBxM7JhQHjl9ahYl6+oL7dtXSYor77Glg244oTXHxQjDqUV/953IVn3BevbMkiKbZRCTkjFB4Kn2N7Dw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "AU5TIMmP5orncg/p/+4z2l+HPh++wBHPeNv/uw3PPBF/gS1hgtoNhoKAu0IS40YMNv7oPcyKqQQUNwlHBIkXDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Ty4QXyujEcPau45m7imAO51UvSobAh6mZitRnS+6ULbi9xfD7ov9rd8R+36Qg5m0RxzbZn7wM9jI+98r2rjPAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "0j4pjjHw+2OUEfanwWkINNXFSqoobOgnsLY+kF1IwGfdPQF5aMHHNple6Yw5kZ/Pgems8rCeN6CagvSP9mIlAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "J2JvciwkjtXLCA4Bu1dkJarYF5tiB+UEWoE1XswBLFdYmAresPGgVob0aTTZN+KMpPci+XzC9t8j6u9uOSvMCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "zQkCA01CqIN3MkprbFdTu/OCfiqC8lryacY9isYETBx6RXAvS6M6YwGksseFrM87IsRMaqqHhSzyC/cKXFz2CQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "7LItXW6xvldY8qMQFbC1hS70jkTn5KKNE241SJ3BRDfZmJcqZ5shVt9KBufrEm8ilGeBtt+pSPr9Eiqdm00UCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "27idRzBumD4FyB4k+7ck2pxmdgBAw7T/JJYMz9ajKTuuFhLyt60ANwTWBGrJdFVVJA21xKjBSiVyoGmLjvFVAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "nDxFgOpBSwnBTEvptS4bAvXAuluvrhiqB4eZgb6RXc/YlXzQKJXpDHKy8kdJhTP5WHfVzVunMkCI1JZKE25jCw=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-23T11:18:33.160345191Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "DB079C178AA8313BAE4D487835968A64D723F0B9E8500D729C505BDE8375AFF4",
+            "next_validators_hash": "02158955D6D6E3E29CE8E67487829E8019FEB601861A8B621D6AE3F8A709C44D",
+            "consensus_hash": "DB079C178AA8313BAE4D487835968A64D723F0B9E8500D729C505BDE8375AFF4",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "DF0FB279749BC5EBFDBE595392DA058AC06D2AC0D0C8D6F49F269A2E96E01CEC",
+              "part_set_header": {
+                "total": 1,
+                "hash": "DF0FB279749BC5EBFDBE595392DA058AC06D2AC0D0C8D6F49F269A2E96E01CEC"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "d0UIc51y6rvuUiRUNJgKvUD4rN320xo3k/m0H/Kjp8PEoTzPgoSWMzKBLkBK+eQsGbDg/WmYZvQPPgIW0RKLAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "TKe3TN7e7GOVhTT2OVcnuITL2dD6azjgwgvHgGAcygXjnjddxwBM8F7wbpaiUmw9yne/4W5GcyllvYbU6adhBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "gGo2BOqsOWRKCxl9d7xCnrITe3ZLOxxY6YBL6atbwS5gbPGcVb340EzbOAT7i6iQLwQkPC5U9QOZpq4ETfA1AQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "02158955D6D6E3E29CE8E67487829E8019FEB601861A8B621D6AE3F8A709C44D",
+            "next_validators_hash": "DB079C178AA8313BAE4D487835968A64D723F0B9E8500D729C505BDE8375AFF4",
+            "consensus_hash": "02158955D6D6E3E29CE8E67487829E8019FEB601861A8B621D6AE3F8A709C44D",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "EAC805939208F7851F6517652FBFF87D9CBD455A"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "A99C145EDFE87199B2AA4B986F376046537BFD73F184ADD6C91CC5120BF30953",
+              "part_set_header": {
+                "total": 1,
+                "hash": "A99C145EDFE87199B2AA4B986F376046537BFD73F184ADD6C91CC5120BF30953"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "INVALID"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestMoreThanTwoThirdsSign.json
+++ b/light/mbt/json/MC10_3_faulty_TestMoreThanTwoThirdsSign.json
@@ -1,0 +1,484 @@
+{
+  "description": "MC10_3_faulty_TestMoreThanTwoThirdsSign.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "2965D1EE82CD65DA79D5AB2E71432186570D338E4D91B8E1474316DE56CF9411",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "DB0BA4ECABB87C42CAE573A180605C9906E9B1AC3E957B948EA6725CDD870318",
+          "part_set_header": {
+            "total": 1,
+            "hash": "DB0BA4ECABB87C42CAE573A180605C9906E9B1AC3E957B948EA6725CDD870318"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ozzlmZ7dRowEREAByd1uU9Y4mPIZANr3B99odY4ZKAe+uacMDc+Ie2JjxdRUtLQd21QKfRMTPqVlHPgI6QeQCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Jl0x9uZshlwUHtAUGZnWCK98ptX3qLtAPoaQzDgdP8N0FeTjDXxE71fkSqgVqAuy84w1yzq5T8zM6om9O/8WBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "jouqTj9Kjx2PDk5buitgIL9rIZOmokaD9M76xFnFaZ72vOJllaSOXSD6SWhLt8NHbxsxi3rfZdZNfUsObCWwDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "aLv5r+W9JY+pBL29x4k4cF25PuUFbRhTUUhxCslw5jUAPgCe5npfNrAcoxaMwNJ3fQ1XIZNN+PstS97UQPxmDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "t2sHHw7u4Nzu0IfjTKyjs8zMmMvsore/I+/FEaGHqta58pk0DzqBRp92tOCkeKetXVoz8C1BhSOxZ7snxe+yCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "xZM9x983j61dsIor+XXBrumwR9/GqYTqdnpGvYBjk4Dcu2vILyJm0HHEcsXS9U4miC1OHG9VcMFkuX9MCGYoAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "aQa3ONX7vDilvNFP5g8oc4WlcK4P+Fg0RSaHzVtjnadV8RRCo50BUVIHnv8SHOU+8JnXgW7o54lALyvCy53IAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "05ZRaZ4Baym+/gusR9qTDdxNY7dQNDHfRmlmMVJp6GBefbPMO2aG/tAuYfKADUXcvkiSOQydd0YCc24yKfE7Cg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "bCwVgMIxEKh4kvucSnu6UqScIDW6/vZRdGMAKkwHSARDicUlJTvcw0SJbgRuss/Fb/5G8jZhHHA/vlgxO3syBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "1P//4fzmPiIyXDXBtxB+wuGzhcTjYGJzHphH27zjQd2MDBqGp2kzJrCcT8/KkTISUxjNmdJn2GxsvK9mkEosDQ=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-23T11:18:43.160345192Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "4",
+            "time": "1970-01-01T00:00:04Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "AA233689B2E8BBD64FF3CCCF318BBE12C0229E42D538192B1A15165E83338461",
+            "next_validators_hash": "7B9CCEE93EDB721FC6BF2C6FACEB6B05FF183A538DE728E4075F14D03F408B6B",
+            "consensus_hash": "AA233689B2E8BBD64FF3CCCF318BBE12C0229E42D538192B1A15165E83338461",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595"
+          },
+          "commit": {
+            "height": "4",
+            "round": 1,
+            "block_id": {
+              "hash": "C05E276383E9D24C37ADEFE2AC9050A9160FD0FDC205517C5AC34618BB9524A3",
+              "part_set_header": {
+                "total": 1,
+                "hash": "C05E276383E9D24C37ADEFE2AC9050A9160FD0FDC205517C5AC34618BB9524A3"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "ypaLPnd3M7MKUvERDhGOpYfwQUs428raBp+J+45IPGLMuypxmFnmewv3WEjIcnwWSXGMVJvp79t/rWLEPkZGAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "xDuUW7ZnRrE0DNS7OzxLMqePgQe9bo9gkimglaz04FIkvpxyESnDp18+KsUTWf8J1sIvLPuFi5uf6jk56CdHCg=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:05Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "2965D1EE82CD65DA79D5AB2E71432186570D338E4D91B8E1474316DE56CF9411",
+            "next_validators_hash": "467ECBD89AF9A570C955B4750F426DD6025D79E1003EE25128259CBC7212AF19",
+            "consensus_hash": "2965D1EE82CD65DA79D5AB2E71432186570D338E4D91B8E1474316DE56CF9411",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "E03116437874B94EB3D252B1F0966B868DD505EE6542AA3391E19905383BBCC4",
+              "part_set_header": {
+                "total": 1,
+                "hash": "E03116437874B94EB3D252B1F0966B868DD505EE6542AA3391E19905383BBCC4"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "PLX15E82BqSY01Ec0D419g8e7uGMuNL35PU4XYNeID//Iqjv/ufmQ5kiofm9LKpZhkVJw7nOGz4fVdr5iCNBAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "eS2Uv3O7oVWCGTGciL9hU6YxPWYktRirhbO9YgP7q86tp7WyfSPqOpfcku6VKon1/pUSByTcEqTuanDCffDbDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "NW9KDzW+KjC9/EBkEMTydzF7gdEpb/i8tGztK7oa0f3Rzpk3Ojx5HXBAMqacgpsi3iV6UFHejY7erqgdplugBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "aCKfdwbSQMgxIJ5kZCrhYyHT0EAGs/6H9TOpgxs1C50ixMKR/w1852O58FfOteDwGmmqZEvyTebfi+lM9gEVCQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "+C6tlcu56sPwR9t/S62UrNuQIqzF1DttdTq6X4b1bAD4s1oQxdy3R2dUIwMEI1MjTrSkm4oNBHRTf+97zAuOBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "8FQiXqeFLT4aCo2s6pkUqgTEy3f0lqrA87QZacRMaPB78AepofIV2yVntEQpFC7GojGblVtvmvn+oEbvU216DQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "mkK5X1OZ+9o0KiYgSq/hSTNsBBFpptNj/bJb4nkvGoM+5ZV+UPk3ry4gr1JAVF74/tAbfuMLYhH0Qk3oxYI+AQ=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:06Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestMoreThanTwoThirdsValsetChanges.json
+++ b/light/mbt/json/MC10_3_faulty_TestMoreThanTwoThirdsValsetChanges.json
@@ -1,0 +1,532 @@
+{
+  "description": "MC10_3_faulty_TestMoreThanTwoThirdsValsetChanges.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "176AB388E0E618804986C0C0CD598B4CAF43EAC951367BA18BF7DD5CE1C6A147",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "FA79345E6917B775AE4D5C1D2EB80DCFAEABD23DD52AD719DD1D74BB756EAA98",
+          "part_set_header": {
+            "total": 1,
+            "hash": "FA79345E6917B775AE4D5C1D2EB80DCFAEABD23DD52AD719DD1D74BB756EAA98"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "b4EEs6bu0AC1twxXA0e8UbhV9NwmUqGTGswdi6BOuSggQ5MagG+N89/Y9586132/L/NJsoBJ9TqSHwtWMigWCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ObrFqy7gx+RZosxLf72sApBpAneo1oKMWmD5W07ZD6ObC6hAl2ANChEwCfuncmvosy4pFKR3KW2H3OLhWtFaDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "TEsboU8JjUCMC33UzpTxows3uS+T0KLvZAjaQ53ljGgHWK4H/17/FeAsqJEsGlQqMzPB0ciyfe2vO21GEyHlBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "98xMT6SrSfR2Cn1Ttt1rTZilR5julJod2Todsq4uiri3GY+zb0qVnjDusnhlWLGLy7D3tkheIhKTNDxRSay5Cw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "pAVMFEk35FZJlNFwdxPEnY8ILCNKlmUyZLiVo5ojf/20biXSMHrjZPXvT5iUV8nMV4KAXSuBpp4FXnWKbDTAAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "CY396TcX6XFTBU3xQLAns2nqwca4aJ1eXJidsmODwWM9HuRU/aQUgaAwQMSuXdK+E3/7yH0whlm9sO3VwSq6Cw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "1PeS8GCMDzN8Gg/kogtjkgGDBWol6hCKc95dritjcPibvDElkCqx3baJaMAZMQ4QxaURNp9TxgT13Mu6z3NEBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "4X5cZSE/mx5bqEmaBoZdjpdvJWg+Yuja1SCqeFQ9rBLAn6IYLkzNUMBtm0jHjD2IsLa63jQWpr4Xwa73EJ/UBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "zvuS9XMPIZz1IXc0W1Ws/H6n9hn+s10eB7cDbUtUMYPErX1JFIZIzQgYthjOJv2/ZsOXVori8Je4S+FjmbxeDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "iUVxUnAIkw3pgclBA3JFKBzjaM+oSM3oXPQpdI6c1nC2j2yx6aZ/tRfnSJHLlHbAljG3aUGhf/97vsQFQKTkBA=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:14:43.160336528Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "963EFE134F0D3AF487972A0101AAEAEA424E71925E175570829CF7395F4BAE8F",
+            "next_validators_hash": "392872B20B8ECD0E88ECC07306229EA89A27B5999F7DADD531B86D27A253087C",
+            "consensus_hash": "963EFE134F0D3AF487972A0101AAEAEA424E71925E175570829CF7395F4BAE8F",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "A13A8DE7DD1D8AFBB2452678E5123E796197F31EBEA77734D1F701F0FABFA8BC",
+              "part_set_header": {
+                "total": 1,
+                "hash": "A13A8DE7DD1D8AFBB2452678E5123E796197F31EBEA77734D1F701F0FABFA8BC"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "RpoJAfTZ2cfM6uGJQYhauj7kZHwL/NAY09QcecAou+KqtQ9xIivBqc1gm7hj+KSIF/tP6878jR1J3u4VPhfQBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "OoWt5o9s4XfxZw7D3XjY1gA2JFbhM5PlaDFZVIao5KXVl5x5RsqEK+ovExlMWP6ohKINQhBqfPsDY5O3XBJgBg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "i2LzFxxsmwXvlIFF+t9r7IbQz1WQdMei132hleVNBcJJHrR9tXkUPkSFNblrB+t2K743NXu5GBvoGMvMfmYYDQ=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:04Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "176AB388E0E618804986C0C0CD598B4CAF43EAC951367BA18BF7DD5CE1C6A147",
+            "next_validators_hash": "9F5850F474B6728CA3D284E245218C1292539D7D3623911BB99CB1D5CC405FE9",
+            "consensus_hash": "176AB388E0E618804986C0C0CD598B4CAF43EAC951367BA18BF7DD5CE1C6A147",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "F48D4568CCE7F534A033CCC8A3797FD25931962AF53C41C31EF5F4C7F0889954",
+              "part_set_header": {
+                "total": 1,
+                "hash": "F48D4568CCE7F534A033CCC8A3797FD25931962AF53C41C31EF5F4C7F0889954"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "TCFkbnD3ww1lqNu6/Gc9sJevzjRmP18QKCDDCUjlK/gjACuU8nOihdN5ndGbTlQYCQCGKc2dGEM0yu+/AbVTBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "Nkd0fUij0uvNRVtnZ+rvB5caqav9sllHWLFBuGemb6CTCDfZfAzNJTIKH1lzx6QoPS5RD0dCLWcrNX41bKLbCg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "YbK4ZrAlA2f7oL8uV1JAbebKzaXhftKbeOV1dgEMCLxk11ubra6ezaojVbgwJMJMiMlWe8Ti7GYlPdL/JgvjAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "wJ49wlLGoqe2flDqJDmGVqP2y1r7sOdbKQD/fIYC3uSL34oYDDRZDIJEPw3dnjZ1dNf1N4zO96oGl1cV/AlADQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "PS11a5TF6tLydqqbi8zSt+WvTpDgc++gABMuEUd75/3dAo/zF1LOvmYw2H5NzGA1LbS051IYodOy4P2O4jgpAQ=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:04Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestNonMonotonicHeight.json
+++ b/light/mbt/json/MC10_3_faulty_TestNonMonotonicHeight.json
@@ -1,0 +1,285 @@
+{
+  "description": "MC10_3_faulty_TestNonMonotonicHeight.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "1640E0CCDE91ADE4BD1F4CCDAC7AEC2CA60D1C9684BBAB5C512549831146A78E",
+          "part_set_header": {
+            "total": 1,
+            "hash": "1640E0CCDE91ADE4BD1F4CCDAC7AEC2CA60D1C9684BBAB5C512549831146A78E"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "YKtyUeLxeJ9jOiLOPzAraYG1IfwGuHy5DOgXZ4ieKfEstDdtNx4+9dCtR6+pEJtLdd/5YJOGELhTuKgu6/vQAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Md2j0QtKDHsecgb4kwJgkt9qpkM/SmfKsjqvXf4arND4VORr8dML+YlF6sY3kG6rEW19nB8noQNFPWWwXCOqBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "gFNbs1pZ5Jmfa1cC6AoURUZnEx2ZVacKgd2rK0J0yLoXOs5hXXodnxueLKjuJt5PKBJKvma9I1Imd7V7/PrmDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ZiNt9GaMg5lOyH1ykYv+ad6Lrfr+lXo+FuDABYzb6EF6sYHripkonGW7EKg6S8Ro6V2HVPZFS5sIazPAFzhxAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "FUN1hR4HqpRxXwXdD3zjbNEC3mSVTvegVx4OlFuGvcYYQtahQKADOsaEpzOvr9ETvjiT1o7D1dtq+y9qVSN1Dg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "B7vsLjHulMTqlUI3+fuzu77PIuUezk7jJ0VaZKiZ4ddaSEr8ZZNh9ey3SZTDFZdWDLoraqQP0tycjpIOY2RxAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "7WGOnPC2hX0YV16eUKqGVtuxhxcSPEJbQGgwumMKrzS3vAcHrE9wgFLJoVFgmMxSwMON0Rwe8aPhNQs57wNSCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "FBgGEUUKNYNWTwszM2DLt1DpKyF6M8yT+HbvfmP1JKR0XeBMpeQQY5Wlskbx5GR7OQVgnrBBiyHrp2rHWf13AA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "8BozP+NDEoSHeF+f81FHc/wOTA5UX6lZQqukt06npNpKuNNsw06PUeqTz8jKnT0/DLC+s7Zkw3dqDM/6LDXuDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "OerI5gID8IWtmtnBMbgc1OivhxEt/fb3Lq3GsBrZPyHbtt1yj3gxNlmjW45X6CLqbHp7kCWLZrWdFUDWEVqNCw=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:15:02.160336530Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "1",
+            "time": "1970-01-01T00:00:04Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "FF4000ADBE56F66E13DA36A96E27886E8BA90C0C61DBD5A84F527741EC08E010",
+            "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "consensus_hash": "FF4000ADBE56F66E13DA36A96E27886E8BA90C0C61DBD5A84F527741EC08E010",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "1",
+            "round": 1,
+            "block_id": {
+              "hash": "EE45898F4CF9C40215D0FEE3804CBBF407552ECD02AF13213A570C9FBABC7ED6",
+              "part_set_header": {
+                "total": 1,
+                "hash": "EE45898F4CF9C40215D0FEE3804CBBF407552ECD02AF13213A570C9FBABC7ED6"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "ycHeE9ub3rMPStWIoD8QA6Iy2ntVjSG1eYtperVfLJQN1vTgSRDOUXjGVKd/Yg6UXvwL6+VuDXTYNQBA+FD7CA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "M4xr0S15j4dtYsECbTqV/4IdkZvKMPHLEHRhxG/INp6hoSv7JzfB+OR3Wt4hptrKJ6K5XyfVsENqm1IsNv17BA=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "INVALID"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestOneThirdValsetChanges.json
+++ b/light/mbt/json/MC10_3_faulty_TestOneThirdValsetChanges.json
@@ -1,0 +1,481 @@
+{
+  "description": "MC10_3_faulty_TestOneThirdValsetChanges.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "99BF0E09D566F982BCE391F690B09555ACCB7A16A9AA722C89AF6AE49DC73280",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "DDE89683622011DA8D07E13D35FD360DDCF0CEA4AB7F9CC92AF893A83FC60BBA",
+          "part_set_header": {
+            "total": 1,
+            "hash": "DDE89683622011DA8D07E13D35FD360DDCF0CEA4AB7F9CC92AF893A83FC60BBA"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "yMPpYmfyF8ALymRyMu2WJNxeNX46DG06rLqKIFPg6xe2IDc8wzIi6fW9hpbsv+SE51Gi6v29sZDv4388h/nzBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "WwzTbNNQ9tD3/IyJ5lMXHS9yphmxIRP4rExvjOWkQgswMOyEJ67XaJiOVHnF9YC1xTYEawIwSfEc4BI3CQzrDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "uEzQtidlZe4XVOAlNcmJqDW2gfHiuqcax2dBzH2+gIp7ldhTY5NFWLnpxLlvRA8E6BL3o0Wjv29cYS6Qo4/UCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "EJIGjbyXNNYQKfxO1ZM6pmXV88Ynpvh1MaGXW3cJi/mN/2/1IJ4vonUfD8G3SY+I6IiCj8fPsMYVYCXFnQLNDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "OC0YbkXOcVoVdpIv4t6WMakm154eOrykays6w9y5N8DsFDDqyHleuavoZwmwbf5FiF+11bRylx0AhB8gR8vKBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "lbX25U7LZoJPrsNgYkovKF5z6fOGx+RsVuf7A1vok77m6ozfglAoeUXNW39GeY9mYXcc4yTJndXdVdeCXLtLAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "sZkVOXoCfTdxVh4Oz5WlXR/PgpN9skAnq1iFcV22qslneJdJ/JKC/1KycOyklYudI4KM5k76h1GNNfnlgyTgAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "BxhRWCgLGZIKfREVIDuzIZM1BhSrpKbAmdKbH8kOGoVR6rl+kUrG5PYUXSYJ7ci54AEW+UEBSsMfkzjvJ/HrAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "hb8z95t+p8l404l8PljUWkJ5W6fIWpo8yOSRzKjGOkx8ict4n2KW2+IhzmZmWaEos9Z7OJUfyWTDZbppp3+VDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "m8dsUFlzCvqxd1y5KkK8C6UeQN28GKZDM6tAIhCIBYgBtlhOXDy9Agiog5b0l0o0CklguFwh1dBwHB9eDTe0Aw=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:14:32.160336527Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "D308EE95B26412057E9637C1B57B0F7D9ACF2EBA2A94475B9DC0E8D234679646",
+            "next_validators_hash": "2CA6773E3D12179231C6A8335F84C1074714E0993015FE154C2BA0240F089E2F",
+            "consensus_hash": "D308EE95B26412057E9637C1B57B0F7D9ACF2EBA2A94475B9DC0E8D234679646",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "97DD33B0BB07E9FFF24C114F4ACC4CBD4B5974020B8F1C7328A4D5EAB7626039",
+              "part_set_header": {
+                "total": 1,
+                "hash": "97DD33B0BB07E9FFF24C114F4ACC4CBD4B5974020B8F1C7328A4D5EAB7626039"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "hCypI9ySPDYaSSnUUwBEdbJgaQc8MGvODdOZ9BKOVW3QSBNzmWQAO3ZaIEudSA9MYV2eruFQrEBmfl1yws0kCg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "sg1vbX/O8VBZTHnGCX1GbWdc1KsHmj7NOzmJ7+ylowSxzgHBgDq6qAp1dp1L9THK2uz+czP1A7Oa8o5BQkMcBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "hjePLM0PaboffDDh/bI9ZkmaDcpQsrl820kv5o/vFcKv15zUkbhoFFj4fnSxxmw1Qfdvlr70sq71g87lf+NTAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "zzoyZmbhR7riwCorONtO7qnwXrb2SkEbeX9JQD/4oZc5p9T4XnNF+NLryR4PMHZmFXLd9eQ1465UaP/PllSJBg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "b4R6io5yCvMHnphQ+o17vxXMXxJNQEP3AZk+OsO7KYNVwF8Zda875/PafcF/Tyjci8zkxKpAQD/abrk/713bAg=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "99BF0E09D566F982BCE391F690B09555ACCB7A16A9AA722C89AF6AE49DC73280",
+            "next_validators_hash": "D308EE95B26412057E9637C1B57B0F7D9ACF2EBA2A94475B9DC0E8D234679646",
+            "consensus_hash": "99BF0E09D566F982BCE391F690B09555ACCB7A16A9AA722C89AF6AE49DC73280",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "D430BFE46AE3DEA5565C33B2A9BEC9B69B91450CFAC1E7D45DB78ACC1AAAAE67",
+              "part_set_header": {
+                "total": 1,
+                "hash": "D430BFE46AE3DEA5565C33B2A9BEC9B69B91450CFAC1E7D45DB78ACC1AAAAE67"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "JgfcQbPL3KWYWYcAeI1/LUB95k7FUmBk+S1voR+YlITqMIdeoVBBC+398RT7jJ+q7MAF/UsV+OPs81IpEq6CAw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "haMyyZ3RkDLC2BZW5sFwg/2kuGzWkjazQO13Q/Yt3Ly+ErZLZOWKzD3CeQvE9JQx1QAOehC6Cw8MABT/226gAw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "R9g0ImsUpDXmYuMNCH+xKyc7i117M2oJVyWKH+lKnfop2ieeYFB3yt2IHC1J9/BxKWNJomL4bLYBhHZcBUPFAA=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestSuccess.json
+++ b/light/mbt/json/MC10_3_faulty_TestSuccess.json
@@ -1,0 +1,500 @@
+{
+  "description": "MC10_3_faulty_TestSuccess.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "3E89CA05C1E0BCA99EE3983F62806D228D3F690FEFD4062D4F0E99768CD61789",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "04EDC718809307BDD78C059DBDA869A60D27162E55773C61DA4621D8ADBEB3C4",
+          "part_set_header": {
+            "total": 1,
+            "hash": "04EDC718809307BDD78C059DBDA869A60D27162E55773C61DA4621D8ADBEB3C4"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "mSmX/agdww/fGeZNqWkKLiis577AXpy4tyNERPjN/VCTCkm5itjzVAtoI2tlzE6IlMIs/3wlEGhqXDABwUMqBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "pQf5j445mWsTlDiWf9JHVScYP1I/kaf1c4IWtF+qnJNEcmqmWrVxIBQLwZYXRi1v8GGdHnyIpS3/RgWa8txPCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "zN7hlElXEcBUYwTaFYil3hY/xKuBR9EyMqyb+ECNO6vq/plTyfX33x5FHtGPzKKt1PLz0j6N1TkZ96hyarWzBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "5Go3N7W7wNMpyHEU1Ker5KigqLmYC9YNepDikFSK2FiROdYDxcI7BGISj7HRX8vOVSuj+6V/+p+I+nSod6KhAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "KyALeqOqh9gxx7UcWwFVUpgH+L2J1K9FG6bE6H287tZuLVjB6D2Izk1j+gmFqqU47cLvatjtzp8UjsLyLMHYCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "yd8UOmXdPAhwpzS9yEGJwdPryRVtxibWM5VYn0n6uEldkcCty/3hvMR1jMz1krqfQHAE1qbq+rtBuwaPGYNbCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "mpWJuWqjtDeyyYHaI9g2RBOnkkw+15RDxIf+lfedDnWeUly4xAiWYsQCaZiZagPbXvfMmJ6J5s+a8q927kvQBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ARhLagyQ/KghaPN7hzZx5po/CTcdfUXyLM8OEqwzLT+X1xfyLR21qTo08RNgzIOlrucytLnsuYAguXdQyZUfBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "qHgqFqBjvz778Q47oC1x81NHcfRuIF1qggDHFNhEt222U8Auu6ula3XXNQDgYGyvvVZ4WDWu+PBsDQDx6X2MAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "3u77xC5QW9udM1R/L9TY3Hu02408lOPoHnYo4uBAt/0CsNugVZgVIlqlc29CJ37QfUE8MhDFnPC47TUI1lzfBA=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:12:44.160336516Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:04Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "8CFD9B169D02B800A45B6D7F291547A4DD13566DDF225A64B7CA8BF8051756FE",
+            "next_validators_hash": "003CBC45E62941E5179845CD79DD26063C6731CC19F8DF61C3F8AC7563544799",
+            "consensus_hash": "8CFD9B169D02B800A45B6D7F291547A4DD13566DDF225A64B7CA8BF8051756FE",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "67E542AC29B3F1D41511C113AD9FF0BDE95A576FC6034DEF62A282013386122E",
+              "part_set_header": {
+                "total": 1,
+                "hash": "67E542AC29B3F1D41511C113AD9FF0BDE95A576FC6034DEF62A282013386122E"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "pxliW9xy2DR+YzHsHxqXu9Wyi1EQ2djYOpJGAKcECumIix6qtBgvgg/VRzIpHgCFgGmdhpbwtmH+NmovPCo6CA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "p+4ad9Wuet63woOhOzCPxwBhM7hyGeT53rg/+3T98EENJXNStMfSkDV9JXUaAvzuPsY6LI8pKTCnV2K/Up0jBQ=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:05Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "3E89CA05C1E0BCA99EE3983F62806D228D3F690FEFD4062D4F0E99768CD61789",
+            "next_validators_hash": "8CFD9B169D02B800A45B6D7F291547A4DD13566DDF225A64B7CA8BF8051756FE",
+            "consensus_hash": "3E89CA05C1E0BCA99EE3983F62806D228D3F690FEFD4062D4F0E99768CD61789",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "40B6CB84DCB8D72B8DE12388683C575DF4FDA088F8C93EF05040325494E96AD4",
+              "part_set_header": {
+                "total": 1,
+                "hash": "40B6CB84DCB8D72B8DE12388683C575DF4FDA088F8C93EF05040325494E96AD4"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "nRwaVGqPP5UynquwlTdm/oUlbYzvP8vrns0t+tQSosq7ofvSMXj7VUGNzKAH6akDziGmE5wqNTxvQkQ/6ZKsCw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "mSXRbee+pWSv8ZwnVc66+hisoSViMpgHTBbbtjg+Cn/1BANvUoWAdi7mvojKwHZiqNlF9xizh+3Nxd7eZp+eCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "Cc5UA1KttNnswayXW9cmCF7zndZx1/piBf1sHnny/HDX806xoOZwjhOm/ikDzFRpi056gbScbhY/b/Ohbv19CQ=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:05Z",
+      "verdict": "SUCCESS"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:04Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "8CFD9B169D02B800A45B6D7F291547A4DD13566DDF225A64B7CA8BF8051756FE",
+            "next_validators_hash": "003CBC45E62941E5179845CD79DD26063C6731CC19F8DF61C3F8AC7563544799",
+            "consensus_hash": "8CFD9B169D02B800A45B6D7F291547A4DD13566DDF225A64B7CA8BF8051756FE",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "67E542AC29B3F1D41511C113AD9FF0BDE95A576FC6034DEF62A282013386122E",
+              "part_set_header": {
+                "total": 1,
+                "hash": "67E542AC29B3F1D41511C113AD9FF0BDE95A576FC6034DEF62A282013386122E"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "pxliW9xy2DR+YzHsHxqXu9Wyi1EQ2djYOpJGAKcECumIix6qtBgvgg/VRzIpHgCFgGmdhpbwtmH+NmovPCo6CA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "p+4ad9Wuet63woOhOzCPxwBhM7hyGeT53rg/+3T98EENJXNStMfSkDV9JXUaAvzuPsY6LI8pKTCnV2K/Up0jBQ=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:22Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestTwoThirdsValsetChanges.json
+++ b/light/mbt/json/MC10_3_faulty_TestTwoThirdsValsetChanges.json
@@ -1,0 +1,571 @@
+{
+  "description": "MC10_3_faulty_TestTwoThirdsValsetChanges.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "60D10A776DF92ABD0D5A7B3A4CC902566945D9F89F52573272BC1400497292A0",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "82E01D82F14E93C0A3D101CE233890197A7EC2E38E9AC239ACDFC353E90C859D",
+          "part_set_header": {
+            "total": 1,
+            "hash": "82E01D82F14E93C0A3D101CE233890197A7EC2E38E9AC239ACDFC353E90C859D"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "LJAk6yKPTKhjclEVODbeyPptuaNzUzEhxfLwh8RdUwS/9lA3YGa5pNtK1PYEqOAO2f0iOLwP8D9eFmNEdXAABA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "u39XAJY9qeDAEmtrXpb1NJRUCSrF3TWCn3jK/j9zsSBN1hDuyfZDlmk5Mle/sQW/SJ6LLOSkpC39hl7knj3PBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "1TILTM2r6wZAh3YMLSSv4IvHIx8XKVkOFlW9FxGLLndEejjPf7WDPBR5MfBn/3ekQenWBRLoyFyd34kZkgEPDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "wUF7fDyPwi4cDMe5152QghnpByVBNQyPXcNpMuzfXvJfNEdwEdHppgJcTt1EMvs3MQLZACDz8Z/8M7pppxTJBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "D1vLECP9c+8w6uw5p4bxaY1yB4l3dGdMjl17mPkV7Eh9jo6hAlS3l9MuQpqLDwT8RACmPscE1BqF8bdPBr9sCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "uQOWfxsA2gU2P4jUT1QfEefcD23mUmBE/OqQxfufXkr96wAxpOnYiIZOPnkyEgPkBz7BzwSVwUKWaa1kBOGBBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "xWSHv8t1fC1ZG+xLVnp7KiMYCOMtE9qTvXsKdpY4sh+/KLt2eSvXwiKOcVk1aC9dzLCAt5JCMGG1+OH3j1osDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "lbpHa2UAf1BbKqw/qpat8/i6rV0OUyOWt2lxU96vcly+I2DvTxTlM1ywViEdgYUTO3nVUi02sN1Fbvsu3nrCBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "MFaeFiw7Al2PVDV7o4NGg/J3D4Ibux1fOpLVD1Deu2+fYbeTRDZk2OBY99j3fVT2Z5ca6W5Npupdois9L2ffCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "xdw7meYxrj+2AVBPfBa2oR8wrcrXzDqoPjSdpuDpwn1wu3f37DnZJM93T0rPvIpYDmmE383TLB8+rBHtl/1TCA=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:14:53.160336529Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "72407809904D98048E5D4C8F4DBD86ECE9F364452FBE26731FD2E79715237D82",
+            "next_validators_hash": "E014469B162A36F2A25BC2693574BF6F7F986B8A71CE750ED09E2983F8822DFA",
+            "consensus_hash": "72407809904D98048E5D4C8F4DBD86ECE9F364452FBE26731FD2E79715237D82",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "D5EE819C1962839D6CB5D988FCABEEF311D7A8C3D0AD49A40E323B177E5790C9",
+              "part_set_header": {
+                "total": 1,
+                "hash": "D5EE819C1962839D6CB5D988FCABEEF311D7A8C3D0AD49A40E323B177E5790C9"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "GeoYSVHOLRy7HRpqgyQxwvxnSqL7KYIYxyrmrPBz+CJ3QP++Sle4rAHzvTnGxRnU1H1NiklmL685bMMyUg9iBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "yMrFh9DionVdrIMaJeKCVaNojlktVlqhu85LWJ1xtpjbYoaErlY0VJFJEDedAXrQKvq5NX8lwzkkvKYiLsJpDw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "aUd/oBBeHJz5EI1c8i1mv6Rn908uEc2SJjxGKQH+jlPaH5RU1Db6s7EMej4mvVIZXWk2E5Me1Ntmj8QZddA8BA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "f/+38LaQjs+ef+as2XRjhczECBLVepZYLI5L749fkbS+5mUT35wseev5KKNTTjjZYAGeAXR8VQxjFtg8pOIoAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "nUKYMKpeZ5X6uBpNzJxBca+/8pYaxdrCnYUKG9jPy28FOrnkb9Xprv+ZOrw1uk2kgMSZhy5ozpyJiQR6v2v5DA=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "60D10A776DF92ABD0D5A7B3A4CC902566945D9F89F52573272BC1400497292A0",
+            "next_validators_hash": "72407809904D98048E5D4C8F4DBD86ECE9F364452FBE26731FD2E79715237D82",
+            "consensus_hash": "60D10A776DF92ABD0D5A7B3A4CC902566945D9F89F52573272BC1400497292A0",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "F6D89854C402F602982A778B3B8FA8965E579B4CEB3E61A5743650D2A529B140",
+              "part_set_header": {
+                "total": 1,
+                "hash": "F6D89854C402F602982A778B3B8FA8965E579B4CEB3E61A5743650D2A529B140"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "IpYR1yxy4ZlTQsJl2mNlFSArnl6sdelsKdC4ssCLOEoNoLIUkkQaUooeSTlqqPLz1KJH9vQWSJCDMhAXW37PAQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "rpMLTNyDSfp4d2EtGIly2+G1RNdUCO7gOA4GhWPiXB/ocKiXCg+0gQKMxJN6Pp0CPCV0LfE0i004wkghYBbnAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "GB4nWP2nK4RPMO4DvD1VOBnOgQ1kU0I9p989e8lK1vci55yPKN0ITI7YhPc2u02sXVlT5nm4V3xD9Su7PD2ZDQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "Muc4p5btzG6hXX+wMrqGbPvDcWLL2JcT0V0iUbU3umrDgSbldHoP1ULKYd6Wtykq6FXs+FgVWsqt8DXKMPQODw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "uN5u8meJAxn6DszjhTFlqyHkkGiiNQC08yIClgJkc2HPRr1Y6rBI3hFNL7ojZ1tGPr0OWqjSbsKbg5xcC4ZfAg=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestUntrustedBeforeTrusted.json
+++ b/light/mbt/json/MC10_3_faulty_TestUntrustedBeforeTrusted.json
@@ -1,0 +1,297 @@
+{
+  "description": "MC10_3_faulty_TestUntrustedBeforeTrusted.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "1640E0CCDE91ADE4BD1F4CCDAC7AEC2CA60D1C9684BBAB5C512549831146A78E",
+          "part_set_header": {
+            "total": 1,
+            "hash": "1640E0CCDE91ADE4BD1F4CCDAC7AEC2CA60D1C9684BBAB5C512549831146A78E"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "YKtyUeLxeJ9jOiLOPzAraYG1IfwGuHy5DOgXZ4ieKfEstDdtNx4+9dCtR6+pEJtLdd/5YJOGELhTuKgu6/vQAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Md2j0QtKDHsecgb4kwJgkt9qpkM/SmfKsjqvXf4arND4VORr8dML+YlF6sY3kG6rEW19nB8noQNFPWWwXCOqBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "gFNbs1pZ5Jmfa1cC6AoURUZnEx2ZVacKgd2rK0J0yLoXOs5hXXodnxueLKjuJt5PKBJKvma9I1Imd7V7/PrmDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ZiNt9GaMg5lOyH1ykYv+ad6Lrfr+lXo+FuDABYzb6EF6sYHripkonGW7EKg6S8Ro6V2HVPZFS5sIazPAFzhxAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "FUN1hR4HqpRxXwXdD3zjbNEC3mSVTvegVx4OlFuGvcYYQtahQKADOsaEpzOvr9ETvjiT1o7D1dtq+y9qVSN1Dg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "B7vsLjHulMTqlUI3+fuzu77PIuUezk7jJ0VaZKiZ4ddaSEr8ZZNh9ey3SZTDFZdWDLoraqQP0tycjpIOY2RxAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "7WGOnPC2hX0YV16eUKqGVtuxhxcSPEJbQGgwumMKrzS3vAcHrE9wgFLJoVFgmMxSwMON0Rwe8aPhNQs57wNSCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "FBgGEUUKNYNWTwszM2DLt1DpKyF6M8yT+HbvfmP1JKR0XeBMpeQQY5Wlskbx5GR7OQVgnrBBiyHrp2rHWf13AA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "8BozP+NDEoSHeF+f81FHc/wOTA5UX6lZQqukt06npNpKuNNsw06PUeqTz8jKnT0/DLC+s7Zkw3dqDM/6LDXuDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "OerI5gID8IWtmtnBMbgc1OivhxEt/fb3Lq3GsBrZPyHbtt1yj3gxNlmjW45X6CLqbHp7kCWLZrWdFUDWEVqNCw=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:13:17.160336519Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:00Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "6176A7BDFCCC42C458A7DB712EACB965C4D3B8F35E337186B16185AD5742036B",
+            "next_validators_hash": "8A94F866B708E5BB629B20491A185219A37D0CB7F0A5CCD21381185814368A01",
+            "consensus_hash": "6176A7BDFCCC42C458A7DB712EACB965C4D3B8F35E337186B16185AD5742036B",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "4052F240E51FE7DA281620D957997B3384D824191AA528FBBB40254D6B2E698F",
+              "part_set_header": {
+                "total": 1,
+                "hash": "4052F240E51FE7DA281620D957997B3384D824191AA528FBBB40254D6B2E698F"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:00Z",
+                "signature": "7St4tO/VJNo/a95e6Jccxvt7eEj3Q4VJTix492NP3TABLd1sDz01EgO3z0YSgS7xU8orgKtVv3WgXe4k0ZjWAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:00Z",
+                "signature": "lqhFc3QBJi5aDEV/UxPPbOvEJxABUQXfz3CDs2/Azn63WEWvUMJROfmfFfpw64NBCZbj+uwUk2KMigG8ut4WAA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:21Z",
+      "verdict": "INVALID"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestValsetChangesFully.json
+++ b/light/mbt/json/MC10_3_faulty_TestValsetChangesFully.json
@@ -1,0 +1,412 @@
+{
+  "description": "MC10_3_faulty_TestValsetChangesFully.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "FF26C9F30E01D7216CCDA4F32BDB84E6B7CACA1F72B9291E231FD926F232870A",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "E3763A75EBDB0AAB6F6B6150E585792567BB9A764B6E4C51DB23A6A6891450A8",
+          "part_set_header": {
+            "total": 1,
+            "hash": "E3763A75EBDB0AAB6F6B6150E585792567BB9A764B6E4C51DB23A6A6891450A8"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "hE8NfpX8rjZG/K0zAlu9LpyVVjRz9KqZp7fS5UeytNHt3msi3j2sTKwxq07XEFU8lxzpbgFB77Ud7pYG3M4GAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "tM+m0hWTSIOKUoCLxY3hVwWmF1kW2ZFBcU5untGmTt1xtTvDml8M6JgVrbXZuACZ1yFMh0FR5g1Ui7iDDYsUBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "APXjqyh1eb6MIZy7H8WrMU9L4Qkln6dHbh8bhiN+RDrU/8rNCpeeCRUKGn2lxNR9yjHyP3bSgFh8RdtXKUM9Dg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "MOIeNvrvHAA/zCzmrJLGqkcv1yS3SIVRdO+Oo3kU96ExGsx1KvJ9XvbBzDJIDNhvfJ+kRhX8TdxQFbmzdGDnCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "6vdAq4gIep/UfIXBdYwNait+YlPsLo/D2N6bpUavFCfZ3+WAWvLeeDf4FDBgfZsFYIUirA0Gsy1DWws5TYO2Bg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "vpo8Lm1HiiGLkmOXkAngqWFMkL4KSvs1elhVKI+8XXA/PfnqrbHzF4r2uc5UThAUdlDtBW2eR/GG/xzCCXVgBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "k485Mgm5AGbcXay/4nTcmSORa2PoP1Dh55aSH/TlJjhL8xdNsaLw2DHXYhRtu4L0BCEeOqRRYU8CptC9MkfcBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "afh057WIhI7sjC+eT1dmpzuIMaBj0zxN86qUHa9lIzS9qSX8JlPyB77Zy7M1Ri+Ls5pG7BN7jL9VmTaGK1GbAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "4I3mtUKE2sSms6SPzMArZjuubz2R3oRxvCq79hU7EUvbMAxdvGvQKUdck4jCF5Gp8oalICOwbOFIzp9qRbaKCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "x0nJ0aQHHdPFMMwjI1c+Kko5laryFIF2oZoJgEgDREEB4MpkAmyklB4wY74gEiDCm8ZjfKDIDkOx4eTgFT/eCQ=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:14:13.160336525Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "4",
+            "time": "1970-01-01T00:00:04Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "C37E7CF70E34854CCB7EE409AFEE41035B0A632CF8CE406B9559E3DF7408886C",
+            "next_validators_hash": "F36904F4410F1498760BDF0637A3051CD0A8B9B05E668C8CC580B8C6CBC9F7D5",
+            "consensus_hash": "C37E7CF70E34854CCB7EE409AFEE41035B0A632CF8CE406B9559E3DF7408886C",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
+          },
+          "commit": {
+            "height": "4",
+            "round": 1,
+            "block_id": {
+              "hash": "478E24F03B560D92BC05D790A7ABE0B0098299FB29089295EA48F75F1C3954E3",
+              "part_set_header": {
+                "total": 1,
+                "hash": "478E24F03B560D92BC05D790A7ABE0B0098299FB29089295EA48F75F1C3954E3"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "R63XDsDVN2oMsqut4wvWgTyBOWPnLgpqlZ04sLAiSxF3/3MLpgLUEC6X5RSQqys3kIHFjA75Ll8UnOcgpamJBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "X/JxKW0uCPZqh/5o1c+9LvgSqAMD+YYF6I3k5qs6RCjbBfBBKXFtS1dJnrbgE3ZEaXUbgxEktkyFOCwYBIHzDA=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "FF26C9F30E01D7216CCDA4F32BDB84E6B7CACA1F72B9291E231FD926F232870A",
+            "next_validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+            "consensus_hash": "FF26C9F30E01D7216CCDA4F32BDB84E6B7CACA1F72B9291E231FD926F232870A",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "A10115034093490C84E70F0A26FAE68B852DFF29E6A3D500AC6FE7B097DF786C",
+              "part_set_header": {
+                "total": 1,
+                "hash": "A10115034093490C84E70F0A26FAE68B852DFF29E6A3D500AC6FE7B097DF786C"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "Z45Dyi4H0UfJEh8v8G6qYNGDhZ9pw+9WX5+aAPn/+WmanQ6LG9p0k0BGD1eq/ifIMt95DDaWxRYch8rnkUxpBw=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestValsetDifferentAllSteps.json
+++ b/light/mbt/json/MC10_3_faulty_TestValsetDifferentAllSteps.json
@@ -1,0 +1,523 @@
+{
+  "description": "MC10_3_faulty_TestValsetDifferentAllSteps.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "8CFD9B169D02B800A45B6D7F291547A4DD13566DDF225A64B7CA8BF8051756FE",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "5B46CBA15BBC6D93D7E021B692726D3F240C7138BA85D3AD18FB02C2744A1F2B",
+          "part_set_header": {
+            "total": 1,
+            "hash": "5B46CBA15BBC6D93D7E021B692726D3F240C7138BA85D3AD18FB02C2744A1F2B"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "U12mHgHK9xSj2GO+YQyhnorbvPCeMLMZxCrFbkNQH/PLXFAbjBgx0tzbWIxNtyUR1RldICnGBnuahrgOY0XmBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "RR9FQvXSceQKNUg7joHEnXmBCLaSbxzKfh98sEgs+60B20pdXmg2JQvhI5CIzol3jgGYE2z01Q3Ub2yWKoVuBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "0pCCzoKLpyMH+ZsO0CmPTAVkR59eFPRjInam+vECHl7U45B0ZZOgC1cwpWTDfGyUrr9eMBpOI/44GKfhVUewBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Y8fLU/9nsRV4gxCYtYaJYW4V3mr8HyKRCTMYwrute8Tj/hrQLy778HYW/dBSqcjrBXJLYBL4p140U2takPOKBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "m6AAEZUUt4kkEe3rSNaaZFIvoRLz+VFUocc1k+EesDF6VoJXvFBhQFVWtmwfk0ajE9nRRIAzOPa7D8aKouGhAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Dl38rb9c2BbIaxXjBhcEgNQzpXfklvs36D0pQeH8nVFPeTQTbpCh5botRWP9mn7dqr048sQDiHdQn7GaNf1oDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "tp/72871dlGjzkjx+jTiebQoARr1m3vNXsDt7jaQYPnSlRq1LiTw8pp0bw2Js7CJL2B89nw7wygtFe+Cb/wGAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "i0KlOAmHLmoDwLfzkS12ai0eQmY8g9MuZqTAXFo65gyk3hR9zMngW10Xrsrdy9hWPbmNSPpdhcRyQxhCtZtkBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "n+ROEb0PGBGdzthvS1LlfGsK4TdgL7gZZJIFkXDDJ52IfhvWAIFIam2dWWdkutHfIuEFNa1HbjsscyjIkUlqCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "wYyyoydmDtLTct/wKLQHVdK77i3ww80Vf/F4DbjRN+7hw2By8/0dpLQgmAC99vk+llH1gWbcXydnRo6lj0TzDw=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:13:02.160336518Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "39DBA2010F7E16CC79EBAD61892C1B479DC95B9C904814E0A7C67756765EADA7",
+            "next_validators_hash": "D9D3DE97910E14CC1C23788445ECDA023B053AFDA13885D9F62499EE5484F523",
+            "consensus_hash": "39DBA2010F7E16CC79EBAD61892C1B479DC95B9C904814E0A7C67756765EADA7",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "B453C39AC5ACFDC9C9B48AC646439672D93EEC0310454D31B68416683AA58D11",
+              "part_set_header": {
+                "total": 1,
+                "hash": "B453C39AC5ACFDC9C9B48AC646439672D93EEC0310454D31B68416683AA58D11"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "0una0LdAbx/etjIzjQheDtAaTmfjjBn2xf21AKlj4RGEpUFFwtokDfGRRLu/czXmmMg39kZPSXsa5Sp5lJ4rCQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "uOcrEIXUNDiwTsY4cSWiG9OyZv92VfHydAXr49VnYvHoA8Fh+po8YXxoGdYGICDWYDRwYaKfDu9OWMpSivOvBA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "RR5GWOYxc8gp7KJuRK6PnffOw/ARRVkU/lrNGqqewd5AvDZc1k7SgyDmaqXFNLqJZC4DTPTjBgq06W92shlXCg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "8UWymbB96UuRcoSJRJdxYqb9rA9BAs4bJuXHMJjMckm437lHfZsbHaBee1fbrJjE74aCv374Ao3YifGkW3ItAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "v+cYGfrt1GqXTYZTWtAgeZIkoWRlFjDoxvefdz1vOpAhBADsef+11w0BF+D1Z8iVp6t8CXTFDhkk7dkMHXEFBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "eaRZA6xdBv/UUDw2KihPNieuZMg48gxiGTNre4kZ3cl0sMSp34bN4xbu5KwjFFllQxwk9Z1qj4rBY/IIEwfhBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "rG3ZOwMyjvGT/Hn2IOQIcBLwpGzR15m+v4VRpVgnPNTVXIN1NilceoducUKr7K5ikQ6QmjsEJYPkFXW0KG5cBw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:18Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "8CFD9B169D02B800A45B6D7F291547A4DD13566DDF225A64B7CA8BF8051756FE",
+            "next_validators_hash": "39DBA2010F7E16CC79EBAD61892C1B479DC95B9C904814E0A7C67756765EADA7",
+            "consensus_hash": "8CFD9B169D02B800A45B6D7F291547A4DD13566DDF225A64B7CA8BF8051756FE",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "C438A28DF9550C6842498D16E8B54A55D75627B97FEBFA935B965EF98C6E5DE3",
+              "part_set_header": {
+                "total": 1,
+                "hash": "C438A28DF9550C6842498D16E8B54A55D75627B97FEBFA935B965EF98C6E5DE3"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "0iZxh6SprHuRXPbmNzh1tbQgA8xzqzLFiqilQugQMO3JWTvYDnOqreg1otbATnAFsgMyS6weYFm+FwmXniLkBg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "12zk1Zq7NjK3RpBCpHJKi7Q5/ROobM7HQKKKZgE964y+3F+SrTDKelceGAG9VKlr2SRQLqWHTEFTvSdnAIlwAQ=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestValsetDoubles.json
+++ b/light/mbt/json/MC10_3_faulty_TestValsetDoubles.json
@@ -1,0 +1,421 @@
+{
+  "description": "MC10_3_faulty_TestValsetDoubles.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "A59D6F477071F643CF788692B97104F3E8E2B5C163DC88767D1092D6F19BC750",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "A358A91D8F8FA2B41CB83236A46B64DBFBA307D3D1831935E847140C5C2FA294",
+          "part_set_header": {
+            "total": 1,
+            "hash": "A358A91D8F8FA2B41CB83236A46B64DBFBA307D3D1831935E847140C5C2FA294"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "fdydZqVutodMRbqlLGV4k2GwhKTkATijZqS1IigJZyQOp5TzUaSOAfPOiu96tPh2zrAMjC99nKo9o5V34BXLDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Ws2EzTImIU2zpvAwrNIr2wIUA9XqUjeNSTeh/sbt4i4Xe1lsDLjPs8GJsJWN4QT1VKEqTCZQphqcM5yVbFN3BQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "9gnD/xiPGRye/+FqmBr1wJO5SsNvgoMKj07KYuNenW+yH7wgkf8/RN1V7tBoGeRHbzlcFXO9nSUV33+yZCpgCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Z3++vviIlSCT3wHuuNtxRQy2rh545vrtLcWz2msC8eu5JyZHwrvtT8ay+ev9C5vtV9JXUE2cU7B5/klw2Ll5Bw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "JYoRKc1hKltu027Hf0L4JFH1W98IPjjsiI/BJ4In+lXUck+HIM+rAo3TFLV+vHL762hYKKr8tDABV9299CiqAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "A6OrvY5EktasM8NOZy59a9pXSYXjO860jSH0neQtk1MZxytUFI1Qab2edVgRFkedqFxDCZ9d5TjGzU3fMeN5Bg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ldvQ1qSzd6EXoLzlp7/5/cLToCUxGmfftIKKww/VUAdLPoGduh32B/gH5wRWGYnlcp2KGNjvIfUC99J2QPQZAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "w3qDy9R3dk8sgHuXvcUeQ2u7l5KPwPBwvjeKM5zWNkBM+ZemwdIbGvV3OMskjlexMza1gvglvi9IWX4nRN0CAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "u1CoZi2XOFc5D5bqPG9k5PS5MWUZB3/G/hVAfzScq+s7PEnceNkfTHW+lYVT7SpfYgi7m8q2BeCiMxdAdfE0Bw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "wV/SjKjMFaVZ78ewOV522TDK8/BrNhjC5ok+TkZUDWvDBpw60et8eKg+mPWAcnHAsUxtHMCTQ0XRokR9NwXOAw=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:13:55.160336523Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "2741031AA03B47590836834106A5C0F29F0504A26D27504E17FEF676BCA0318D",
+            "next_validators_hash": "C6DA4BCE1E2784196B14187C8C0A110AF99749CEF7F93408F86250407FBA008B",
+            "consensus_hash": "2741031AA03B47590836834106A5C0F29F0504A26D27504E17FEF676BCA0318D",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "85823C47858916FB623E770B7FEB738489B7B243E88C8F732B7EA3263A0B5CFF",
+              "part_set_header": {
+                "total": 1,
+                "hash": "85823C47858916FB623E770B7FEB738489B7B243E88C8F732B7EA3263A0B5CFF"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "DYQHQqFYV3HZ1c4bMdmY/HtYT9EzjhtG3U/wir5t3iEEEOqok56qsnC3qXoDpjuG2d/ysqApQbMZO2mtfgssDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "KFXZf2jreJgegwa6h3csQXmyaa7s6JwkaYOf4pVZSD5UsQgJ+wJq3IRMN8nUJlaQ12tosNsqNRxoDp2maA5fAg=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "A59D6F477071F643CF788692B97104F3E8E2B5C163DC88767D1092D6F19BC750",
+            "next_validators_hash": "2741031AA03B47590836834106A5C0F29F0504A26D27504E17FEF676BCA0318D",
+            "consensus_hash": "A59D6F477071F643CF788692B97104F3E8E2B5C163DC88767D1092D6F19BC750",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "3AD79F236F419677560CF65CECC7A0EA59924D835618A77BA1410A1F3ADBD738",
+              "part_set_header": {
+                "total": 1,
+                "hash": "3AD79F236F419677560CF65CECC7A0EA59924D835618A77BA1410A1F3ADBD738"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "1yLJS8Pi+v2S1lwp/w1B1lRYGECP1tK/RdpAXKuxdtM9/JzuY+tbfCKsHqSwZ3dbx0uCWzsom4BUEiTPxMBrAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "TScOumvXKSryU9jOiReTdMMNNx3QwcFe+cNYkaTHMNokny9GWKlud9Y/5AWDobAnOjEtYmcEL/JUoXquN4BQDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "mzcxQo+2VxH4mypwoncVC3ffBqBWDQx7RTDDQtmnFhra7nVKRG4ngl4YTRF6rB+Y+0o0bR8Ypy5nArY76jTiCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "f/sfXcTG5joW/+NLwA18VCR9ODWeKmpwCdLjMOi2UadXgZU4KPyMTJCeJTrB29f/Er4X5uN5Ef2jzLE+j8bnDA=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC10_3_faulty_TestValsetHalves.json
+++ b/light/mbt/json/MC10_3_faulty_TestValsetHalves.json
@@ -1,0 +1,484 @@
+{
+  "description": "MC10_3_faulty_TestValsetHalves.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "next_validators_hash": "2B7DC338431405F14F29A5C2607CC3868B74BF26BE5DA459974FBFED333DC991",
+        "consensus_hash": "5C805BF3F94032D94639182AAC38872547ACE84871022EC9B68E8E8B946E691D",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "BBBE10BE8D668C66D9076583283CADA5CD1CEE9A3992C13BE5B45ADE960F8750",
+          "part_set_header": {
+            "total": 1,
+            "hash": "BBBE10BE8D668C66D9076583283CADA5CD1CEE9A3992C13BE5B45ADE960F8750"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "zArxZCXHoGJKmnAgvasl5dxaR7gmy+rhcrKxlleL9X5RTbN7wAwQ7JbklS4vBzgeAtEMBbM9KpK3OAQ42A31DQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "0GZ8YzNULsBWVGRkEp3o3rA5X6uZOoz9q9NBwUUMrRLbrRYWLoFP1hxNl0fdbL6ylpk1phA84Rb9HhU+a8GPDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "jeFrkKolWKSBku18Yii0YKpr58sS81ue5TbPN9PqcH0iGZ8Mfd3Gs4l7W/EODGNz3ABfEDeu/dkgvPcqZ5R7Bg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "5kfcT8zgMGYMc/jr4/mX4Qj/FBRkorU7RU0SEtUj08/2yaKaccy8mjKOV7hPmOoHt5U0CEE8Fj3yrJhidD0wCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "p6HB2u9WqIP2JEx9CDpvxIzPVYJZPodCOKjYKlRc8VKDLLqutWwzFjTCFqc0v37v4Yg6/tynw8UGO6bT2MHIAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "cCuCgjrbKMU/IhGnytqWxQmvG7M9wV9Y3f9rOwuoLvtpnHkO8beMKnrFOWZHIEgX5NYKnKMqmPGe0ImqV6A9AA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "brcegYga/dA8OfzwqFlcpC6wD5J4qM9B+5paOFs07VBA+NmFV+20SxEZe38U/ToCV17T9w1znm+opDNzqj9kDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "vo+EYYlRplNQ6PDNxH3gKYM0w3/KFAqOmKpDPicHA0KWsWOy0u7mf8+JIvh/085vOplvS3CVO/laZICKvmlqBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "j1Las3ABGJ+FP5nWXzEpWSbfpskx4im58K0GDjOmCwqzV+zCTg9bYc/SRL48DEhzXFiBnn1UmCsSVC4fP99uDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ue+gmdF58TwTmZoUFjxtGloi86tjs6qAly5gXmLf7V34PY34mLB/WLxYDIak4kvXksVh2mMqbxJ1m7YgCAB1Ag=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:14:04.160336524Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:04Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "C3FC03232DCB5AD88E0EAD7E8B58881B17CE8EEF457C23881DC95E0C2B4A2F6B",
+            "next_validators_hash": "15D757EBE103766843DFBDB3070DF7FB281A4CCD9668A5111E0E6992D0C217CB",
+            "consensus_hash": "C3FC03232DCB5AD88E0EAD7E8B58881B17CE8EEF457C23881DC95E0C2B4A2F6B",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "6C2B05122235056F5F1D21B125A6BC5A52D6007C64069E174F12866F26D15DAB",
+              "part_set_header": {
+                "total": 1,
+                "hash": "6C2B05122235056F5F1D21B125A6BC5A52D6007C64069E174F12866F26D15DAB"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "kuIr0BPhrLpR/ZACWu8EUmi7+qzs1xOIt/zXnEpV/2+LSfegYSdns7s3kbw2BxvpYi/rw9H+WU+BXHJDPACKBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "1MsB5fCTBQAV8aAOAGVFoVS/Y/BIX54v88u0Nl1dCST6yRYJ9rONQqr9rxbNgVwPhv5GiPPzztVwbutllwRdBQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "6wSU46NHBlt2R6whMxzfCdTRSk2kgI1yml3w1OXKO31mSqEWym+uE33CenupXGHS1kj9EQtoBdW+JLzOJJ/YDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "sOQn7c/HRkAzRiTJRoZ4vU7QvkIdLu2OOdj40xp5wr+kD+emNRzhGBIiZDJOo3zDr4UNdsWM7eaYn2LD5X2ZDw=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "2B7DC338431405F14F29A5C2607CC3868B74BF26BE5DA459974FBFED333DC991",
+            "next_validators_hash": "C3FC03232DCB5AD88E0EAD7E8B58881B17CE8EEF457C23881DC95E0C2B4A2F6B",
+            "consensus_hash": "2B7DC338431405F14F29A5C2607CC3868B74BF26BE5DA459974FBFED333DC991",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "146BFB9B87B6C26C3C73743E0B3819B475A2EBA0310AA09E45055E079D47BE50",
+              "part_set_header": {
+                "total": 1,
+                "hash": "146BFB9B87B6C26C3C73743E0B3819B475A2EBA0310AA09E45055E079D47BE50"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "uCOE2s3yY77cPFUFtgeECW80zquYyLLJ6NBFm5mLyjWPqp8DNxVM6ocQ/ihThEKn7Q1Vr8HQ4Gw/0mJIFmXoBg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "8HgtkOeKRb4kQqdVYgc7KcClFJ411EXfu50FgII7hErRJWaQ2ACt2DjbJ8S2vlw4E/U9HeaD4SFw8Qm+N+ycAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "FGeh6MSq5W/34eEIN6qXuUjnd53h4C7SIhalnoh/UCt9YPTsqrRasaMLdSGsJKW6fWNIFa9tZKJodL8qqgDHBA=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/mbt/json/MC4_4_faulty_Test2NotEnoughTrustFailure.json
+++ b/light/mbt/json/MC4_4_faulty_Test2NotEnoughTrustFailure.json
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+        "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "0D038B1BA2ED7B1EF4D4E250C54D3F8D7186068658FAA53900CA83F4280B1EF2",
+          "hash": "C106084B050BDCC5AEBC414628992E43B6216544E19826BAB46027350C5FD3C5",
           "part_set_header": {
             "total": 1,
-            "hash": "0D038B1BA2ED7B1EF4D4E250C54D3F8D7186068658FAA53900CA83F4280B1EF2"
+            "hash": "C106084B050BDCC5AEBC414628992E43B6216544E19826BAB46027350C5FD3C5"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "XJC+kaVazdli/oMNHnFQOujOJLxFnez2DAUv5Uy+wPGeypkinrk2c79ZmlB5YHBTJaLh6yotq1XiLzy3zUAJAQ=="
+            "signature": "q0CS2J0SFpdIVuqaHEmdp8epPcZli61bfVkdA720J+TzJ06ahepHUry6P/ZD+ex6GuQcSjBP6mfzp0ksjqf3BQ=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "pj86O2mwAQcn/MggMVEK1F6yhqnaMcxqxKyZ9DgIfFVqJIgQLb5SsuqyxPcMxxRhDTjjqfkATRGIiHPEthrFCQ=="
+            "signature": "jKDmxZTfFv5xlj3byRSxV8gMDQUirQE4O8hPKvp9EvmIWwCX1S7D/qQo+GhCvfiF3QPdQ3kRCpdvwrTuq+6RBA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "QssWTiluThPYflhI3bBuoeIBXlMR39I+vJb7EvLf6FVyxp0Ih7kW26wkmqjgHf0RyDAu9sny3FBrc/WbPXhFDQ=="
+            "signature": "AL2jwdkeW/o9DjLU3vfcqKG9QCqnhKxdPN4i/miR6FIA87v4Y45jFvZw8Ue6hhwkGKs3d1QghJXVlRJFg8VXDw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "9xg3G66gizJBzWybdYKRtyg8c52U6vKmUT9TKb5MQ5MP/6IVCbhnvUjzw4Oe5stsnHMGvsx6Q7IVS3Ma7CbBDA=="
+            "signature": "gV5npKv90ghI2wj2MP06qkVyWTbjBwBzdQnBS3ssggEE+is/BRMQQfKEKpmTAF0KIS+eZj7jmj8b+isxC3QfDw=="
           }
         ]
       }
@@ -62,10 +62,10 @@
     "next_validator_set": {
       "validators": [
         {
-          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
           "pub_key": {
             "type": "tendermint/PubKeyEd25519",
-            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
           },
           "voting_power": "50",
           "proposer_priority": null
@@ -73,7 +73,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-21T08:45:28.160326992Z"
+    "now": "2020-10-22T11:25:32.160336593Z"
   },
   "input": [
     {
@@ -85,86 +85,13 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "4",
+            "height": "5",
             "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
-          },
-          "commit": {
-            "height": "4",
-            "round": 1,
-            "block_id": {
-              "hash": "734FC4AE3FEEAD34654D611A867E3A4F2F921DD2B8F27289EFC52C90EFC2B8D8",
-              "part_set_header": {
-                "total": 1,
-                "hash": "734FC4AE3FEEAD34654D611A867E3A4F2F921DD2B8F27289EFC52C90EFC2B8D8"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "x7RNTkbf71fnTEyl7G6i8U5gi33nWZLha1nbZJjsIsbm7CCxcfsgU4uTWaHrZXCo1Ywok9zXgt0gaGOt7uR+BA=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:18Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "3",
-            "time": "1970-01-01T00:00:03Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
             "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "next_validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
             "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
             "app_hash": "",
             "last_results_hash": null,
@@ -172,21 +99,21 @@
             "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
           },
           "commit": {
-            "height": "3",
+            "height": "5",
             "round": 1,
             "block_id": {
-              "hash": "E60D3DC5A38CE0773BF911BE62514F5FE6C12FA574F0571965E8EDE2D8899C01",
+              "hash": "A15CC71ADF04AFF14EF25C3D05DB38EC2BCA1C18CFC59C6B9A86A7B2AF661FED",
               "part_set_header": {
                 "total": 1,
-                "hash": "E60D3DC5A38CE0773BF911BE62514F5FE6C12FA574F0571965E8EDE2D8899C01"
+                "hash": "A15CC71ADF04AFF14EF25C3D05DB38EC2BCA1C18CFC59C6B9A86A7B2AF661FED"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "L5MQUXKrrRk9I/wnx3Pai49qFdzSkkYRzM9eO7gOI5ofG2LaJoDMttkCKp2kp9/3koSWssnX+/Uuvy62XU/hCA=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "WFsCEwmYKtUhlrtlOoJWgOcF7xfPm20ktNZ1CIbAZcNSl7QtGauNAkyWIdcFf7UHUp2KRKqOep2yQrFX5hlVCw=="
               }
             ]
           }
@@ -206,6 +133,15 @@
         },
         "next_validator_set": {
           "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
             {
               "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
@@ -231,41 +167,35 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "2",
-            "time": "1970-01-01T00:00:02Z",
+            "height": "4",
+            "time": "1970-01-01T00:00:05Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "consensus_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
           },
           "commit": {
-            "height": "2",
+            "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "2EA87BC69EB6739C5A1E06BCA5E7C9B8A5C163EB1ECF01EDD1A4A9B167C313C5",
+              "hash": "B62316BBBDC510C9DB039B7E766DEEF16A2009C08A9DA7E46C4FD282DAEF4384",
               "part_set_header": {
                 "total": 1,
-                "hash": "2EA87BC69EB6739C5A1E06BCA5E7C9B8A5C163EB1ECF01EDD1A4A9B167C313C5"
+                "hash": "B62316BBBDC510C9DB039B7E766DEEF16A2009C08A9DA7E46C4FD282DAEF4384"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:02Z",
-                "signature": "bSYYr6R4pu+tcq8ji6Jnnf5EkMPcCImyROgN16KNQxzvw82fLVQ2C+E3Ry9vEV86G0fQBaxL6SFd8xers7zzDw=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:02Z",
-                "signature": "jlxTNsZ8h1uyVjWndZrvBAZpAonQhfSoC/MZSwWb0tIgpJ4/YlqUQZoRnr+QsV5btJfpDeknFD++5LAjUcsrDg=="
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "oTuYllfHkpJ0m5GqIgMMEaYAVQN2FO2M9SRkPxJwnbx8YJlz7KizK3YL3ug2jj7JS83TjjoPg383Oj4IIaJaBA=="
               }
             ]
           }
@@ -273,10 +203,83 @@
         "validator_set": {
           "validators": [
             {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:18Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "4",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+          },
+          "commit": {
+            "height": "4",
+            "round": 1,
+            "block_id": {
+              "hash": "076B61062F37241CEA8B4D49F51998C9ED6D642F7E3FA5F03DE5AE945217E2FA",
+              "part_set_header": {
+                "total": 1,
+                "hash": "076B61062F37241CEA8B4D49F51998C9ED6D642F7E3FA5F03DE5AE945217E2FA"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -298,7 +301,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:22Z",
+      "now": "1970-01-01T00:23:21Z",
       "verdict": "INVALID"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_Test3NotEnoughTrustFailure.json
+++ b/light/mbt/json/MC4_4_faulty_Test3NotEnoughTrustFailure.json
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
+        "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "F7DC6F348F04E01EC7DEA4348A3BFA2F0D7533900986EA66F6006C70BDD52D2E",
+          "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D",
           "part_set_header": {
             "total": 1,
-            "hash": "F7DC6F348F04E01EC7DEA4348A3BFA2F0D7533900986EA66F6006C70BDD52D2E"
+            "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "S5wM4flAsMJ7uGSGduppmUqDeFZBUBFKkp+LTy249+AgM3oup9ULs7eUzNiwjhV4gWnPnLJ91m6IZ3s047xzAg=="
+            "signature": "8rGIxi7DjBLFlHUo/lAgTpmzsnTZ8HOgnQaIoe+HEM5AmrjBaVDWVMb5/nNAnJTj4hcReCh4jviXcyRkItFJCA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "ZLOGEO5mgrVoTpFA5DLMLX0ggBWnWLWmMF5tAorZC732T+oR2u2USAvGhkZtpM73WN3NUp04aVHInGMsYtz9Dg=="
+            "signature": "3cXnzhzJLKeF47ulcIWjgqsv9JBf9olbAo0mcjo7Ij6TfmCpJO6SmTiacBkiznsFSOc1ZSH+cHDBKA4AT7ozAg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "Lwa9l7+dJci4+mXD9ZsvLnbX0TuzWYIjfj9vU51rAftFRGEig7DHToufWaMfjwGMN53WrG72YfHAXxBigWaBBg=="
+            "signature": "4O8c5hxoHR861ldolxeY9W1iXCdxYJVIf0xD3+sANSxo0ipXayv8IS7YFw1zzZvDbjRRazVzbfyBYf2jl4JeDw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "SSHBm3HdeyC1fgPqjTp647mRGxaCKA/GGraM0UFcuXv3mUjfjowL8CNjthJHgXIQCmYdF0HDwLZb1SCvWFe0Aw=="
+            "signature": "2Hel7uygQXpjYRJZiwtPLKNxT2Tg1/F5Zzs3VZpleFII9H1e5Gs02UjU0lybSXBKk/tD+NXPsdchrH/6/DmwAQ=="
           }
         ]
       }
@@ -87,11 +87,20 @@
           },
           "voting_power": "50",
           "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
         }
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-21T08:46:51.160327001Z"
+    "now": "2020-10-22T11:26:32.160336599Z"
   },
   "input": [
     {
@@ -104,7 +113,7 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:07Z",
+            "time": "1970-01-01T00:00:09Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
@@ -120,18 +129,18 @@
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "A63EEADF3FB32E33B113FF28726100E2ACA295E7C467005BF35FB43ADC0D53C8",
+              "hash": "6F48485E60111E43C4DE038BB9CDD44564C93D71C116EC185DA1CA51284D6B9A",
               "part_set_header": {
                 "total": 1,
-                "hash": "A63EEADF3FB32E33B113FF28726100E2ACA295E7C467005BF35FB43ADC0D53C8"
+                "hash": "6F48485E60111E43C4DE038BB9CDD44564C93D71C116EC185DA1CA51284D6B9A"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:07Z",
-                "signature": "lDmtsNALIr3ZysmMkrYW5jPufVGQcR7U2rpGFwJfFeTQSohqm9yVjzLVeGsPZFjdmGUltxwi7nH63iIIjl7VCg=="
+                "timestamp": "1970-01-01T00:00:09Z",
+                "signature": "/8/bkz5DU3ECIvx8UHRTNOetutPcz4RVPoJR/9iCMS1jlPI7jjGGK4n/+6uLx+MVqF5TPEq8HN0+G/tQUY+JBw=="
               }
             ]
           }
@@ -164,7 +173,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:08Z",
+      "now": "1970-01-01T00:00:11Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -177,34 +186,34 @@
             },
             "chain_id": "test-chain",
             "height": "3",
-            "time": "1970-01-01T00:00:07Z",
+            "time": "1970-01-01T00:00:10Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
-            "next_validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
-            "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "consensus_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
           },
           "commit": {
             "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "13C32ED0F2BED33E19B4832CEEB6F949E822449F770B9B3A7F02254F391B7CD0",
+              "hash": "2C5A95A0A97CC5A06903124554FEEA2A38FB4AAF2B5A4D4F72B987F1ABC12D6C",
               "part_set_header": {
                 "total": 1,
-                "hash": "13C32ED0F2BED33E19B4832CEEB6F949E822449F770B9B3A7F02254F391B7CD0"
+                "hash": "2C5A95A0A97CC5A06903124554FEEA2A38FB4AAF2B5A4D4F72B987F1ABC12D6C"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:07Z",
-                "signature": "KZ0VUajBcnvw1Lp7DnYFGTPt6sstretUcfMY9nkszfQtvcJ1x4sFvJ/D0LWkpsNVMtNSWYobw+gfETQLVbmAAQ=="
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:10Z",
+                "signature": "271CyAAOmTQ9Vdsx5ijke+XMNDrbIW/0FPWNVzNRHlMX7Fo6PcBajxHO+sP5fMy9QbAidM6gFJntcJjGFKw8Aw=="
               }
             ]
           }
@@ -212,10 +221,10 @@
         "validator_set": {
           "validators": [
             {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -224,15 +233,6 @@
         },
         "next_validator_set": {
           "validators": [
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
@@ -246,7 +246,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:09Z",
+      "now": "1970-01-01T00:00:14Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -259,13 +259,13 @@
             },
             "chain_id": "test-chain",
             "height": "2",
-            "time": "1970-01-01T00:00:03Z",
+            "time": "1970-01-01T00:00:06Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
-            "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-            "consensus_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
+            "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "next_validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
@@ -275,66 +275,41 @@
             "height": "2",
             "round": 1,
             "block_id": {
-              "hash": "E98C8412BF8736722EEBFF209C5D0AB9F82B599344D043139B4D4747E1FF21EE",
+              "hash": "3639909017CD7FDC732E5B3F5A613A9CDBBB47F32D4A53A7876377C17D926CA0",
               "part_set_header": {
                 "total": 1,
-                "hash": "E98C8412BF8736722EEBFF209C5D0AB9F82B599344D043139B4D4747E1FF21EE"
+                "hash": "3639909017CD7FDC732E5B3F5A613A9CDBBB47F32D4A53A7876377C17D926CA0"
               }
             },
             "signatures": [
               {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "V2LEkvNw6vwCh5t/eTqOE0QMnRveeNV6nS9bqAD8S/dDtVnzUTwfwEgEHPwPFJDkszVkZ/9pqoKTInoO2bsHAg=="
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "AyDrm3XpFjB1OWJdYegH3dYp+Q9ZXV/kAstddVzpvU4pL187Tad2bNMqcgoroTiwaCWC7jtOrHd4l8Tq5myjDA=="
+                "timestamp": "1970-01-01T00:00:06Z",
+                "signature": "PCBYbquWPkoB07j3l7sBtwNu00foKi+AV/G29aL/tU5HCOIAFw/zuMuFFW6a4E4QnNoZ6GAkEzGmSVdHu3+dDQ=="
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "cyQzNOgKd1OKNQJChG/E0pk9+fZ4p8bIpAqD5oZy0xT+e1DywIVUVDx0LBqbfm38C4djq3klKMvTUwTcDypCDQ=="
+                "timestamp": "1970-01-01T00:00:06Z",
+                "signature": "+qZqoihw+tA2SCW8oprua2P5MgH8KQXgowqbgMNhasUF7Ym6vmDIMLjB3cVtzCjyV6fxUlzip2PvrssB1RcpBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:06Z",
+                "signature": "MBXgP2XFKh2ExpTrixEnegQs+cUyIp/Q3G9YenuHOGmGM0J10DtRP0gKvEojXu4tZ3PIJMd2rBvqgtZE3nydDg=="
               }
             ]
           }
         },
         "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
           "validators": [
             {
               "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
@@ -374,9 +349,31 @@
             }
           ]
         },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:09Z",
+      "now": "1970-01-01T00:23:20Z",
       "verdict": "SUCCESS"
     },
     {
@@ -389,7 +386,7 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:07Z",
+            "time": "1970-01-01T00:00:09Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
@@ -405,18 +402,18 @@
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "A63EEADF3FB32E33B113FF28726100E2ACA295E7C467005BF35FB43ADC0D53C8",
+              "hash": "6F48485E60111E43C4DE038BB9CDD44564C93D71C116EC185DA1CA51284D6B9A",
               "part_set_header": {
                 "total": 1,
-                "hash": "A63EEADF3FB32E33B113FF28726100E2ACA295E7C467005BF35FB43ADC0D53C8"
+                "hash": "6F48485E60111E43C4DE038BB9CDD44564C93D71C116EC185DA1CA51284D6B9A"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:07Z",
-                "signature": "lDmtsNALIr3ZysmMkrYW5jPufVGQcR7U2rpGFwJfFeTQSohqm9yVjzLVeGsPZFjdmGUltxwi7nH63iIIjl7VCg=="
+                "timestamp": "1970-01-01T00:00:09Z",
+                "signature": "/8/bkz5DU3ECIvx8UHRTNOetutPcz4RVPoJR/9iCMS1jlPI7jjGGK4n/+6uLx+MVqF5TPEq8HN0+G/tQUY+JBw=="
               }
             ]
           }
@@ -449,7 +446,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:09Z",
+      "now": "1970-01-01T00:23:20Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -462,34 +459,34 @@
             },
             "chain_id": "test-chain",
             "height": "3",
-            "time": "1970-01-01T00:00:07Z",
+            "time": "1970-01-01T00:00:10Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
-            "next_validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
-            "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "consensus_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
           },
           "commit": {
             "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "13C32ED0F2BED33E19B4832CEEB6F949E822449F770B9B3A7F02254F391B7CD0",
+              "hash": "2C5A95A0A97CC5A06903124554FEEA2A38FB4AAF2B5A4D4F72B987F1ABC12D6C",
               "part_set_header": {
                 "total": 1,
-                "hash": "13C32ED0F2BED33E19B4832CEEB6F949E822449F770B9B3A7F02254F391B7CD0"
+                "hash": "2C5A95A0A97CC5A06903124554FEEA2A38FB4AAF2B5A4D4F72B987F1ABC12D6C"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:07Z",
-                "signature": "KZ0VUajBcnvw1Lp7DnYFGTPt6sstretUcfMY9nkszfQtvcJ1x4sFvJ/D0LWkpsNVMtNSWYobw+gfETQLVbmAAQ=="
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:10Z",
+                "signature": "271CyAAOmTQ9Vdsx5ijke+XMNDrbIW/0FPWNVzNRHlMX7Fo6PcBajxHO+sP5fMy9QbAidM6gFJntcJjGFKw8Aw=="
               }
             ]
           }
@@ -497,10 +494,10 @@
         "validator_set": {
           "validators": [
             {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -509,15 +506,6 @@
         },
         "next_validator_set": {
           "validators": [
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
@@ -531,7 +519,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:09Z",
+      "now": "1970-01-01T00:23:30Z",
       "verdict": "INVALID"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_Test3NotEnoughTrustSuccess.json
+++ b/light/mbt/json/MC4_4_faulty_Test3NotEnoughTrustSuccess.json
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+        "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "C106084B050BDCC5AEBC414628992E43B6216544E19826BAB46027350C5FD3C5",
+          "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D",
           "part_set_header": {
             "total": 1,
-            "hash": "C106084B050BDCC5AEBC414628992E43B6216544E19826BAB46027350C5FD3C5"
+            "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D"
           }
         },
         "signatures": [
@@ -36,31 +36,58 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "q0CS2J0SFpdIVuqaHEmdp8epPcZli61bfVkdA720J+TzJ06ahepHUry6P/ZD+ex6GuQcSjBP6mfzp0ksjqf3BQ=="
+            "signature": "8rGIxi7DjBLFlHUo/lAgTpmzsnTZ8HOgnQaIoe+HEM5AmrjBaVDWVMb5/nNAnJTj4hcReCh4jviXcyRkItFJCA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "jKDmxZTfFv5xlj3byRSxV8gMDQUirQE4O8hPKvp9EvmIWwCX1S7D/qQo+GhCvfiF3QPdQ3kRCpdvwrTuq+6RBA=="
+            "signature": "3cXnzhzJLKeF47ulcIWjgqsv9JBf9olbAo0mcjo7Ij6TfmCpJO6SmTiacBkiznsFSOc1ZSH+cHDBKA4AT7ozAg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "AL2jwdkeW/o9DjLU3vfcqKG9QCqnhKxdPN4i/miR6FIA87v4Y45jFvZw8Ue6hhwkGKs3d1QghJXVlRJFg8VXDw=="
+            "signature": "4O8c5hxoHR861ldolxeY9W1iXCdxYJVIf0xD3+sANSxo0ipXayv8IS7YFw1zzZvDbjRRazVzbfyBYf2jl4JeDw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "gV5npKv90ghI2wj2MP06qkVyWTbjBwBzdQnBS3ssggEE+is/BRMQQfKEKpmTAF0KIS+eZj7jmj8b+isxC3QfDw=="
+            "signature": "2Hel7uygQXpjYRJZiwtPLKNxT2Tg1/F5Zzs3VZpleFII9H1e5Gs02UjU0lybSXBKk/tD+NXPsdchrH/6/DmwAQ=="
           }
         ]
       }
     },
     "next_validator_set": {
       "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
         {
           "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
           "pub_key": {
@@ -73,7 +100,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-21T08:46:06.160326996Z"
+    "now": "2020-10-22T11:26:09.160336596Z"
   },
   "input": [
     {
@@ -86,55 +113,40 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:05Z",
+            "time": "1970-01-01T00:00:07Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
-            "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-            "consensus_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
+            "validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "next_validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "consensus_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
           },
           "commit": {
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "EED66C25F857A3DA1443411CCB93DD943574A8A55F55C8E2248A129E270F9BE3",
+              "hash": "1A64CD99D98722FE7696A2DB6FB7700871F50A4A7CE5CDB6260D9E4FBE70DC85",
               "part_set_header": {
                 "total": 1,
-                "hash": "EED66C25F857A3DA1443411CCB93DD943574A8A55F55C8E2248A129E270F9BE3"
+                "hash": "1A64CD99D98722FE7696A2DB6FB7700871F50A4A7CE5CDB6260D9E4FBE70DC85"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "/GSuwjyWvPmjmcCtrg+00QmcjerrnGZueyLJvAJxhJ5gumkVvCvXB05HDoHL0D523nJHR9hMBOFMA+7cywRoCA=="
-              },
-              {
-                "block_id_flag": 2,
                 "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "wrXQ0BgJMF8EV+CWmmGersvCF9RI6/qbhBPxgAcLixV65N8RiWGba+sCfr9UHjHAEYsCsyFgQR2OLC7Bg1PKBA=="
+                "timestamp": "1970-01-01T00:00:07Z",
+                "signature": "/Ttmssppy/A/3xK1CkRjcHTTi38wXz668aoIasCZA7RdXutIFWmYbpdwYZAViuCyrYYGQyRyu5UgbcQmtZFtAQ=="
               }
             ]
           }
         },
         "validator_set": {
           "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
@@ -149,28 +161,10 @@
         "next_validator_set": {
           "validators": [
             {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
                 "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -188,7 +182,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:06Z",
+      "now": "1970-01-01T00:00:10Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -201,94 +195,12 @@
             },
             "chain_id": "test-chain",
             "height": "3",
-            "time": "1970-01-01T00:00:04Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "next_validators_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
-            "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
-          },
-          "commit": {
-            "height": "3",
-            "round": 1,
-            "block_id": {
-              "hash": "0E61042148BB059117B880E371AEC93341630D01E665088844BC1D8DFA5B6B23",
-              "part_set_header": {
-                "total": 1,
-                "hash": "0E61042148BB059117B880E371AEC93341630D01E665088844BC1D8DFA5B6B23"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "e/kNbh2aUmnowrri9eWLo9Wf1ZuPS1cobu+ITfz0uFn8LZcQtrQXkB7sfRrTDfRGvOkm3CpWnxD+UeQTxa12CQ=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:00:07Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "2",
-            "time": "1970-01-01T00:00:02Z",
+            "time": "1970-01-01T00:00:06Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
             "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
-            "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
             "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
             "app_hash": "",
             "last_results_hash": null,
@@ -296,21 +208,21 @@
             "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
           },
           "commit": {
-            "height": "2",
+            "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "FE0A34650DA8A9402EA231A4D03FD1F39E0D7F894456D7268A582244FB968605",
+              "hash": "C3F1F20ADE479509807601A92D8EC33462D5D41EFE6E05618EE16F13BF89269A",
               "part_set_header": {
                 "total": 1,
-                "hash": "FE0A34650DA8A9402EA231A4D03FD1F39E0D7F894456D7268A582244FB968605"
+                "hash": "C3F1F20ADE479509807601A92D8EC33462D5D41EFE6E05618EE16F13BF89269A"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:02Z",
-                "signature": "aVeQWMH20B1IGFIwH50HDv3qrDsvbuCuco918Spc/nHc06YJ9LYLSvo8gd7g4EoCY71eRLwPLOoHXk8Nas+XAw=="
+                "timestamp": "1970-01-01T00:00:06Z",
+                "signature": "Uw+4g0UHbLBb+nm7kcfVUTLwSopLUptTfLgRDrNxMNtKDB715Kf4SpyzO69z4aRetP8hnXrZ5lubYjwHhTneCg=="
               }
             ]
           }
@@ -331,10 +243,10 @@
         "next_validator_set": {
           "validators": [
             {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -343,7 +255,125 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:08Z",
+      "now": "1970-01-01T00:00:10Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:05Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "9C90F15650D93F6A4B49E40665C3E13140004DC77942D56E021D2796D0578734",
+              "part_set_header": {
+                "total": 1,
+                "hash": "9C90F15650D93F6A4B49E40665C3E13140004DC77942D56E021D2796D0578734"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "FvbM+oLqoLq9WftCXaA/IZO3wK3FL5k2dM3gy0JVbKnto8MwpEqoZ7FhxJC3D3BbzkssXwch6jl1RflCMjLsCQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "fOWQExg/fFpJTqGvZVQCdi+TieWdPZ9HAsiP3GVBfICzzSX63KsUuqeMgRMftRThwNVH2wwsjhP9Mm4ATbRWDw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "SRvxnKtIuNRiK4bxFk8yOMsisJAg/P0gQQlrXTHSXVhk0XvPhMPSDQFVMy0q4shMBDrI1dVM762EDJehWlN/Bw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "QWk8Zkqo4LOSsCbCBm9FSNf9/ztBKwoYk0u0h185FGGmBMDe5K/s4k9Va6xG5CD4CxH3Y+y8+vTmJ0+VCZL2Bg=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:12Z",
       "verdict": "SUCCESS"
     },
     {
@@ -356,55 +386,40 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:05Z",
+            "time": "1970-01-01T00:00:07Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
-            "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-            "consensus_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
+            "validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "next_validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "consensus_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
           },
           "commit": {
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "EED66C25F857A3DA1443411CCB93DD943574A8A55F55C8E2248A129E270F9BE3",
+              "hash": "1A64CD99D98722FE7696A2DB6FB7700871F50A4A7CE5CDB6260D9E4FBE70DC85",
               "part_set_header": {
                 "total": 1,
-                "hash": "EED66C25F857A3DA1443411CCB93DD943574A8A55F55C8E2248A129E270F9BE3"
+                "hash": "1A64CD99D98722FE7696A2DB6FB7700871F50A4A7CE5CDB6260D9E4FBE70DC85"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "/GSuwjyWvPmjmcCtrg+00QmcjerrnGZueyLJvAJxhJ5gumkVvCvXB05HDoHL0D523nJHR9hMBOFMA+7cywRoCA=="
-              },
-              {
-                "block_id_flag": 2,
                 "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "wrXQ0BgJMF8EV+CWmmGersvCF9RI6/qbhBPxgAcLixV65N8RiWGba+sCfr9UHjHAEYsCsyFgQR2OLC7Bg1PKBA=="
+                "timestamp": "1970-01-01T00:00:07Z",
+                "signature": "/Ttmssppy/A/3xK1CkRjcHTTi38wXz668aoIasCZA7RdXutIFWmYbpdwYZAViuCyrYYGQyRyu5UgbcQmtZFtAQ=="
               }
             ]
           }
         },
         "validator_set": {
           "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
@@ -419,28 +434,10 @@
         "next_validator_set": {
           "validators": [
             {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
                 "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -458,7 +455,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:08Z",
+      "now": "1970-01-01T00:23:24Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -471,34 +468,34 @@
             },
             "chain_id": "test-chain",
             "height": "3",
-            "time": "1970-01-01T00:00:04Z",
+            "time": "1970-01-01T00:00:06Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "next_validators_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
-            "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+            "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
           },
           "commit": {
             "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "0E61042148BB059117B880E371AEC93341630D01E665088844BC1D8DFA5B6B23",
+              "hash": "C3F1F20ADE479509807601A92D8EC33462D5D41EFE6E05618EE16F13BF89269A",
               "part_set_header": {
                 "total": 1,
-                "hash": "0E61042148BB059117B880E371AEC93341630D01E665088844BC1D8DFA5B6B23"
+                "hash": "C3F1F20ADE479509807601A92D8EC33462D5D41EFE6E05618EE16F13BF89269A"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "e/kNbh2aUmnowrri9eWLo9Wf1ZuPS1cobu+ITfz0uFn8LZcQtrQXkB7sfRrTDfRGvOkm3CpWnxD+UeQTxa12CQ=="
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:06Z",
+                "signature": "Uw+4g0UHbLBb+nm7kcfVUTLwSopLUptTfLgRDrNxMNtKDB715Kf4SpyzO69z4aRetP8hnXrZ5lubYjwHhTneCg=="
               }
             ]
           }
@@ -506,10 +503,10 @@
         "validator_set": {
           "validators": [
             {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -518,15 +515,6 @@
         },
         "next_validator_set": {
           "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
@@ -540,7 +528,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:08Z",
+      "now": "1970-01-01T00:23:24Z",
       "verdict": "SUCCESS"
     },
     {
@@ -553,55 +541,40 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:05Z",
+            "time": "1970-01-01T00:00:07Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
-            "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-            "consensus_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
+            "validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "next_validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "consensus_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
           },
           "commit": {
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "EED66C25F857A3DA1443411CCB93DD943574A8A55F55C8E2248A129E270F9BE3",
+              "hash": "1A64CD99D98722FE7696A2DB6FB7700871F50A4A7CE5CDB6260D9E4FBE70DC85",
               "part_set_header": {
                 "total": 1,
-                "hash": "EED66C25F857A3DA1443411CCB93DD943574A8A55F55C8E2248A129E270F9BE3"
+                "hash": "1A64CD99D98722FE7696A2DB6FB7700871F50A4A7CE5CDB6260D9E4FBE70DC85"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "/GSuwjyWvPmjmcCtrg+00QmcjerrnGZueyLJvAJxhJ5gumkVvCvXB05HDoHL0D523nJHR9hMBOFMA+7cywRoCA=="
-              },
-              {
-                "block_id_flag": 2,
                 "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "wrXQ0BgJMF8EV+CWmmGersvCF9RI6/qbhBPxgAcLixV65N8RiWGba+sCfr9UHjHAEYsCsyFgQR2OLC7Bg1PKBA=="
+                "timestamp": "1970-01-01T00:00:07Z",
+                "signature": "/Ttmssppy/A/3xK1CkRjcHTTi38wXz668aoIasCZA7RdXutIFWmYbpdwYZAViuCyrYYGQyRyu5UgbcQmtZFtAQ=="
               }
             ]
           }
         },
         "validator_set": {
           "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
@@ -616,28 +589,10 @@
         "next_validator_set": {
           "validators": [
             {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
                 "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -655,7 +610,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:08Z",
+      "now": "1970-01-01T00:23:24Z",
       "verdict": "SUCCESS"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestEmptyCommitEmptyValset.json
+++ b/light/mbt/json/MC4_4_faulty_TestEmptyCommitEmptyValset.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_TestHeaderFromFuture.json",
+  "description": "MC4_4_faulty_TestEmptyCommitEmptyValset.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+        "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D",
+          "hash": "C106084B050BDCC5AEBC414628992E43B6216544E19826BAB46027350C5FD3C5",
           "part_set_header": {
             "total": 1,
-            "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D"
+            "hash": "C106084B050BDCC5AEBC414628992E43B6216544E19826BAB46027350C5FD3C5"
           }
         },
         "signatures": [
@@ -36,58 +36,31 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "8rGIxi7DjBLFlHUo/lAgTpmzsnTZ8HOgnQaIoe+HEM5AmrjBaVDWVMb5/nNAnJTj4hcReCh4jviXcyRkItFJCA=="
+            "signature": "q0CS2J0SFpdIVuqaHEmdp8epPcZli61bfVkdA720J+TzJ06ahepHUry6P/ZD+ex6GuQcSjBP6mfzp0ksjqf3BQ=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "3cXnzhzJLKeF47ulcIWjgqsv9JBf9olbAo0mcjo7Ij6TfmCpJO6SmTiacBkiznsFSOc1ZSH+cHDBKA4AT7ozAg=="
+            "signature": "jKDmxZTfFv5xlj3byRSxV8gMDQUirQE4O8hPKvp9EvmIWwCX1S7D/qQo+GhCvfiF3QPdQ3kRCpdvwrTuq+6RBA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "4O8c5hxoHR861ldolxeY9W1iXCdxYJVIf0xD3+sANSxo0ipXayv8IS7YFw1zzZvDbjRRazVzbfyBYf2jl4JeDw=="
+            "signature": "AL2jwdkeW/o9DjLU3vfcqKG9QCqnhKxdPN4i/miR6FIA87v4Y45jFvZw8Ue6hhwkGKs3d1QghJXVlRJFg8VXDw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "2Hel7uygQXpjYRJZiwtPLKNxT2Tg1/F5Zzs3VZpleFII9H1e5Gs02UjU0lybSXBKk/tD+NXPsdchrH/6/DmwAQ=="
+            "signature": "gV5npKv90ghI2wj2MP06qkVyWTbjBwBzdQnBS3ssggEE+is/BRMQQfKEKpmTAF0KIS+eZj7jmj8b+isxC3QfDw=="
           }
         ]
       }
     },
     "next_validator_set": {
       "validators": [
-        {
-          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
-        {
-          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
-        {
-          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
         {
           "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
           "pub_key": {
@@ -100,7 +73,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:26:49.160336600Z"
+    "now": "2020-10-22T12:32:42.160336996Z"
   },
   "input": [
     {
@@ -112,52 +85,36 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "1",
-            "time": "1970-01-01T00:23:25Z",
+            "height": "4",
+            "time": "1970-01-01T00:00:02Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
-            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "consensus_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
+            "validators_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "next_validators_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
+            "consensus_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "730D3D6B2E9F4F0F23879458F2D02E0004F0F241"
           },
           "commit": {
-            "height": "1",
+            "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "A95521DB540DB6D5B829DD0533D0B164BAB99CCDD12F886D5A2C830644846B3F",
+              "hash": "83FD12045130E534E63801C987A8F4DF30683C417D6D648FF47C0A13765D2EBF",
               "part_set_header": {
                 "total": 1,
-                "hash": "A95521DB540DB6D5B829DD0533D0B164BAB99CCDD12F886D5A2C830644846B3F"
+                "hash": "83FD12045130E534E63801C987A8F4DF30683C417D6D648FF47C0A13765D2EBF"
               }
             },
-            "signatures": [
-              {
-                "block_id_flag": 1,
-                "validator_address": null,
-                "timestamp": null,
-                "signature": null
-              },
-              {
-                "block_id_flag": 1,
-                "validator_address": null,
-                "timestamp": null,
-                "signature": null
-              },
-              {
-                "block_id_flag": 1,
-                "validator_address": null,
-                "timestamp": null,
-                "signature": null
-              }
-            ]
+            "signatures": []
           }
         },
         "validator_set": {
+          "validators": []
+        },
+        "next_validator_set": {
           "validators": [
             {
               "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
@@ -168,28 +125,6 @@
               "voting_power": "50",
               "proposer_priority": null
             },
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
             {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
@@ -212,7 +147,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:24Z",
+      "now": "1970-01-01T00:23:20Z",
       "verdict": "INVALID"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestEmptyCommitNonEmptyValset.json
+++ b/light/mbt/json/MC4_4_faulty_TestEmptyCommitNonEmptyValset.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_TestHeaderFromFuture.json",
+  "description": "MC4_4_faulty_TestEmptyCommitNonEmptyValset.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+        "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D",
+          "hash": "658DEEC010B33EDB1977FA7B38087A8C547D65272F6A63854959E517AAD20597",
           "part_set_header": {
             "total": 1,
-            "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D"
+            "hash": "658DEEC010B33EDB1977FA7B38087A8C547D65272F6A63854959E517AAD20597"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "8rGIxi7DjBLFlHUo/lAgTpmzsnTZ8HOgnQaIoe+HEM5AmrjBaVDWVMb5/nNAnJTj4hcReCh4jviXcyRkItFJCA=="
+            "signature": "gUvww0D+bCNnq0wY4GvDkWAUQO3kbi9YvmoRBAC3goRZ6mW8Fh6V9hrMQYbpRpf7LZqFAdnleFgXnnEuKz17Bg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "3cXnzhzJLKeF47ulcIWjgqsv9JBf9olbAo0mcjo7Ij6TfmCpJO6SmTiacBkiznsFSOc1ZSH+cHDBKA4AT7ozAg=="
+            "signature": "54nTri+VJoBu8HCTb+c92aYrPiMSM71qVDkdRtwmE40LWPUFkTJNTqTLXbBXutQ1p5s6PyuB+p4UfWAwYCuUCQ=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "4O8c5hxoHR861ldolxeY9W1iXCdxYJVIf0xD3+sANSxo0ipXayv8IS7YFw1zzZvDbjRRazVzbfyBYf2jl4JeDw=="
+            "signature": "PWesm77j/+sQh1p00pDJv3R3B9tpe1HlfhaTS2be/5FZfq3EMH3ceplTSNGsQKo0p4f8N9UUq+TYwm+3dsZeBg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "2Hel7uygQXpjYRJZiwtPLKNxT2Tg1/F5Zzs3VZpleFII9H1e5Gs02UjU0lybSXBKk/tD+NXPsdchrH/6/DmwAQ=="
+            "signature": "ngAHu3FpNX6aW4B7xmFd7ckNScOM+lfuCQuMDs7uq20UoNnnGasFOcFMXD+0dQnRndEu1RItr+0kgxKaD6OtAQ=="
           }
         ]
       }
@@ -69,38 +69,11 @@
           },
           "voting_power": "50",
           "proposer_priority": null
-        },
-        {
-          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
-        {
-          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
-        {
-          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
         }
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:26:49.160336600Z"
+    "now": "2020-10-22T12:32:48.160336996Z"
   },
   "input": [
     {
@@ -112,42 +85,30 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "1",
-            "time": "1970-01-01T00:23:25Z",
+            "height": "4",
+            "time": "1970-01-01T00:00:02Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
-            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "consensus_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
+            "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "next_validators_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
+            "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
           },
           "commit": {
-            "height": "1",
+            "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "A95521DB540DB6D5B829DD0533D0B164BAB99CCDD12F886D5A2C830644846B3F",
+              "hash": "A29878838905F87EEC5ABA6EF7BFA2E641F3671469B60C3A9AF75B669AB7F7AB",
               "part_set_header": {
                 "total": 1,
-                "hash": "A95521DB540DB6D5B829DD0533D0B164BAB99CCDD12F886D5A2C830644846B3F"
+                "hash": "A29878838905F87EEC5ABA6EF7BFA2E641F3671469B60C3A9AF75B669AB7F7AB"
               }
             },
             "signatures": [
-              {
-                "block_id_flag": 1,
-                "validator_address": null,
-                "timestamp": null,
-                "signature": null
-              },
-              {
-                "block_id_flag": 1,
-                "validator_address": null,
-                "timestamp": null,
-                "signature": null
-              },
               {
                 "block_id_flag": 1,
                 "validator_address": null,
@@ -159,24 +120,6 @@
         },
         "validator_set": {
           "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
@@ -207,12 +150,21 @@
               },
               "voting_power": "50",
               "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
             }
           ]
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:24Z",
+      "now": "1970-01-01T00:23:20Z",
       "verdict": "INVALID"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestFailure.json
+++ b/light/mbt/json/MC4_4_faulty_TestFailure.json
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+        "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "658DEEC010B33EDB1977FA7B38087A8C547D65272F6A63854959E517AAD20597",
+          "hash": "F8BF7840885A99FA64C63E1E7FE82D8F52B0AA1BA2EF07F2635C802395ADCBC1",
           "part_set_header": {
             "total": 1,
-            "hash": "658DEEC010B33EDB1977FA7B38087A8C547D65272F6A63854959E517AAD20597"
+            "hash": "F8BF7840885A99FA64C63E1E7FE82D8F52B0AA1BA2EF07F2635C802395ADCBC1"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "gUvww0D+bCNnq0wY4GvDkWAUQO3kbi9YvmoRBAC3goRZ6mW8Fh6V9hrMQYbpRpf7LZqFAdnleFgXnnEuKz17Bg=="
+            "signature": "N5ZDai/KuXqdr5EuFqrVrsCoFSVu6vMZ9KiO/Lsf51EZfZp8XB0z2O7ZE7Y0r8HJ7EAD/qUWl+YPd6vly9yWAg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "54nTri+VJoBu8HCTb+c92aYrPiMSM71qVDkdRtwmE40LWPUFkTJNTqTLXbBXutQ1p5s6PyuB+p4UfWAwYCuUCQ=="
+            "signature": "agSsZySOIbHGrxevGukb5D4h6HAZduJy1dnGpmv1CfkRTnZoybKroPsLxPKbz1X8HCFSyHl4AmvCo8AxjmMfAA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "PWesm77j/+sQh1p00pDJv3R3B9tpe1HlfhaTS2be/5FZfq3EMH3ceplTSNGsQKo0p4f8N9UUq+TYwm+3dsZeBg=="
+            "signature": "Ka/EiGMHhSSB/W9Q5xQJZxDtxdMrMe+ot+KuGHEQM8/PLXysv8jdqSJxJJDVG5W/oC574KZV2VVB5Z0Dwf8+AQ=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "ngAHu3FpNX6aW4B7xmFd7ckNScOM+lfuCQuMDs7uq20UoNnnGasFOcFMXD+0dQnRndEu1RItr+0kgxKaD6OtAQ=="
+            "signature": "4n3lkaT66wZu6RBZ5/Dr0ewnPaWhKx6sJecUfva71XrFONJgbrX998bEbhObhFNzrEoFhCOcupgZYmcn4sB5Bg=="
           }
         ]
       }
@@ -69,189 +69,22 @@
           },
           "voting_power": "50",
           "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
         }
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-21T08:44:52.160326989Z"
+    "now": "2020-10-22T12:32:36.160336995Z"
   },
   "input": [
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:05Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
-            "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
-            "consensus_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
-          },
-          "commit": {
-            "height": "4",
-            "round": 1,
-            "block_id": {
-              "hash": "32DD1A7D7E5C8106E14255B40F029DC568E3326512B50F45012580CD6683B9E6",
-              "part_set_header": {
-                "total": 1,
-                "hash": "32DD1A7D7E5C8106E14255B40F029DC568E3326512B50F45012580CD6683B9E6"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "RL9tPx8XS753xu4ziuoICsAVRmqhu34gx3NN0gsNGQw+HvECVb77g9pvcapRPDkkVf89be6dAIy/WjrsfATGDg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "kqxDTznWv65+GJA08AV4JTMBeKzDaG7jAhMA7P4YgFkM2KDKw2vOBw0R4LnLkzZQWJUkbzXeYRHcVoJlT35JAg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "aWEOTgdl9m5vBKDSCrUloM/2AfUp+SNDqbpJFEuhBv0DYmeRJDCEoeQnGACjaZHjW4LjaxgNnTOSBVFlaP/vAg=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:16Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "2",
-            "time": "1970-01-01T00:00:03Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
-            "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
-            "consensus_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
-          },
-          "commit": {
-            "height": "2",
-            "round": 1,
-            "block_id": {
-              "hash": "A14AED7ED200C7F85F89C9A43029E0CE88691532193E198E3F45AA3375AE8D01",
-              "part_set_header": {
-                "total": 1,
-                "hash": "A14AED7ED200C7F85F89C9A43029E0CE88691532193E198E3F45AA3375AE8D01"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "42tNU0fwo3UKq2toY2p39ykL6ZhWrCIoGjzE5O0mmvn92SZHAg1OUGmn4c5bUF6H2kNKZXCn6Zp6T/UxhlEOBQ=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:16Z",
-      "verdict": "SUCCESS"
-    },
     {
       "block": {
         "signed_header": {
@@ -266,30 +99,118 @@
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
-            "next_validators_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
-            "consensus_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "consensus_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "8F9616DB1690AFC2B882E171F573254BCFBABE365C58D7A2A9E811E0320875BE",
+              "part_set_header": {
+                "total": 1,
+                "hash": "8F9616DB1690AFC2B882E171F573254BCFBABE365C58D7A2A9E811E0320875BE"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "vIfl9XJirNLO+7/BBXS8hz+Bfm5a2VdhUEtY52p4zdBCCQzMGPvjbgWceCcHfwKam9+hLFwYE5mzGtdj3bP8Cw=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:06Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
             "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
           },
           "commit": {
-            "height": "3",
+            "height": "2",
             "round": 1,
             "block_id": {
-              "hash": "AFABB1F6927F1D7845EA474BCF523AF948644C7B1301CBC17B8A264903B9AD16",
+              "hash": "C8DB218DF82EED4D84CF9F12E3250C81CE7126D5AE8AABD288CBA10C3DB1F448",
               "part_set_header": {
                 "total": 1,
-                "hash": "AFABB1F6927F1D7845EA474BCF523AF948644C7B1301CBC17B8A264903B9AD16"
+                "hash": "C8DB218DF82EED4D84CF9F12E3250C81CE7126D5AE8AABD288CBA10C3DB1F448"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "If14ddLKYwosISJdPovBpU2K1+R91ZqDY/JAyuPsGXCXm70ZyciRQBoGEOVVzAs3s3hfc+OZAScGtpK8meyxDw=="
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "bptU3oYcsIhDIDjmbD4x0RcJldWkV2sw/lmNs7cIkredWdznuoUMP3VXmRFOlegMcTifGm+p+30HpUthRMmzAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "pqMKpLJ9P01PyLYOtnV1BX/GIFwQJpFXSQPITMuQ8HXesEyy9Z1p/2fCP33Q7L9IrGVoaW+eJCKLdPjsWAyiBw=="
               }
             ]
           }
@@ -304,11 +225,29 @@
               },
               "voting_power": "50",
               "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
             }
           ]
         },
         "next_validator_set": {
           "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
             {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
@@ -340,7 +279,72 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:24Z",
+      "now": "1970-01-01T00:00:06Z",
+      "verdict": "SUCCESS"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "4",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "consensus_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "730D3D6B2E9F4F0F23879458F2D02E0004F0F241"
+          },
+          "commit": {
+            "height": "4",
+            "round": 1,
+            "block_id": {
+              "hash": "4E6D41EC61854F34183019D843B001630790A12A4A4A87C7277BD67163AE6529",
+              "part_set_header": {
+                "total": 1,
+                "hash": "4E6D41EC61854F34183019D843B001630790A12A4A4A87C7277BD67163AE6529"
+              }
+            },
+            "signatures": []
+          }
+        },
+        "validator_set": {
+          "validators": []
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:23Z",
       "verdict": "INVALID"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestHalfValsetChanges.json
+++ b/light/mbt/json/MC4_4_faulty_TestHalfValsetChanges.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_TestSuccess.json",
+  "description": "MC4_4_faulty_TestHalfValsetChanges.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "AAFE392AA939DA2A051F3C57707569B1836F93ACC8F35B57BB3CDF615B649013",
+        "next_validators_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "1C7FFFFB7BA0E2AA68FD6C9AB0F5E177A78AA392A60C9ECC89CAD3DAE1C80E57",
+          "hash": "42C62AB26BDCD052FD7D87449C1CA700A79780D55E2FC8129614D4D2DC24CB08",
           "part_set_header": {
             "total": 1,
-            "hash": "1C7FFFFB7BA0E2AA68FD6C9AB0F5E177A78AA392A60C9ECC89CAD3DAE1C80E57"
+            "hash": "42C62AB26BDCD052FD7D87449C1CA700A79780D55E2FC8129614D4D2DC24CB08"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "FKIpE4jILZ3tmeBUFmaT48nAxIBsAIRcnQ6dBdqHV6Xjhd2Bex94Yaqgg7Lv5NL1HACt5qH60qVRiEsv5oJwAA=="
+            "signature": "mzNheVmshOSGCNfL/NfBBpJcofUx6cqclvEMOc9rZJ6A2pOrxO8ZymXej0FvksZ5mmhfLvZ0aW+as59WMldWBw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "uuvlEKa9M4a+VtHoE2Racjm2Tzb41Hf/TH35lP158juWjHEgg2k1MnthMhcFaBxdeCucQulrAwUGd99/L4+uCg=="
+            "signature": "KisuL/gVSTDQP1Q51uBKd8xDZM4mX+rRKIpMlkfUYF+qW4K51sPvqL/pgKSiUwBPAoGRBzwLoavPg9oiyRwPBA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "Lolcqh4BLNDC4KTdmaB1bCXA0KjCKB8Rk73qvfL1oojxIIuA1l6WBES9iDPdoEe2QwPwOMtwbGj/A1NwJnvgAw=="
+            "signature": "fgq+19zjPxTp8HILDBaW8VJg+wzyVkthtmf0HJxdoaXd+uZRQ7LDS2Tn7LXMKAQ9Q0sjtZ4BA3H3sfv9wA56BA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "NYxAvpFkpNWI9VLFcqdJyOT1KMMD2ZYCKLV4h0yuU+DkoyYmJnJv0dPtUXwalVHw0LT9K1Ad6f7rI3AfLTEuAw=="
+            "signature": "Zy0rovAtLk58hTcprpXU7ikCdbky5rrQ8Y3o+/Xyo7VTt3zYiCdVsYj26agu8SR3cFkV96P2ryHF6NHWGwIJDw=="
           }
         ]
       }
@@ -78,11 +78,20 @@
           },
           "voting_power": "50",
           "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
         }
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:25:01.160336590Z"
+    "now": "2020-10-22T11:27:05.160336602Z"
   },
   "input": [
     {
@@ -95,71 +104,40 @@
             },
             "chain_id": "test-chain",
             "height": "5",
-            "time": "1970-01-01T00:00:03Z",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
-            "next_validators_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
-            "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "consensus_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
           },
           "commit": {
             "height": "5",
             "round": 1,
             "block_id": {
-              "hash": "7881A02ABCFE0A40118D5F2B28AABDE0943DFADC4953E39284B09275A0C51B65",
+              "hash": "91C38CDE59CCAB126D2152835740A930EE3E01414B5FEFC04604AC1D19A8CF45",
               "part_set_header": {
                 "total": 1,
-                "hash": "7881A02ABCFE0A40118D5F2B28AABDE0943DFADC4953E39284B09275A0C51B65"
+                "hash": "91C38CDE59CCAB126D2152835740A930EE3E01414B5FEFC04604AC1D19A8CF45"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "i5lRbpUn4i8g37A6b/0T8ZwUhQ49vriPWD1exvZcFou8J5ybvEz05U3hllaV/asM9j+T5VVEkI/gJsRhQXDxAA=="
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "f4/bRYi8lZCcxLOO8eOLLYiXhX2MG3+nxnKFEY3IgG0sr6KXA3RLoXsI9xmgXcLOmAMckdejtjtCJwvpEKVDAQ=="
               }
             ]
           }
         },
         "validator_set": {
           "validators": [
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
@@ -171,9 +149,22 @@
             }
           ]
         },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:05Z",
+      "now": "1970-01-01T00:23:18Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -190,9 +181,9 @@
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "consensus_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "next_validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "consensus_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
@@ -202,10 +193,10 @@
             "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "C7257252A6DB14548F4E545145A651CEB9B81C5FD0E92C25521B8EE0332772D9",
+              "hash": "DC131BABD586612E709C7BAC1F57A87138CBCFD28CE2D0275923FA19BC8AB2A3",
               "part_set_header": {
                 "total": 1,
-                "hash": "C7257252A6DB14548F4E545145A651CEB9B81C5FD0E92C25521B8EE0332772D9"
+                "hash": "DC131BABD586612E709C7BAC1F57A87138CBCFD28CE2D0275923FA19BC8AB2A3"
               }
             },
             "signatures": [
@@ -213,13 +204,13 @@
                 "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
                 "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "YH+VUpCYFI70Mzibl1by2FEcPbTYi2CbvUZxVgOgjGs+bJlBehJY2dTdY7OEBPp60Kw3YGNZkmzUC7LnIugmCQ=="
+                "signature": "iLL/xT0sgpdbC20a55hxsGBcvH4TeI0mEjaSivTvwbjyB8vX0KbUDjerVVcBRnBvr19TShTziBlgUqarJl7sDg=="
               },
               {
                 "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
                 "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "xUi2Aa/RqoPzxgblNKrB5G/i0HcLJVY0oMxRoKM1xqRI3PMhj4qhdUlJmC5lR0aqBBkfULFUMOilbgxIsxXMBg=="
+                "signature": "WKj8bSk0e74Igkk+PDARcoIHreM2T10illF8xSXlZg/bFInOWayfftZaIWqM/bdlSrD/DNyuD+06e87cocYtAg=="
               }
             ]
           }
@@ -236,10 +227,10 @@
               "proposer_priority": null
             },
             {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -258,10 +249,10 @@
               "proposer_priority": null
             },
             {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -270,7 +261,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:06Z",
+      "now": "1970-01-01T00:23:20Z",
       "verdict": "SUCCESS"
     },
     {
@@ -287,9 +278,9 @@
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
-            "consensus_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "consensus_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
@@ -299,10 +290,10 @@
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "F60F965077E52CF54D34E121EBC3083A8DA21C32C660B538FBB375453A16127F",
+              "hash": "D941E8AF420BE24332DCB7CED5D20714EB82165C5A0B04DA0076E59BAA178FC5",
               "part_set_header": {
                 "total": 1,
-                "hash": "F60F965077E52CF54D34E121EBC3083A8DA21C32C660B538FBB375453A16127F"
+                "hash": "D941E8AF420BE24332DCB7CED5D20714EB82165C5A0B04DA0076E59BAA178FC5"
               }
             },
             "signatures": [
@@ -310,13 +301,13 @@
                 "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
                 "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "sYTZMxPFdi8Ob2In3dbHqWxJAuvADu3LpQd3/J6okK6qjJxcK4O6y66Zm/OVoc9Hrc+Gztjf8xl9lKblezWdCQ=="
+                "signature": "EfV2fzce8n41RGCoigAIx1wIk/lNVDjxeCnzAsrMrJ1WI8KZJ29prJIPP/2MSgXCxWx3vInR/8eCU2R+VqKFCA=="
               },
               {
                 "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
                 "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "nnpVLj/7LX9UBdCvmUYAKAI5ATU3mSITZqok0hCQlfWf0t5L4wSxQwsWF6jcva5IXHoEzGzpth+Dyz9ig6e4BA=="
+                "signature": "KO7f/Cv0Wflvc1ezYYeFzmvHJJUybnxS4TnexXhm29WAyWxyD42U9h5hCRe4Xmh32McD3rk8VyWbfTh92Dl6DA=="
               }
             ]
           }
@@ -333,10 +324,10 @@
               "proposer_priority": null
             },
             {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -346,10 +337,10 @@
         "next_validator_set": {
           "validators": [
             {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -358,7 +349,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:07Z",
+      "now": "1970-01-01T00:23:20Z",
       "verdict": "SUCCESS"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestHalfValsetChangesVerdictNotEnoughTrust.json
+++ b/light/mbt/json/MC4_4_faulty_TestHalfValsetChangesVerdictNotEnoughTrust.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_Test2NotEnoughTrustSuccess.json",
+  "description": "MC4_4_faulty_TestHalfValsetChangesVerdictNotEnoughTrust.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+        "next_validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32",
+          "hash": "6F70738E1F789E42D6F424F15A85D4B90BE287EB5A1E78DC3B2C8502EBAD2B28",
           "part_set_header": {
             "total": 1,
-            "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32"
+            "hash": "6F70738E1F789E42D6F424F15A85D4B90BE287EB5A1E78DC3B2C8502EBAD2B28"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "BwKig3Giy91zDlZ5BSa67+E0EV1K4q6At2piQgg1h48odVOAjEiC4Tt772ologMWt0gdjYzeYtYR15OKtza1Ag=="
+            "signature": "I5AZkBd3JQaOh2sqLkyym3I+sKJqP/4o9hFZW1+PPsIV46C2AkRqNC8OeElW02bTEOncxk5+XLI2M9LGkUfjCg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "EYx9XdH96HYFIJtaddpFF+u/1GBwE1A3/Ds2e5BGHnti62RBwgsdIWe3denuQxgYNPnIymqvrCiBAGEEtYJHBg=="
+            "signature": "XdFpwQTWY5ZIxAViOD1EC+sA5KCDMLLhoFaYjHp0Zuu1o+nDIhVKyuS8CD5IatLtHc7pN6APMZruCrUhKuc7Dg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "QctMtMK8Zes6OspVTkVvKtwWix70IAp0okAi4zJjV981FEnOuK2j8Fd0WQNHHDyqFX7uGTVL5L7JqbBfLuvBAA=="
+            "signature": "lpBxn4D/foZUdjZbl/wkWmRKCMm201a7tc1DuQ81KqEUW3jSer6qJWhXLkkVWd03MaSuA5SDegG3pjrvXdegBw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "yWtJtDMH9NOtAeRqomUYDa23BePOZ+y7FNiAxWZ9a8iYUOOxUU3CoCqxfRm6wpJWW2QUwBicQs7ntnU3z7cpBg=="
+            "signature": "e2kVRdlz5BMgxQMeAeL36SiywpgUyrePcbBUwuZbdFUiK9B3JlNgxg84ZN1OYV5JRIrwaGoIQtE0xHmOr0YgDg=="
           }
         ]
       }
@@ -69,11 +69,20 @@
           },
           "voting_power": "50",
           "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
         }
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:25:22.160336592Z"
+    "now": "2020-10-22T11:27:25.160336604Z"
   },
   "input": [
     {
@@ -85,41 +94,35 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:08Z",
+            "height": "3",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "consensus_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
             "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
           },
           "commit": {
-            "height": "4",
+            "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
+              "hash": "1F3F155A47FFE4E18ED3093779F16433ACF5D93B556ADF18009E90E774DEBC4E",
               "part_set_header": {
                 "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
+                "hash": "1F3F155A47FFE4E18ED3093779F16433ACF5D93B556ADF18009E90E774DEBC4E"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "7iyAn83NM2V6wmgnfiAsNcLW+tUSsNpBZeQF1GZOQi4LSLzme6VgmgPg6y/eNfSkWxFbodRCYtMal7mUbhsaBQ=="
               }
             ]
           }
@@ -134,20 +137,20 @@
               },
               "voting_power": "50",
               "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
             }
           ]
         },
         "next_validator_set": {
           "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
             {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
@@ -161,119 +164,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "3",
-            "time": "1970-01-01T00:00:06Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "consensus_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
-          },
-          "commit": {
-            "height": "3",
-            "round": 1,
-            "block_id": {
-              "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53",
-              "part_set_header": {
-                "total": 1,
-                "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "MaQRn3tj7Suri3Hr7uyegcAKmdKLTe/4eAzjKYHrcGjfO/5RM7ElnS5A/mirppc1etmKflVlbp8lWn5TDDNJCQ=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "PtO5WN7sBXjCWyjU8HSjOf8HAIdCujLwmJLQbEfLXRTWeHRUYCoasFVVtcXaPCBCBTRXvt7adR81ecg8JK+cCg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "e6H6dh3ECPlQsOv3Yw7uVHhvGhlLfE/fcqMFlXyGeofpZOAsYN25QDHX+NbScIHhUQmpInx/ytFiah3IYlwWDw=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:19Z",
+      "now": "1970-01-01T00:00:06Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -286,13 +177,13 @@
             },
             "chain_id": "test-chain",
             "height": "2",
-            "time": "1970-01-01T00:00:05Z",
+            "time": "1970-01-01T00:00:03Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "next_validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "consensus_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
@@ -302,18 +193,24 @@
             "height": "2",
             "round": 1,
             "block_id": {
-              "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF",
+              "hash": "9C1C2B377CA78CBB189FB3712633A55B1601B785C138D147D2A89695D7F94D96",
               "part_set_header": {
                 "total": 1,
-                "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF"
+                "hash": "9C1C2B377CA78CBB189FB3712633A55B1601B785C138D147D2A89695D7F94D96"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "+e4OBaptWoaVX6A/UGsXNrNXJXjztwk1IRvmxWsTWRcxiB4AydLU/uFEiX+rp1PbNHZDhZWsI/Pprb7CY2hsAg=="
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "U5H7MjiMMiwSq87v84QuxW5B5qN7VxDa4V13NPzsZGF0qbJaSV9T4iPcfcRbvT17QQJwbclaWsZ4kjBY+gHhBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "v6mDnyLMUgsEo2v8Z9yWVzVYS1SMacDovxwa45QhcwcehaNXNYURExJavfL2X9XZV0G1DCi15xhJKBW/34r8DA=="
               }
             ]
           }
@@ -328,6 +225,15 @@
               },
               "voting_power": "50",
               "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
             }
           ]
         },
@@ -338,6 +244,15 @@
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
                 "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -364,7 +279,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
+      "now": "1970-01-01T00:00:06Z",
       "verdict": "SUCCESS"
     },
     {
@@ -377,40 +292,40 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:08Z",
+            "time": "1970-01-01T00:00:05Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
+            "next_validators_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
+            "consensus_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
           },
           "commit": {
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
+              "hash": "052B8F2A44204FC4A4CE16EF083C1EEB55B3BFBCE8512B3EEDDEB136DF628003",
               "part_set_header": {
                 "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
+                "hash": "052B8F2A44204FC4A4CE16EF083C1EEB55B3BFBCE8512B3EEDDEB136DF628003"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "6s6VKceWruJ75YLM4GYNjuWF/ADsxXcqPLb6NgE8x43izYHYvXpIUVByJuK7hrDYKMl1JR4mrbwYnqS/PEhKCw=="
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "fzM1IhAqFk5G7unlDeCmvf+BuVkNWIhyFmXbyW4CMSESeyUAUX8qJvuX3HNKJoMMSWqofAteWDNNPIDrcAw5Aw=="
               }
             ]
           }
@@ -418,10 +333,10 @@
         "validator_set": {
           "validators": [
             {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -440,10 +355,28 @@
         "next_validator_set": {
           "validators": [
             {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
                 "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -452,7 +385,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:20Z",
+      "now": "1970-01-01T00:00:06Z",
       "verdict": "SUCCESS"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestHalfValsetChangesVerdictSuccess.json
+++ b/light/mbt/json/MC4_4_faulty_TestHalfValsetChangesVerdictSuccess.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_Test2NotEnoughTrustSuccess.json",
+  "description": "MC4_4_faulty_TestHalfValsetChangesVerdictSuccess.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+        "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32",
+          "hash": "0D038B1BA2ED7B1EF4D4E250C54D3F8D7186068658FAA53900CA83F4280B1EF2",
           "part_set_header": {
             "total": 1,
-            "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32"
+            "hash": "0D038B1BA2ED7B1EF4D4E250C54D3F8D7186068658FAA53900CA83F4280B1EF2"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "BwKig3Giy91zDlZ5BSa67+E0EV1K4q6At2piQgg1h48odVOAjEiC4Tt772ologMWt0gdjYzeYtYR15OKtza1Ag=="
+            "signature": "XJC+kaVazdli/oMNHnFQOujOJLxFnez2DAUv5Uy+wPGeypkinrk2c79ZmlB5YHBTJaLh6yotq1XiLzy3zUAJAQ=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "EYx9XdH96HYFIJtaddpFF+u/1GBwE1A3/Ds2e5BGHnti62RBwgsdIWe3denuQxgYNPnIymqvrCiBAGEEtYJHBg=="
+            "signature": "pj86O2mwAQcn/MggMVEK1F6yhqnaMcxqxKyZ9DgIfFVqJIgQLb5SsuqyxPcMxxRhDTjjqfkATRGIiHPEthrFCQ=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "QctMtMK8Zes6OspVTkVvKtwWix70IAp0okAi4zJjV981FEnOuK2j8Fd0WQNHHDyqFX7uGTVL5L7JqbBfLuvBAA=="
+            "signature": "QssWTiluThPYflhI3bBuoeIBXlMR39I+vJb7EvLf6FVyxp0Ih7kW26wkmqjgHf0RyDAu9sny3FBrc/WbPXhFDQ=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "yWtJtDMH9NOtAeRqomUYDa23BePOZ+y7FNiAxWZ9a8iYUOOxUU3CoCqxfRm6wpJWW2QUwBicQs7ntnU3z7cpBg=="
+            "signature": "9xg3G66gizJBzWybdYKRtyg8c52U6vKmUT9TKb5MQ5MP/6IVCbhnvUjzw4Oe5stsnHMGvsx6Q7IVS3Ma7CbBDA=="
           }
         ]
       }
@@ -62,10 +62,10 @@
     "next_validator_set": {
       "validators": [
         {
-          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
           "pub_key": {
             "type": "tendermint/PubKeyEd25519",
-            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
           },
           "voting_power": "50",
           "proposer_priority": null
@@ -73,7 +73,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:25:22.160336592Z"
+    "now": "2020-10-22T11:27:15.160336603Z"
   },
   "input": [
     {
@@ -85,115 +85,27 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:08Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
-          },
-          "commit": {
-            "height": "4",
-            "round": 1,
-            "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
-              "part_set_header": {
-                "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "3",
+            "height": "5",
             "time": "1970-01-01T00:00:06Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "consensus_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
+            "validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "next_validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "consensus_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
             "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
           },
           "commit": {
-            "height": "3",
+            "height": "5",
             "round": 1,
             "block_id": {
-              "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53",
+              "hash": "07A155D9F9C4B97C53EA778417815C24FDB3BED42016DEBD67AB3614AB19F93C",
               "part_set_header": {
                 "total": 1,
-                "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53"
+                "hash": "07A155D9F9C4B97C53EA778417815C24FDB3BED42016DEBD67AB3614AB19F93C"
               }
             },
             "signatures": [
@@ -201,19 +113,7 @@
                 "block_id_flag": 2,
                 "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
                 "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "MaQRn3tj7Suri3Hr7uyegcAKmdKLTe/4eAzjKYHrcGjfO/5RM7ElnS5A/mirppc1etmKflVlbp8lWn5TDDNJCQ=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "PtO5WN7sBXjCWyjU8HSjOf8HAIdCujLwmJLQbEfLXRTWeHRUYCoasFVVtcXaPCBCBTRXvt7adR81ecg8JK+cCg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "e6H6dh3ECPlQsOv3Yw7uVHhvGhlLfE/fcqMFlXyGeofpZOAsYN25QDHX+NbScIHhUQmpInx/ytFiah3IYlwWDw=="
+                "signature": "B7jXF8Tv/W80H3o7Gi6K1UL45Lxu1+ubAa0tsqwxGjsDuNqcEt+nP3ZyMkSXqp7uDLNHJGtm31qfcQNUH8tbBQ=="
               }
             ]
           }
@@ -225,6 +125,115 @@
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
                 "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:17Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:04Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "5B5436FED1E671FFD44EF656E4A7AD5F6DA1D5CFD40487458C9C654397643A7C",
+              "part_set_header": {
+                "total": 1,
+                "hash": "5B5436FED1E671FFD44EF656E4A7AD5F6DA1D5CFD40487458C9C654397643A7C"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "5hLDkBl1Y9A1Ahl4cZOnyw/Tp3IO8jds2kBZSanXw0CWR7S5upvtIguFNXSbFaeIXNUjuEZusB3yNKsWdGktAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "OpfTqQ/tenDYpGXulqj/BmtQloUpevszLvQ/LhvnHpCw80IBmE4dgibldnSU4xP+AMkZ0KrI2sV7exKU/KBcDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "bLDV5/JG93i7V6PIFcjQS03t6HH/OtOl/s4LAAeas+m3XESOapUo83rWPH4uxPDfvi6/7eTYkpFtr17pPho6Cg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -252,19 +261,10 @@
         "next_validator_set": {
           "validators": [
             {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -273,8 +273,8 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "NOT_ENOUGH_TRUST"
+      "now": "1970-01-01T00:23:18Z",
+      "verdict": "SUCCESS"
     },
     {
       "block": {
@@ -285,13 +285,13 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "2",
+            "height": "4",
             "time": "1970-01-01T00:00:05Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
             "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "next_validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
+            "next_validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
             "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
             "app_hash": "",
             "last_results_hash": null,
@@ -299,13 +299,13 @@
             "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
           },
           "commit": {
-            "height": "2",
+            "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF",
+              "hash": "0C331A94335A3CA23C5488EDD356A275493BC6084ABB803DB30C1E876C583100",
               "part_set_header": {
                 "total": 1,
-                "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF"
+                "hash": "0C331A94335A3CA23C5488EDD356A275493BC6084ABB803DB30C1E876C583100"
               }
             },
             "signatures": [
@@ -313,7 +313,7 @@
                 "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
                 "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "+e4OBaptWoaVX6A/UGsXNrNXJXjztwk1IRvmxWsTWRcxiB4AydLU/uFEiX+rp1PbNHZDhZWsI/Pprb7CY2hsAg=="
+                "signature": "W3YxnO6RMAGvhsCIxvf5efgXoVqr3ke2VNMmqMUUtl4ydCuVwoc8kyndRj/Nr2X0diYstBTKJ7lD/Dvg3NZFBA=="
               }
             ]
           }
@@ -334,15 +334,6 @@
         "next_validator_set": {
           "validators": [
             {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
@@ -365,94 +356,6 @@
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
       "now": "1970-01-01T00:23:19Z",
-      "verdict": "SUCCESS"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:08Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
-          },
-          "commit": {
-            "height": "4",
-            "round": 1,
-            "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
-              "part_set_header": {
-                "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:20Z",
       "verdict": "SUCCESS"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestLessThanThirdValsetChanges.json
+++ b/light/mbt/json/MC4_4_faulty_TestLessThanThirdValsetChanges.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_Test2NotEnoughTrustSuccess.json",
+  "description": "MC4_4_faulty_TestLessThanThirdValsetChanges.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+        "next_validators_hash": "AAFE392AA939DA2A051F3C57707569B1836F93ACC8F35B57BB3CDF615B649013",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32",
+          "hash": "1C7FFFFB7BA0E2AA68FD6C9AB0F5E177A78AA392A60C9ECC89CAD3DAE1C80E57",
           "part_set_header": {
             "total": 1,
-            "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32"
+            "hash": "1C7FFFFB7BA0E2AA68FD6C9AB0F5E177A78AA392A60C9ECC89CAD3DAE1C80E57"
           }
         },
         "signatures": [
@@ -36,31 +36,40 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "BwKig3Giy91zDlZ5BSa67+E0EV1K4q6At2piQgg1h48odVOAjEiC4Tt772ologMWt0gdjYzeYtYR15OKtza1Ag=="
+            "signature": "FKIpE4jILZ3tmeBUFmaT48nAxIBsAIRcnQ6dBdqHV6Xjhd2Bex94Yaqgg7Lv5NL1HACt5qH60qVRiEsv5oJwAA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "EYx9XdH96HYFIJtaddpFF+u/1GBwE1A3/Ds2e5BGHnti62RBwgsdIWe3denuQxgYNPnIymqvrCiBAGEEtYJHBg=="
+            "signature": "uuvlEKa9M4a+VtHoE2Racjm2Tzb41Hf/TH35lP158juWjHEgg2k1MnthMhcFaBxdeCucQulrAwUGd99/L4+uCg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "QctMtMK8Zes6OspVTkVvKtwWix70IAp0okAi4zJjV981FEnOuK2j8Fd0WQNHHDyqFX7uGTVL5L7JqbBfLuvBAA=="
+            "signature": "Lolcqh4BLNDC4KTdmaB1bCXA0KjCKB8Rk73qvfL1oojxIIuA1l6WBES9iDPdoEe2QwPwOMtwbGj/A1NwJnvgAw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "yWtJtDMH9NOtAeRqomUYDa23BePOZ+y7FNiAxWZ9a8iYUOOxUU3CoCqxfRm6wpJWW2QUwBicQs7ntnU3z7cpBg=="
+            "signature": "NYxAvpFkpNWI9VLFcqdJyOT1KMMD2ZYCKLV4h0yuU+DkoyYmJnJv0dPtUXwalVHw0LT9K1Ad6f7rI3AfLTEuAw=="
           }
         ]
       }
     },
     "next_validator_set": {
       "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
         {
           "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
           "pub_key": {
@@ -73,7 +82,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:25:22.160336592Z"
+    "now": "2020-10-22T11:28:06.160336608Z"
   },
   "input": [
     {
@@ -85,241 +94,159 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:08Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
-          },
-          "commit": {
-            "height": "4",
-            "round": 1,
-            "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
-              "part_set_header": {
-                "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "3",
-            "time": "1970-01-01T00:00:06Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "consensus_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
-          },
-          "commit": {
-            "height": "3",
-            "round": 1,
-            "block_id": {
-              "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53",
-              "part_set_header": {
-                "total": 1,
-                "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "MaQRn3tj7Suri3Hr7uyegcAKmdKLTe/4eAzjKYHrcGjfO/5RM7ElnS5A/mirppc1etmKflVlbp8lWn5TDDNJCQ=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "PtO5WN7sBXjCWyjU8HSjOf8HAIdCujLwmJLQbEfLXRTWeHRUYCoasFVVtcXaPCBCBTRXvt7adR81ecg8JK+cCg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "e6H6dh3ECPlQsOv3Yw7uVHhvGhlLfE/fcqMFlXyGeofpZOAsYN25QDHX+NbScIHhUQmpInx/ytFiah3IYlwWDw=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "2",
+            "height": "5",
             "time": "1970-01-01T00:00:05Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
             "next_validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+            "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
           },
           "commit": {
-            "height": "2",
+            "height": "5",
             "round": 1,
             "block_id": {
-              "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF",
+              "hash": "162DE5F4FAACE72EF1EE5396C59441D762CBC84D6F6BB724C8E96025ADDAF458",
               "part_set_header": {
                 "total": 1,
-                "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF"
+                "hash": "162DE5F4FAACE72EF1EE5396C59441D762CBC84D6F6BB724C8E96025ADDAF458"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
                 "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "+e4OBaptWoaVX6A/UGsXNrNXJXjztwk1IRvmxWsTWRcxiB4AydLU/uFEiX+rp1PbNHZDhZWsI/Pprb7CY2hsAg=="
+                "signature": "iNgmd/UGZzyTWQ3WzHwPRpyq9TW2PKPLokBC0qQbBqyeRJ9qbNXOQc25gHXWYkxt+Rak2IssckfD5khXT/vTBg=="
               }
             ]
           }
         },
         "validator_set": {
           "validators": [
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:13Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "next_validators_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
+            "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "3",
+            "round": 1,
+            "block_id": {
+              "hash": "9E2ED8463B41EBC19D2CC5C0CC6189FAE9FD0BFC1B28F427759130EE0B977492",
+              "part_set_header": {
+                "total": 1,
+                "hash": "9E2ED8463B41EBC19D2CC5C0CC6189FAE9FD0BFC1B28F427759130EE0B977492"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "I5O2vgEQMuQnojOZQ+7rTHrhasU0sNjV5TtDZWW5WvvwlSsOL9ndDmL9bDhKw08GI45b/5sDiMmqC/G2E1EPDQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "VNod6MPLwfjhYgGxjTfy18OFR0SCrPdmeQT+oUC1TpE4heVFK+2suD4+dzd/YGAtu/lvC5O6XHpXiezfNJLBCQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "8bKpw1H9H42/ZQ+h4yEzR3/5FnLflk6Z/GU4ywpYHaPEsvtnYEXTjmRN+snEfCwW4LvbEmtvYXsjv0mnTLcKAg=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
             {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
@@ -328,19 +255,6 @@
               },
               "voting_power": "50",
               "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
             },
             {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
@@ -362,9 +276,40 @@
             }
           ]
         },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
+      "now": "1970-01-01T00:23:15Z",
       "verdict": "SUCCESS"
     },
     {
@@ -377,13 +322,13 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:08Z",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "validators_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
             "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "consensus_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
@@ -393,24 +338,30 @@
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
+              "hash": "248DA2EF41A1AD7CACA6E2F42D2FD07B859C46BF1BDDFCC23CD8CAC8B5AB91D4",
               "part_set_header": {
                 "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
+                "hash": "248DA2EF41A1AD7CACA6E2F42D2FD07B859C46BF1BDDFCC23CD8CAC8B5AB91D4"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "kg5PMzlQbZqGFUAcUNq/n3hy8FOgTyUZiExCo+776EUd+HVjm+5fe1WUra6hicVw7fE6nbSy77rb6Lubz8tIAw=="
               },
               {
                 "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "QNVaDq93XD6jt/bm8+pInRHl79u/9hak9rFKD74OBxp1X+YhZwSiPvLpn5tuY6R/GwOKJt/vsV76GS1iHOEOBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "7lxNvoBs1iBdcP4zE1pwJoShhwY+wE4L8rFWBIYChjUZuIt/ZBV2TIyt2zLTOJZvOkCUgEWCrUmXR/YMvBkiCg=="
               }
             ]
           }
@@ -427,10 +378,19 @@
               "proposer_priority": null
             },
             {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -452,7 +412,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:20Z",
+      "now": "1970-01-01T00:23:15Z",
       "verdict": "SUCCESS"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestLessThanTwoThirdsCommit.json
+++ b/light/mbt/json/MC4_4_faulty_TestLessThanTwoThirdsCommit.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_TestHeaderFromFuture.json",
+  "description": "MC4_4_faulty_TestLessThanTwoThirdsCommit.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+        "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D",
+          "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32",
           "part_set_header": {
             "total": 1,
-            "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D"
+            "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32"
           }
         },
         "signatures": [
@@ -36,40 +36,31 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "8rGIxi7DjBLFlHUo/lAgTpmzsnTZ8HOgnQaIoe+HEM5AmrjBaVDWVMb5/nNAnJTj4hcReCh4jviXcyRkItFJCA=="
+            "signature": "BwKig3Giy91zDlZ5BSa67+E0EV1K4q6At2piQgg1h48odVOAjEiC4Tt772ologMWt0gdjYzeYtYR15OKtza1Ag=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "3cXnzhzJLKeF47ulcIWjgqsv9JBf9olbAo0mcjo7Ij6TfmCpJO6SmTiacBkiznsFSOc1ZSH+cHDBKA4AT7ozAg=="
+            "signature": "EYx9XdH96HYFIJtaddpFF+u/1GBwE1A3/Ds2e5BGHnti62RBwgsdIWe3denuQxgYNPnIymqvrCiBAGEEtYJHBg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "4O8c5hxoHR861ldolxeY9W1iXCdxYJVIf0xD3+sANSxo0ipXayv8IS7YFw1zzZvDbjRRazVzbfyBYf2jl4JeDw=="
+            "signature": "QctMtMK8Zes6OspVTkVvKtwWix70IAp0okAi4zJjV981FEnOuK2j8Fd0WQNHHDyqFX7uGTVL5L7JqbBfLuvBAA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "2Hel7uygQXpjYRJZiwtPLKNxT2Tg1/F5Zzs3VZpleFII9H1e5Gs02UjU0lybSXBKk/tD+NXPsdchrH/6/DmwAQ=="
+            "signature": "yWtJtDMH9NOtAeRqomUYDa23BePOZ+y7FNiAxWZ9a8iYUOOxUU3CoCqxfRm6wpJWW2QUwBicQs7ntnU3z7cpBg=="
           }
         ]
       }
     },
     "next_validator_set": {
       "validators": [
-        {
-          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
         {
           "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
           "pub_key": {
@@ -78,29 +69,11 @@
           },
           "voting_power": "50",
           "proposer_priority": null
-        },
-        {
-          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
-        {
-          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
         }
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:26:49.160336600Z"
+    "now": "2020-10-23T09:12:00.160344432Z"
   },
   "input": [
     {
@@ -112,27 +85,27 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "1",
-            "time": "1970-01-01T00:23:25Z",
+            "height": "3",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
-            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "consensus_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
+            "validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "next_validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
+            "consensus_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
           },
           "commit": {
-            "height": "1",
+            "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "A95521DB540DB6D5B829DD0533D0B164BAB99CCDD12F886D5A2C830644846B3F",
+              "hash": "2D1610D51525EF8AB25E909B2ED119ECEE3D172340F0CC2382F316E98E8404A1",
               "part_set_header": {
                 "total": 1,
-                "hash": "A95521DB540DB6D5B829DD0533D0B164BAB99CCDD12F886D5A2C830644846B3F"
+                "hash": "2D1610D51525EF8AB25E909B2ED119ECEE3D172340F0CC2382F316E98E8404A1"
               }
             },
             "signatures": [
@@ -143,52 +116,15 @@
                 "signature": null
               },
               {
-                "block_id_flag": 1,
-                "validator_address": null,
-                "timestamp": null,
-                "signature": null
-              },
-              {
-                "block_id_flag": 1,
-                "validator_address": null,
-                "timestamp": null,
-                "signature": null
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "wF/dv3NmSNw+rEudEwb5H9TnCgkCbsen1LjVh1HGZg+PtlMsp5HVmPZqBqu5NHfwBAFk2J7d7cS3zmrZfKB9Cg=="
               }
             ]
           }
         },
         "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
           "validators": [
             {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
@@ -210,9 +146,40 @@
             }
           ]
         },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:24Z",
+      "now": "1970-01-01T00:23:20Z",
       "verdict": "INVALID"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestLessThanTwoThirdsSign.json
+++ b/light/mbt/json/MC4_4_faulty_TestLessThanTwoThirdsSign.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_TestSuccess.json",
+  "description": "MC4_4_faulty_TestLessThanTwoThirdsSign.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -82,7 +82,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:25:01.160336590Z"
+    "now": "2020-10-23T11:19:12.160345195Z"
   },
   "input": [
     {
@@ -94,35 +94,35 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "5",
-            "time": "1970-01-01T00:00:03Z",
+            "height": "4",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
-            "next_validators_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
-            "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "consensus_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
           },
           "commit": {
-            "height": "5",
+            "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "7881A02ABCFE0A40118D5F2B28AABDE0943DFADC4953E39284B09275A0C51B65",
+              "hash": "7FBAA25BE0FBC955709DDE7B2F79D072194ADB687CAA401CB2E780CD9F4C6EF9",
               "part_set_header": {
                 "total": 1,
-                "hash": "7881A02ABCFE0A40118D5F2B28AABDE0943DFADC4953E39284B09275A0C51B65"
+                "hash": "7FBAA25BE0FBC955709DDE7B2F79D072194ADB687CAA401CB2E780CD9F4C6EF9"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "i5lRbpUn4i8g37A6b/0T8ZwUhQ49vriPWD1exvZcFou8J5ybvEz05U3hllaV/asM9j+T5VVEkI/gJsRhQXDxAA=="
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "zGvLNVG/1oJcbOlVw5IOwnuoGeVdFIpCTxtu8NJCxaWUhqKjLST9Yby3MM6lF5GVYGb9OuQv9dMhnnVZg/QYCw=="
               }
             ]
           }
@@ -130,10 +130,10 @@
         "validator_set": {
           "validators": [
             {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -142,15 +142,6 @@
         },
         "next_validator_set": {
           "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
@@ -190,36 +181,30 @@
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "consensus_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+            "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
           },
           "commit": {
             "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "C7257252A6DB14548F4E545145A651CEB9B81C5FD0E92C25521B8EE0332772D9",
+              "hash": "8ED7FCB15D366398AAA6BC28AC319A5C53E28A953E30D0C8D3A1E848934BD58F",
               "part_set_header": {
                 "total": 1,
-                "hash": "C7257252A6DB14548F4E545145A651CEB9B81C5FD0E92C25521B8EE0332772D9"
+                "hash": "8ED7FCB15D366398AAA6BC28AC319A5C53E28A953E30D0C8D3A1E848934BD58F"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
                 "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "YH+VUpCYFI70Mzibl1by2FEcPbTYi2CbvUZxVgOgjGs+bJlBehJY2dTdY7OEBPp60Kw3YGNZkmzUC7LnIugmCQ=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "xUi2Aa/RqoPzxgblNKrB5G/i0HcLJVY0oMxRoKM1xqRI3PMhj4qhdUlJmC5lR0aqBBkfULFUMOilbgxIsxXMBg=="
+                "signature": "iOhVduRNAvbUxsumOE65tf1lbpK4UFAptiOEY8WW3tU2lXXZ381MYX83APbIpwvxTqFPrNW0tRqtXc0BBYXiAg=="
               }
             ]
           }
@@ -227,19 +212,10 @@
         "validator_set": {
           "validators": [
             {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -248,15 +224,6 @@
         },
         "next_validator_set": {
           "validators": [
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
@@ -271,7 +238,7 @@
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
       "now": "1970-01-01T00:00:06Z",
-      "verdict": "SUCCESS"
+      "verdict": "NOT_ENOUGH_TRUST"
     },
     {
       "block": {
@@ -282,68 +249,52 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:04Z",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
-            "consensus_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "validators_hash": "AAFE392AA939DA2A051F3C57707569B1836F93ACC8F35B57BB3CDF615B649013",
+            "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "consensus_hash": "AAFE392AA939DA2A051F3C57707569B1836F93ACC8F35B57BB3CDF615B649013",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
           },
           "commit": {
-            "height": "4",
+            "height": "2",
             "round": 1,
             "block_id": {
-              "hash": "F60F965077E52CF54D34E121EBC3083A8DA21C32C660B538FBB375453A16127F",
+              "hash": "99207D9FA21B347E553CD91C99D500CA228A76B120B574B7F9DEDB4A727B015D",
               "part_set_header": {
                 "total": 1,
-                "hash": "F60F965077E52CF54D34E121EBC3083A8DA21C32C660B538FBB375453A16127F"
+                "hash": "99207D9FA21B347E553CD91C99D500CA228A76B120B574B7F9DEDB4A727B015D"
               }
             },
             "signatures": [
               {
-                "block_id_flag": 2,
-                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "sYTZMxPFdi8Ob2In3dbHqWxJAuvADu3LpQd3/J6okK6qjJxcK4O6y66Zm/OVoc9Hrc+Gztjf8xl9lKblezWdCQ=="
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "nnpVLj/7LX9UBdCvmUYAKAI5ATU3mSITZqok0hCQlfWf0t5L4wSxQwsWF6jcva5IXHoEzGzpth+Dyz9ig6e4BA=="
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "tZ3xlcDbMYphxuyy5lF7LSNjqza266C9Sk9ZUTS40PFpmOi8Af4tF7X4RGag2vdGlZr6HUjUkSKosylD8qlpDA=="
               }
             ]
           }
         },
         "validator_set": {
-          "validators": [
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
           "validators": [
             {
               "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
@@ -353,13 +304,35 @@
               },
               "voting_power": "50",
               "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
             }
           ]
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:07Z",
-      "verdict": "SUCCESS"
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "INVALID"
     }
   ]
 }

--- a/light/mbt/json/MC4_4_faulty_TestMoreThanTwoThirdsSign.json
+++ b/light/mbt/json/MC4_4_faulty_TestMoreThanTwoThirdsSign.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_Test2NotEnoughTrustSuccess.json",
+  "description": "MC4_4_faulty_TestMoreThanTwoThirdsSign.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+        "next_validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32",
+          "hash": "6F70738E1F789E42D6F424F15A85D4B90BE287EB5A1E78DC3B2C8502EBAD2B28",
           "part_set_header": {
             "total": 1,
-            "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32"
+            "hash": "6F70738E1F789E42D6F424F15A85D4B90BE287EB5A1E78DC3B2C8502EBAD2B28"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "BwKig3Giy91zDlZ5BSa67+E0EV1K4q6At2piQgg1h48odVOAjEiC4Tt772ologMWt0gdjYzeYtYR15OKtza1Ag=="
+            "signature": "I5AZkBd3JQaOh2sqLkyym3I+sKJqP/4o9hFZW1+PPsIV46C2AkRqNC8OeElW02bTEOncxk5+XLI2M9LGkUfjCg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "EYx9XdH96HYFIJtaddpFF+u/1GBwE1A3/Ds2e5BGHnti62RBwgsdIWe3denuQxgYNPnIymqvrCiBAGEEtYJHBg=="
+            "signature": "XdFpwQTWY5ZIxAViOD1EC+sA5KCDMLLhoFaYjHp0Zuu1o+nDIhVKyuS8CD5IatLtHc7pN6APMZruCrUhKuc7Dg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "QctMtMK8Zes6OspVTkVvKtwWix70IAp0okAi4zJjV981FEnOuK2j8Fd0WQNHHDyqFX7uGTVL5L7JqbBfLuvBAA=="
+            "signature": "lpBxn4D/foZUdjZbl/wkWmRKCMm201a7tc1DuQ81KqEUW3jSer6qJWhXLkkVWd03MaSuA5SDegG3pjrvXdegBw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "yWtJtDMH9NOtAeRqomUYDa23BePOZ+y7FNiAxWZ9a8iYUOOxUU3CoCqxfRm6wpJWW2QUwBicQs7ntnU3z7cpBg=="
+            "signature": "e2kVRdlz5BMgxQMeAeL36SiywpgUyrePcbBUwuZbdFUiK9B3JlNgxg84ZN1OYV5JRIrwaGoIQtE0xHmOr0YgDg=="
           }
         ]
       }
@@ -69,11 +69,20 @@
           },
           "voting_power": "50",
           "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
         }
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:25:22.160336592Z"
+    "now": "2020-10-23T11:19:21.160345196Z"
   },
   "input": [
     {
@@ -85,41 +94,35 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:08Z",
+            "height": "3",
+            "time": "1970-01-01T00:00:05Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "consensus_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
             "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
           },
           "commit": {
-            "height": "4",
+            "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
+              "hash": "EF0342F50F4C4DC11FBE523DBB2839A890DBAC9916DD3D184BD365021F642798",
               "part_set_header": {
                 "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
+                "hash": "EF0342F50F4C4DC11FBE523DBB2839A890DBAC9916DD3D184BD365021F642798"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "LuRKF3kNlsc95TyKYR/IjBFgc5qFzjXxcH42tx5rduvZI/T4kSYO7QmWnjPl3l7DJenNNyNya514qze9ZEgYDA=="
               }
             ]
           }
@@ -134,132 +137,11 @@
               },
               "voting_power": "50",
               "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
             }
           ]
         },
         "next_validator_set": {
           "validators": [
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "3",
-            "time": "1970-01-01T00:00:06Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "consensus_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
-          },
-          "commit": {
-            "height": "3",
-            "round": 1,
-            "block_id": {
-              "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53",
-              "part_set_header": {
-                "total": 1,
-                "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "MaQRn3tj7Suri3Hr7uyegcAKmdKLTe/4eAzjKYHrcGjfO/5RM7ElnS5A/mirppc1etmKflVlbp8lWn5TDDNJCQ=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "PtO5WN7sBXjCWyjU8HSjOf8HAIdCujLwmJLQbEfLXRTWeHRUYCoasFVVtcXaPCBCBTRXvt7adR81ecg8JK+cCg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "e6H6dh3ECPlQsOv3Yw7uVHhvGhlLfE/fcqMFlXyGeofpZOAsYN25QDHX+NbScIHhUQmpInx/ytFiah3IYlwWDw=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
@@ -273,7 +155,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
+      "now": "1970-01-01T00:00:06Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -286,13 +168,13 @@
             },
             "chain_id": "test-chain",
             "height": "2",
-            "time": "1970-01-01T00:00:05Z",
+            "time": "1970-01-01T00:00:03Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "next_validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "next_validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
+            "consensus_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
@@ -302,18 +184,24 @@
             "height": "2",
             "round": 1,
             "block_id": {
-              "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF",
+              "hash": "679DB5E6DC897365B04CD574612A84F384A73BCAF4E72C0C2473B7034956077E",
               "part_set_header": {
                 "total": 1,
-                "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF"
+                "hash": "679DB5E6DC897365B04CD574612A84F384A73BCAF4E72C0C2473B7034956077E"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "+e4OBaptWoaVX6A/UGsXNrNXJXjztwk1IRvmxWsTWRcxiB4AydLU/uFEiX+rp1PbNHZDhZWsI/Pprb7CY2hsAg=="
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "CQprYceLYcAq4nVtoTZCiKPxVuL2dcMQ7f0STGpeNdqSs4OVQaXgWjbxmNI7D65u9Qm/WAndNrraVh67fJ2zCg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "XdYya7WmuGRrAjlu2lhqK5DYpZMDYUxWOJDViEdMcpzvTcBBOfmSpI93/ueCnJJYK+xvMs7cf4JjPN0OnIo5AQ=="
               }
             ]
           }
@@ -328,20 +216,20 @@
               },
               "voting_power": "50",
               "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
             }
           ]
         },
         "next_validator_set": {
           "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
@@ -364,7 +252,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
+      "now": "1970-01-01T00:23:20Z",
       "verdict": "SUCCESS"
     },
     {
@@ -377,13 +265,13 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:08Z",
+            "time": "1970-01-01T00:00:05Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "next_validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
+            "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
@@ -393,24 +281,36 @@
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
+              "hash": "FD105EDFB0C7763F755D3C0DC2485AFC8F5392DB17194AB12D2C4F7A4FE65952",
               "part_set_header": {
                 "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
+                "hash": "FD105EDFB0C7763F755D3C0DC2485AFC8F5392DB17194AB12D2C4F7A4FE65952"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "8WsOdhPd67r5HcpEfx2MUIiI346xeKqhw/qpz+GP8T8F5VCLI3MtlivvL18lhyZADTi+sNMLEufudhyOLBkuDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "4pk6/wfLryukhtqfZBOfzRbFEqMpbymebovDgkjRSL6SrYTN5w0VDpg0DyH0v/xrt16m1OhPUfwhqt3wGs9HBA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "7wKIeQ0PcHMVmYPuhVtCI+KGRx1qBY3gyM4H6p4ASVJRjfHDkYYpu/7p5y/v6MeHEoZP3Cxy6j7/259qCIj3Dg=="
               }
             ]
           }
@@ -427,6 +327,24 @@
               "proposer_priority": null
             },
             {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
               "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
@@ -447,12 +365,21 @@
               },
               "voting_power": "50",
               "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
             }
           ]
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:20Z",
+      "now": "1970-01-01T00:23:22Z",
       "verdict": "SUCCESS"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestNonMonotonicHeight.json
+++ b/light/mbt/json/MC4_4_faulty_TestNonMonotonicHeight.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_TestHeaderFromFuture.json",
+  "description": "MC4_4_faulty_TestNonMonotonicHeight.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+        "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D",
+          "hash": "C106084B050BDCC5AEBC414628992E43B6216544E19826BAB46027350C5FD3C5",
           "part_set_header": {
             "total": 1,
-            "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D"
+            "hash": "C106084B050BDCC5AEBC414628992E43B6216544E19826BAB46027350C5FD3C5"
           }
         },
         "signatures": [
@@ -36,58 +36,31 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "8rGIxi7DjBLFlHUo/lAgTpmzsnTZ8HOgnQaIoe+HEM5AmrjBaVDWVMb5/nNAnJTj4hcReCh4jviXcyRkItFJCA=="
+            "signature": "q0CS2J0SFpdIVuqaHEmdp8epPcZli61bfVkdA720J+TzJ06ahepHUry6P/ZD+ex6GuQcSjBP6mfzp0ksjqf3BQ=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "3cXnzhzJLKeF47ulcIWjgqsv9JBf9olbAo0mcjo7Ij6TfmCpJO6SmTiacBkiznsFSOc1ZSH+cHDBKA4AT7ozAg=="
+            "signature": "jKDmxZTfFv5xlj3byRSxV8gMDQUirQE4O8hPKvp9EvmIWwCX1S7D/qQo+GhCvfiF3QPdQ3kRCpdvwrTuq+6RBA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "4O8c5hxoHR861ldolxeY9W1iXCdxYJVIf0xD3+sANSxo0ipXayv8IS7YFw1zzZvDbjRRazVzbfyBYf2jl4JeDw=="
+            "signature": "AL2jwdkeW/o9DjLU3vfcqKG9QCqnhKxdPN4i/miR6FIA87v4Y45jFvZw8Ue6hhwkGKs3d1QghJXVlRJFg8VXDw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "2Hel7uygQXpjYRJZiwtPLKNxT2Tg1/F5Zzs3VZpleFII9H1e5Gs02UjU0lybSXBKk/tD+NXPsdchrH/6/DmwAQ=="
+            "signature": "gV5npKv90ghI2wj2MP06qkVyWTbjBwBzdQnBS3ssggEE+is/BRMQQfKEKpmTAF0KIS+eZj7jmj8b+isxC3QfDw=="
           }
         ]
       }
     },
     "next_validator_set": {
       "validators": [
-        {
-          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
-        {
-          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
-        {
-          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
         {
           "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
           "pub_key": {
@@ -100,7 +73,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:26:49.160336600Z"
+    "now": "2020-10-22T11:28:23.160336610Z"
   },
   "input": [
     {
@@ -113,51 +86,52 @@
             },
             "chain_id": "test-chain",
             "height": "1",
-            "time": "1970-01-01T00:23:25Z",
+            "time": "1970-01-01T00:00:02Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
-            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "consensus_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
+            "validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "next_validators_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
+            "consensus_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
           },
           "commit": {
             "height": "1",
             "round": 1,
             "block_id": {
-              "hash": "A95521DB540DB6D5B829DD0533D0B164BAB99CCDD12F886D5A2C830644846B3F",
+              "hash": "9EA38127C9C1CE47D3E9872FEBEDBFDBC23A93D90367AA09F417CD6E710AA9A8",
               "part_set_header": {
                 "total": 1,
-                "hash": "A95521DB540DB6D5B829DD0533D0B164BAB99CCDD12F886D5A2C830644846B3F"
+                "hash": "9EA38127C9C1CE47D3E9872FEBEDBFDBC23A93D90367AA09F417CD6E710AA9A8"
               }
             },
             "signatures": [
               {
-                "block_id_flag": 1,
-                "validator_address": null,
-                "timestamp": null,
-                "signature": null
-              },
-              {
-                "block_id_flag": 1,
-                "validator_address": null,
-                "timestamp": null,
-                "signature": null
-              },
-              {
-                "block_id_flag": 1,
-                "validator_address": null,
-                "timestamp": null,
-                "signature": null
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "HumsQ0kvIX1I94okl8Gt/i4AHlxFiPwhce9WbK7rjYHQE8i4UOIM6ZNJ7jhWICxRY+r93xVzJ4dIZkMzJN2OBw=="
               }
             ]
           }
         },
         "validator_set": {
+          "validators": [
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
           "validators": [
             {
               "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
@@ -168,28 +142,6 @@
               "voting_power": "50",
               "proposer_priority": null
             },
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
             {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
@@ -212,7 +164,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:24Z",
+      "now": "1970-01-01T00:23:20Z",
       "verdict": "INVALID"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestOneThirdValsetChanges.json
+++ b/light/mbt/json/MC4_4_faulty_TestOneThirdValsetChanges.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_Test2NotEnoughTrustSuccess.json",
+  "description": "MC4_4_faulty_TestOneThirdValsetChanges.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+        "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32",
+          "hash": "658DEEC010B33EDB1977FA7B38087A8C547D65272F6A63854959E517AAD20597",
           "part_set_header": {
             "total": 1,
-            "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32"
+            "hash": "658DEEC010B33EDB1977FA7B38087A8C547D65272F6A63854959E517AAD20597"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "BwKig3Giy91zDlZ5BSa67+E0EV1K4q6At2piQgg1h48odVOAjEiC4Tt772ologMWt0gdjYzeYtYR15OKtza1Ag=="
+            "signature": "gUvww0D+bCNnq0wY4GvDkWAUQO3kbi9YvmoRBAC3goRZ6mW8Fh6V9hrMQYbpRpf7LZqFAdnleFgXnnEuKz17Bg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "EYx9XdH96HYFIJtaddpFF+u/1GBwE1A3/Ds2e5BGHnti62RBwgsdIWe3denuQxgYNPnIymqvrCiBAGEEtYJHBg=="
+            "signature": "54nTri+VJoBu8HCTb+c92aYrPiMSM71qVDkdRtwmE40LWPUFkTJNTqTLXbBXutQ1p5s6PyuB+p4UfWAwYCuUCQ=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "QctMtMK8Zes6OspVTkVvKtwWix70IAp0okAi4zJjV981FEnOuK2j8Fd0WQNHHDyqFX7uGTVL5L7JqbBfLuvBAA=="
+            "signature": "PWesm77j/+sQh1p00pDJv3R3B9tpe1HlfhaTS2be/5FZfq3EMH3ceplTSNGsQKo0p4f8N9UUq+TYwm+3dsZeBg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "yWtJtDMH9NOtAeRqomUYDa23BePOZ+y7FNiAxWZ9a8iYUOOxUU3CoCqxfRm6wpJWW2QUwBicQs7ntnU3z7cpBg=="
+            "signature": "ngAHu3FpNX6aW4B7xmFd7ckNScOM+lfuCQuMDs7uq20UoNnnGasFOcFMXD+0dQnRndEu1RItr+0kgxKaD6OtAQ=="
           }
         ]
       }
@@ -62,10 +62,10 @@
     "next_validator_set": {
       "validators": [
         {
-          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
           "pub_key": {
             "type": "tendermint/PubKeyEd25519",
-            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
           },
           "voting_power": "50",
           "proposer_priority": null
@@ -73,7 +73,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:25:22.160336592Z"
+    "now": "2020-10-22T11:28:16.160336609Z"
   },
   "input": [
     {
@@ -86,226 +86,26 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:08Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
-          },
-          "commit": {
-            "height": "4",
-            "round": 1,
-            "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
-              "part_set_header": {
-                "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "3",
-            "time": "1970-01-01T00:00:06Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "consensus_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
-          },
-          "commit": {
-            "height": "3",
-            "round": 1,
-            "block_id": {
-              "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53",
-              "part_set_header": {
-                "total": 1,
-                "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "MaQRn3tj7Suri3Hr7uyegcAKmdKLTe/4eAzjKYHrcGjfO/5RM7ElnS5A/mirppc1etmKflVlbp8lWn5TDDNJCQ=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "PtO5WN7sBXjCWyjU8HSjOf8HAIdCujLwmJLQbEfLXRTWeHRUYCoasFVVtcXaPCBCBTRXvt7adR81ecg8JK+cCg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "e6H6dh3ECPlQsOv3Yw7uVHhvGhlLfE/fcqMFlXyGeofpZOAsYN25QDHX+NbScIHhUQmpInx/ytFiah3IYlwWDw=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "2",
             "time": "1970-01-01T00:00:05Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "next_validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+            "validators_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
+            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "consensus_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
             "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
           },
           "commit": {
-            "height": "2",
+            "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF",
+              "hash": "19C2A8D5DD804BAF32BD88C81DB6A9894D798033C35EF20095EE67224A746DD0",
               "part_set_header": {
                 "total": 1,
-                "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF"
+                "hash": "19C2A8D5DD804BAF32BD88C81DB6A9894D798033C35EF20095EE67224A746DD0"
               }
             },
             "signatures": [
@@ -313,7 +113,19 @@
                 "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
                 "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "+e4OBaptWoaVX6A/UGsXNrNXJXjztwk1IRvmxWsTWRcxiB4AydLU/uFEiX+rp1PbNHZDhZWsI/Pprb7CY2hsAg=="
+                "signature": "wtuoqu1tYQtCFOMeYcvFFYKYfuxWLqztahb/ov2VgJu9C50JbGgUhRQGG7jF8ve3ZzX+9wSCZywNHMktVhUXBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "QrNq42XvCo16zHOmVoBt2PGdddGdNauTnKmXqiR9o6R+g/LcWANC7P23GeUtov56HCaPd6acMbcaotanWqQOBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "A8jPwEUu49Er73xFNnkOJd/YFr7MWs3mB5FFRWiS8ntzgSmbmii4ihrg5S/rbLdJ2XGNcC5XC0ne18Pcq+2GAw=="
               }
             ]
           }
@@ -328,6 +140,97 @@
               },
               "voting_power": "50",
               "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:06Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "next_validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
+            "consensus_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "54C7AA877B2EAC437AC9977E49FFDB86A5E0E04B6C107BA261B15468AFD2EDC6",
+              "part_set_header": {
+                "total": 1,
+                "hash": "54C7AA877B2EAC437AC9977E49FFDB86A5E0E04B6C107BA261B15468AFD2EDC6"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "Fqj1FgyE6O7FQWGLHJNWbUlOgZNcmbhFubhWySAML5IXHNRuQLOKoR4Xlv1ADuIc6MJamXxsxLbfOWFa0ZanCg=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
             }
           ]
         },
@@ -364,7 +267,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
+      "now": "1970-01-01T00:00:06Z",
       "verdict": "SUCCESS"
     },
     {
@@ -376,41 +279,47 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:08Z",
+            "height": "3",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
+            "next_validators_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
+            "consensus_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
             "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
           },
           "commit": {
-            "height": "4",
+            "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
+              "hash": "5F28741D26480BE6A2D86D9B016C2949572A9132048C4F4896FD222A0C9104D8",
               "part_set_header": {
                 "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
+                "hash": "5F28741D26480BE6A2D86D9B016C2949572A9132048C4F4896FD222A0C9104D8"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "qSfJzYxkMoh/8WmwCDfeHBvpptwlwGlsOEx1/ZngLQ1unw546zFsb9A00IRKJK8sCrKO691PCyr0ieDXi7DYAg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "eomyT7npk83f4+wu2RPhmtrwl7ttec2tl6YgZN00eC11J2NP2yaJvDKhc3quSbCCYOPn9Egr03ag6uedhZx1Bg=="
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "BYcH6gzn/3bKmaVUbnl2TNX7b14Dgcr8sc6yLQi9tVHlDYMjSV2W5LSurYmt5IZR67AcuOyoTrK/noYUWJhvCw=="
               }
             ]
           }
@@ -427,6 +336,15 @@
               "proposer_priority": null
             },
             {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
               "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
@@ -440,10 +358,28 @@
         "next_validator_set": {
           "validators": [
             {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
                 "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -452,7 +388,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:20Z",
+      "now": "1970-01-01T00:00:06Z",
       "verdict": "SUCCESS"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestUntrustedBeforeTrusted.json
+++ b/light/mbt/json/MC4_4_faulty_TestUntrustedBeforeTrusted.json
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+        "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D",
+          "hash": "F8BF7840885A99FA64C63E1E7FE82D8F52B0AA1BA2EF07F2635C802395ADCBC1",
           "part_set_header": {
             "total": 1,
-            "hash": "6B68DB34DEF944920D6638B3AA84FE1DF790BC8BDC5189E201F23730D5756A9D"
+            "hash": "F8BF7840885A99FA64C63E1E7FE82D8F52B0AA1BA2EF07F2635C802395ADCBC1"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "8rGIxi7DjBLFlHUo/lAgTpmzsnTZ8HOgnQaIoe+HEM5AmrjBaVDWVMb5/nNAnJTj4hcReCh4jviXcyRkItFJCA=="
+            "signature": "N5ZDai/KuXqdr5EuFqrVrsCoFSVu6vMZ9KiO/Lsf51EZfZp8XB0z2O7ZE7Y0r8HJ7EAD/qUWl+YPd6vly9yWAg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "3cXnzhzJLKeF47ulcIWjgqsv9JBf9olbAo0mcjo7Ij6TfmCpJO6SmTiacBkiznsFSOc1ZSH+cHDBKA4AT7ozAg=="
+            "signature": "agSsZySOIbHGrxevGukb5D4h6HAZduJy1dnGpmv1CfkRTnZoybKroPsLxPKbz1X8HCFSyHl4AmvCo8AxjmMfAA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "4O8c5hxoHR861ldolxeY9W1iXCdxYJVIf0xD3+sANSxo0ipXayv8IS7YFw1zzZvDbjRRazVzbfyBYf2jl4JeDw=="
+            "signature": "Ka/EiGMHhSSB/W9Q5xQJZxDtxdMrMe+ot+KuGHEQM8/PLXysv8jdqSJxJJDVG5W/oC574KZV2VVB5Z0Dwf8+AQ=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "2Hel7uygQXpjYRJZiwtPLKNxT2Tg1/F5Zzs3VZpleFII9H1e5Gs02UjU0lybSXBKk/tD+NXPsdchrH/6/DmwAQ=="
+            "signature": "4n3lkaT66wZu6RBZ5/Dr0ewnPaWhKx6sJecUfva71XrFONJgbrX998bEbhObhFNzrEoFhCOcupgZYmcn4sB5Bg=="
           }
         ]
       }
@@ -71,24 +71,6 @@
           "proposer_priority": null
         },
         {
-          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
-        {
-          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-          "pub_key": {
-            "type": "tendermint/PubKeyEd25519",
-            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-          },
-          "voting_power": "50",
-          "proposer_priority": null
-        },
-        {
           "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
           "pub_key": {
             "type": "tendermint/PubKeyEd25519",
@@ -100,7 +82,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-21T08:47:47.160327006Z"
+    "now": "2020-10-22T11:26:55.160336601Z"
   },
   "input": [
     {
@@ -112,13 +94,13 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "4",
+            "height": "1",
             "time": "1970-01-01T00:00:00Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
             "validators_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
-            "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "next_validators_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
             "consensus_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
             "app_hash": "",
             "last_results_hash": null,
@@ -126,21 +108,21 @@
             "proposer_address": "730D3D6B2E9F4F0F23879458F2D02E0004F0F241"
           },
           "commit": {
-            "height": "4",
+            "height": "1",
             "round": 1,
             "block_id": {
-              "hash": "D1E7988F2C5B176E1AE1D7CA03F17A2734B1A90B154D41D0C01FEE49BA63DBAA",
+              "hash": "3BF175611AB22F5AE52AF0A74C34509384E35CDC15863735767014E09846A3A3",
               "part_set_header": {
                 "total": 1,
-                "hash": "D1E7988F2C5B176E1AE1D7CA03F17A2734B1A90B154D41D0C01FEE49BA63DBAA"
+                "hash": "3BF175611AB22F5AE52AF0A74C34509384E35CDC15863735767014E09846A3A3"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
                 "timestamp": "1970-01-01T00:00:00Z",
-                "signature": "lJ/0qcg9/3PcEtnDSR10pswu0kZjfD8GSp03Esc/O6Odg8v20ZFIZCLUEbyFays23MfMpI08bYJrF9QnKjMQAw=="
+                "signature": "ZFpEsch/8LqKlImmxEPsY2f/t9qB2g39I8XNUTJbFGzOu4GOfDX269315f15URmJSfgGV8I4XX25rBWF3310Dw=="
               }
             ]
           }
@@ -158,12 +140,21 @@
               },
               "voting_power": "50",
               "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
             }
           ]
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:24Z",
+      "now": "1970-01-01T00:23:20Z",
       "verdict": "INVALID"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestValsetChangesFully.json
+++ b/light/mbt/json/MC4_4_faulty_TestValsetChangesFully.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_TestSuccess.json",
+  "description": "MC4_4_faulty_TestValsetChangesFully.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "AAFE392AA939DA2A051F3C57707569B1836F93ACC8F35B57BB3CDF615B649013",
+        "next_validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "1C7FFFFB7BA0E2AA68FD6C9AB0F5E177A78AA392A60C9ECC89CAD3DAE1C80E57",
+          "hash": "A5ED6144C7003D68A267156E28228A4ADC690A03FC491A83920B41F855BB299B",
           "part_set_header": {
             "total": 1,
-            "hash": "1C7FFFFB7BA0E2AA68FD6C9AB0F5E177A78AA392A60C9ECC89CAD3DAE1C80E57"
+            "hash": "A5ED6144C7003D68A267156E28228A4ADC690A03FC491A83920B41F855BB299B"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "FKIpE4jILZ3tmeBUFmaT48nAxIBsAIRcnQ6dBdqHV6Xjhd2Bex94Yaqgg7Lv5NL1HACt5qH60qVRiEsv5oJwAA=="
+            "signature": "hTOXQPlsMVnL7Zf0W7SMrjRHu/toFNmvl11nKlabnqGS/+HwdMuXPl9NUJ+6TeLoeLbMd4jlL9VlFFsHGFw5Aw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "uuvlEKa9M4a+VtHoE2Racjm2Tzb41Hf/TH35lP158juWjHEgg2k1MnthMhcFaBxdeCucQulrAwUGd99/L4+uCg=="
+            "signature": "I8KITnGyQ8/CPgotAOzRzJFnxWY1+0EtUjCqTbGGzZYGvMVdOCBI0vJSSfFKrotDdiBX+LEujwDhvanzYo9ZAg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "Lolcqh4BLNDC4KTdmaB1bCXA0KjCKB8Rk73qvfL1oojxIIuA1l6WBES9iDPdoEe2QwPwOMtwbGj/A1NwJnvgAw=="
+            "signature": "WARVzJvfwdy//eW5vBhVUkc7JotrzW9gokFrRHhbB0teuejlv5E1CoghipOtCwL+5TC7DrDjO1nAVMN6UOY2Bg=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "NYxAvpFkpNWI9VLFcqdJyOT1KMMD2ZYCKLV4h0yuU+DkoyYmJnJv0dPtUXwalVHw0LT9K1Ad6f7rI3AfLTEuAw=="
+            "signature": "FDtH8Wf3oJfknMVVKaoA2Veh0OSPOBzKA24iapbcXyOVaMVGeDmOAJIDRGXS6dUMtNM4QCnod8IvyDTpfO9rDg=="
           }
         ]
       }
@@ -71,10 +71,19 @@
           "proposer_priority": null
         },
         {
-          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
           "pub_key": {
             "type": "tendermint/PubKeyEd25519",
-            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
           },
           "voting_power": "50",
           "proposer_priority": null
@@ -82,7 +91,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:25:01.160336590Z"
+    "now": "2020-10-22T11:27:55.160336607Z"
   },
   "input": [
     {
@@ -94,13 +103,119 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "5",
-            "time": "1970-01-01T00:00:03Z",
+            "height": "4",
+            "time": "1970-01-01T00:00:05Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "next_validators_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
+            "consensus_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+          },
+          "commit": {
+            "height": "4",
+            "round": 1,
+            "block_id": {
+              "hash": "F13D3322081DBDEB5BDEED089304A016CCA39F28E4F8C59324AA8B557CFCFC1F",
+              "part_set_header": {
+                "total": 1,
+                "hash": "F13D3322081DBDEB5BDEED089304A016CCA39F28E4F8C59324AA8B557CFCFC1F"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "Fx/QNjmw+NdCh/mqckweffW+TRW/DaK0+blabZCShyo7z6nig19J61owrmTtU4FlwCxnpP4KKFxLLd4tUu/NAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "yD+i4zPmP6T0JfPWz9Mm2BTvEveIjgA3J3IIocX47szcnbw+DW0+rYLDhprUSy4Y7JFkoIxZXp5qu4whkVGxBQ=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:18Z",
+      "verdict": "NOT_ENOUGH_TRUST"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "3",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
             "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
-            "next_validators_hash": "5F7419DA4B1BCFC2D2EB8C663405D9FF67DDE3BF88DB0A8A5D579E6FF1AD814E",
+            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
             "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
             "app_hash": "",
             "last_results_hash": null,
@@ -108,21 +223,21 @@
             "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
           },
           "commit": {
-            "height": "5",
+            "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "7881A02ABCFE0A40118D5F2B28AABDE0943DFADC4953E39284B09275A0C51B65",
+              "hash": "2BB38DF1FB0201097BC5E8B112DD7637758E6595FDD88B441FB49E8A24290FF3",
               "part_set_header": {
                 "total": 1,
-                "hash": "7881A02ABCFE0A40118D5F2B28AABDE0943DFADC4953E39284B09275A0C51B65"
+                "hash": "2BB38DF1FB0201097BC5E8B112DD7637758E6595FDD88B441FB49E8A24290FF3"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "i5lRbpUn4i8g37A6b/0T8ZwUhQ49vriPWD1exvZcFou8J5ybvEz05U3hllaV/asM9j+T5VVEkI/gJsRhQXDxAA=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "fMfbq0k+aKWtXpdR8Bzpi/5fKknbPz3YxcZBw61OkephofeQEXMsnEUdWQ9dGw71khik1c8fuqB1yixgwO4bBg=="
               }
             ]
           }
@@ -143,15 +258,6 @@
         "next_validator_set": {
           "validators": [
             {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
@@ -173,7 +279,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:05Z",
+      "now": "1970-01-01T00:23:18Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -185,165 +291,52 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "3",
-            "time": "1970-01-01T00:00:03Z",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "next_validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "consensus_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
+            "validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
+            "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "consensus_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
           },
           "commit": {
-            "height": "3",
+            "height": "2",
             "round": 1,
             "block_id": {
-              "hash": "C7257252A6DB14548F4E545145A651CEB9B81C5FD0E92C25521B8EE0332772D9",
+              "hash": "5087FB31511F911893BFDBCC36DC87F59C3D6D22CDE4B8CA1CF0F7CEC5EBD60D",
               "part_set_header": {
                 "total": 1,
-                "hash": "C7257252A6DB14548F4E545145A651CEB9B81C5FD0E92C25521B8EE0332772D9"
+                "hash": "5087FB31511F911893BFDBCC36DC87F59C3D6D22CDE4B8CA1CF0F7CEC5EBD60D"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "YH+VUpCYFI70Mzibl1by2FEcPbTYi2CbvUZxVgOgjGs+bJlBehJY2dTdY7OEBPp60Kw3YGNZkmzUC7LnIugmCQ=="
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "vGgE20/Ks8N85nyZggzMS2ASe92eEWS4huNstlhUSQFqJcpQd6k6JD1IBF+2jtyxbytp3u50V30PMtjSc4tuCQ=="
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "xUi2Aa/RqoPzxgblNKrB5G/i0HcLJVY0oMxRoKM1xqRI3PMhj4qhdUlJmC5lR0aqBBkfULFUMOilbgxIsxXMBg=="
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "xrlBMcfGstu15qjjwhIEIMenpVhwN30JlkO5ufaGr2YhiOr/xKhYceyliHILvJ3pPMuV0UfM6h7Vlsp+57OYCQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "n8Pn9KLP/6piGPwYRNeKd7HcOK1uXevM48RKsaSjPVF7a67rewF/uKeDzw6hZ04O6/DTg0eSj+iQV+sLROgXBg=="
               }
             ]
           }
         },
         "validator_set": {
-          "validators": [
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:00:06Z",
-      "verdict": "SUCCESS"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:04Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
-            "consensus_hash": "E624CE5E2693812E58E8DBB64C7A05149A58157114D34F08CB5992FE2BECC0A7",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
-          },
-          "commit": {
-            "height": "4",
-            "round": 1,
-            "block_id": {
-              "hash": "F60F965077E52CF54D34E121EBC3083A8DA21C32C660B538FBB375453A16127F",
-              "part_set_header": {
-                "total": 1,
-                "hash": "F60F965077E52CF54D34E121EBC3083A8DA21C32C660B538FBB375453A16127F"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "sYTZMxPFdi8Ob2In3dbHqWxJAuvADu3LpQd3/J6okK6qjJxcK4O6y66Zm/OVoc9Hrc+Gztjf8xl9lKblezWdCQ=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "nnpVLj/7LX9UBdCvmUYAKAI5ATU3mSITZqok0hCQlfWf0t5L4wSxQwsWF6jcva5IXHoEzGzpth+Dyz9ig6e4BA=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
           "validators": [
             {
               "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
@@ -353,12 +346,43 @@
               },
               "voting_power": "50",
               "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
             }
           ]
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:07Z",
+      "now": "1970-01-01T00:23:18Z",
       "verdict": "SUCCESS"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestValsetDifferentAllSteps.json
+++ b/light/mbt/json/MC4_4_faulty_TestValsetDifferentAllSteps.json
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
+        "next_validators_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "42C62AB26BDCD052FD7D87449C1CA700A79780D55E2FC8129614D4D2DC24CB08",
+          "hash": "EAA36857D0DB20A7B1E315A74E9871F509D7FD52CD3172CFD7A0A9E360CD6759",
           "part_set_header": {
             "total": 1,
-            "hash": "42C62AB26BDCD052FD7D87449C1CA700A79780D55E2FC8129614D4D2DC24CB08"
+            "hash": "EAA36857D0DB20A7B1E315A74E9871F509D7FD52CD3172CFD7A0A9E360CD6759"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "mzNheVmshOSGCNfL/NfBBpJcofUx6cqclvEMOc9rZJ6A2pOrxO8ZymXej0FvksZ5mmhfLvZ0aW+as59WMldWBw=="
+            "signature": "qnqWPNmmyQfNJkhPH2YBpWRlGjoLOoTzGLAKYuBuDzuLpDhvh+F4AOwsalo+qR70Lpx/yKU/+BTLPGxIIP47DA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "KisuL/gVSTDQP1Q51uBKd8xDZM4mX+rRKIpMlkfUYF+qW4K51sPvqL/pgKSiUwBPAoGRBzwLoavPg9oiyRwPBA=="
+            "signature": "n0hMeOMwr+ZtcObdo2T99UzOfulXuCS7nbNCVbo7IrgqLHfo6xlxEddlOdYQp+3quMGI79osrl4EYvTB5wU4Cw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "fgq+19zjPxTp8HILDBaW8VJg+wzyVkthtmf0HJxdoaXd+uZRQ7LDS2Tn7LXMKAQ9Q0sjtZ4BA3H3sfv9wA56BA=="
+            "signature": "v52uJnW0wNu4YPG7K46I+sGGJxj+0wx09KQZZsbmspL02nH3LhZahLFb3KBhswHevKKlo52X4VKszwRnlw+yDA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "Zy0rovAtLk58hTcprpXU7ikCdbky5rrQ8Y3o+/Xyo7VTt3zYiCdVsYj26agu8SR3cFkV96P2ryHF6NHWGwIJDw=="
+            "signature": "HuW1zhtKSgz1Z5JXr2Gyvw3q/bh2Wxf34cmkn8j/d5v3EZtDzfl+T4Y42Pgb9cnBLpKF2YmUkKcv2pyoctf5AA=="
           }
         ]
       }
@@ -62,19 +62,19 @@
     "next_validator_set": {
       "validators": [
         {
-          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
           "pub_key": {
             "type": "tendermint/PubKeyEd25519",
-            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
           },
           "voting_power": "50",
           "proposer_priority": null
         },
         {
-          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
           "pub_key": {
             "type": "tendermint/PubKeyEd25519",
-            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
           },
           "voting_power": "50",
           "proposer_priority": null
@@ -91,7 +91,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-21T08:47:18.160327003Z"
+    "now": "2020-10-22T11:26:42.160336600Z"
   },
   "input": [
     {
@@ -103,35 +103,35 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:05Z",
+            "height": "5",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
-            "next_validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
-            "consensus_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "validators_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
+            "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "consensus_hash": "C8F8530F1A2E69409F2E0B4F86BB568695BC9790BA77EAC1505600D5506E22DA",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF"
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
           },
           "commit": {
-            "height": "4",
+            "height": "5",
             "round": 1,
             "block_id": {
-              "hash": "943FD341C1558245A93577E0A7CF48089B9E0FA175DE817A61EF7233AF810BF6",
+              "hash": "5491FE6DC9B3BD19DC0D2DAA1D72C6294D774D6EFAC275EEABE1625F2F202214",
               "part_set_header": {
                 "total": 1,
-                "hash": "943FD341C1558245A93577E0A7CF48089B9E0FA175DE817A61EF7233AF810BF6"
+                "hash": "5491FE6DC9B3BD19DC0D2DAA1D72C6294D774D6EFAC275EEABE1625F2F202214"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "Y9RiUiuj/kTgPU1BCNrWbNSHEcyf3nr1o0ohY1xkRf89rYRu34oJSWU65paMAfPAosfeaHHPjYXG2whJk+dGBQ=="
+                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "Qz1Ef2ICvXm5GuBlXdTbdqv3rw8mXVM0v79t1bF+p+xycHctJsZwERqroMeOTJ7Aqv7t7KisX+TLa1KpPefkBw=="
               }
             ]
           }
@@ -139,10 +139,10 @@
         "validator_set": {
           "validators": [
             {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -159,64 +159,16 @@
               },
               "voting_power": "50",
               "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:00:06Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
             },
-            "chain_id": "test-chain",
-            "height": "3",
-            "time": "1970-01-01T00:00:04Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
-            "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
-            "consensus_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
-          },
-          "commit": {
-            "height": "3",
-            "round": 1,
-            "block_id": {
-              "hash": "48A8E428AF500C9BD5674A9A2FC1217DD97B144FD623DDD2C4679022E19A5615",
-              "part_set_header": {
-                "total": 1,
-                "hash": "48A8E428AF500C9BD5674A9A2FC1217DD97B144FD623DDD2C4679022E19A5615"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "WUKkETiWSMDSgd/7sxOD8KgDrL/kg78vXbA2r42+qEvuzZSuwob+7yHXYEn32lDtLl5lnsENVIjtqUrEPkQKBg=="
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
               },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:04Z",
-                "signature": "3H9a3YJJjqewYR3HhSMxM3yAy0niBUhWX0+6K67UJVeEtXXVIk/OQJ9HeVmghsayGEJGvzcyjbHDD9CIkk/VDw=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
+              "voting_power": "50",
+              "proposer_priority": null
+            },
             {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
@@ -237,22 +189,9 @@
             }
           ]
         },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:06Z",
+      "now": "1970-01-01T00:23:18Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -264,62 +203,47 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "2",
-            "time": "1970-01-01T00:00:03Z",
+            "height": "3",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
-            "next_validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
-            "consensus_hash": "010ED897B4B347175BC54ADF87D640393862FF3D5038302CD523B0E97FC20079",
+            "validators_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
+            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "consensus_hash": "8F7563A251157673D3222D25CC728CE0C9D049A33D8776DC9A2465DEEEC4F5CD",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
           },
           "commit": {
-            "height": "2",
+            "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "208411D47FC3C56A3243E8BA57010A144BAD926F2FEFFBFDFB695CF19D2788CF",
+              "hash": "F13C24E0D7F16E08CA6FC1E4463F81B4A5F22D3A76F2CE0A5C082D476553D226",
               "part_set_header": {
                 "total": 1,
-                "hash": "208411D47FC3C56A3243E8BA57010A144BAD926F2FEFFBFDFB695CF19D2788CF"
+                "hash": "F13C24E0D7F16E08CA6FC1E4463F81B4A5F22D3A76F2CE0A5C082D476553D226"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "EDJIttaUcyoVcfIyOdHTw6qmtY8Jrf5cEMquCYOxnahu6BUNYbomz8L2t0uscbJqrDzMaW1nGDAyNrIEoBlnDQ=="
-              },
-              {
-                "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "QtatsO+ghgyDEJKDMmoVKdeDT8E3srh7WecyladY0ityBF9TKcrBNBIImCvPlStVu5uUbmM5NbG9+2In/F3DDA=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "hAUSpQjWbcFgdgPPwsDYHawdRu9IGz3OJGnZa+gX48HV+dynmadS4jVZMMwEUMZBWRZ06YEsL+x+KEXP1xWYDw=="
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:03Z",
-                "signature": "RJ9f2beJHCxhuYBHmPc3oWdDlQ8DOfBJOz9vN8tvEmhA0zb2qE9Zxe4jyO7Xr9wvq09yXQShTZKDsjOhOF6GAQ=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "p3hy6pfGMzVetZWYUzSfyunH3dxpc/5HtCzVOMyYwBc76UsdPqpDl4kMb1b41cIE2ZXK8vAElVkCjsNWTcdDDw=="
               }
             ]
           }
         },
         "validator_set": {
           "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
             {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
@@ -350,7 +274,71 @@
               },
               "voting_power": "50",
               "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:18Z",
+      "verdict": "SUCCESS"
+    },
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
             },
+            "chain_id": "test-chain",
+            "height": "4",
+            "time": "1970-01-01T00:00:05Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "consensus_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
+          },
+          "commit": {
+            "height": "4",
+            "round": 1,
+            "block_id": {
+              "hash": "C4DCBB4EF9689D1C45AB4981BA83D3293C6966A750C1443267501E058DA736A7",
+              "part_set_header": {
+                "total": 1,
+                "hash": "C4DCBB4EF9689D1C45AB4981BA83D3293C6966A750C1443267501E058DA736A7"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "k9Viw7xSufnjHG6QneIaujnjnQu/yUprHqgn2nA9BvtEgXEhp42iHVAq8a79e0VBiS+viw0NDhHP1LneMjNDDw=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
             {
               "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
               "pub_key": {
@@ -364,7 +352,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:00:06Z",
+      "now": "1970-01-01T00:23:18Z",
       "verdict": "SUCCESS"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestValsetDoubles.json
+++ b/light/mbt/json/MC4_4_faulty_TestValsetDoubles.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_Test2NotEnoughTrustSuccess.json",
+  "description": "MC4_4_faulty_TestValsetDoubles.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -73,7 +73,7 @@
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:25:22.160336592Z"
+    "now": "2020-10-22T11:27:35.160336605Z"
   },
   "input": [
     {
@@ -86,45 +86,67 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:08Z",
+            "time": "1970-01-01T00:00:05Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
+            "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "consensus_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "81D85BE9567F7069A4760C663062E66660DADF34"
           },
           "commit": {
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
+              "hash": "F40618641ABE35CDC39482E0F06A96F5B39AAF17319177A6E0DE6A0E43777D50",
               "part_set_header": {
                 "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
+                "hash": "F40618641ABE35CDC39482E0F06A96F5B39AAF17319177A6E0DE6A0E43777D50"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "J0UBEL5K1oAdMNciSVb+3+gegNHrVjqEHUVF23GnUmwnCEg3R/B1Sobow0LbEhDcUPCkiMelv4h0eae7GseXBw=="
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
+                "timestamp": "1970-01-01T00:00:05Z",
+                "signature": "AY7zNdwhG0ayw0ozLCpvLoRN/IZcL/JlyAH5OpioGJbHO5hwqTq6r+pbMK6mV0s1mRdG8QeG72mF6C9AkOBBDQ=="
               }
             ]
           }
         },
         "validator_set": {
+          "validators": [
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
           "validators": [
             {
               "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
@@ -146,22 +168,9 @@
             }
           ]
         },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
+      "now": "1970-01-01T00:00:06Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -174,13 +183,13 @@
             },
             "chain_id": "test-chain",
             "height": "3",
-            "time": "1970-01-01T00:00:06Z",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "consensus_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
+            "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
+            "next_validators_hash": "C4DFBC98F77BE756D7EB3B475471189E82F7760DD111754AA2A25CF548AE6EF8",
+            "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
@@ -190,30 +199,36 @@
             "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53",
+              "hash": "4FB876CD7FDB46E62FEAA6724392B9A42FD70FF5AC5384E114D0A0D362685199",
               "part_set_header": {
                 "total": 1,
-                "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53"
+                "hash": "4FB876CD7FDB46E62FEAA6724392B9A42FD70FF5AC5384E114D0A0D362685199"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "MaQRn3tj7Suri3Hr7uyegcAKmdKLTe/4eAzjKYHrcGjfO/5RM7ElnS5A/mirppc1etmKflVlbp8lWn5TDDNJCQ=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "nI/zR0rJrKnUY5CX21jLXZLZaSR8iIiFOBqEIsjEIy+LHTSohnl6RRHAohcwFRAwc+TVqOa4EQIhr+MX1fiVBw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "PtO5WN7sBXjCWyjU8HSjOf8HAIdCujLwmJLQbEfLXRTWeHRUYCoasFVVtcXaPCBCBTRXvt7adR81ecg8JK+cCg=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "bvUcXuhOFhaK7njHnauJFwImAGp2zh4DDBeyqfUwgu2+sVwjfWMcODBIUhOQ15mhKAYAQvNvWlO33GlXefTuCA=="
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "e6H6dh3ECPlQsOv3Yw7uVHhvGhlLfE/fcqMFlXyGeofpZOAsYN25QDHX+NbScIHhUQmpInx/ytFiah3IYlwWDw=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "gzE/ampFUWg5uh1eZSQW8HBYqrzVpRbwmhY11fgDgYrSimWdUfIIPNCSn/FrPamzZkvPxM3tZQBFpkBxZUOxCA=="
               }
             ]
           }
@@ -225,6 +240,15 @@
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
                 "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -252,10 +276,10 @@
         "next_validator_set": {
           "validators": [
             {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -273,7 +297,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
+      "now": "1970-01-01T00:00:07Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -286,12 +310,12 @@
             },
             "chain_id": "test-chain",
             "height": "2",
-            "time": "1970-01-01T00:00:05Z",
+            "time": "1970-01-01T00:00:02Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
             "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "next_validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
+            "next_validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
             "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
             "app_hash": "",
             "last_results_hash": null,
@@ -302,18 +326,18 @@
             "height": "2",
             "round": 1,
             "block_id": {
-              "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF",
+              "hash": "CF167F31983CF1FCD60D738320B8AF6B6A8271A39B6C8765D53D2E7DF12219CE",
               "part_set_header": {
                 "total": 1,
-                "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF"
+                "hash": "CF167F31983CF1FCD60D738320B8AF6B6A8271A39B6C8765D53D2E7DF12219CE"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "+e4OBaptWoaVX6A/UGsXNrNXJXjztwk1IRvmxWsTWRcxiB4AydLU/uFEiX+rp1PbNHZDhZWsI/Pprb7CY2hsAg=="
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "okL+HbWgnmcIy9yqkxvy3TC+3XHUuxicfVWLmQYnhpx2aLG1KsoccyQo0qo3RX3Hdlv0P2LYHNCfTpdj/Va5Bw=="
               }
             ]
           }
@@ -343,6 +367,15 @@
               "proposer_priority": null
             },
             {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
@@ -364,95 +397,7 @@
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "SUCCESS"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:08Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
-          },
-          "commit": {
-            "height": "4",
-            "round": 1,
-            "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
-              "part_set_header": {
-                "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
-              }
-            },
-            "signatures": [
-              {
-                "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:20Z",
+      "now": "1970-01-01T00:00:07Z",
       "verdict": "SUCCESS"
     }
   ]

--- a/light/mbt/json/MC4_4_faulty_TestValsetHalves.json
+++ b/light/mbt/json/MC4_4_faulty_TestValsetHalves.json
@@ -1,5 +1,5 @@
 {
-  "description": "MC4_4_faulty_Test2NotEnoughTrustSuccess.json",
+  "description": "MC4_4_faulty_TestValsetHalves.json",
   "initial": {
     "signed_header": {
       "header": {
@@ -14,7 +14,7 @@
         "last_commit_hash": null,
         "data_hash": null,
         "validators_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
-        "next_validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
+        "next_validators_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
         "consensus_hash": "5A69ACB73672274A2C020C7FAE539B2086D30F3B7E5B168A8031A21931FCA07D",
         "app_hash": "",
         "last_results_hash": null,
@@ -25,10 +25,10 @@
         "height": "1",
         "round": 1,
         "block_id": {
-          "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32",
+          "hash": "EAA36857D0DB20A7B1E315A74E9871F509D7FD52CD3172CFD7A0A9E360CD6759",
           "part_set_header": {
             "total": 1,
-            "hash": "533DE06C9907E5E41EF18C68E28B04BF8F16D35EA053EE413ACE9A9F3A106B32"
+            "hash": "EAA36857D0DB20A7B1E315A74E9871F509D7FD52CD3172CFD7A0A9E360CD6759"
           }
         },
         "signatures": [
@@ -36,25 +36,25 @@
             "block_id_flag": 2,
             "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "BwKig3Giy91zDlZ5BSa67+E0EV1K4q6At2piQgg1h48odVOAjEiC4Tt772ologMWt0gdjYzeYtYR15OKtza1Ag=="
+            "signature": "qnqWPNmmyQfNJkhPH2YBpWRlGjoLOoTzGLAKYuBuDzuLpDhvh+F4AOwsalo+qR70Lpx/yKU/+BTLPGxIIP47DA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "EYx9XdH96HYFIJtaddpFF+u/1GBwE1A3/Ds2e5BGHnti62RBwgsdIWe3denuQxgYNPnIymqvrCiBAGEEtYJHBg=="
+            "signature": "n0hMeOMwr+ZtcObdo2T99UzOfulXuCS7nbNCVbo7IrgqLHfo6xlxEddlOdYQp+3quMGI79osrl4EYvTB5wU4Cw=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "QctMtMK8Zes6OspVTkVvKtwWix70IAp0okAi4zJjV981FEnOuK2j8Fd0WQNHHDyqFX7uGTVL5L7JqbBfLuvBAA=="
+            "signature": "v52uJnW0wNu4YPG7K46I+sGGJxj+0wx09KQZZsbmspL02nH3LhZahLFb3KBhswHevKKlo52X4VKszwRnlw+yDA=="
           },
           {
             "block_id_flag": 2,
             "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
             "timestamp": "1970-01-01T00:00:01Z",
-            "signature": "yWtJtDMH9NOtAeRqomUYDa23BePOZ+y7FNiAxWZ9a8iYUOOxUU3CoCqxfRm6wpJWW2QUwBicQs7ntnU3z7cpBg=="
+            "signature": "HuW1zhtKSgz1Z5JXr2Gyvw3q/bh2Wxf34cmkn8j/d5v3EZtDzfl+T4Y42Pgb9cnBLpKF2YmUkKcv2pyoctf5AA=="
           }
         ]
       }
@@ -69,11 +69,29 @@
           },
           "voting_power": "50",
           "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
         }
       ]
     },
     "trusting_period": "1400000000000",
-    "now": "2020-10-22T11:25:22.160336592Z"
+    "now": "2020-10-22T11:27:45.160336606Z"
   },
   "input": [
     {
@@ -86,13 +104,13 @@
             },
             "chain_id": "test-chain",
             "height": "4",
-            "time": "1970-01-01T00:00:08Z",
+            "time": "1970-01-01T00:00:04Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "validators_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
+            "next_validators_hash": "C8CFFADA9808F685C4111693E1ADFDDBBEE9B9493493BEF805419F143C5B0D0A",
+            "consensus_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
@@ -102,24 +120,24 @@
             "height": "4",
             "round": 1,
             "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
+              "hash": "A34520B3FC556555163053FE75A389D0D5CBD8D9190085FF9AE5AF1292D88891",
               "part_set_header": {
                 "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
+                "hash": "A34520B3FC556555163053FE75A389D0D5CBD8D9190085FF9AE5AF1292D88891"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "7+AQRDJIiVidQNz0VzN7NwMXDM+h5haARaBonMAPbq1QYKF6BWP9aZPyzH3+MBySMWWVWNlBIhmp7fO+BTUTCQ=="
               },
               {
                 "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:04Z",
+                "signature": "eb71dofHA5MpHGCbWOVwSgKaYaNGV6upmWw8HadRhD+gFqDjGrltV01ACf/TlrxF7T5ygAFDjej8Qhp4seYxDA=="
               }
             ]
           }
@@ -136,19 +154,6 @@
               "proposer_priority": null
             },
             {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
               "address": "81D85BE9567F7069A4760C663062E66660DADF34",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
@@ -159,9 +164,22 @@
             }
           ]
         },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
+      "now": "1970-01-01T00:00:05Z",
       "verdict": "NOT_ENOUGH_TRUST"
     },
     {
@@ -174,13 +192,13 @@
             },
             "chain_id": "test-chain",
             "height": "3",
-            "time": "1970-01-01T00:00:06Z",
+            "time": "1970-01-01T00:00:03Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "next_validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "consensus_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
+            "validators_hash": "AAFE392AA939DA2A051F3C57707569B1836F93ACC8F35B57BB3CDF615B649013",
+            "next_validators_hash": "2B141A0A08B7EF0A65BC5F4D92F00BDEF0279124DEAC497BEF4C4336D0A3CE6F",
+            "consensus_hash": "AAFE392AA939DA2A051F3C57707569B1836F93ACC8F35B57BB3CDF615B649013",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
@@ -190,136 +208,39 @@
             "height": "3",
             "round": 1,
             "block_id": {
-              "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53",
+              "hash": "66A6F09E467FD0F5E65C8C0DF1C846B5180530E84B1EE1F350842C4B98E431EA",
               "part_set_header": {
                 "total": 1,
-                "hash": "16E7D4043AEEEABD0F1D9E4664B1AA11AA3CFD69A37CD3D9BA594A6CCB91CA53"
+                "hash": "66A6F09E467FD0F5E65C8C0DF1C846B5180530E84B1EE1F350842C4B98E431EA"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "MaQRn3tj7Suri3Hr7uyegcAKmdKLTe/4eAzjKYHrcGjfO/5RM7ElnS5A/mirppc1etmKflVlbp8lWn5TDDNJCQ=="
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "26oV/N3/hE9JpGWyjPsiy4mJQJF3OvETn1+pSdtfk59L5xlj4W2+UMNlfDq5/k4sx6lC5mCRjmFEwAd4A0pPAw=="
               },
-              {
-                "block_id_flag": 2,
-                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "PtO5WN7sBXjCWyjU8HSjOf8HAIdCujLwmJLQbEfLXRTWeHRUYCoasFVVtcXaPCBCBTRXvt7adR81ecg8JK+cCg=="
-              },
-              {
-                "block_id_flag": 2,
-                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:06Z",
-                "signature": "e6H6dh3ECPlQsOv3Yw7uVHhvGhlLfE/fcqMFlXyGeofpZOAsYN25QDHX+NbScIHhUQmpInx/ytFiah3IYlwWDw=="
-              }
-            ]
-          }
-        },
-        "validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "next_validator_set": {
-          "validators": [
-            {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
-            }
-          ]
-        },
-        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
-      },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "NOT_ENOUGH_TRUST"
-    },
-    {
-      "block": {
-        "signed_header": {
-          "header": {
-            "version": {
-              "block": "11",
-              "app": "0"
-            },
-            "chain_id": "test-chain",
-            "height": "2",
-            "time": "1970-01-01T00:00:05Z",
-            "last_block_id": null,
-            "last_commit_hash": null,
-            "data_hash": null,
-            "validators_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "next_validators_hash": "6E2A33745D333F9362F399C3DC982064067614AAB0FD4C59DE5720D88E00F254",
-            "consensus_hash": "75E6DD63C2DC2B58FE0ED82792EAB369C4308C7EC16B69446382CC4B41D46068",
-            "app_hash": "",
-            "last_results_hash": null,
-            "evidence_hash": null,
-            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
-          },
-          "commit": {
-            "height": "2",
-            "round": 1,
-            "block_id": {
-              "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF",
-              "part_set_header": {
-                "total": 1,
-                "hash": "D523A86B6E5DC56A84666859345AD496900A6BD9D9F97F2147629DF5A946E8DF"
-              }
-            },
-            "signatures": [
               {
                 "block_id_flag": 2,
                 "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
-                "timestamp": "1970-01-01T00:00:05Z",
-                "signature": "+e4OBaptWoaVX6A/UGsXNrNXJXjztwk1IRvmxWsTWRcxiB4AydLU/uFEiX+rp1PbNHZDhZWsI/Pprb7CY2hsAg=="
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "SZrS0I6jdU7mlbGL3G4WKbhIjpzRzn4BhHMoOFUqh+KfQxpHIP7GW1vIvCb14MSLWu8qAESHUPOKRqqhrYdCCg=="
               }
             ]
           }
         },
         "validator_set": {
           "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
             {
               "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
@@ -350,22 +271,13 @@
               },
               "voting_power": "50",
               "proposer_priority": null
-            },
-            {
-              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-              "pub_key": {
-                "type": "tendermint/PubKeyEd25519",
-                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
-              },
-              "voting_power": "50",
-              "proposer_priority": null
             }
           ]
         },
         "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
       },
-      "now": "1970-01-01T00:23:19Z",
-      "verdict": "SUCCESS"
+      "now": "1970-01-01T00:23:20Z",
+      "verdict": "NOT_ENOUGH_TRUST"
     },
     {
       "block": {
@@ -376,41 +288,47 @@
               "app": "0"
             },
             "chain_id": "test-chain",
-            "height": "4",
-            "time": "1970-01-01T00:00:08Z",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
             "last_block_id": null,
             "last_commit_hash": null,
             "data_hash": null,
-            "validators_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
-            "next_validators_hash": "F49C3E794533450FEA327755F5962F99C88F5545453E6D517BBDD96EA066B50C",
-            "consensus_hash": "A4AC4A82A6DA63B5F3F3862C625F5D14B5FD0BEE6E34DCA44E91EBBA4BA44365",
+            "validators_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
+            "next_validators_hash": "AAFE392AA939DA2A051F3C57707569B1836F93ACC8F35B57BB3CDF615B649013",
+            "consensus_hash": "F6AF3B9193F2672E2E3830EC49F0D7E527291DEDA4326EDB7A6FB812BE8F3251",
             "app_hash": "",
             "last_results_hash": null,
             "evidence_hash": null,
-            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+            "proposer_address": "6AE5C701F508EB5B63343858E068C5843F28105F"
           },
           "commit": {
-            "height": "4",
+            "height": "2",
             "round": 1,
             "block_id": {
-              "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2",
+              "hash": "C87D253AF6AA7259F097418E71F95C4EFD8DEFEAF9B49FA3D8C4BB199E1E6DF2",
               "part_set_header": {
                 "total": 1,
-                "hash": "949F178D79C4180A103EAF98EC021E9BFF6EAE5C328BAF55F88F8FE88266CCB2"
+                "hash": "C87D253AF6AA7259F097418E71F95C4EFD8DEFEAF9B49FA3D8C4BB199E1E6DF2"
               }
             },
             "signatures": [
               {
                 "block_id_flag": 2,
-                "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "V3DDI9P5Ss5FCOq0zuY4SyCa7pYb4zIt9Wi0FUUA8M5HzVLEqyD51EIo9I4Xf50mvyWdbaZbR6YO7z0ViZQiBg=="
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "765LAUwPhY5uXdOACu0BSaWd8f4TuxnVhISxMrOgCmmERoqrxo//4fY+Ht9zuvvp0nflO7Rh7fvPCc1x+8ioDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "SdXFxyG3XmZv9NBewJ7s7fhvoeW2lWt4aP3ORq2HbVKsOxJUuGwYNeDfgTILR3FhcSoyhCXYfSt+ej12g8GwDg=="
               },
               {
                 "block_id_flag": 2,
                 "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
-                "timestamp": "1970-01-01T00:00:08Z",
-                "signature": "1HwY48HEx8V9ZYVrBr7AtaTLe9j5TZWbq0YJrxbQXcc6gi7uk0L4hnaYklUm7ej4IU0/j044ebU72jja1ZgHAA=="
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "LGAHThbg5WDZVcDL5L0vpvq3EAhHoF9j1RylwDkTYRYk4/UQ0Qlw523wFfogZqw5X5WrDcled4DQUFSBPLB/Bw=="
               }
             ]
           }
@@ -418,10 +336,19 @@
         "validator_set": {
           "validators": [
             {
-              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
               },
               "voting_power": "50",
               "proposer_priority": null
@@ -440,10 +367,19 @@
         "next_validator_set": {
           "validators": [
             {
-              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
               "pub_key": {
                 "type": "tendermint/PubKeyEd25519",
-                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
               },
               "voting_power": "50",
               "proposer_priority": null

--- a/light/mbt/json/MC50_2_faulty_TestFailure.json
+++ b/light/mbt/json/MC50_2_faulty_TestFailure.json
@@ -1,0 +1,1272 @@
+{
+  "description": "MC50_2_faulty_TestFailure.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "E88731710E052776471249E555FE1C510FC8DF692F13D051B8381231233A38F5",
+        "next_validators_hash": "78A00EA505FC5926D3ECD38AD1BCB7C6942E6B4E0654F17681B0D300BEE38875",
+        "consensus_hash": "E88731710E052776471249E555FE1C510FC8DF692F13D051B8381231233A38F5",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "A11F83E70EB46306863C4DEC64DDE25503DE288A20BBD8B55E22EF9F031CFE51",
+          "part_set_header": {
+            "total": 1,
+            "hash": "A11F83E70EB46306863C4DEC64DDE25503DE288A20BBD8B55E22EF9F031CFE51"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "MgxT1hsGgWEq1m+ugOWKz+th43Rm4wZmtxLzUzp1yhRhLwNR2NE7UGHPzqxv6dOuZtzUUk91hAcTwCl0jDMzBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "pT9QMUv3328YPXT2QphnH4OlskY596rv0Rs49AfDHXncjHLxXfi0QwasnLjHSp0lkeqKd6X/s/IEGhKNpLHpDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "26E91E700545D79E8A18092C393DB76294DF393A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Pkkvy/z/rVl8pl00T9ZDcpffqcWLDjGG46NAHHnRh2l0Ja8bY9hMeyBB4mKfRIbNgrxfcrTH0TSbHBWgh/hXCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "8JWjV+8uYH0kyx3jONQ6QbD6q198R1S1+y5Sp7zn8Ladxxzdmvw221UG0EAs78BrU3kJAsO7EgGXmBIrbhYqDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "WbT+e8VzLI5r2qks/yFeJb9Inq5j/EmyBpXmx0RWH47yWs4BeXUBRb+49pZxLLy11yjULytivDN62CPSBIa4CA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "361491162A6178776B903E57AB7C4D909394B4B4",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "4OWAVGkXfaSW2a8ssW3N+W8Z813T7Cl/KYNAsRW6R7U/zhPnaxRAxRRKdjQioSGj3ZOJIXEw8bsHlwnUoc2CAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "EAvv383RcEyHyvEnrtZVB1vkrqFvGAohqIfvoeEpRekuPIUn5yPUjv7B2tHH0UodGqZbAxCdT/AuFTbWFB7+Dw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "YwUoWTN9d+T6lWXPGHWYO/+qUpnuGu70Pb8LS34NUNh2P0mYBIWTU51HJtQocsVGZNvoj2PcXlSQRvT3rGGADQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ACbr6L3GpavPQL8Toa5Fax4xLSTBand/1GmPBjF+hA1Watt383Uqy/h0IGu6QuvymSTZhFCl+x94qcZj2ViJDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "42D162EDB46B7C1FEA616810A7617A6369958ADE",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "HVUEpNahIFNEi9F2Iezp8+aHRAjdmJQXHq3wxhAG8+W8mKO+5DfWpPCnJJIMnXt6sO6vgpItT34xNsZJcu3aCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Yz/VRHbG1hEEho9zipU74F1Rc97nR3mtTkAxlKUWd1JY3JRDQezrqz2c5hYq0nMhw+21D0nCaoh099QF4g+ODA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "xhO0lmC5lJAV94KC4i6Z46M+3OcBqwM/byGEN7Xljfx8SgXS4uGMXyDagzKhSSQXUmFYMs7DA6k+fCOHlaA7DA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ll36YrESrLEzJgijU8lg+RjQ7HkPUqzTabWPzPVQCHF0RdILY+6S8zQgPv1qkm4t4l6MjlFoa3gaH5PNukhxBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "jzfv116ISDMtyQZvl+TIqa4JKvlkZAda++4EULg56gbQKeq3DI9lieJ80gwnHyWnBoctX3+pRv7uxIsYMJgwBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "s8DL0ME0M/07qhjxjj/UbTP78tQ6plK6UQRr58yB0m6gRXdmMqyKyitrFoSDNZgVFLHfA5PStTEp7trLlb3oDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "nKWio2Vhd+KnjRGPeDDslaohrUObv5kqzjiNua5pLABHk964rbXbPD9cHMWPUw2C0y4GLkHWP2imSgbY8CIDBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "GKwiP4orVRz7UnMItWSPYW4C4sBRfLXVQEb471n64txgVmgRhy4dlJHgvG/X0Ywgj59r3qfL+kGWrm0Z2Z+wCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "0o16f1itrb+vYJlSJBMzpzvefR85vfZj5xFvANurQAAs52QcbSZeQwp2Mtw9UjSqR4pM12ZLKHjO1EFLBAklBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "cQswd857z0cegDyMhIItHaaAxipl5v9Gr7ZQIUd5wEvk0KBJjibeLCEpTTqaWFoBSquNl38AD0rcBcl4054pDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "JDQaJ9Cm+0JkuBMNaBSfQVnIQwrdw/RTVBJH28YekssOtIr7YCknmsV2kuf/KPeGtDuk8T88d+gaBvjgh72JAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "AM/+OjR8git+dS9y9Ay7gJvOtjuwDERNFefWTLiBhZCyBbqUT3fvFmqte8p/RIZ13ut++vEQP28yj20LREPuBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "8wGdG9Of8PQqQJtV6osbK2ZCjcvmmcylcPVCGF3OyWP2pCy9jCLRsm5gumCZp3A67HDaRrxxdJJ/XgCA7znYDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "k1kTp7O+El8Om7CLoSBzh06dEVOChMH4jj0dwnFsn0CtGV/sr8M8q6riHTLjGtYc1UzZMFCfqZff3rvks4WJCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "2Mby7GS77kAitvbFgw2z4ssXI5tne4iXAqjcfwZAs/GWgflf9Sj847j97aeL+H4v2abJ6ZkRZXSfGqGT4lxsAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "1DwkiZC61dWmVhXe7VbflK2EcOWnjbQjwcodGVA7ZYNOSCKpJ8rUzI/hdM2pRGsuRa65Sc56RqnkILHL8TRqBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "IcZB9Fn8gV07Ttd+EcQvKby9W1c9WzcEZvVyTJWpcoAmspmErcVkUE4ulxpUnr7VFl/kcc8X9jwHfQ6WBCciBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "92932AD7E082B90296C192F3113710CD6F99432E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "91wi485R2I8nTSqVliRizk/moHRxoaulHL+HkhDCBphyBWnmacWB9l46c6KFUQdH0ygjrHAGQJ3ZJ4dGfUOqDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "haRUzbASfLYWCunkh4H0S21PBRjJHCwOYeXwLQMSpTx5nrHY3UUN8dtWY/fFA5eQV01x8img6pK1mT2tqhFhBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "K0ryyZs8t71FQvjzg8BYGAsA3+lsDH8Zjp81tMu6qzoDevvGLCheSdTFVb/YgSohA90NK0Onm6FnEuMOpBIrDw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "vbGcJeB0lvR0VTsNoLiM7QSz3DPCYwwJiEc+WzitlEY1uC6SjXOtukAivPl1u2qj2u8Oh43XlhCNEWs+FVDEBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "HmniqbaR6vOeewRELeJrzsS3AmyYQjFuO6pT5h1/iNyQX1/DgqMKlcgIXNEU8P8ra8C51AFEwQSjQKlqnOqHAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "1WEhsbOTviJVkQPIRdvGcavtJ74MYpvpqg2T4Rp8CXMVYVLOX108RN6KitadSrahjw6Ek7Y5JwX7EATfLpeYBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "4Ie6p/aqEoywLslCICiTFgOMMzAm8nTi6/gjiHZ0Fjum0xWwr+91au815jL+aeVdxTV52Xi3aRBLMCCWOZr3CQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "MI458dLyANHqqykTczMbedif25VIdqgKjL+JgZyambw9M+HTm4pTtTzLfxQcYImI6+doN3/BZdmeFu/0Ji0ZBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "/joPrXYfDtqNI5nQWSHsSqsiqkDBgIPXYvoJkt2WWacIQsqUPLpEWWV+IFa+MNb89u9rtab9uVNmKpcVZgYuCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ixuGX2MngCZAejvYAy9VsdWNdCd1QaziBmSvnQU/4ExMg8J+lCZjrGOil7YiVAPfUWZcyrcLwk1ZuS9hGEIoAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "m89d2jnl2XLpJRW61uPe7VatpUXHwWtouR08Yl+KVNtK0m8wcO8wbtzzxb/9kCaPvo32O1AADqS5l9PSZ0oaDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "k3/vBqvBLtQiX5BLyeARaTM1CZk5bx0Td8rMrPG+a6K1+JXGHDdPjZwykBLudMSOeGWzPIBKnluFV1FHvEJ/AQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "VoLjfSukf2C/C65SG00TtCuON08XglYS66Vgb6OCZh5BnePD95vvp0bQG0HmzH/+cFNigGMhUOsCefqnyhCnDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "zCJbFcYjDl5mRm+5dOWNwPvppd5TnagUFX93NKFvnzpClQINGRw8ZTpdhvn0+lTu6OaCv+lIZ7r2l1unNcXNAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "zDUSqrJKLKVXUL4W7ESSp7qMame8Ii7G6gI6MrDzoHfllYqgDxgRddqZjSF17S3IhNNQcYOPAGG9/Otwo2g7CQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Fl7ktGmVc834LpLmBIaTwhaxsuM2FeEYdKHQOvbJoCaFB/tf9lWl9MvxhiLIUxadOJslzxDSdG9u1nGwbeBuCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "wkoeOtLv83cznjWZBxLSjkQcIxEsJ4DsldOT49kZ2EGdzCvnhfH9dbEFdldaU/FdorcHlqMqA9lm4vEX/hL0CQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D447195654516BE994064E03868856302AEAF1D1",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "05zwtWnenX5LsH5TM+7kup6jOdLWYD1MkVEhnzV0Ol6SSbQtGF1ammdFcz2zRMrOOlN70Xh0njitkqHGKTJ0Ag=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "R5RH/iNP3jDdKBYBvZAGeSeEWeP5siv4qnv9wwhMaKX2IqLFzbEN/qJwQkERS7B+MaYXXmebOpmKl47Bmk0/CA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ehPhN9aL3kgMxMSo+Euoe5OqIZaUM83SG6RUmBXYkuxVn6vwEEP36tNcW1gRyiM/9vhPMJLO3RxhlbCtixvqCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "7uy8VZCdWtqb3iNVDEKkaZ122N9KUtsdqgnH7+RGFZPEBaUOuRFvOS0zVxmNOAn7QikYfi8Ri/S9UBXrX2LfDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F1DA81336F50B87982CF10581D308080031406C6",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Y2V+FbCjp+L3J31KrJT0PM4xhBu1F3u9Tntx3KQ9eAfHoo3c8HyB88y1VQr3mgeIf7WLR4/g+4T0oau0SogXBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "+Q+0Ev8ZWP32M8Gbad8S6j4Xt1KPwd/wxN09xDU5oxqkEw+2UKG/UPmz/XkniQsJcDVxvsG6bqvwgOOlXxJfDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "q81kHRr8fKTGu4Zutm9T61IfIgvKOfGqj1WQuye3zQCV9bx1lyC4J7cnt79vWClqiEt2tyueyZDCARp1exA9Bg=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Spb0BakJqr3uNaAEqdaGbv77bQEwym0/6cl/tnCdkGM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "UGBPzd5VtGwtUkXOkCgJuzUO6s7Zk0RGKCo/Csdlqf4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "UseUFPt/FyVO1D19U7tHq4/CAsW/JxWOeTbw/ZftxMM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "uEXsZIGASOuKR3SQn2cakTAkulEbm2kElVjj50W2oJw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6lcuin9eD6uwAu9qjsoRjtd+uCtVUZbn//5UqLng9mI="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "55KLg7eVl0IyiFhu7r38WGQizm6hglE4rsAo68dGK28="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D447195654516BE994064E03868856302AEAF1D1",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "CkWTr7zqfXcDHuTn961EfHkJv82Ql1oibFWbfROfbCc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:12:31.160336515Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:03Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "6A486E092A49D062DF03A6CC25CCF131010C7F9DEBDA22179570B2EA41C736EF",
+            "next_validators_hash": "C5D963027CF3701BB362ADC67BAD9F8B382E96D01803CD095092A29558D5AD7E",
+            "consensus_hash": "6A486E092A49D062DF03A6CC25CCF131010C7F9DEBDA22179570B2EA41C736EF",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "BA33004D623E7E89E18890B80FAE348FA476D6460023DB61E14F08A89AD56B62",
+              "part_set_header": {
+                "total": 1,
+                "hash": "BA33004D623E7E89E18890B80FAE348FA476D6460023DB61E14F08A89AD56B62"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "61KHQKJWM5OHXsVZJ028wr0OHmB8gdIPOUBDP04eFf9OK9ol81VgxxtF78ji6qB/Lo41jUfuAkc4nY97AEH5CQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "3F8x2MTu3uoHcRml8kM0Ys6bmY1g1uGtWPTmtZWCd11Q254AI/pKlWtzcgAYwqFKDPcZP5d//h+tB684wkr+AQ=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "T0u36SsrKsb5HbbM+SbI3/DSGw+/6WVIEKbl8pxaT0GsXX1Oj+N52+kzhJ8ktVjETSSH6bGqL0L9pSpWIhl/BQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+                "timestamp": "1970-01-01T00:00:03Z",
+                "signature": "R0upPjBQryH5iKAsdY4DQulGX5qOsUFoEZiKPuiRfeotB6k4MUVLUJDK0+i7WLhRmSRWOxBALfeU8Tev9GcTDw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Uq1fQj/TXkpg+zP37a//6YC04vQHWraWfYSg88fMHxw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "M5rP8lPaJdES+Bd4oWI/va2sRUvbJiYINzOpUdiuO8Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "mGpmR8PNc6w2cUzPwAQhkSadkyGOuKMl68Nji5E3h5o="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GR4akX9jBcU4iFUBqB3NGwD3CuSTGPHiaWofAhCjCiE="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Pfy3anXtYHMFjDLvM+5jJN3iS5Ypz9NMJ1KTNVjfJ7I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "2ekMO1AKawC1gbXty/y6KBVpUfC9RcKyf3sR0ZK7UR8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UseUFPt/FyVO1D19U7tHq4/CAsW/JxWOeTbw/ZftxMM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZHfThztGFsj0VfR6xV1r5ZA09Q6/+np9oYXs8CWY4F8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "55KLg7eVl0IyiFhu7r38WGQizm6hglE4rsAo68dGK28="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QEsifvLPeeGUsnI5MjI+gOXd2aU+NOqCwE6+Cs/LQRQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "xzIY0miEtnX/3fduBl9vYN2iDEmt7HIGK3Qb0bywdbU="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D447195654516BE994064E03868856302AEAF1D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "CkWTr7zqfXcDHuTn961EfHkJv82Ql1oibFWbfROfbCc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F4d36ebIiyCzz/pk4sGrxYnls8XuzOfMRh/lF2LTdA4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "wqp6kT/3DEZ81E8BAdD802/NccJcCyBWBVrah3EOTFk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "26E91E700545D79E8A18092C393DB76294DF393A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F8xDDGP4gRkFMeuIlULpbOP6aGPdTe5gZT7kCCnAQIY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "fWMaYDTFwdDo7SVw9hBIraX2GVqvzKhNKEUkr/2ZnEc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Uq1fQj/TXkpg+zP37a//6YC04vQHWraWfYSg88fMHxw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "361491162A6178776B903E57AB7C4D909394B4B4",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QlwrDiydr8tfRonzwMnML1JYtWUHQZiG6aqhWsXRriA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "etUp4mnEHDdNnJSwu5KW8EMXYt7n94iYZm+y7xa9ym8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "R1rD/692T348fL4cA0mvvbK9aANwT0vBNAT5B9+p+rw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Spb0BakJqr3uNaAEqdaGbv77bQEwym0/6cl/tnCdkGM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "JqkfZ01ZvkPHj9ohj0F2Saa5t6KIX5uq1bhHS7YAyxk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "M5rP8lPaJdES+Bd4oWI/va2sRUvbJiYINzOpUdiuO8Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "mGpmR8PNc6w2cUzPwAQhkSadkyGOuKMl68Nji5E3h5o="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GR4akX9jBcU4iFUBqB3NGwD3CuSTGPHiaWofAhCjCiE="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "r7QqYEO8hh6xOwJMpsH+gYer+oOcuP/UQyG7NNsLLHk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Pfy3anXtYHMFjDLvM+5jJN3iS5Ypz9NMJ1KTNVjfJ7I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "JgRep5bgxhsdM6EVAEzE/cEaxMsdR6/VtG24KHgHDyc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UGBPzd5VtGwtUkXOkCgJuzUO6s7Zk0RGKCo/Csdlqf4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "2ekMO1AKawC1gbXty/y6KBVpUfC9RcKyf3sR0ZK7UR8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "92932AD7E082B90296C192F3113710CD6F99432E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GJlkT7S82nRWW34K5ax6ZCW9EV2nt1E/PF1P5LQgJdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UseUFPt/FyVO1D19U7tHq4/CAsW/JxWOeTbw/ZftxMM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Hm8gqT6zv3BHDTjlY1nLMK2U4gte/cducumkYBgvXig="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "z7XkAAZ+x6klleinW1VTrsMLnAwNF9LHBFprFx1E4bA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "uEXsZIGASOuKR3SQn2cakTAkulEbm2kElVjj50W2oJw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZHfThztGFsj0VfR6xV1r5ZA09Q6/+np9oYXs8CWY4F8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "L7pTIdyDJ9DHXRXMGcDeLxQ7KUP3AKiPpggq385vkrA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6lcuin9eD6uwAu9qjsoRjtd+uCtVUZbn//5UqLng9mI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "8f/zBc9sYTK1e73NefD07XG1gA/fqVsf8CZ5EyualYk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Ct8qHvpO82bPqzj2YxHkFgE+fmxVF0q7fTuvXzsK6Cw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZDJSsUONDbWTaQATQjuhqxsQFTnSyzSburJRflWe6ro="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QEsifvLPeeGUsnI5MjI+gOXd2aU+NOqCwE6+Cs/LQRQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "xzIY0miEtnX/3fduBl9vYN2iDEmt7HIGK3Qb0bywdbU="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D447195654516BE994064E03868856302AEAF1D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "K+cn+8TPKo7d9dNhdj999tu1T108JCxecojB0pkssl0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F1DA81336F50B87982CF10581D308080031406C6",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "TCNu3Qckfx5+zXKvDTIHAFd/FZgbk013UFYIZqWl7w8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F4d36ebIiyCzz/pk4sGrxYnls8XuzOfMRh/lF2LTdA4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "wqp6kT/3DEZ81E8BAdD802/NccJcCyBWBVrah3EOTFk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:23:23Z",
+      "verdict": "INVALID"
+    }
+  ]
+}

--- a/light/mbt/json/MC50_2_faulty_TestSuccess.json
+++ b/light/mbt/json/MC50_2_faulty_TestSuccess.json
@@ -1,0 +1,1530 @@
+{
+  "description": "MC50_2_faulty_TestSuccess.json",
+  "initial": {
+    "signed_header": {
+      "header": {
+        "version": {
+          "block": "11",
+          "app": "0"
+        },
+        "chain_id": "test-chain",
+        "height": "1",
+        "time": "1970-01-01T00:00:01Z",
+        "last_block_id": null,
+        "last_commit_hash": null,
+        "data_hash": null,
+        "validators_hash": "E88731710E052776471249E555FE1C510FC8DF692F13D051B8381231233A38F5",
+        "next_validators_hash": "2A57A2A6D22355993FD2D05546048E3431A075F1B9D9501741FACF4519019F22",
+        "consensus_hash": "E88731710E052776471249E555FE1C510FC8DF692F13D051B8381231233A38F5",
+        "app_hash": "",
+        "last_results_hash": null,
+        "evidence_hash": null,
+        "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+      },
+      "commit": {
+        "height": "1",
+        "round": 1,
+        "block_id": {
+          "hash": "D2B6D95DB95A9CCCB9DB233BDBBE38BB3C5E82B054F33DB10928824CD4E39B1F",
+          "part_set_header": {
+            "total": 1,
+            "hash": "D2B6D95DB95A9CCCB9DB233BDBBE38BB3C5E82B054F33DB10928824CD4E39B1F"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Tvf9D4LPqf+SUh1RA5clJIFShkukZLF6RzEWNoUe22fGBvsSWQ2En7/c4meMldD/g44dAMu7CgZdtG3UWJkWCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "aS9BhMpmp0K6uxim+ngQGMzij95bRsJmUwrEJN4wKqp/kYK2anQUgePEPid0dcGZ3L694t+BmhRdgp+NChEOCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "26E91E700545D79E8A18092C393DB76294DF393A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "NnGi1rz3nb3AyP4DldrVwOUNPyiusKgjI3BmvxPHOoNBhJrimtUpo6MVSsXD0g1pFc3pUUTap6NXmIaSNOiLCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "2T9SEaKAhEJBwCgyS1chyQ4W2H85cs+XL+L+YiFJbwrQCXWKZwE5UV0G5LDTbOKfkJw+X9XeZuKJ42ufoTuhBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "lx6l5g6K4NsYQ/eniLWIXextWS8D+GysTVcfhRZ0+7DnsS/Dl50lF2SyAq191+MSy7BiKOidWnIdKozgO462Cw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "361491162A6178776B903E57AB7C4D909394B4B4",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "OT0WByy+++1/fIZ6vhQOVyPqzPgaAR9MUdQ8J33ikIlMIyEh54DTeadSSCUrXNl/7MsMJS4kR0Up7gz/o0WWBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "1nVGIMl6y00/3pIX1/0MouSpPWA+eyfW27EfWFMiU28w4oVj5Iu+rsq+8cHOa1balFBK4ElpbZN9knp86UvdAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "/ntA97tbBQ9MiYgfikp2aARycHxipat8pJdFasJtSBZ4GibQk9KiuRpS4MF+jQXvugy+iW4eBwCHF3XU60rMDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "i5NkTgII4+yxhL5ibYPY0Ix5FPF1zBG4GKi1Dx8StcQc2O6d0ibwYvnqQzZAY8geXq4ZnImgNvcpGz+LLASeCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "42D162EDB46B7C1FEA616810A7617A6369958ADE",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "n4wLN4gFwjSXmI1mUG1xPhfKa5bkmPCzMBI+C8GM9iLj/bkgpPzi6FBB+NhjiJ59KWD3FrVQYxGRnd4FpmfLCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "V9YC1MToS1x+g1KiK7XY+YTLYTRv9Z0MbVxwvHJS0cM3/v1HIqklBdbccNXk7kRbb2Jqw8ABxdroYo/UzsXJDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "gx9E7n59TYxl4KDhmF8VeeFBkv0m5gBzvVPPmQfzRIbceHg+kAIghgpcpNnI0rXg6JoTbyt+qXCpUCH7766RBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "vZMbLOk63WqI1a81Kc0VnElUS+Kufs35cGwf9Z5wGbe25xInbM9LtFF8Qz16uApUapBfwJ+2wIydtBvt7vG0Dg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Coh/ne3utaPfdsyv93vXO73+cp3jJD08bEt6KiP2rlqcWQvCNDeK3PSxlvb6m9hAXNmyAjjfTH/TwE1UvX9NDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Ai78pPYkOcNQX/jwbB2nNv6wscMueAWsd9fmSollmskr64h/buTOnfPSQWlHK/MWMVUil4lqBVbAOpLPoD62Ag=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "qx+Sof6t1END01+YT5IGnZaNEMMlcUhWuVrLh1po7h6yomf3ZCv/xoPPpqnPNstnCkC+2C4sQOPGvvAdMalGAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "iUV2944mm10Sb2rtVxi2JXxGSo0X6DJWBWGxtzPARFYxgaGjhfXK+1YGCrtqJmo67wp85jx0lh1BFMf/sM+WAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "mHZR6+/0T0d6UJCc8fTi4Tl0lIqGS0ijJdggwDpuoMDUEJvQBw53I7F4jfAwhywtE1hHagHFV7XOTJSLbLRZCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "xRuuT81nIx+gAEwcGIKPhYTzySZ71bA1DFhedak+PVewUJZreMSJO3dRhvWcZjkA9Nf17FW56Pwz7okCaZ3iDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7E8248EC7F3B6127B889255109FB4D5FDAAA771D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "oVkla809caw/g7yZiFpILuW7nK8FzCoNtRiy7IBHYwtm/gFr4Fesz0KnxAVTkshlJ1anuBmkYNaXmi5Uu08CBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Fxuxf09JFpi77gf7kq26goqrTHDSWewkVWWI3CJPPjGWZN5hzFvoSA5LrE3HdDtIBjIiXpKKmJ6TWgyHFNzJBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "dkdJuOX7Z+VNEQlxlcWwVPGdrRMmDbbdkdhoe4A5DAVQoPS0amzoyHuBt5V/hvqcMV5SgswBz34SRbMirv3sDQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "3e7J6fctQAE9c6GfyP/U1Pnq+NkbEsIMcmTwLiVvcN7pBNcMcA0lTwvuzOBf8lgkivXfALWnGYwb7K+cRQ4ZBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "JorrDVOP+hp+T5dB6M6PDgS9M5ze3/K+uDnTuCnP0oHEzr2IpOWZt7zOex9Q1uNwrZ4UCktgVnlDqw8ATnWEBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "GFh+ocI0HuGhqlvFFdFtwI6ah5B/BDpIPBNlgfGCsEm2HFKT7b5JrwvdMnED/WCGJPlBTMD7bReKmKvEnxXGBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "Z/ln4q1aEGqLxyuhuVucopI9zxudvLNdFrRf1y1lUXKnY0okYqEFAiRPc1ZYwqOpLUWL2wCNN3YnEXf+h84bBw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "92932AD7E082B90296C192F3113710CD6F99432E",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "2XhtVZgEFCasMKGH3WvP6CXrRJK0om4yrE/bKWxDwI+BhQcvmquEI8FbO6CIjpe8gI/BMrGRJqNR3W2ydPs1AA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "JKvVIpXv+TPL81daWOfjpCfKSPrf8GZt3hnUNrxAAa4/Ov/ePSquBeyZ4SzSjh1IH2yeByW0gOqE5wF942ZDBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "o8HNmoUL/wTPEuSyQB09fNny4EHhSxcDtZcSGmh3JZ2h7RkxKfyJubVpk5gXVmBondtVZnPimG2rdq++8jf5DA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "+DoKQDkShmrsjMKj+/K6vzvQVJuV+61Kd6s8Ltat9fALbe7ia9Gq4eIswLS8VqrLV99Jy50E5zfkCwC0eXXpBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "sh+mhsXAxTuQdh5dEVZC0EyoOypAKmQLTMPISHZGpnmAy71Ka5m39b+3IjMoY11/g/zrMd25F637Xn8O9OqNAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "uJQ/f6Z4zHyKPJ3mUAh7kGkiWyLwRfwi1+zbT2E0ftISvObvNXk9bGcrrn2pOwKz16Bzdkfwi66XUiCYKNLBCQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "D9CY3Az2eD/Txg0RJ0/kzHOO+v3CciqldXPdjnHOcO26UjbJYTJ763JrBCoGWvMWuzbIg6BW+dQM7yQr5p2mBg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "wuEQXP2tki6hufVr9FWHsUC3LN0Sw8vc2Ajtvso8uCd5dEdkpHLPGfPRxuTyiNlSFeE7Slqyne8bGj6tN8dICw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "j/zkC9I5j4p/inw0uD0QvH/elzlSFqLX6dKheB99e+TAP+KiMWrVvkVlVAMh+NbpEPQAy/H2uPGwqEtGop/tCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "kkvnK1u2qTcsoPx4+GwumKh9RACXr1STVeiz2XyM06rJBQWpkth3wjVXFTOUIl5VpkLzAnxNrK5+kqpFAI64BQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "PBJavJy09mwDzMIJjsyG5VZv+jlv47FtrdHAaYEIqspuZAgka1d4ys9yth8BxJPmL4IFqtABi8TQVzONNjWMAg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "BDAF748069A1EA08E56D8C4EEFF4C73C915700A9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "ymAN8BpEjcurWwQhly/tsFCOrQS3C/IlhnU0FLLTyEtQgb9yAMwPM27RTdxp5/ID4qu9JwbKxbWHefkjGWjoDA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "BgoyYn0EM3TXG3FqwOxJ1xsYBVQXGVlHUV8ifLn//ZROKpkeJXdjG/7SAfs43lvkI2SWV4yOwP8JohG8WaGECg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "L/W2bhTQKJ3UJ52XkH99FeL5pzueTd28On6whgyFfoRgXm26u+t4W+useQmGf26aAx6EmEFIt46oYmW+Qf2wAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "JfLmP0fAbH3iDORDFzwbiGGVM+fbfiGlSMovEVgu1lAwtRyoNNpmTFvfBKB9W547hEGDYELB1XB1if3WwYMpCg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "yUu5LQQ28QtbjWIdSMF3tInope070se2fxl31+SyyBjkgmuQNvYfaiAC4HwLZkMXuunZ4q0Q6TVaFSRtbLZ6Ag=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "XHL2SnKo7NOA9gZzcgHEu/PJMa+jVrhZExe73qqSIv8ch7zVRNo77cxogMlDzVFI23/idC2/JPn/Jp7xW1lcBQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D447195654516BE994064E03868856302AEAF1D1",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "vkWakqtK80jrery+CzINCrzgAU1FEKd4U+ZL3cb2Yz4IJ8LxBTw7IJNMhfP2UauH9l6TkNOjfjz2Rk+mPLd4Bw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "LKMlvMlulBwFGtP5FmOMhmBru5Y0Jpzrys+vOUDq1tbGYvYc71wy2C7y8blAqeNQG0ENmXEmvuGpbd/v/ixGCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "dWU/tniyGUN0KXXNB5m77DKjYnojx5kjSzqeQGws+ShxdKtO2bklDg2+53nDhsPysvlspnTgwm3+Wd6horGgAw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "EF80C29AF6C6B38F325A28497787921DFB8AD677",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "iH0CGVcXV5WCBbPYi1JiFYC0y74QAXR3VYWDgqH59Gpc3BZDCUgri5xZ0KGTf43kq6IikpEyj4RUHjp1lqwyBA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F1DA81336F50B87982CF10581D308080031406C6",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "vTpS2QqFNEOjvqlcxM95YTL7WxOP4fN6WLm+/sAPZ58fpdRb+nZ7ZzFgoJkGgAqnC0TR22so6BWPAzbymIyHDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "z+L2unI+Am0++rfwCsY5jm3QF8R4TwpYGqhmpOPUgK8VDcQxlxCP6nU1g4RSqaJkljQCZRzEPCDVm6pTWOWdAA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "signature": "qiIdkiGQPHMmj1qr3lCHpAgTjFNZKAOitdMEIQR+M8aOuey/DQEE+EgoqokOZGFURWQ73q6N/W+jSJ5hBi/cDA=="
+          }
+        ]
+      }
+    },
+    "next_validator_set": {
+      "validators": [
+        {
+          "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "26E91E700545D79E8A18092C393DB76294DF393A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "F8xDDGP4gRkFMeuIlULpbOP6aGPdTe5gZT7kCCnAQIY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "fWMaYDTFwdDo7SVw9hBIraX2GVqvzKhNKEUkr/2ZnEc="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Uq1fQj/TXkpg+zP37a//6YC04vQHWraWfYSg88fMHxw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "JqkfZ01ZvkPHj9ohj0F2Saa5t6KIX5uq1bhHS7YAyxk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "mGpmR8PNc6w2cUzPwAQhkSadkyGOuKMl68Nji5E3h5o="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GR4akX9jBcU4iFUBqB3NGwD3CuSTGPHiaWofAhCjCiE="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Pfy3anXtYHMFjDLvM+5jJN3iS5Ypz9NMJ1KTNVjfJ7I="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "UGBPzd5VtGwtUkXOkCgJuzUO6s7Zk0RGKCo/Csdlqf4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "2ekMO1AKawC1gbXty/y6KBVpUfC9RcKyf3sR0ZK7UR8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "92932AD7E082B90296C192F3113710CD6F99432E",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GJlkT7S82nRWW34K5ax6ZCW9EV2nt1E/PF1P5LQgJdg="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "UseUFPt/FyVO1D19U7tHq4/CAsW/JxWOeTbw/ZftxMM="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Hm8gqT6zv3BHDTjlY1nLMK2U4gte/cducumkYBgvXig="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "z7XkAAZ+x6klleinW1VTrsMLnAwNF9LHBFprFx1E4bA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "uEXsZIGASOuKR3SQn2cakTAkulEbm2kElVjj50W2oJw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "ZHfThztGFsj0VfR6xV1r5ZA09Q6/+np9oYXs8CWY4F8="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "L7pTIdyDJ9DHXRXMGcDeLxQ7KUP3AKiPpggq385vkrA="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "8f/zBc9sYTK1e73NefD07XG1gA/fqVsf8CZ5EyualYk="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "Ct8qHvpO82bPqzj2YxHkFgE+fmxVF0q7fTuvXzsK6Cw="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "55KLg7eVl0IyiFhu7r38WGQizm6hglE4rsAo68dGK28="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "QEsifvLPeeGUsnI5MjI+gOXd2aU+NOqCwE6+Cs/LQRQ="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "xzIY0miEtnX/3fduBl9vYN2iDEmt7HIGK3Qb0bywdbU="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D447195654516BE994064E03868856302AEAF1D1",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "K+cn+8TPKo7d9dNhdj999tu1T108JCxecojB0pkssl0="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        },
+        {
+          "address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+          "pub_key": {
+            "type": "tendermint/PubKeyEd25519",
+            "value": "F4d36ebIiyCzz/pk4sGrxYnls8XuzOfMRh/lF2LTdA4="
+          },
+          "voting_power": "50",
+          "proposer_priority": null
+        }
+      ]
+    },
+    "trusting_period": "1400000000000",
+    "now": "2020-10-22T11:11:50.160336511Z"
+  },
+  "input": [
+    {
+      "block": {
+        "signed_header": {
+          "header": {
+            "version": {
+              "block": "11",
+              "app": "0"
+            },
+            "chain_id": "test-chain",
+            "height": "2",
+            "time": "1970-01-01T00:00:02Z",
+            "last_block_id": null,
+            "last_commit_hash": null,
+            "data_hash": null,
+            "validators_hash": "2A57A2A6D22355993FD2D05546048E3431A075F1B9D9501741FACF4519019F22",
+            "next_validators_hash": "C36B9A57E21E1D6D72CE2700CFF7551F792A52B41BBA9C228AF3C61CF4683F0D",
+            "consensus_hash": "2A57A2A6D22355993FD2D05546048E3431A075F1B9D9501741FACF4519019F22",
+            "app_hash": "",
+            "last_results_hash": null,
+            "evidence_hash": null,
+            "proposer_address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A"
+          },
+          "commit": {
+            "height": "2",
+            "round": 1,
+            "block_id": {
+              "hash": "5E17E970998187C4774ADDC407F719B74DA43C30D129DF53DC7E41BA6AA0C726",
+              "part_set_header": {
+                "total": 1,
+                "hash": "5E17E970998187C4774ADDC407F719B74DA43C30D129DF53DC7E41BA6AA0C726"
+              }
+            },
+            "signatures": [
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "26E91E700545D79E8A18092C393DB76294DF393A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "AKov+J8B678APCtqrv972R9qsW54pjmG7PIaYa69bM+IB2Uoi8PP++4/mv8/Sugq8i3L0Ec3h5jxB0kjaKyzBw=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "N0a0rOuA6A4DsMW3EXt2Fx9eptvTJzan3uqCvuGHLFX8jSSWS8+bI3XHqzcUmFiUB9qcrlXbDbxFOGg9yDHZAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "EKlkNzpM9+Df5xhZcAU59SCj3D8DRQhsgPiXvI6ZUXSKHtJy7Vz7gcZ438On2m7NVgd5ZlCuHk+kvcBYqGZXCQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "kYtLXpidhkFVD+iZirJSloYwt9HQp4AcS0SZhsNdskw6vb7hztXars1sor9bkKuD3K4BvZ9AtXn7oiYMbXmyCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "y8gOxMKmwhGmcbRQgHw0nk10gqt/+ErMm3VDhRXVPljRS6Redettf+eL4ijE/LIIo5bnxEOkMxySM8FKa8GaDg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "8AFSvcUWVJ1YLSAOEaEDFqFOHOn1P9QflhpSk+BORaNkHB5kguhdJEr9bgPPXiC26GRabdgeRNtMk8gK04k8Ag=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "JpkP4oPBltOK/mGr9fl2TSPjk2yiEVIICmtwf3Yl2RIbBNFaTSXs7QKWASkzTGN4Z6nPU7n33KuGM5BWdlPNCw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "NK6pLILpqCXrfvwiuLiKR3blSdCtZfLLtKUFYijokuN+x9Q0RAY+3ZC3yJqmXD7pEpRxvxhW+SjmVbahrD5qCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "fnABGbu7Qpe2qmGtuCpa4ZplYwx8YPJOHsveoe2qLIGzIP6/2L/Gqk8aHpUg5bJiuWNOL8nf9iyak8JnlCpSBw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "81D85BE9567F7069A4760C663062E66660DADF34",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "VDoC9AaqlybDTSDKL1vhUHkofildFBAyjUersZ+1X08jGR//ujPGtiXeM/scX+yp2O8Hyo2p6nrgjQntUHGwCA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "cRaMA/xjm9HZ2kbeD8w1nd2DV5dfLnx1Dtj6kEagtLBd0lO/C0co3XycA6d3yB13GtFEaFv2inRDP4TbiyXXCg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "SHU0xt+IdDT05Q5WaQ1089hmC9kvph+60Cd6uBiGiTueRledNwttryfRlOYTZqc5diVgzUAIeMCROyMtuTV/DA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "xTU4GrA8oTiGssVw/BXZ1DQG4eBxSyhT55UJeNuQjd9YDgjd9h+BJqPYB2mVyT1QAeZLltGiU0qLQcHPnqSHDw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "u2DqYs88VkDJwWLDuIelmbg8MTYAMDuWHyGAr31cvGTAM4YQwVOEh/Z7ECUNm5J+FRo5RXsle9EuFKgFK/0aAA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "ARxNcWjZfgzNMjzyNIP2SDjYVPit4GQvORNpDdQkB+DQt98c316cUnIOiezauqB5K/7KOULC3rtMMCK1LpybDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "Jba2aTKX4iO3MsROMma5hNMrJ/vONcd3TnVhu0mZDu+Ep7IZWzHo0ddvDaEHq+tkERb+wLr6W2rhuTnW+w20Bg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "7Vuq0OK0m5UbEjivNGpTeZJoW3Hum4lJ11AzROb2ltQpvJbFiMV3snqlT4Ta+xmD+7is/68I8q45kRoeCa5WAQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "KchXlaZ28ldU24sFKW6KIX+ylmN2KmVsf2kWhFs8HDt03Xdvy6TbHguaadbYblx90nrWN44A6fPgh2gVUGNmDA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "FZwC7rt5NcuO3m4twBz6gdWHlHLySRwAzwRHpH4ByQt8lATJOs0y5KD9GqPSM5OZ9Ww1CY3LP/WHrkxrWefODg=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "L2q8h4T7zqC4NzLXoM5lne/UAAP1P1ryeVqqdlQYVLyTG9UtPA3aq0HlTpUc/uAHhrYDAs2ewjmYYItaccVrBA=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "SU6CKk3ZNb11ZZLUvdOJEHRDOYaiIOhXFdGy2W4TAZruEj3eMC3sO4pawnkOdkQbgfHoMLGJmxhjbDpgBpEwDg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "1pt/NP4QQMZTM6JjiPmSs7Irot6mMIQRIUdcT6XyJNFBKP1drNGFg2jinHypZY0v2KcSabLdvt7Mfmss/3r3Dw=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "q6NnUZly6nxzvCVkZ2dIjUUoCls3q/L2yxt6StTLHOpdNQgEK9wIZfDDzZDo+MITsMv2DEiHB36bw34JGzkGDA=="
+              },
+              {
+                "block_id_flag": 1,
+                "validator_address": null,
+                "timestamp": null,
+                "signature": null
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D447195654516BE994064E03868856302AEAF1D1",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "8nZhpIwPGz+9Bxxm9ziDCQxMkdEgzB7K7fuliBOU6OICLp2oOXIWyK7nLo6fUrQZ4tcuUVrrfKc/6eApAUJCBQ=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "MB9yfFWXOGkbJmqpj5JJX4uyLHDxWZwVVAQdNpXWBraknLWhFxY03BUT9jbLxbjSWGffSasvOi7dsmBHlO0iCg=="
+              },
+              {
+                "block_id_flag": 2,
+                "validator_address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+                "timestamp": "1970-01-01T00:00:02Z",
+                "signature": "lsEYTErSuVaesgh5onHVHiGE2+J74bSzpkpBmrrbivVCzb6Zv9OibuUvX5k+hgl6HZvm7b4Gx5SCPtNyWnZ8CA=="
+              }
+            ]
+          }
+        },
+        "validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "26E91E700545D79E8A18092C393DB76294DF393A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F8xDDGP4gRkFMeuIlULpbOP6aGPdTe5gZT7kCCnAQIY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "fWMaYDTFwdDo7SVw9hBIraX2GVqvzKhNKEUkr/2ZnEc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "2D963CD0FA15D15C1C200D578CCDC2C692B72036",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Uq1fQj/TXkpg+zP37a//6YC04vQHWraWfYSg88fMHxw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "JqkfZ01ZvkPHj9ohj0F2Saa5t6KIX5uq1bhHS7YAyxk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "mGpmR8PNc6w2cUzPwAQhkSadkyGOuKMl68Nji5E3h5o="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6CC7AC5844AFFDC522094543E7552F1C60FF02AC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GR4akX9jBcU4iFUBqB3NGwD3CuSTGPHiaWofAhCjCiE="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Pfy3anXtYHMFjDLvM+5jJN3iS5Ypz9NMJ1KTNVjfJ7I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UGBPzd5VtGwtUkXOkCgJuzUO6s7Zk0RGKCo/Csdlqf4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "80E8155B244AD20287F2C51BBE609355FA5B082D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "2ekMO1AKawC1gbXty/y6KBVpUfC9RcKyf3sR0ZK7UR8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8CEBC3AA7D2C6E71F7385EC0E1BC182938724C0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6mYEZ5I4fKC1goMotZ3yTYH19SAvSrD+hpIsVxLxPWQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "92932AD7E082B90296C192F3113710CD6F99432E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GJlkT7S82nRWW34K5ax6ZCW9EV2nt1E/PF1P5LQgJdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "990CDD32CD8EF97E5EC9D3E9F8C25543A7EDAA33",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UseUFPt/FyVO1D19U7tHq4/CAsW/JxWOeTbw/ZftxMM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Hm8gqT6zv3BHDTjlY1nLMK2U4gte/cducumkYBgvXig="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "z7XkAAZ+x6klleinW1VTrsMLnAwNF9LHBFprFx1E4bA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A3C681BA9B2175F4E3E48DA799F79E2D66852E73",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "uEXsZIGASOuKR3SQn2cakTAkulEbm2kElVjj50W2oJw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZHfThztGFsj0VfR6xV1r5ZA09Q6/+np9oYXs8CWY4F8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "L7pTIdyDJ9DHXRXMGcDeLxQ7KUP3AKiPpggq385vkrA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "8f/zBc9sYTK1e73NefD07XG1gA/fqVsf8CZ5EyualYk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Ct8qHvpO82bPqzj2YxHkFgE+fmxVF0q7fTuvXzsK6Cw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C479DB6F37AB9757035CFBE10B687E27668EE7DF",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "3wf60CidQcsIO7TksXzEZsJefMUFF73k6nP1YeEo9to="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "55KLg7eVl0IyiFhu7r38WGQizm6hglE4rsAo68dGK28="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QEsifvLPeeGUsnI5MjI+gOXd2aU+NOqCwE6+Cs/LQRQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D281629B8289556EC5E1C9C2A78FEB2B0A18B4EC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "xzIY0miEtnX/3fduBl9vYN2iDEmt7HIGK3Qb0bywdbU="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D3E01BA109EB39DC5537FC1AD493DC51696099C2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "rzORQgLg90Tc4xBKwEsvgMZQS6yxvhzvZB3B/zbDW0A="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D447195654516BE994064E03868856302AEAF1D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "K+cn+8TPKo7d9dNhdj999tu1T108JCxecojB0pkssl0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F4d36ebIiyCzz/pk4sGrxYnls8XuzOfMRh/lF2LTdA4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "next_validator_set": {
+          "validators": [
+            {
+              "address": "0616A636E7D0579A632EC37ED3C3F2B7E8522A0A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "kwd8trZ8t5ASwgUbBEAnDq49nRRrrKvt2onhS4JSfQM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "118D4509F88D6ABE5EC516CB707F5303B9E2C15C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "StsLNXvtOvrk90slRz5iMalcyL2LZswVnFT704LCwdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "26E91E700545D79E8A18092C393DB76294DF393A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F8xDDGP4gRkFMeuIlULpbOP6aGPdTe5gZT7kCCnAQIY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "27F2EBD163141DBB2108462E490EECB01EA5E29F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "fWMaYDTFwdDo7SVw9hBIraX2GVqvzKhNKEUkr/2ZnEc="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "361491162A6178776B903E57AB7C4D909394B4B4",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QlwrDiydr8tfRonzwMnML1JYtWUHQZiG6aqhWsXRriA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "36B42D1EDA17C600C19CD91EE53FDAA37ABBD84F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "etUp4mnEHDdNnJSwu5KW8EMXYt7n94iYZm+y7xa9ym8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3A56282ED3926B193E010D387E0E9FEA6368F034",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "R1rD/692T348fL4cA0mvvbK9aANwT0vBNAT5B9+p+rw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "3C977CABBB911557FC1A07FAFB7F005EC9FB0565",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Spb0BakJqr3uNaAEqdaGbv77bQEwym0/6cl/tnCdkGM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "42D162EDB46B7C1FEA616810A7617A6369958ADE",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "U4HzaR1kBj9HGcZU1I3rIZMwMoikUmYQyIMZktuBOF0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4443AEEAB1B9C041A3BC505CBD5E9DAAD7287E5F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "JqkfZ01ZvkPHj9ohj0F2Saa5t6KIX5uq1bhHS7YAyxk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "495438D2011E254FF2FD340629AE2D74E2188A4F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "M5rP8lPaJdES+Bd4oWI/va2sRUvbJiYINzOpUdiuO8Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "4D9FD26B2372FBFE05C0452D534C6014C4D7F887",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "mGpmR8PNc6w2cUzPwAQhkSadkyGOuKMl68Nji5E3h5o="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "5CC93DA93D8C513DFB5B1CA972AD472EDBD0D4F8",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "+b3DF2I8j3TrDePELV4L4ssCLIoq34BBp0RyU/QmmYY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "6AE5C701F508EB5B63343858E068C5843F28105F",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQEC/HB4sDBAVhHtUzyv4yct9ZGnudaP209QQBSTfSQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "725F885D0173D8D85AADCF776253F5BFF3AC0018",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "r7QqYEO8hh6xOwJMpsH+gYer+oOcuP/UQyG7NNsLLHk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "72CB93184275A21BE0E0C5EE07E4B45BD6A78725",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "IPoyPEpBWphJbDnocj0x7bFbIX0grHlypAkknLjia3E="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "7C0A50C406A9012DDFB6C07E2E976B4662FB4D78",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Pfy3anXtYHMFjDLvM+5jJN3iS5Ypz9NMJ1KTNVjfJ7I="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "804A4582D02409176BA9BCC2656428EE250C23F2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "UGBPzd5VtGwtUkXOkCgJuzUO6s7Zk0RGKCo/Csdlqf4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "81D85BE9567F7069A4760C663062E66660DADF34",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Lk4zm2cJO4FpzXFF9WUV9NzOLfr5jV+ps7EhwUDKlZM="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "89813D501FB36796F5BEEC2E8B6A48FFEFF45595",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "VV0Fv/VdsyNrvfi+Kh+ld2pVHLZdNJLztUwJSKis/WI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "8FB58C7333B5BE046834BE2B6426A0B6D268167A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "x+WPfQQNWVCyH1qcBEoS6beOqg/wvv0BNks5Lotb28c="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "92932AD7E082B90296C192F3113710CD6F99432E",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GJlkT7S82nRWW34K5ax6ZCW9EV2nt1E/PF1P5LQgJdg="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A05EC3EDD42F9AD5615733694CAA91A0300FDB67",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Hm8gqT6zv3BHDTjlY1nLMK2U4gte/cducumkYBgvXig="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1F2F7907A1E17B1A26EA519B8FC99FCCE841925",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "GQBydj5eqXzfBc++Y+9Q5RaUtEXtQghUR0duadGH9dk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A1FD6FD230258CF676B492740312EEF2FFDB2613",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "z7XkAAZ+x6klleinW1VTrsMLnAwNF9LHBFprFx1E4bA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "A90828D1AA8F76EB2A8C1064895715E7B2DBE60C",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "ZHfThztGFsj0VfR6xV1r5ZA09Q6/+np9oYXs8CWY4F8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AD28DEF4048F1BC51A8800A26E697A7771A6AF40",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "L7pTIdyDJ9DHXRXMGcDeLxQ7KUP3AKiPpggq385vkrA="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "AF50C2828B727556CC4CC04CBA32FBECC229D49D",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "6lcuin9eD6uwAu9qjsoRjtd+uCtVUZbn//5UqLng9mI="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B481198C8646CFFC33A07077741EACAF5AE33C84",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "8f/zBc9sYTK1e73NefD07XG1gA/fqVsf8CZ5EyualYk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "B75D43BFE6B5E82190CCA5DD19527F97D5E55CCC",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "Ct8qHvpO82bPqzj2YxHkFgE+fmxVF0q7fTuvXzsK6Cw="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "C6669D562F234ADC5209E39C21934E0E8E5B2D38",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "55KLg7eVl0IyiFhu7r38WGQizm6hglE4rsAo68dGK28="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "CD086FC216F0BBE97FAF5042D211118480C48130",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "QEsifvLPeeGUsnI5MjI+gOXd2aU+NOqCwE6+Cs/LQRQ="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D447195654516BE994064E03868856302AEAF1D1",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "u7GVl6wdnCsWjxNSxnOCwxnZTWLYTlaB6to7efS7RWY="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "D81E34C3A984B29FE89AF1ADF76037ECA63B68B9",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "K+cn+8TPKo7d9dNhdj999tu1T108JCxecojB0pkssl0="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "EAC805939208F7851F6517652FBFF87D9CBD455A",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "KnxmZvSDBv86GS7gm1kAHa2i2WXmu+MVkpD/jeybV/Q="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F1DA81336F50B87982CF10581D308080031406C6",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "TCNu3Qckfx5+zXKvDTIHAFd/FZgbk013UFYIZqWl7w8="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "F6C52523A5DD417F1B8CDE588F0163CE82BB39B2",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "F4d36ebIiyCzz/pk4sGrxYnls8XuzOfMRh/lF2LTdA4="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            },
+            {
+              "address": "FCE4B81596E59258D6F5F5F724645A9E77952ACA",
+              "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "wqp6kT/3DEZ81E8BAdD802/NccJcCyBWBVrah3EOTFk="
+              },
+              "voting_power": "50",
+              "proposer_priority": null
+            }
+          ]
+        },
+        "provider": "BADFADAD0BEFEEDC0C0ADEADBEEFC0FFEEFACADE"
+      },
+      "now": "1970-01-01T00:00:03Z",
+      "verdict": "SUCCESS"
+    }
+  ]
+}

--- a/light/verifier.go
+++ b/light/verifier.go
@@ -54,6 +54,16 @@ func VerifyNonAdjacent(
 		return ErrInvalidHeader{err}
 	}
 
+	// Ensure that +2/3 of new validators signed correctly.
+	//
+	// NOTE: this should always be the last check because untrustedVals can be
+	// intentionally made very large to DOS the light client. not the case for
+	// VerifyAdjacent, where validator set is known in advance.
+	if err := untrustedVals.VerifyCommitLight(trustedHeader.ChainID, untrustedHeader.Commit.BlockID,
+		untrustedHeader.Height, untrustedHeader.Commit); err != nil {
+		return ErrInvalidHeader{err}
+	}
+
 	// Ensure that +`trustLevel` (default 1/3) or more of last trusted validators signed correctly.
 	err := trustedVals.VerifyCommitLightTrusting(trustedHeader.ChainID, untrustedHeader.Commit, trustLevel)
 	if err != nil {
@@ -63,16 +73,6 @@ func VerifyNonAdjacent(
 		default:
 			return e
 		}
-	}
-
-	// Ensure that +2/3 of new validators signed correctly.
-	//
-	// NOTE: this should always be the last check because untrustedVals can be
-	// intentionally made very large to DOS the light client. not the case for
-	// VerifyAdjacent, where validator set is known in advance.
-	if err := untrustedVals.VerifyCommitLight(trustedHeader.ChainID, untrustedHeader.Commit.BlockID,
-		untrustedHeader.Height, untrustedHeader.Commit); err != nil {
-		return ErrInvalidHeader{err}
 	}
 
 	return nil


### PR DESCRIPTION
Closes #5602

**DO NOT MERGE**

Notice how passing tests requires moving the "2/3+ signatures" check above the "overlap" check. Doing so, I believe, creates a security thread. The reason is explained in this comment:

```
	// NOTE: this should always be the last check because untrustedVals can be
	// intentionally made very large to DOS the light client. not the case for
	// VerifyAdjacent, where validator set is known in advance.
```