### PR TITLE
Makefile: always pull image in proto-gen-docker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ proto-gen:
 .PHONY: proto-gen
 
 proto-gen-docker:
+	@docker pull -q tendermintdev/docker-build-proto
 	@echo "Generating Protobuf files"
 	@docker run -v $(shell pwd):/workspace --workdir /workspace tendermintdev/docker-build-proto sh ./scripts/protocgen.sh
 .PHONY: proto-gen-docker


### PR DESCRIPTION
The `proto-gen-docker` target didn't pull an updated Docker image, and would use a local image if present which could be outdated and produce wrong results.