### PR TITLE
test: fix TestPEXReactorRunning data race

### DIFF
--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -94,6 +94,11 @@ func TestPEXReactorRunning(t *testing.T) {
 		})
 	}
 
+	for _, sw := range switches {
+		err := sw.Start() // start switch and reactors
+		require.Nil(t, err)
+	}
+
 	addOtherNodeAddrToAddrBook := func(switchIndex, otherSwitchIndex int) {
 		addr := switches[otherSwitchIndex].NetAddress()
 		err := books[switchIndex].AddAddress(addr, addr)
@@ -103,11 +108,6 @@ func TestPEXReactorRunning(t *testing.T) {
 	addOtherNodeAddrToAddrBook(0, 1)
 	addOtherNodeAddrToAddrBook(1, 0)
 	addOtherNodeAddrToAddrBook(2, 1)
-
-	for _, sw := range switches {
-		err := sw.Start() // start switch and reactors
-		require.Nil(t, err)
-	}
 
 	assertPeersWithTimeout(t, switches, 10*time.Millisecond, 10*time.Second, N-1)
 


### PR DESCRIPTION
Fixes #5941.

Not entirely sure that this will fix the problem (couldn't reproduce), but in any case this is an artifact of a hack in the P2P transport refactor to make it work with the legacy P2P stack, and will be removed when the refactor is done anyway.