### PR TITLE
.goreleaser: add windows, remove arm (32 bit)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,9 +14,9 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
-      - arm
       - arm64
 
 checksum:


### PR DESCRIPTION
This updates the goreleaser tooling to build the same binaries that were built for the 0.34.0 release. 
