### PR TITLE
localnet: fix node starting issue with --proxy-app flag

### DIFF
--- a/networks/local/localnode/Dockerfile
+++ b/networks/local/localnode/Dockerfile
@@ -8,7 +8,7 @@ VOLUME [ /tendermint ]
 WORKDIR /tendermint
 EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
-CMD ["node", "--proxy_app", "kvstore"]
+CMD ["node", "--proxy-app", "kvstore"]
 STOPSIGNAL SIGTERM
 
 COPY wrapper.sh /usr/bin/wrapper.sh


### PR DESCRIPTION
### Description

When starting a local net the `--proxy-app` flag is incorrect.

The command is outlined here => [run_node.go](https://github.com/tendermint/tendermint/blob/master/cmd/tendermint/commands/run_node.go#L46)

### What the issue looks like
![Selection_042](https://user-images.githubusercontent.com/6751821/102341606-ff3d1b00-3f8f-11eb-8269-34fad5317ba7.png)


### How to test

- `make build`
- `make localnet-start`

