### PR TITLE
blockchain/v1: handle peers without blocks

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -35,3 +35,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [types] \#5523 Change json naming of `PartSetHeader` within `BlockID` from `parts` to `part_set_header` (@marbar3778)
 - [privval] \#5638 Increase read/write timeout to 5s and calculate ping interval based on it (@JoeKash)
+- [blockchain/v1] [\#5701](https://github.com/tendermint/tendermint/pull/5701) Handle peers without blocks (@melekes)

--- a/blockchain/v1/reactor_fsm.go
+++ b/blockchain/v1/reactor_fsm.go
@@ -277,6 +277,7 @@ func init() {
 				return waitForBlock, err
 			case noBlockResponseEv:
 				fsm.logger.Error("peer does not have requested block", "peer", data.peerID)
+				fsm.pool.SetNoBlock(data.peerID, data.height)
 
 				return waitForBlock, nil
 			case processedBlockEv:

--- a/blockchain/v1/reactor_fsm_test.go
+++ b/blockchain/v1/reactor_fsm_test.go
@@ -102,6 +102,19 @@ func sProcessedBlockEv(current, expected string, reactorError error) fsmStepTest
 	}
 }
 
+func sNoBlockResponseEv(current, expected string, peerID p2p.ID, height int64, err error) fsmStepTestValues {
+	return fsmStepTestValues{
+		currentState: current,
+		event:        noBlockResponseEv,
+		data: bReactorEventData{
+			peerID: peerID,
+			height: height,
+		},
+		wantState: expected,
+		wantErr:   err,
+	}
+}
+
 func sStatusEv(current, expected string, peerID p2p.ID, height int64, err error) fsmStepTestValues {
 	return fsmStepTestValues{
 		currentState: current,
@@ -337,6 +350,46 @@ func TestFSMBlockVerificationFailure(t *testing.T) {
 
 				// process block failure, should remove P1 and all blocks
 				sProcessedBlockEv("waitForBlock", "waitForBlock", errBlockVerificationFailure),
+
+				// get blocks 1-3 from P2
+				sMakeRequestsEv("waitForBlock", "waitForBlock", maxNumRequests),
+				sBlockRespEv("waitForBlock", "waitForBlock", "P2", 1, []int64{}),
+				sBlockRespEv("waitForBlock", "waitForBlock", "P2", 2, []int64{1}),
+				sBlockRespEv("waitForBlock", "waitForBlock", "P2", 3, []int64{1, 2}),
+
+				// finish after processing blocks 1 and 2
+				sProcessedBlockEv("waitForBlock", "waitForBlock", nil),
+				sProcessedBlockEv("waitForBlock", "finished", nil),
+			},
+		},
+	}
+
+	executeFSMTests(t, tests, false)
+}
+
+func TestFSMNoBlockResponse(t *testing.T) {
+	tests := []testFields{
+		{
+			name:               "no block response",
+			startingHeight:     1,
+			maxRequestsPerPeer: 3,
+			steps: []fsmStepTestValues{
+				sStartFSMEv(),
+
+				// add P1 and get blocks 1-3 from it
+				sStatusEv("waitForPeer", "waitForBlock", "P1", 3, nil),
+				sMakeRequestsEv("waitForBlock", "waitForBlock", maxNumRequests),
+				sBlockRespEv("waitForBlock", "waitForBlock", "P1", 1, []int64{}),
+				sBlockRespEv("waitForBlock", "waitForBlock", "P1", 2, []int64{1}),
+				sBlockRespEv("waitForBlock", "waitForBlock", "P1", 3, []int64{1, 2}),
+
+				// add P2
+				sStatusEv("waitForBlock", "waitForBlock", "P2", 3, nil),
+
+				// process block failure, should remove P1 and all blocks
+				sNoBlockResponseEv("waitForBlock", "waitForBlock", "P1", 1, nil),
+				sNoBlockResponseEv("waitForBlock", "waitForBlock", "P1", 2, nil),
+				sNoBlockResponseEv("waitForBlock", "waitForBlock", "P1", 3, nil),
 
 				// get blocks 1-3 from P2
 				sMakeRequestsEv("waitForBlock", "waitForBlock", maxNumRequests),


### PR DESCRIPTION
Closes #5444

Now we record the fact that a peer does not have a requested block and later use this information to make a new request for the same block from another peer.