### PR TITLE
How a Byzantine node can fork Tendermint (HIGH RISK)

### DIFF
--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -847,6 +847,10 @@ func (m *mockTicker) ScheduleTimeout(ti timeoutInfo) {
 		m.c <- ti
 		m.fired = true
 	}
+	if ti.Step == cstypes.RoundStepPrecommitWait {
+		m.c <- ti
+		m.fired = true
+	}
 }
 
 func (m *mockTicker) Chan() <-chan timeoutInfo {


### PR DESCRIPTION
This test shows how a byzantine node can easily make a fork in Tendermint Consensus Engine with taking advantage of possible network partitioning.

Imagine we have four nodes: (N<sub>x</sub>, N<sub>y</sub>, N<sub>b</sub>, N<sub>p</sub>) which:
N<sub>b</sub> is a byzantine node and N<sub>x</sub>, N<sub>y</sub>, N<sub>p</sub> are honest nodes, however N<sub>p</sub> is partitioned and see the network through N<sub>b</sub> (Byzantine node).

In Height H,  B sends its pre-votes to all the nodes but only sends valid pre-commit to P and nil pre-commit to X,Y.  Node P will immediately goes to the next height (H+1). 
Nodes X,Y don't have require votes (3f+1 votes) to commit the block, therefore they go to the next round. A fork happens here and the whole network will be halted forever.

In these logs you can see how a forks happens:

Node_1
```
Validator 1!
I am byzantine!

Entering height/round: 1/0, LastCommitHash: 
Vote: PREVOTE/1/0, addr: F51F836237F10F169999647D133BB72CD05C3C80, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/0, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/0, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: :0:000000000000

Entering height/round: 1/1, LastCommitHash: 
Vote: PRECOMMIT/1/0, addr: F51F836237F10F169999647D133BB72CD05C3C80, blockID: :0:000000000000
Vote: PREVOTE/1/1, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/0, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/1, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/1, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/1, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F

Entering height/round: 2/0, LastCommitHash: d50f97c798e740f991f04733c757206b1669ca46b2ad6ff940e8a4f2a842539d
```

Node_2
```
Validator 2!

Entering height/round: 1/0, LastCommitHash: 
Vote: PREVOTE/1/0, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/0, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: :0:000000000000
Vote: PREVOTE/1/0, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F

Entering height/round: 1/1, LastCommitHash: 
Vote: PREVOTE/1/1, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/1, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/1, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/1, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/1, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/1, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F

Entering height/round: 2/0, LastCommitHash: c612ada0a2504b0374b2e706f519ba37ba5df89233917fffa2b7907f3f97d934
```
Node_3
```
Entering height/round: 1/0, LastCommitHash: 
Vote: PREVOTE/1/0, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/0, addr: F51F836237F10F169999647D133BB72CD05C3C80, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: F51F836237F10F169999647D133BB72CD05C3C80, blockID: :0:000000000000

Entering height/round: 2/0, LastCommitHash: d50f97c798e740f991f04733c757206b1669ca46b2ad6ff940e8a4f2a842539d
```

Node_4
```
Validator 4!

Entering height/round: 1/0, LastCommitHash: 
Vote: PREVOTE/1/0, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: :0:000000000000
Vote: PREVOTE/1/0, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/0, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/0, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F

Entering height/round: 1/1, LastCommitHash: 
Vote: PREVOTE/1/1, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/1, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PREVOTE/1/1, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/1, addr: F8D0AA62B438CDBC06359EC417DE0B007932572E, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/1, addr: 090853AA0E364C37BDCFEBB9BE4DD0DB3D9C7A48, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F
Vote: PRECOMMIT/1/1, addr: 5AC9925B2BC110052012CB56253E6ED2CB81E0EB, blockID: 660A6CC26AF82456A0A63C56A7704398860F9459165E544C7F69DE4CDE6EC97D:1:50AA329CC16F

Entering height/round: 2/0, LastCommitHash: c612ada0a2504b0374b2e706f519ba37ba5df89233917fffa2b7907f3f97d934
```

Main problem:
In PBFT `null votes` are designed to move the views (Practical Byzantine Fault Tolerance section 4.4). In tendermint nil votes are not so clear and should be ignored if there are 2f+1 prevotes for any particular block. 







