### PR TITLE
terminate go-fuzz gracefully (w/ SIGINT)

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -21,23 +21,23 @@ jobs:
 
       - name: Fuzz mempool
         working-directory: test/fuzz
-        run: timeout 10m make fuzz-mempool
+        run: timeout -s SIGINT 10m make fuzz-mempool
 
       - name: Fuzz p2p-addrbook
         working-directory: test/fuzz
-        run: timeout 10m make fuzz-p2p-addrbook
+        run: timeout -s SIGINT 10m make fuzz-p2p-addrbook
 
       - name: Fuzz p2p-pex
         working-directory: test/fuzz
-        run: timeout 10m make fuzz-p2p-pex
+        run: timeout -s SIGINT 10m make fuzz-p2p-pex
 
       - name: Fuzz p2p-sc
         working-directory: test/fuzz
-        run: timeout 10m make fuzz-p2p-sc
+        run: timeout -s SIGINT 10m make fuzz-p2p-sc
 
       - name: Fuzz p2p-rpc-server
         working-directory: test/fuzz
-        run: timeout 10m make fuzz-rpc-server
+        run: timeout -s SIGINT 10m make fuzz-rpc-server
 
       - name: Set crashers count
         working-directory: test/fuzz

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -21,23 +21,33 @@ jobs:
 
       - name: Fuzz mempool
         working-directory: test/fuzz
-        run: timeout -s SIGINT 10m make fuzz-mempool
+        run: timeout -s SIGINT --preserve-status 10m make fuzz-mempool
+        # ignore the last non-zero exit code (130)
+        shell: bash {0}
 
       - name: Fuzz p2p-addrbook
         working-directory: test/fuzz
-        run: timeout -s SIGINT 10m make fuzz-p2p-addrbook
+        run: timeout -s SIGINT --preserve-status 10m make fuzz-p2p-addrbook
+        # ignore the last non-zero exit code (130)
+        shell: bash {0}
 
       - name: Fuzz p2p-pex
         working-directory: test/fuzz
-        run: timeout -s SIGINT 10m make fuzz-p2p-pex
+        run: timeout -s SIGINT --preserve-status 10m make fuzz-p2p-pex
+        # ignore the last non-zero exit code (130)
+        shell: bash {0}
 
       - name: Fuzz p2p-sc
         working-directory: test/fuzz
-        run: timeout -s SIGINT 10m make fuzz-p2p-sc
+        run: timeout -s SIGINT --preserve-status 10m make fuzz-p2p-sc
+        # ignore the last non-zero exit code (130)
+        shell: bash {0}
 
       - name: Fuzz p2p-rpc-server
         working-directory: test/fuzz
-        run: timeout -s SIGINT 10m make fuzz-rpc-server
+        run: timeout -s SIGINT --preserve-status 10m make fuzz-rpc-server
+        # ignore the last non-zero exit code (130)
+        shell: bash {0}
 
       - name: Set crashers count
         working-directory: test/fuzz

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -22,32 +22,27 @@ jobs:
       - name: Fuzz mempool
         working-directory: test/fuzz
         run: timeout -s SIGINT --preserve-status 10m make fuzz-mempool
-        # ignore the last non-zero exit code (130)
-        shell: bash {0}
+        continue-on-error: true
 
       - name: Fuzz p2p-addrbook
         working-directory: test/fuzz
         run: timeout -s SIGINT --preserve-status 10m make fuzz-p2p-addrbook
-        # ignore the last non-zero exit code (130)
-        shell: bash {0}
+        continue-on-error: true
 
       - name: Fuzz p2p-pex
         working-directory: test/fuzz
         run: timeout -s SIGINT --preserve-status 10m make fuzz-p2p-pex
-        # ignore the last non-zero exit code (130)
-        shell: bash {0}
+        continue-on-error: true
 
       - name: Fuzz p2p-sc
         working-directory: test/fuzz
         run: timeout -s SIGINT --preserve-status 10m make fuzz-p2p-sc
-        # ignore the last non-zero exit code (130)
-        shell: bash {0}
+        continue-on-error: true
 
       - name: Fuzz p2p-rpc-server
         working-directory: test/fuzz
         run: timeout -s SIGINT --preserve-status 10m make fuzz-rpc-server
-        # ignore the last non-zero exit code (130)
-        shell: bash {0}
+        continue-on-error: true
 
       - name: Set crashers count
         working-directory: test/fuzz


### PR DESCRIPTION
and preserve exit code.

```
2021/01/26 03:34:49 workers: 2, corpus: 4 (8m28s ago), crashers: 0, restarts: 1/9976, execs: 11013732 (21596/sec), cover: 121, uptime: 8m30s
make: *** [fuzz-mempool] Terminated
Makefile:5: recipe for target 'fuzz-mempool' failed
Error: Process completed with exit code 124.
```

https://github.com/tendermint/tendermint/runs/1766661614

`continue-on-error` should make GH ignore any error codes.