### PR TITLE
docs: update tendermint version in go guides

### DIFF
--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -588,7 +588,7 @@ go 1.15
 
 require (
 	github.com/dgraph-io/badger v1.6.2
-	github.com/tendermint/tendermint v0.34.0-rc4
+	github.com/tendermint/tendermint v0.34.0
 )
 ```
 
@@ -601,8 +601,8 @@ go build
 To create a default configuration, nodeKey and private validator files, let's
 execute `tendermint init`. But before we do that, we will need to install
 Tendermint Core. Please refer to [the official
-guide](https://docs.tendermint.com/master/introduction/install.html). If you're
-installing from source, don't forget to checkout the latest release (`git
+guide](https://docs.tendermint.com/master/introduction/install.html). **If you're
+installing from source, don't forget to checkout the latest release** (`git
 checkout vX.Y.Z`). Don't forget to check that the application uses the same
 major version.
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -98,6 +98,10 @@ func NewKVStoreApplication() *KVStoreApplication {
 	return &KVStoreApplication{}
 }
 
+func (KVStoreApplication) SetOption(abcitypes.RequestSetOption) abcitypes.ResponseSetOption {
+	return abcitypes.ResponseSetOption{}
+}
+
 func (KVStoreApplication) Info(req abcitypes.RequestInfo) abcitypes.ResponseInfo {
 	return abcitypes.ResponseInfo{}
 }

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -101,6 +101,10 @@ func NewKVStoreApplication() *KVStoreApplication {
 	return &KVStoreApplication{}
 }
 
+func (KVStoreApplication) SetOption(abcitypes.RequestSetOption) abcitypes.ResponseSetOption {
+	return abcitypes.ResponseSetOption{}
+}
+
 func (KVStoreApplication) Info(req abcitypes.RequestInfo) abcitypes.ResponseInfo {
 	return abcitypes.ResponseInfo{}
 }

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -444,7 +444,7 @@ go 1.15
 
 require (
 	github.com/dgraph-io/badger v1.6.2
-	github.com/tendermint/tendermint v0.34.0-rc4
+	github.com/tendermint/tendermint v0.34.0
 )
 ```
 
@@ -457,8 +457,8 @@ go build
 To create a default configuration, nodeKey and private validator files, let's
 execute `tendermint init`. But before we do that, we will need to install
 Tendermint Core. Please refer to [the official
-guide](https://docs.tendermint.com/master/introduction/install.html). If you're
-installing from source, don't forget to checkout the latest release (`git
+guide](https://docs.tendermint.com/master/introduction/install.html). **If you're
+installing from source, don't forget to checkout the latest release** (`git
 checkout vX.Y.Z`). Don't forget to check that the application uses the same
 major version.
 


### PR DESCRIPTION
also, stress out that the users need to install the latest release, not
the latest master.

Refs #5735
