### PR TITLE
crypto: fix infinite recursion in Secp256k1 string formatting (#5707)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,3 +26,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### BUG FIXES
 
+- [crypto] \#5707 Fix infinite recursion in string formatting of Secp256k1 keys (@erikgrinaker)

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -158,7 +158,7 @@ func (pubKey PubKey) Bytes() []byte {
 }
 
 func (pubKey PubKey) String() string {
-	return fmt.Sprintf("PubKeySecp256k1{%X}", pubKey[:])
+	return fmt.Sprintf("PubKeySecp256k1{%X}", []byte(pubKey))
 }
 
 func (pubKey PubKey) Equals(other crypto.PubKey) bool {


### PR DESCRIPTION
This caused stack overflow panics in E2E tests, e.g.:

```
2020-11-24T02:37:17.6085640Z [35mvalidator04    |[0m runtime: goroutine stack exceeds 1000000000-byte limit
2020-11-24T02:37:17.6087818Z [35mvalidator04    |[0m runtime: sp=0xc0234b23c0 stack=[0xc0234b2000, 0xc0434b2000]
2020-11-24T02:37:17.6088920Z [35mvalidator04    |[0m fatal error: stack overflow
2020-11-24T02:37:17.6089776Z [35mvalidator04    |[0m
2020-11-24T02:37:17.6090569Z [35mvalidator04    |[0m runtime stack:
2020-11-24T02:37:17.6091677Z [35mvalidator04    |[0m runtime.throw(0x12dc476, 0xe)
2020-11-24T02:37:17.6093123Z [35mvalidator04    |[0m 	/usr/local/go/src/runtime/panic.go:1116 +0x72
2020-11-24T02:37:17.6094320Z [35mvalidator04    |[0m runtime.newstack()
2020-11-24T02:37:17.6095374Z [35mvalidator04    |[0m 	/usr/local/go/src/runtime/stack.go:1067 +0x78d
2020-11-24T02:37:17.6096381Z [35mvalidator04    |[0m runtime.morestack()
2020-11-24T02:37:17.6097657Z [35mvalidator04    |[0m 	/usr/local/go/src/runtime/asm_amd64.s:449 +0x8f
2020-11-24T02:37:17.6098505Z [35mvalidator04    |[0m
2020-11-24T02:37:17.6099328Z [35mvalidator04    |[0m goroutine 88 [running]:
2020-11-24T02:37:17.6100470Z [35mvalidator04    |[0m runtime.heapBitsSetType(0xc009565380, 0x20, 0x18, 0x1137e00)
2020-11-24T02:37:17.6101961Z [35mvalidator04    |[0m 	/usr/local/go/src/runtime/mbitmap.go:911 +0xaa5 fp=0xc0234b23d0 sp=0xc0234b23c8 pc=0x432625
2020-11-24T02:37:17.6103906Z [35mvalidator04    |[0m runtime.mallocgc(0x20, 0x1137e00, 0x117b601, 0x11e9240)
2020-11-24T02:37:17.6105179Z [35mvalidator04    |[0m 	/usr/local/go/src/runtime/malloc.go:1090 +0x5a5 fp=0xc0234b2470 sp=0xc0234b23d0 pc=0x428b25
2020-11-24T02:37:17.6106540Z [35mvalidator04    |[0m runtime.convTslice(0xc002743710, 0x21, 0x21, 0xc0234b24e8)
2020-11-24T02:37:17.6107861Z [35mvalidator04    |[0m 	/usr/local/go/src/runtime/iface.go:385 +0x59 fp=0xc0234b24a0 sp=0xc0234b2470 pc=0x426379
2020-11-24T02:37:17.6109315Z [35mvalidator04    |[0m github.com/tendermint/tendermint/crypto/secp256k1.PubKey.String(...)
2020-11-24T02:37:17.6151692Z [35mvalidator04    |[0m 	/src/tendermint/crypto/secp256k1/secp256k1.go:161
2020-11-24T02:37:17.6153872Z [35mvalidator04    |[0m github.com/tendermint/tendermint/crypto/secp256k1.(*PubKey).String(0xc009565360, 0x11e9240, 0xc009565360)
2020-11-24T02:37:17.6157421Z [35mvalidator04    |[0m 	<autogenerated>:1 +0x65 fp=0xc0234b24f8 sp=0xc0234b24a0 pc=0x656965
2020-11-24T02:37:17.6159134Z [35mvalidator04    |[0m fmt.(*pp).handleMethods(0xc00956c680, 0x58, 0xc0234b2801)
2020-11-24T02:37:17.6161462Z [35mvalidator04    |[0m 	/usr/local/go/src/fmt/print.go:630 +0x30a fp=0xc0234b2768 sp=0xc0234b24f8 pc=0x518b8a
[...]
2020-11-24T02:37:17.6649685Z [35mvalidator04    |[0m 	/usr/local/go/src/fmt/print.go:630 +0x30a fp=0xc0234b7f48 sp=0xc0234b7cd8 pc=0x518b8a
2020-11-24T02:37:17.6651177Z [35mvalidator04    |[0m created by github.com/tendermint/tendermint/node.startStateSync
2020-11-24T02:37:17.6652521Z [35mvalidator04    |[0m 	/src/tendermint/node/node.go:587 +0x150

```

## Description

_Please add a description of the changes that this PR introduces and the files that
are the most critical to review._ 

Closes: #XXX

