### PR TITLE
evidence: buffer evidence from consensus

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -65,3 +65,5 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [privval] \#5638 Increase read/write timeout to 5s and calculate ping interval based on it (@JoeKash)
 - [blockchain/v1] [\#5701](https://github.com/tendermint/tendermint/pull/5701) Handle peers without blocks (@melekes)
 - [blockchain/v1] \#5711 Fix deadlock (@melekes)
+- [evidence] \#5890 Add a buffer to evidence from consensus to avoid broadcasting and proposing evidence before the
+height of such an evidence has finished (@cmwaters)


### PR DESCRIPTION
## Description

Evidence coming from consensus is stored in a temporary buffer before being flushed to the evidence pool and thus halted until the voting in the height of the evidence is finished before being broadcasted and proposed. This avoids the issue of some nodes verifying and proposing evidence at a height where the block hasn't been committed yet which could cause those peers who never saw the double votes to  panic.


