### PR TITLE
test/e2e: tolerate up to 2/3 missed signatures for a validator

### DIFF
--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -115,8 +115,8 @@ func TestValidator_Sign(t *testing.T) {
 		}
 
 		require.False(t, signCount == 0 && expectCount > 0,
-			"node did not sign any blocks (expected %v)", expectCount)
-		require.Less(t, float64(expectCount-signCount)/float64(expectCount), 0.5,
+			"validator did not sign any blocks (expected %v)", expectCount)
+		require.Less(t, float64(expectCount-signCount)/float64(expectCount), 0.33,
 			"validator missed signing too many blocks (signed %v out of %v)", signCount, expectCount)
 	})
 }


### PR DESCRIPTION
E2E tests often fail due to fast sync stalls causing the validator to miss signing blocks. This increases the tolerance for missed signatures to 2/3 to allow validators to spend more time starting up.