### PR TITLE
blockchain/v2: remove peers from the processor  (#5607)

### DIFF
--- a/blockchain/v2/reactor.go
+++ b/blockchain/v2/reactor.go
@@ -389,6 +389,10 @@ func (r *BlockchainReactor) demux(events <-chan Event) {
 			case scSchedulerFail:
 				r.logger.Error("Scheduler failure", "err", event.reason.Error())
 			case scPeersPruned:
+				// Remove peers from the processor.
+				for _, peerID := range event.peers {
+					r.processor.send(scPeerError{peerID: peerID, reason: errors.New("peer was pruned")})
+				}
 				r.logger.Debug("Pruned peers", "count", len(event.peers))
 			case noOpEvent:
 			default:

--- a/blockchain/v2/scheduler.go
+++ b/blockchain/v2/scheduler.go
@@ -302,7 +302,7 @@ func (sc *scheduler) setPeerRange(peerID p2p.ID, base int64, height int64) error
 	peer := sc.ensurePeer(peerID)
 
 	if peer.state == peerStateRemoved {
-		return fmt.Errorf("cannot set peer height for a peer in peerStateRemoved")
+		return nil // noop
 	}
 
 	if height < peer.height {

--- a/blockchain/v2/scheduler_test.go
+++ b/blockchain/v2/scheduler_test.go
@@ -531,7 +531,6 @@ func TestScSetPeerRange(t *testing.T) {
 				peers: map[string]*scPeer{"P1": {height: 2, state: peerStateRemoved}}},
 			args:       args{peerID: "P1", height: 4},
 			wantFields: scTestParams{peers: map[string]*scPeer{"P1": {height: 2, state: peerStateRemoved}}},
-			wantErr:    true,
 		},
 		{
 			name: "decrease height of single peer",
@@ -1995,7 +1994,7 @@ func TestScHandleStatusResponse(t *testing.T) {
 			name:      "increase height of removed peer",
 			fields:    scTestParams{peers: map[string]*scPeer{"P1": {height: 2, state: peerStateRemoved}}},
 			args:      args{event: statusRespP1Ev},
-			wantEvent: scPeerError{peerID: "P1", reason: fmt.Errorf("some error")},
+			wantEvent: noOpEvent{},
 		},
 
 		{


### PR DESCRIPTION
after they were pruned by the scheduler

Closes #5513
