### PR TITLE
p2p: fix MConnection inbound traffic statistics and rate limiting

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - P2P Protocol
 
 - Go API
+  - [libs/protoio] Return number of bytes read in `Reader.ReadMsg()` (@erikgrinaker)
 
 - Blockchain Protocol
 
@@ -23,3 +24,5 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 ### IMPROVEMENTS
 
 ### BUG FIXES
+
+- [p2p] \#5868 Fix inbound traffic statistics and rate limiting in `MConnection` (@erikgrinaker)

--- a/libs/protoio/reader.go
+++ b/libs/protoio/reader.go
@@ -39,41 +39,58 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-// NewDelimitedReader reads varint-delimited Protobuf messages from a reader. Unlike the gogoproto
-// NewDelimitedReader, this does not buffer the reader, which may cause poor performance but is
-// necessary when only reading single messages (e.g. in the p2p package).
+// NewDelimitedReader reads varint-delimited Protobuf messages from a reader.
+// Unlike the gogoproto NewDelimitedReader, this does not buffer the reader,
+// which may cause poor performance but is necessary when only reading single
+// messages (e.g. in the p2p package). It also returns the number of bytes
+// read, which is necessary for the p2p package.
 func NewDelimitedReader(r io.Reader, maxSize int) ReadCloser {
 	var closer io.Closer
 	if c, ok := r.(io.Closer); ok {
 		closer = c
 	}
-	return &varintReader{newByteReader(r), nil, maxSize, closer}
+	return &varintReader{r, nil, maxSize, closer}
 }
 
 type varintReader struct {
-	r       *byteReader
+	r       io.Reader
 	buf     []byte
 	maxSize int
 	closer  io.Closer
 }
 
