### PR TITLE
CHANGELOG: update to reflect v0.34.0-rc6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 *November 5, 2020*
 
-## v0.34.0-rc5
-
 Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermint).
 
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,40 @@
 # Changelog
 
+## v0.34.0-rc6
+
+*November 5, 2020*
+
+## v0.34.0-rc5
+
+Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermint).
+
+### BREAKING CHANGES
+
+- [evidence] [\#5610](https://github.com/tendermint/tendermint/issues/5610) Make it possible for abci evidence to be formed from tm evidence (@cmwaters) 
+    - This makes breaking changes to `DuplicateVoteEvidence` and `LightClientAttackEvidence` 
+    such that ABCI evidence can be reconstructed from these types, and is necessary for nodes 
+    to successfully sync to block heights with recorded evidence
+
+### IMPROVEMENTS
+
+- [statesync] [\#5516](https://github.com/tendermint/tendermint/issues/5516) Check that all heights necessary to rebuild state for a snapshot exist before adding the snapshot to the pool. (@erikgrinaker)
+
+### BUG FIXES
+
+- [blockchain/v2] [\#5499](https://github.com/tendermint/tendermint/issues/5499) Fix "duplicate block enqueued by processor" panic (@melekes)
+- [abci/grpc] [\#5520](https://github.com/tendermint/tendermint/issues/5520) Return async responses in order, to avoid mempool panics. (@erikgrinaker)
+- [blockchain/v2] [\#5530](https://github.com/tendermint/tendermint/issues/5530) Fix "processed height 4541 but expected height 4540" panic (@melekes)
+- [consensus/wal] Fix WAL autorepair by opening target WAL in read/write mode (@erikgrinaker)
+- [block] [\#5567](https://github.com/tendermint/tendermint/issues/5567) Fix MaxCommitSigBytes (@cmwaters)
+- [blockchain/v2] [\#5553](https://github.com/tendermint/tendermint/issues/5553) Make the removal of an already removed peer a noop (@melekes)
+- [evidence] [\#5574](https://github.com/tendermint/tendermint/issues/5574) Fix bug where node sends committed evidence to peer (@cmwaters)
+- [privval] [\#5583](https://github.com/tendermint/tendermint/issues/5583) Make `Vote`, `Proposal` & `PubKey` non-nullable in Responses (@marbar3778)
+- [light] [\#5392](https://github.com/tendermint/tendermint/issues/5392) Make light client home directory same as the full node default (@cmwaters)
+
+
 ## v0.34.0-rc5
 
 *October 13, 2020*
-
 
 Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermint).
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,15 +24,6 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### IMPROVEMENTS
 
-- [statesync] \#5516 Check that all heights necessary to rebuild state for a snapshot exist before adding the snapshot to the pool. (@erikgrinaker)
-
 ### BUG FIXES
 
-- [blockchain/v2] \#5499 Fix "duplicate block enqueued by processor" panic (@melekes)
-- [abci/grpc] \#5520 Return async responses in order, to avoid mempool panics. (@erikgrinaker)
 - [types] \#5523 Change json naming of `PartSetHeader` within `BlockID` from `parts` to `part_set_header` (@marbar3778)
-- [blockchain/v2] \#5530 Fix "processed height 4541 but expected height 4540" panic (@melekes)
-- [consensus/wal] Fix WAL autorepair by opening target WAL in read/write mode (@erikgrinaker)
-- [blockchain/v2] \#5553 Make the removal of an already removed peer a noop (@melekes)
-- [evidence] \#5574 Fix bug where node sends committed evidence to peer (@cmwaters)
-- [evidence] \5610 Make it possible for abci evidence to be formed from tm evidence (@cmwaters)


### PR DESCRIPTION
Note that this also deletes everything from CHANGELOG_PENDING that was included in RC6. 