### PR TITLE
ci: make timeout-minutes 8 for golangci

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
-    timeout-minutes: 4
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v2
       - uses: technote-space/get-diff-action@v4


### PR DESCRIPTION
## Description

make timeout 8 minutes for golangci. I need to look into why its taking longer in the cleanup stage. Golangci linting is passing but cancelling due to the timeout. 

Closes: #XXX

