### PR TITLE
localnet: use 27000 port for prometheus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "26656-26657:26656-26657"
       - "6060:6060"
-      - "9090:9090"
+      - "26660:26660"
     environment:
       - ID=0
       - LOG=${LOG:-tendermint.log}
@@ -21,7 +21,7 @@ services:
     container_name: node1
     image: "tendermint/localnode"
     ports:
-      - "26659-26660:26656-26657"
+      - "26661-26662:26656-26657"
     environment:
       - ID=1
       - LOG=${LOG:-tendermint.log}
@@ -38,7 +38,7 @@ services:
       - ID=2
       - LOG=${LOG:-tendermint.log}
     ports:
-      - "26661-26662:26656-26657"
+      - "26663-26664:26656-26657"
     volumes:
       - ./build:/tendermint:Z
     networks:
@@ -52,7 +52,7 @@ services:
       - ID=3
       - LOG=${LOG:-tendermint.log}
     ports:
-      - "26663-26664:26656-26657"
+      - "26665-26666:26656-26657"
     volumes:
       - ./build:/tendermint:Z
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "26656-26657:26656-26657"
       - "6060:6060"
-      - "26660:26660"
+      - "26665:26660"
     environment:
       - ID=0
       - LOG=${LOG:-tendermint.log}
@@ -21,7 +21,7 @@ services:
     container_name: node1
     image: "tendermint/localnode"
     ports:
-      - "26661-26662:26656-26657"
+      - "26659-26660:26656-26657"
     environment:
       - ID=1
       - LOG=${LOG:-tendermint.log}
@@ -38,7 +38,7 @@ services:
       - ID=2
       - LOG=${LOG:-tendermint.log}
     ports:
-      - "26663-26664:26656-26657"
+      - "26661-26662:26656-26657"
     volumes:
       - ./build:/tendermint:Z
     networks:
@@ -52,7 +52,7 @@ services:
       - ID=3
       - LOG=${LOG:-tendermint.log}
     ports:
-      - "26665-26666:26656-26657"
+      - "26663-26664:26656-26657"
     volumes:
       - ./build:/tendermint:Z
     networks:
@@ -67,4 +67,3 @@ networks:
       config:
       -
         subnet: 192.167.10.0/16
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "26656-26657:26656-26657"
       - "6060:6060"
-      - "26665:26660"
+      - "27000:26660"
     environment:
       - ID=0
       - LOG=${LOG:-tendermint.log}

--- a/networks/local/localnode/config-template.toml
+++ b/networks/local/localnode/config-template.toml
@@ -4,4 +4,3 @@ pprof-laddr = ":6060"
 
 [instrumentation]
 prometheus = true
-prometheus-listen-addr = ":9090"


### PR DESCRIPTION
## Description

This relates to #5805 and changes the port from :9090 to :27000 as :9090 is the default port that the actual prometheus server runs on. 

In order to do this, I have shifted the rpc and p2p ports of the other three nodes down 


