### PR TITLE
test: use 'f' functions with formatting directives

### DIFF
--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -46,7 +46,7 @@ func TestHeaderEvents(t *testing.T) {
 			evt, err := client.WaitForOneEvent(c, evtTyp, waitForEventTimeout)
 			require.Nil(t, err, "%d: %+v", i, err)
 			_, ok := evt.(types.EventDataNewBlockHeader)
-			require.True(t, ok, "%d: %#v", i, evt)
+			require.Truef(t, ok, "%d: %#v", i, evt)
 			// TODO: more checks...
 		})
 	}

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -121,9 +121,9 @@ func TestInfo(t *testing.T) {
 func TestNetInfo(t *testing.T) {
 	for i, c := range GetClients() {
 		nc, ok := c.(client.NetworkClient)
-		require.True(t, ok, "%d", i)
+		require.Truef(t, ok, "%d", i)
 		netinfo, err := nc.NetInfo(context.Background())
-		require.Nil(t, err, "%d: %+v", i, err)
+		require.Nilf(t, err, "%d: %+v", i, err)
 		assert.True(t, netinfo.Listening)
 		assert.Equal(t, 0, len(netinfo.Peers))
 	}
@@ -133,7 +133,7 @@ func TestDumpConsensusState(t *testing.T) {
 	for i, c := range GetClients() {
 		// FIXME: fix server so it doesn't panic on invalid input
 		nc, ok := c.(client.NetworkClient)
-		require.True(t, ok, "%d", i)
+		require.Truef(t, ok, "%d", i)
 		cons, err := nc.DumpConsensusState(context.Background())
 		require.Nil(t, err, "%d: %+v", i, err)
 		assert.NotEmpty(t, cons.RoundState)
@@ -145,7 +145,7 @@ func TestConsensusState(t *testing.T) {
 	for i, c := range GetClients() {
 		// FIXME: fix server so it doesn't panic on invalid input
 		nc, ok := c.(client.NetworkClient)
-		require.True(t, ok, "%d", i)
+		require.Truef(t, ok, "%d", i)
 		cons, err := nc.ConsensusState(context.Background())
 		require.Nil(t, err, "%d: %+v", i, err)
 		assert.NotEmpty(t, cons.RoundState)
@@ -155,7 +155,7 @@ func TestConsensusState(t *testing.T) {
 func TestHealth(t *testing.T) {
 	for i, c := range GetClients() {
 		nc, ok := c.(client.NetworkClient)
-		require.True(t, ok, "%d", i)
+		require.Truef(t, ok, "%d", i)
 		_, err := nc.Health(context.Background())
 		require.Nil(t, err, "%d: %+v", i, err)
 	}
@@ -416,7 +416,7 @@ func TestNumUnconfirmedTxs(t *testing.T) {
 	mempoolSize := mempool.Size()
 	for i, c := range GetClients() {
 		mc, ok := c.(client.MempoolClient)
-		require.True(t, ok, "%d", i)
+		require.Truef(t, ok, "%d", i)
 		res, err := mc.NumUnconfirmedTxs(context.Background())
 		require.Nil(t, err, "%d: %+v", i, err)
 
@@ -621,9 +621,9 @@ func TestTxSearch(t *testing.T) {
 			}
 			require.Equal(t, txCount, result.TotalCount)
 			for _, tx := range result.Txs {
-				require.False(t, seen[tx.Height],
+				require.Falsef(t, seen[tx.Height],
 					"Found duplicate height %v in page %v", tx.Height, page)
-				require.Greater(t, tx.Height, maxHeight,
+				require.Greaterf(t, tx.Height, maxHeight,
 					"Found decreasing height %v (max seen %v) in page %v", tx.Height, maxHeight, page)
 				seen[tx.Height] = true
 				maxHeight = tx.Height

--- a/rpc/jsonrpc/client/args_test.go
+++ b/rpc/jsonrpc/client/args_test.go
@@ -33,7 +33,7 @@ func TestArgToJSON(t *testing.T) {
 		require.Nil(err, "%d: %+v", i, err)
 		require.Equal(1, len(args), "%d", i)
 		data, ok := args["data"].(string)
-		require.True(ok, "%d: %#v", i, args["data"])
-		assert.Equal(tc.expected, data, "%d", i)
+		require.Truef(ok, "%d: %#v", i, args["data"])
+		assert.Equalf(tc.expected, data, "%d", i)
 	}
 }

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -402,7 +402,7 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 	select {
 	case msg := <-updatesSub.Out():
 		event, ok := msg.Data().(types.EventDataValidatorSetUpdates)
-		require.True(t, ok, "Expected event of type EventDataValidatorSetUpdates, got %T", msg.Data())
+		require.Truef(t, ok, "Expected event of type EventDataValidatorSetUpdates, got %T", msg.Data())
 		if assert.NotEmpty(t, event.ValidatorUpdates) {
 			assert.Equal(t, pubkey, event.ValidatorUpdates[0].PubKey)
 			assert.EqualValues(t, 10, event.ValidatorUpdates[0].VotingPower)

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -156,7 +156,7 @@ func TestValidateBlockCommit(t *testing.T) {
 			block, _ := state.MakeBlock(height, makeTxs(height), wrongHeightCommit, nil, proposerAddr)
 			err = blockExec.ValidateBlock(state, block)
 			_, isErrInvalidCommitHeight := err.(types.ErrInvalidCommitHeight)
-			require.True(t, isErrInvalidCommitHeight, "expected ErrInvalidCommitHeight at height %d but got: %v", height, err)
+			require.Truef(t, isErrInvalidCommitHeight, "expected ErrInvalidCommitHeight at height %d but got: %v", height, err)
 
 			/*
 				#2589: test len(block.LastCommit.Signatures) == state.LastValidators.Size()
@@ -164,7 +164,7 @@ func TestValidateBlockCommit(t *testing.T) {
 			block, _ = state.MakeBlock(height, makeTxs(height), wrongSigsCommit, nil, proposerAddr)
 			err = blockExec.ValidateBlock(state, block)
 			_, isErrInvalidCommitSignatures := err.(types.ErrInvalidCommitSignatures)
-			require.True(t, isErrInvalidCommitSignatures,
+			require.Truef(t, isErrInvalidCommitSignatures,
 				"expected ErrInvalidCommitSignatures at height %d, but got: %v",
 				height,
 				err,
@@ -272,7 +272,7 @@ func TestValidateBlockEvidence(t *testing.T) {
 			err := blockExec.ValidateBlock(state, block)
 			if assert.Error(t, err) {
 				_, ok := err.(*types.ErrEvidenceOverflow)
-				require.True(t, ok, "expected error to be of type ErrEvidenceOverflow at height %d but got %v", height, err)
+				require.Truef(t, ok, "expected error to be of type ErrEvidenceOverflow at height %d but got %v", height, err)
 			}
 		}
 

--- a/test/e2e/tests/evidence_test.go
+++ b/test/e2e/tests/evidence_test.go
@@ -35,7 +35,7 @@ func TestEvidence_Misbehavior(t *testing.T) {
 
 			// Check that evidence was as expected
 			misbehavior, ok := node.Misbehaviors[nodeEvidence.Height()]
-			require.True(t, ok, "found unexpected evidence %v in height %v",
+			require.Truef(t, ok, "found unexpected evidence %v in height %v",
 				nodeEvidence, block.Height)
 
 			switch misbehavior {
@@ -50,7 +50,7 @@ func TestEvidence_Misbehavior(t *testing.T) {
 		// see if there is any evidence that we were expecting but didn't see
 		for height, misbehavior := range node.Misbehaviors {
 			_, ok := seenEvidence[height]
-			require.True(t, ok, "expected evidence for %v misbehavior at height %v by node but was never found",
+			require.Truef(t, ok, "expected evidence for %v misbehavior at height %v by node but was never found",
 				misbehavior, height)
 		}
 	})

--- a/test/e2e/tests/net_test.go
+++ b/test/e2e/tests/net_test.go
@@ -40,7 +40,7 @@ func TestNet_Peers(t *testing.T) {
 		}
 
 		for name := range seen {
-			require.True(t, seen[name], "node %v not peered with %v", node.Name, name)
+			require.Truef(t, seen[name], "node %v not peered with %v", node.Name, name)
 		}
 	})
 }

--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -75,9 +75,9 @@ func TestValidator_Propose(t *testing.T) {
 			valSchedule.Increment(1)
 		}
 
-		require.False(t, proposeCount == 0 && expectCount > 0,
+		require.Falsef(t, proposeCount == 0 && expectCount > 0,
 			"node did not propose any blocks (expected %v)", expectCount)
-		require.Less(t, expectCount-proposeCount, 5,
+		require.Lessf(t, expectCount-proposeCount, 5,
 			"validator missed proposing too many blocks (proposed %v out of %v)", proposeCount, expectCount)
 	})
 }
@@ -109,14 +109,14 @@ func TestValidator_Sign(t *testing.T) {
 					signCount++
 				}
 			} else {
-				require.False(t, signed, "unexpected signature for block %v", block.LastCommit.Height)
+				require.Falsef(t, signed, "unexpected signature for block %v", block.LastCommit.Height)
 			}
 			valSchedule.Increment(1)
 		}
 
-		require.False(t, signCount == 0 && expectCount > 0,
+		require.Falsef(t, signCount == 0 && expectCount > 0,
 			"node did not sign any blocks (expected %v)", expectCount)
-		require.Less(t, float64(expectCount-signCount)/float64(expectCount), 0.5,
+		require.Lessf(t, float64(expectCount-signCount)/float64(expectCount), 0.5,
 			"validator missed signing too many blocks (signed %v out of %v)", signCount, expectCount)
 	})
 }


### PR DESCRIPTION
A bunch of our tests forgot the `f` when using formatting directives, so we got test log lines like 

```
[validator missed signing too many blocks (signed %v out of %v) 28 58]
```

when we should have 

```
[validator missed signing too many blocks (signed 28 out of 58)]
```