### PR TITLE
ABCI: Update readme to fix broken link to proto

### DIFF
--- a/abci/README.md
+++ b/abci/README.md
@@ -20,7 +20,7 @@ To get up and running quickly, see the [getting started guide](../docs/app-dev/g
 A detailed description of the ABCI methods and message types is contained in:
 
 - [The main spec](https://github.com/tendermint/spec/blob/master/spec/abci/abci.md)
-- [A protobuf file](./types/types.proto)
+- [A protobuf file](../proto/tendermint/abci/types.proto)
 - [A Go interface](./types/application.go)
 
 ## Protocol Buffers


### PR DESCRIPTION
## Description

Proto definitions file was moved and link was broken. Fixed as relative link.

