### PR TITLE
blockchain v0: fix waitgroup data race

### DIFF
--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -150,6 +150,7 @@ func (r *Reactor) OnStart() error {
 			return err
 		}
 
+		r.poolWG.Add(1)
 		go r.poolRoutine(false)
 	}
 
@@ -354,7 +355,9 @@ func (r *Reactor) SwitchToFastSync(state sm.State) error {
 		return err
 	}
 
+	r.poolWG.Add(1)
 	go r.poolRoutine(true)
+
 	return nil
 }
 
@@ -426,7 +429,6 @@ func (r *Reactor) poolRoutine(stateSynced bool) {
 
 	go r.requestRoutine()
 
-	r.poolWG.Add(1)
 	defer r.poolWG.Done()
 
 FOR_LOOP:


### PR DESCRIPTION
## Description

Fixes the data race in usage of `WaitGroup`. Specifically, the case where we invoke `Wait` _before_ the first delta `Add` call when the current waitgroup counter is zero. See https://golang.org/pkg/sync/#WaitGroup.Add.

Still not sure how this manifests itself in a test since the reactor has to be stopped virtually immediately after being started (I think?).

Regardless, this is the appropriate fix.

closes: #5968

