### PR TITLE
mempool: really fix mempool tests timeout

### DIFF
--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -224,7 +224,6 @@ func (r *Reactor) processMempoolCh() {
 		case envelope := <-r.mempoolCh.In():
 			if err := r.handleMessage(r.mempoolCh.ID(), envelope); err != nil {
 				r.Logger.Error("failed to process message", "ch_id", r.mempoolCh.ID(), "envelope", envelope, "err", err)
-
 				r.mempoolCh.Error() <- p2p.PeerError{
 					PeerID:   envelope.From,
 					Err:      err,

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -225,8 +225,6 @@ func (r *Reactor) processMempoolCh() {
 			if err := r.handleMessage(r.mempoolCh.ID(), envelope); err != nil {
 				r.Logger.Error("failed to process message", "ch_id", r.mempoolCh.ID(), "envelope", envelope, "err", err)
 
-				fmt.Println("MESSAGE HANDLER ERROR:", err)
-
 				r.mempoolCh.Error() <- p2p.PeerError{
 					PeerID:   envelope.From,
 					Err:      err,

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -229,8 +229,6 @@ func (r *Reactor) processMempoolCh() {
 					Err:      err,
 					Severity: p2p.PeerErrorSeverityLow,
 				}
-
-				fmt.Println("SENT PEER ERROR ON CHANNEL")
 			}
 
 		case <-r.closeCh:

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -167,11 +167,11 @@ func TestReactorBroadcastTxs(t *testing.T) {
 
 	// ignore all peer errors
 	for _, suite := range testSuites {
-		go func() {
+		go func(s *reactorTestSuite) {
 			// drop all errors on the mempool channel
-			for range suite.mempoolPeerErrCh {
+			for range s.mempoolPeerErrCh {
 			}
-		}()
+		}(suite)
 	}
 
 	primary := testSuites[0]
@@ -283,11 +283,11 @@ func TestReactorNoBroadcastToSender(t *testing.T) {
 
 	// ignore all peer errors
 	for _, suite := range testSuites {
-		go func() {
+		go func(s *reactorTestSuite) {
 			// drop all errors on the mempool channel
-			for range suite.mempoolPeerErrCh {
+			for range s.mempoolPeerErrCh {
 			}
-		}()
+		}(suite)
 	}
 
 	peerID := uint16(1)
@@ -337,11 +337,11 @@ func TestReactor_MaxTxBytes(t *testing.T) {
 
 	// ignore all peer errors
 	for _, suite := range testSuites {
-		go func() {
+		go func(s *reactorTestSuite) {
 			// drop all errors on the mempool channel
-			for range suite.mempoolPeerErrCh {
+			for range s.mempoolPeerErrCh {
 			}
-		}()
+		}(suite)
 	}
 
 	primary := testSuites[0]
@@ -350,7 +350,7 @@ func TestReactor_MaxTxBytes(t *testing.T) {
 	// Simulate a router by listening for all outbound envelopes and proxying the
 	// envelopes to the respective peer (suite).
 	wg := new(sync.WaitGroup)
-	simulateRouter(wg, primary, testSuites, 1, true)
+	simulateRouter(wg, primary, testSuites, 1)
 
 	// Broadcast a tx, which has the max size and ensure it's received by the
 	// second reactor.
@@ -456,11 +456,11 @@ func TestBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
 
 	// ignore all peer errors
 	for _, suite := range testSuites {
-		go func() {
+		go func(s *reactorTestSuite) {
 			// drop all errors on the mempool channel
-			for range suite.mempoolPeerErrCh {
+			for range s.mempoolPeerErrCh {
 			}
-		}()
+		}(suite)
 	}
 
 	// connect peer

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -97,7 +97,6 @@ func simulateRouter(
 	primary *reactorTestSuite,
 	suites []*reactorTestSuite,
 	numOut int,
-	dropChErr bool,
 ) {
 
 	wg.Add(1)
@@ -123,19 +122,6 @@ func simulateRouter(
 		}
 
 		wg.Done()
-	}()
-
-	go func() {
-		for pErr := range primary.mempoolPeerErrCh {
-			if dropChErr {
-				primary.reactor.Logger.Debug("dropped peer error", "err", pErr.Err)
-			} else {
-				primary.peerUpdatesCh <- p2p.PeerUpdate{
-					PeerID: pErr.PeerID,
-					Status: p2p.PeerStatusRemoved,
-				}
-			}
-		}
 	}()
 }
 
@@ -179,13 +165,22 @@ func TestReactorBroadcastTxs(t *testing.T) {
 		testSuites[i] = setup(t, config.Mempool, logger, 0)
 	}
 
+	// ignore all peer errors
+	for _, suite := range testSuites {
+		go func() {
+			// drop all errors on the mempool channel
+			for range suite.mempoolPeerErrCh {
+			}
+		}()
+	}
+
 	primary := testSuites[0]
 	secondaries := testSuites[1:]
 
 	// Simulate a router by listening for all outbound envelopes and proxying the
 	// envelopes to the respective peer (suite).
 	wg := new(sync.WaitGroup)
-	simulateRouter(wg, primary, testSuites, numTxs*len(secondaries), true)
+	simulateRouter(wg, primary, testSuites, numTxs*len(secondaries))
 
 	txs := checkTxs(t, primary.reactor.mempool, numTxs, UnknownPeerID)
 
@@ -286,11 +281,14 @@ func TestReactorNoBroadcastToSender(t *testing.T) {
 	primary := testSuites[0]
 	secondary := testSuites[1]
 
-	go func() {
-		// drop all errors on the mempool channel
-		for range primary.mempoolPeerErrCh {
-		}
-	}()
+	// ignore all peer errors
+	for _, suite := range testSuites {
+		go func() {
+			// drop all errors on the mempool channel
+			for range suite.mempoolPeerErrCh {
+			}
+		}()
+	}
 
 	peerID := uint16(1)
 	_ = checkTxs(t, primary.reactor.mempool, numTxs, peerID)
@@ -335,6 +333,15 @@ func TestReactor_MaxTxBytes(t *testing.T) {
 	for i := 0; i < len(testSuites); i++ {
 		logger := log.TestingLogger().With("node", i)
 		testSuites[i] = setup(t, config.Mempool, logger, 0)
+	}
+
+	// ignore all peer errors
+	for _, suite := range testSuites {
+		go func() {
+			// drop all errors on the mempool channel
+			for range suite.mempoolPeerErrCh {
+			}
+		}()
 	}
 
 	primary := testSuites[0]
@@ -439,14 +446,22 @@ func TestBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
 
 	config := cfg.TestConfig()
 
-	primary := setup(t, config.Mempool, log.TestingLogger().With("node", 0), 0)
-	secondary := setup(t, config.Mempool, log.TestingLogger().With("node", 1), 0)
+	testSuites := []*reactorTestSuite{
+		setup(t, config.Mempool, log.TestingLogger().With("node", 0), 0),
+		setup(t, config.Mempool, log.TestingLogger().With("node", 1), 0),
+	}
 
-	go func() {
-		// drop all errors on the mempool channel
-		for range primary.mempoolPeerErrCh {
-		}
-	}()
+	primary := testSuites[0]
+	secondary := testSuites[1]
+
+	// ignore all peer errors
+	for _, suite := range testSuites {
+		go func() {
+			// drop all errors on the mempool channel
+			for range suite.mempoolPeerErrCh {
+			}
+		}()
+	}
 
 	// connect peer
 	primary.peerUpdatesCh <- p2p.PeerUpdate{


### PR DESCRIPTION
Fix the timeout issue for the mempool tests by dropping mempool channel errors for _all_ reactors, not just the "primary".

closes: #5956