### PR TITLE
scripts: make linkifier default to 'pull' rather than 'issue'

### DIFF
--- a/scripts/linkify_changelog.py
+++ b/scripts/linkify_changelog.py
@@ -3,11 +3,11 @@ import re
 
 # This script goes through the provided file, and replaces any " \#<number>",
 # with the valid mark down formatted link to it. e.g.
-# " [\#number](https://github.com/tendermint/tendermint/issues/<number>)
-# Note that if the number is for a PR, github will auto-redirect you when you click the link.
+# " [\#number](https://github.com/tendermint/tendermint/pull/<number>)
+# Note that if the number is for a an issue, github will auto-redirect you when you click the link.
 # It is safe to run the script multiple times in succession. 
 #
 # Example usage $ python3 linkify_changelog.py ../CHANGELOG_PENDING.md
 for line in fileinput.input(inplace=1):
-    line = re.sub(r"\s\\#([0-9]*)", r" [\\#\1](https://github.com/tendermint/tendermint/issues/\1)", line.rstrip())
+    line = re.sub(r"\s\\#([0-9]*)", r" [\\#\1](https://github.com/tendermint/tendermint/pull/\1)", line.rstrip())
     print(line)


### PR DESCRIPTION
Our changelog entries usually reference PRs rather than issues; this script makes the links default to the more common choice. 