### PR TITLE
docs: fix typo in state sync example

### DIFF
--- a/docs/nodes/state-sync.md
+++ b/docs/nodes/state-sync.md
@@ -29,7 +29,7 @@ If you are relying on publicly exposed RPC's to get the need information, you ca
 Example: 
 
 ```bash
-curl -s https://233.123.0.140:26657:26657/commit | jq "{height: .result.signed_header.header.height, hash: .result.signed_header.commit.block_id.hash}"
+curl -s https://233.123.0.140:26657/commit | jq "{height: .result.signed_header.header.height, hash: .result.signed_header.commit.block_id.hash}"
 ```
 
 The response will be: 


### PR DESCRIPTION
https://233.123.0.140:26657:26657/commit --> https://233.123.0.140:26657/commit

## Description

_Please add a description of the changes that this PR introduces and the files that
are the most critical to review._ 

Closes: #XXX

