### PR TITLE
Private key file recovery

### DIFF
--- a/privval/file.go
+++ b/privval/file.go
@@ -182,6 +182,12 @@ func GenFilePV(keyFilePath, stateFilePath, keyType string) (*FilePV, error) {
 	}
 }
 
+// RecoverFilePV recovers a validator from the given private key
+// and sets the filePaths, but does not call Save().
+func RecoverFilePV(privKey crypto.PrivKey, keyFilePath, stateFilePath string) *FilePV {
+	return NewFilePV(privKey, keyFilePath, stateFilePath)
+}
+
 // LoadFilePV loads a FilePV from the filePaths.  The FilePV handles double
 // signing prevention by persisting data to the stateFilePath.  If either file path
 // does not exist, the program will exit.

--- a/privval/file_test.go
+++ b/privval/file_test.go
@@ -41,6 +41,22 @@ func TestGenLoadValidator(t *testing.T) {
 	assert.Equal(height, privVal.LastSignState.Height, "expected privval.LastHeight to have been saved")
 }
 
+func TestRecoverValidator(t *testing.T) {
+	assert := assert.New(t)
+
+	tempKeyFile, err := ioutil.TempFile("", "priv_validator_key_")
+	require.Nil(t, err)
+	tempStateFile, err := ioutil.TempFile("", "priv_validator_state_")
+	require.Nil(t, err)
+
+	privKey := ed25519.GenPrivKeyFromSecret([]byte("it's a secret"))
+	privVal := RecoverFilePV(privKey, tempKeyFile.Name(), tempStateFile.Name())
+	privVal.Save()
+
+	recovered := RecoverFilePV(privKey, tempKeyFile.Name(), tempKeyFile.Name())
+	assert.Equal(privVal.GetAddress(), recovered.GetAddress(), "expected recovered addr to be the same")
+}
+
 func TestResetValidator(t *testing.T) {
 	tempKeyFile, err := ioutil.TempFile("", "priv_validator_key_")
 	require.Nil(t, err)


### PR DESCRIPTION
## Description
This PR adds the possibility to recover a private validator key file from a provided private key. 
This might be particularly useful to Cosmos validators, allowing them to externally supply a seed phrase to make sure they have a backup in the case they loose their validator key. 

#### Notes
It might be useful to backport this to v0.34, on which Cosmos v0.40 is currently based


Closes: #XXX

