### PR TITLE
p2p: improve PeerManager prototype

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -766,7 +766,7 @@ func (s *peerStore) Ranked() ([]*peerInfo, error) {
 	sort.Slice(peers, func(i, j int) bool {
 		// FIXME: If necessary, consider precomputing scores before sorting,
 		// to reduce the number of Score() calls.
-		return peers[i].Score() < peers[j].Score()
+		return peers[i].Score() > peers[j].Score()
 	})
 	return peers, nil
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -418,10 +418,8 @@ func (m *PeerManager) DialNext() (NodeID, PeerAddress, error) {
 	if err != nil {
 		return "", PeerAddress{}, err
 	}
-	betterActivePeers := 0
 	for _, peer := range ranked {
 		if m.dialing[peer.ID] || m.connected[peer.ID] {
-			betterActivePeers++
 			continue
 		}
 
@@ -431,10 +429,10 @@ func (m *PeerManager) DialNext() (NodeID, PeerAddress, error) {
 			}
 
 			// At this point we have an eligible address to dial. If we're full
-			// but have upgrade capacity (as checked above), we need to make
-			// sure there exists an evictable peer of a lower score that we can
-			// replace. If so, we can go ahead and dial it, and EvictNext() will
-			// evict it later.
+			// but have peer upgrade capacity (as checked above), we need to
+			// make sure there exists an evictable peer of a lower score that we
+			// can replace. If so, we can go ahead and dial this peer, and
+			// EvictNext() will evict a lower-scored one later.
 			//
 			// If we don't find one, there is no point in trying additional
 			// peers, since they will all have the same or lower score than this

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -327,6 +327,7 @@ func NewPeerManager(options PeerManagerOptions) *PeerManager {
 		store:         newPeerStore(),
 		dialing:       map[NodeID]bool{},
 		connected:     map[NodeID]bool{},
+		evicting:      map[NodeID]bool{},
 		subscriptions: map[*PeerUpdatesCh]*PeerUpdatesCh{},
 	}
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -219,7 +219,7 @@ const (
 // PeerManager manages peer lifecycle information, using a peerStore for
 // underlying storage. Its primary purpose is to determine which peers to
 // connect to next, make sure a peer only has a single active connection (either
-// inbound or outbound), and evict peers to make room for higher-ranked peers.
+// inbound or outbound), and evict peers to make room for higher-scored peers.
 // It does not manage actual connections (this is handled by the Router),
 // only the peer lifecycle state.
 //
@@ -239,8 +239,8 @@ const (
 // - Disconnected: peer disconnects, unmarking as connected and broadcasts a
 //   PeerStatusDown peer update.
 //
-// If we need to evict a peer, e.g. because we have connected to too many peers
-// or because we need to make room for higher-ranked peers, the flow is as follows:
+// If we need to evict a peer, typically because we have connected to additional
+// higher-scored peers and need to shed lower-scored ones,, the flow is as follows:
 // - EvictNext: returns a peer ID to evict, marking peer as evicting.
 // - Disconnected: peer was disconnected, unmarking as connected and evicting,
 //   and broadcasts a PeerStatusDown peer update.
@@ -266,8 +266,8 @@ type PeerManager struct {
 // PeerManagerOptions specifies options for a PeerManager.
 type PeerManagerOptions struct {
 	// PersistentPeers are peers that we want to maintain persistent connections
-	// to. These will be ranked higher than other peers, and if
-	// MaxConnectedUpgrade is non-zero any lower-ranked peers will be evicted if
+	// to. These will be scored higher than other peers, and if
+	// MaxConnectedUpgrade is non-zero any lower-scored peers will be evicted if
 	// necessary to make room for these.
 	PersistentPeers []NodeID
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -433,7 +433,8 @@ func (m *PeerManager) DialNext() (NodeID, PeerAddress, error) {
 			// At this point we have an eligible address to dial. If we're full
 			// but have upgrade capacity (as checked above), we need to make
 			// sure there exists an evictable peer of a lower score that we can
-			// replace.
+			// replace. If so, we can go ahead and dial it, and EvictNext() will
+			// evict it later.
 			//
 			// If we don't find one, there is no point in trying additional
 			// peers, since they will all have the same or lower score than this

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -252,10 +252,10 @@ type PeerManager struct {
 	subscriptions map[*PeerUpdatesCh]*PeerUpdatesCh // keyed by struct identity (address)
 }
 
-// newPeerManager creates a new peer manager.
-func newPeerManager(store *peerStore) *PeerManager {
+// NewPeerManager creates a new peer manager.
+func NewPeerManager() *PeerManager {
 	return &PeerManager{
-		store:         store,
+		store:         newPeerStore(),
 		dialing:       map[NodeID]bool{},
 		connected:     map[NodeID]bool{},
 		subscriptions: map[*PeerUpdatesCh]*PeerUpdatesCh{},
@@ -477,9 +477,9 @@ func (m *PeerManager) Disconnected(peerID NodeID) error {
 // peerStore stores information about peers. It is currently a bare-bones
 // in-memory store, and will be fleshed out later.
 //
-// peerStore is not thread-safe, since it assumes it is only used by peerManager
-// which handles concurrency control. This allows multiple operations to be
-// executed atomically, since the peerManager will hold a mutex while executing.
+// peerStore is not thread-safe, since it assumes it is only used by PeerManager
+// which handles concurrency control. This allows the manager to execute multiple
+// operations atomically while it holds the mutex.
 type peerStore struct {
 	peers map[NodeID]peerInfo
 }

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -23,15 +23,18 @@ import (
 // either the channel is closed by the caller or the router is stopped, at which
 // point the input message queue is closed and removed.
 //
-// On startup, the router spawns off two primary goroutines that maintain
+// On startup, the router spawns off three primary goroutines that maintain
 // connections to peers and run for the lifetime of the router:
 //
-//   Router.dialPeers(): in a loop, asks the peerStore to dispense an
-//   eligible peer to connect to, and attempts to resolve and dial each
-//   address until successful.
+//   Router.dialPeers(): in a loop, asks the PeerManager for the next peer
+//   address to contact, resolves it into endpoints, and attempts to dial
+//   each one.
 //
 //   Router.acceptPeers(): in a loop, waits for the next inbound connection
-//   from a peer, and attempts to claim it in the peerStore.
+//   from a peer, and checks with the PeerManager if it should be accepted.
+//
+//   Router.evictPeers(): in a loop, asks the PeerManager for any connected
+//   peers to evict, and disconnects them.
 //
 // Once either an inbound or outbound connection has been made, an outbound
 // message queue is registered in Router.peerQueues and a goroutine is spawned

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -237,6 +237,9 @@ func (r *Router) acceptPeers(transport Transport) {
 		default:
 		}
 
+		// FIXME: We may need transports to enforce some sort of rate limiting
+		// here (e.g. by IP address), or alternatively have PeerManager.Accepted()
+		// do it for us.
 		conn, err := transport.Accept(context.Background())
 		switch err {
 		case nil:
@@ -501,10 +504,11 @@ func (r *Router) evictPeers() {
 
 		r.logger.Info("evicting peer", "peer", peerID)
 		r.peerMtx.RLock()
-		if queue, ok := r.peerQueues[peerID]; ok {
+		queue, ok := r.peerQueues[peerID]
+		r.peerMtx.RUnlock()
+		if ok {
 			queue.close()
 		}
-		r.peerMtx.RUnlock()
 	}
 }
 

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -74,7 +74,7 @@ type Router struct {
 	*service.BaseService
 	logger      log.Logger
 	transports  map[Protocol]Transport
-	peerManager *peerManager
+	peerManager *PeerManager
 
 	// FIXME: Consider using sync.Map.
 	peerMtx    sync.RWMutex

--- a/p2p/router_test.go
+++ b/p2p/router_test.go
@@ -41,7 +41,7 @@ func TestRouter(t *testing.T) {
 		peerTransport := network.GenerateTransport()
 		peerRouter := p2p.NewRouter(
 			logger.With("peerID", i),
-			p2p.NewPeerManager(),
+			p2p.NewPeerManager(p2p.PeerManagerOptions{}),
 			map[p2p.Protocol]p2p.Transport{
 				p2p.MemoryProtocol: peerTransport,
 			},
@@ -59,7 +59,7 @@ func TestRouter(t *testing.T) {
 	}
 
 	// Start the main router and connect it to the peers above.
-	peerManager := p2p.NewPeerManager()
+	peerManager := p2p.NewPeerManager(p2p.PeerManagerOptions{})
 	for _, address := range peers {
 		err := peerManager.Add(address)
 		require.NoError(t, err)


### PR DESCRIPTION
This improves the prototype peer manager by:

* Exporting `PeerManager`, making it accessible by e.g. reactors.
* Replacing `Router.SubscribePeerUpdates()` with `PeerManager.Subscribe()`.
* Tracking address/peer connection statistics, and retrying dial failures with exponential backoff.
* Prioritizing peers, with persistent peers configuration.
* Limiting simultaneous connections.
* Evicting peers and upgrading to higher-priority peers.
* Tracking peer heights, as a workaround for legacy shared peer state APIs.

This is getting to a point where we need to determine precise semantics and implement tests, so we should figure out whether it's a reasonable abstraction that we want to use. The main questions are around the API model (i.e. synchronous method calls with the router polling the manager, vs. an event-driven model using channels, vs. the peer manager calling methods on the router to connect/disconnect peers), and who should have the responsibility of managing actual connections (currently the router, while the manager only tracks peer state).