### PR TITLE
abci/grpc: fix invalid mutex handling in StopForError()

### DIFF
--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -132,11 +132,11 @@ func (cli *grpcClient) OnStop() {
 }
 
 func (cli *grpcClient) StopForError(err error) {
-	cli.mtx.Lock()
 	if !cli.IsRunning() {
 		return
 	}
 
+	cli.mtx.Lock()
 	if cli.err == nil {
 		cli.err = err
 	}


### PR DESCRIPTION
Fixes #5840.