### PR TITLE
Makefile: use git 2.20-compatible branch detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ BUILDDIR ?= $(CURDIR)/build
 BUILD_TAGS?=tendermint
 
 # If building a release, please checkout the version tag to get the correct version setting
-ifneq ($(shell git branch --show-current),)
-VERSION := unreleased-$(shell git branch --show-current)-$(shell git rev-parse HEAD)
+ifneq ($(shell git symbolic-ref -q --short HEAD),)
+VERSION := unreleased-$(shell git symbolic-ref -q --short HEAD)-$(shell git rev-parse HEAD)
 else
 VERSION := $(shell git describe)
 endif


### PR DESCRIPTION
`Makefile` used `git branch --show-current` for branch detection. This option was introduced in Git 2.22. However, the current Debian release (Buster), which is used by the `golang:1.15` Docker image, uses Git 2.20. This gives spurious errors e.g. when running the E2E tests:

```
error: unknown option `show-current'
```

This PR changes the branch detection to be compatible with Git 2.20. The behavior appears to be the same as `git branch --show-current`, both when on a branch, on a tag, and on a detached HEAD.