### PR TITLE
abci: use protoio for length delimitation

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - Apps
   - [ABCI] \#5447 Remove `SetOption` method from `ABCI.Client` interface
   - [ABCI] \#5447 Reset `Oneof` indexes for  `Request` and `Response`.
+  - [ABCI] \#5818 Use protoio for msg length delimitation. Migrates from int64 to uint64 length delimiters.
 
 - P2P Protocol
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,6 +10,8 @@ This guide provides instructions for upgrading to specific versions of Tendermin
 
 * The method `SetOption` has been removed from the ABCI.Client interface. This feature was used in the early ABCI implementation's.
 
+* Messages are written to a byte stream using uin64 length delimiters instead of int64.
+
 ### Config Changes
 
 * `fast_sync = "v1"` is no longer supported. Please use `v2` instead.


### PR DESCRIPTION
## Description

Migrate ABCI to use `protoio` (uint64 length delimitation) instead of specific int64 length delimiters.

Closes: #5783

