### PR TITLE
move broadcast_evidence rpc call from info to evidence

### DIFF
--- a/rpc/core/evidence.go
+++ b/rpc/core/evidence.go
@@ -10,7 +10,7 @@ import (
 )
 
 // BroadcastEvidence broadcasts evidence of the misbehavior.
-// More: https://docs.tendermint.com/master/rpc/#/Info/broadcast_evidence
+// More: https://docs.tendermint.com/master/rpc/#/Evidence/broadcast_evidence
 func BroadcastEvidence(ctx *rpctypes.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
 	if ev == nil {
 		return nil, errors.New("no evidence was provided")

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -1144,7 +1144,7 @@ paths:
             type: string
             example: "JSON_EVIDENCE_encoded"
       tags:
-        - Info
+        - Evidence
       description: |
         Broadcast evidence of the misbehavior.
       responses:


### PR DESCRIPTION
## Description

`broadcast_evidence`, like `broadcast_tx`, should not be part of the Info group but should reside in the `Evidence` tab that we especially allocated for it.

NOTE: Not too sure if this is actually the way to fix it


