### PR TITLE
state sync: last consensus params height is not set

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -68,3 +68,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [blockchain/v1] \#5711 Fix deadlock (@melekes)
 - [evidence] \#5890 Add a buffer to evidence from consensus to avoid broadcasting and proposing evidence before the
 height of such an evidence has finished (@cmwaters)
+- [statesync] \#5889 Set `LastHeightConsensusParamsChanged` when bootstrapping Tendermint state (@cmwaters)

--- a/state/store.go
+++ b/state/store.go
@@ -222,7 +222,7 @@ func (store dbStore) Bootstrap(state State) error {
 		return err
 	}
 
-	if err := store.saveConsensusParamsInfo(height, height, state.ConsensusParams); err != nil {
+	if err := store.saveConsensusParamsInfo(height, state.LastHeightConsensusParamsChanged, state.ConsensusParams); err != nil {
 		return err
 	}
 

--- a/state/store.go
+++ b/state/store.go
@@ -222,7 +222,8 @@ func (store dbStore) Bootstrap(state State) error {
 		return err
 	}
 
-	if err := store.saveConsensusParamsInfo(height, state.LastHeightConsensusParamsChanged, state.ConsensusParams); err != nil {
+	if err := store.saveConsensusParamsInfo(height,
+		state.LastHeightConsensusParamsChanged, state.ConsensusParams); err != nil {
 		return err
 	}
 

--- a/statesync/stateprovider.go
+++ b/statesync/stateprovider.go
@@ -185,6 +185,7 @@ func (s *lightClientStateProvider) State(ctx context.Context, height uint64) (sm
 			nextLightBlock.Height, err)
 	}
 	state.ConsensusParams = result.ConsensusParams
+	state.LastHeightConsensusParamsChanged = nextLightBlock.Height
 
 	return state, nil
 }

--- a/statesync/stateprovider.go
+++ b/statesync/stateprovider.go
@@ -150,7 +150,7 @@ func (s *lightClientStateProvider) State(ctx context.Context, height uint64) (sm
 	if err != nil {
 		return sm.State{}, err
 	}
-	curLightBlock, err := s.lc.VerifyLightBlockAtHeight(ctx, int64(height+1), time.Now())
+	currentLightBlock, err := s.lc.VerifyLightBlockAtHeight(ctx, int64(height+1), time.Now())
 	if err != nil {
 		return sm.State{}, err
 	}
@@ -162,10 +162,10 @@ func (s *lightClientStateProvider) State(ctx context.Context, height uint64) (sm
 	state.LastBlockHeight = lastLightBlock.Height
 	state.LastBlockTime = lastLightBlock.Time
 	state.LastBlockID = lastLightBlock.Commit.BlockID
-	state.AppHash = curLightBlock.AppHash
-	state.LastResultsHash = curLightBlock.LastResultsHash
+	state.AppHash = currentLightBlock.AppHash
+	state.LastResultsHash = currentLightBlock.LastResultsHash
 	state.LastValidators = lastLightBlock.ValidatorSet
-	state.Validators = curLightBlock.ValidatorSet
+	state.Validators = currentLightBlock.ValidatorSet
 	state.NextValidators = nextLightBlock.ValidatorSet
 	state.LastHeightValidatorsChanged = nextLightBlock.Height
 
@@ -179,13 +179,13 @@ func (s *lightClientStateProvider) State(ctx context.Context, height uint64) (sm
 		return sm.State{}, fmt.Errorf("unable to create RPC client: %w", err)
 	}
 	rpcclient := lightrpc.NewClient(primaryRPC, s.lc)
-	result, err := rpcclient.ConsensusParams(ctx, &nextLightBlock.Height)
+	result, err := rpcclient.ConsensusParams(ctx, &currentLightBlock.Height)
 	if err != nil {
 		return sm.State{}, fmt.Errorf("unable to fetch consensus parameters for height %v: %w",
 			nextLightBlock.Height, err)
 	}
 	state.ConsensusParams = result.ConsensusParams
-	state.LastHeightConsensusParamsChanged = nextLightBlock.Height
+	state.LastHeightConsensusParamsChanged = currentLightBlock.Height
 
 	return state, nil
 }


### PR DESCRIPTION
## Description

When state syncing, we currently don't save `state.LastHeightConsensusParamsChanged`. This causes it to be set with a value of 0 when it is saved to the state store. `Bootstap()` the function that is called ignores this value

```go
if err := store.saveConsensusParamsInfo(height, height, state.ConsensusParams); err != nil {
	return err
}
```

However, state keeps the 0 value meaning at following heights when state is saved, `LastHeightConsensusParamsChanged` is 0

```go
if err := store.saveConsensusParamsInfo(nextHeight,
        state.LastHeightConsensusParamsChanged, state.ConsensusParams); err != nil {
	return err
}
```

This means that the state store isn't saving the consensus params rather referencing the consensus params at height 0 which don't exist and causes this error to arise when pruning:

```
err="failed to prune state store: couldn't find consensus params at height 0 as last changed from height 11: value retrieved from db is empty"
```

The second part of this is that we are requesting the consensus params of `state.LastBlockHeight + 2` and saving it as `state.LastBlockHeight + 1`

