### PR TITLE
mempool: fix reactor tests

### DIFF
--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -376,11 +376,13 @@ func TestDontExhaustMaxActiveIDs(t *testing.T) {
 	reactor := setup(t, config.Mempool, log.TestingLogger().With("node", 0), 0)
 
 	go func() {
+		// drop all messages on the mempool channel
 		for range reactor.mempoolOutCh {
 		}
 	}()
 
 	go func() {
+		// drop all errors on the mempool channel
 		for range reactor.mempoolPeerErrCh {
 		}
 	}()
@@ -436,6 +438,7 @@ func TestBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
 	secondary := setup(t, config.Mempool, log.TestingLogger().With("node", 1), 0)
 
 	go func() {
+		// drop all errors on the mempool channel
 		for range primary.mempoolPeerErrCh {
 		}
 	}()

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -380,6 +380,11 @@ func TestDontExhaustMaxActiveIDs(t *testing.T) {
 		}
 	}()
 
+	go func() {
+		for range reactor.mempoolPeerErrCh {
+		}
+	}()
+
 	peerID, err := p2p.NewNodeID("00ffaa")
 	require.NoError(t, err)
 
@@ -429,6 +434,11 @@ func TestBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
 
 	primary := setup(t, config.Mempool, log.TestingLogger().With("node", 0), 0)
 	secondary := setup(t, config.Mempool, log.TestingLogger().With("node", 1), 0)
+
+	go func() {
+		for range primary.mempoolPeerErrCh {
+		}
+	}()
 
 	// connect peer
 	primary.peerUpdatesCh <- p2p.PeerUpdate{


### PR DESCRIPTION
## Description

Update the faux router to either drop channel errors or handle them based on an argument. This prevents deadlocks in tests where we try to send an error on the mempool channel but there is no reader.

Closes: #5956