-func (r *varintReader) ReadMsg(msg proto.Message) error {
-	length64, err := binary.ReadUvarint(newByteReader(r.r))
+func (r *varintReader) ReadMsg(msg proto.Message) (int, error) {
+	// ReadUvarint needs an io.ByteReader, and we also need to keep track of the
+	// number of bytes read, so we use our own byteReader. This can't be
+	// buffered, so the caller should pass a buffered io.Reader to avoid poor
+	// performance.
+	byteReader := newByteReader(r.r)
+	l, err := binary.ReadUvarint(byteReader)
+	n := byteReader.bytesRead
 	if err != nil {
-		return err
+		return n, err
 	}
-	length := int(length64)
-	if length < 0 || length > r.maxSize {
-		return fmt.Errorf("message exceeds max size (%v > %v)", length, r.maxSize)
+
+	// Make sure length doesn't overflow the native int size (e.g. 32-bit),
+	// and that the returned sum of n+length doesn't overflow either.
+	length := int(l)
+	if l >= uint64(^uint(0)>>1) || length < 0 || n+length < 0 {
+		return n, fmt.Errorf("invalid out-of-range message length %v", l)
 	}
+	if length > r.maxSize {
+		return n, fmt.Errorf("message exceeds max size (%v > %v)", length, r.maxSize)
+	}
+
 	if len(r.buf) < length {
 		r.buf = make([]byte, length)
 	}
 	buf := r.buf[:length]
-	if _, err := io.ReadFull(r.r, buf); err != nil {
-		return err
+	nr, err := io.ReadFull(r.r, buf)
+	n += nr
+	if err != nil {
+		return n, err
 	}
-	return proto.Unmarshal(buf, msg)
+	return n, proto.Unmarshal(buf, msg)
 }
 
 func (r *varintReader) Close() error {
@@ -84,5 +101,6 @@ func (r *varintReader) Close() error {
 }
 
 func UnmarshalDelimited(data []byte, msg proto.Message) error {
-	return NewDelimitedReader(bytes.NewReader(data), len(data)).ReadMsg(msg)
+	_, err := NewDelimitedReader(bytes.NewReader(data), len(data)).ReadMsg(msg)
+	return err
 }

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -583,7 +583,8 @@ FOR_LOOP:
 		// Read packet type
 		var packet tmp2p.Packet
 
-		err := protoReader.ReadMsg(&packet)
+		_n, err := protoReader.ReadMsg(&packet)
+		c.recvMonitor.Update(_n)
 		if err != nil {
 			// stopServices was invoked and we are shutting down
 			// receiving is excpected to fail since we will close the connection

--- a/p2p/conn/connection_test.go
+++ b/p2p/conn/connection_test.go
@@ -185,7 +185,7 @@ func TestMConnectionPongTimeoutResultsInError(t *testing.T) {
 	go func() {
 		// read ping
 		var pkt tmp2p.Packet
-		err := protoio.NewDelimitedReader(server, maxPingPongPacketSize).ReadMsg(&pkt)
+		_, err := protoio.NewDelimitedReader(server, maxPingPongPacketSize).ReadMsg(&pkt)
 		require.NoError(t, err)
 		serverGotPing <- struct{}{}
 	}()
@@ -236,7 +236,7 @@ func TestMConnectionMultiplePongsInTheBeginning(t *testing.T) {
 	go func() {
 		// read ping (one byte)
 		var packet tmp2p.Packet
-		err := protoio.NewDelimitedReader(server, maxPingPongPacketSize).ReadMsg(&packet)
+		_, err := protoio.NewDelimitedReader(server, maxPingPongPacketSize).ReadMsg(&packet)
 		require.NoError(t, err)
 		serverGotPing <- struct{}{}
 
@@ -284,19 +284,19 @@ func TestMConnectionMultiplePings(t *testing.T) {
 	_, err = protoWriter.WriteMsg(mustWrapPacket(&tmp2p.PacketPing{}))
 	require.NoError(t, err)
 
-	err = protoReader.ReadMsg(&pkt)
+	_, err = protoReader.ReadMsg(&pkt)
 	require.NoError(t, err)
 
 	_, err = protoWriter.WriteMsg(mustWrapPacket(&tmp2p.PacketPing{}))
 	require.NoError(t, err)
 
-	err = protoReader.ReadMsg(&pkt)
+	_, err = protoReader.ReadMsg(&pkt)
 	require.NoError(t, err)
 
 	_, err = protoWriter.WriteMsg(mustWrapPacket(&tmp2p.PacketPing{}))
 	require.NoError(t, err)
 
-	err = protoReader.ReadMsg(&pkt)
+	_, err = protoReader.ReadMsg(&pkt)
 	require.NoError(t, err)
 
 	assert.True(t, mconn.IsRunning())
@@ -331,7 +331,7 @@ func TestMConnectionPingPongs(t *testing.T) {
 		var pkt tmp2p.PacketPing
 
 		// read ping
-		err = protoReader.ReadMsg(&pkt)
+		_, err = protoReader.ReadMsg(&pkt)
 		require.NoError(t, err)
 		serverGotPing <- struct{}{}
 
@@ -342,7 +342,7 @@ func TestMConnectionPingPongs(t *testing.T) {
 		time.Sleep(mconn.config.PingInterval)
 
 		// read ping
-		err = protoReader.ReadMsg(&pkt)
+		_, err = protoReader.ReadMsg(&pkt)
 		require.NoError(t, err)
 		serverGotPing <- struct{}{}
 

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -313,7 +313,7 @@ func shareEphPubKey(conn io.ReadWriter, locEphPub *[32]byte) (remEphPub *[32]byt
 		},
 		func(_ int) (val interface{}, abort bool, err error) {
 			var bytes gogotypes.BytesValue
-			err = protoio.NewDelimitedReader(conn, 1024*1024).ReadMsg(&bytes)
+			_, err = protoio.NewDelimitedReader(conn, 1024*1024).ReadMsg(&bytes)
 			if err != nil {
 				return nil, true, err // abort
 			}
@@ -419,7 +419,7 @@ func shareAuthSignature(sc io.ReadWriter, pubKey crypto.PubKey, signature []byte
 		},
 		func(_ int) (val interface{}, abort bool, err error) {
 			var pba tmp2p.AuthSigMessage
-			err = protoio.NewDelimitedReader(sc, 1024*1024).ReadMsg(&pba)
+			_, err = protoio.NewDelimitedReader(sc, 1024*1024).ReadMsg(&pba)
 			if err != nil {
 				return nil, true, err // abort
 			}

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -537,7 +537,7 @@ func handshake(
 	}(errc, c)
 	go func(errc chan<- error, c net.Conn) {
 		protoReader := protoio.NewDelimitedReader(c, MaxNodeInfoSize())
-		err := protoReader.ReadMsg(&pbpeerNodeInfo)
+		_, err := protoReader.ReadMsg(&pbpeerNodeInfo)
 		errc <- err
 	}(errc, c)
 

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -594,7 +594,7 @@ func TestTransportHandshake(t *testing.T) {
 			)
 
 			protoReader := protoio.NewDelimitedReader(c, MaxNodeInfoSize())
-			err := protoReader.ReadMsg(&pbni)
+			_, err := protoReader.ReadMsg(&pbni)
 			if err != nil {
 				t.Error(err)
 			}

--- a/privval/signer_endpoint.go
+++ b/privval/signer_endpoint.go
@@ -96,7 +96,7 @@ func (se *signerEndpoint) ReadMessage() (msg privvalproto.Message, err error) {
 	}
 	const maxRemoteSignerMsgSize = 1024 * 10
 	protoReader := protoio.NewDelimitedReader(se.conn, maxRemoteSignerMsgSize)
-	err = protoReader.ReadMsg(&msg)
+	_, err = protoReader.ReadMsg(&msg)
 	if _, ok := err.(timeoutError); ok {
 		if err != nil {
 			err = fmt.Errorf("%v: %w", err, ErrReadTimeout)


### PR DESCRIPTION
Backport of #5868. Inbound traffic monitoring (and by extension inbound rate limiting) was inadvertently removed in 660e72a.