### PR TITLE
test: disable TestPEXReactorSeedModeFlushStop due to flake

### DIFF
--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -376,6 +376,7 @@ func TestPEXReactorDialsPeerUpToMaxAttemptsInSeedMode(t *testing.T) {
 // with FlushStop. Before a fix, this non-deterministically reproduced
 // https://github.com/tendermint/tendermint/issues/3231.
 func TestPEXReactorSeedModeFlushStop(t *testing.T) {
+	t.Skip("flaky test, will be replaced by new P2P stack")
 	N := 2
 	switches := make([]*p2p.Switch, N)
 


### PR DESCRIPTION
This test occasionally fails because the peer is already stopped. It is unclear to me exactly what this test is supposed to do, since calling `FlushStop()` will stop the peer, but the test asserts that the peer shouldn't have been stopped by `FlushStop()` since calling `Stop()` afterwards will error in that case.

The current PEX reactor will be removed in the new P2P stack anyway.