### PR TITLE
p2p: fix IPv6 address handling in new transport API

### DIFF
--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -69,7 +69,7 @@ func (e Endpoint) String() string {
 	if len(e.IP) > 0 {
 		u.Host = e.IP.String()
 		if e.Port > 0 {
-			u.Host += fmt.Sprintf(":%v", e.Port)
+			u.Host = net.JoinHostPort(u.Host, fmt.Sprintf("%v", e.Port))
 		}
 	} else if e.Path != "" {
 		u.Opaque = e.Path

--- a/p2p/transport_mconn.go
+++ b/p2p/transport_mconn.go
@@ -253,7 +253,8 @@ func (m *MConnTransport) Dial(ctx context.Context, endpoint Endpoint) (Connectio
 	defer cancel()
 
 	dialer := net.Dialer{}
-	tcpConn, err := dialer.DialContext(ctx, "tcp", fmt.Sprintf("%v:%v", endpoint.IP, endpoint.Port))
+	tcpConn, err := dialer.DialContext(ctx, "tcp",
+		net.JoinHostPort(endpoint.IP.String(), fmt.Sprintf("%v", endpoint.Port)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The old code naïvely concatenated IP and port, which doesn't work for IPv6 addresses where `:` can be part of the IP as well.