### PR TITLE
test: don't use foo-bar.net in TestHTTPClientMakeHTTPDialer

### DIFF
--- a/rpc/jsonrpc/client/http_json_client_test.go
+++ b/rpc/jsonrpc/client/http_json_client_test.go
@@ -1,23 +1,37 @@
 package client
 
 import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPClientMakeHTTPDialer(t *testing.T) {
-	remote := []string{"https://foo-bar.com:80", "http://foo-bar.net:80", "https://user:pass@foo-bar.net:80"}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Hi!\n"))
+	}))
+	defer ts.Close()
 
-	for _, f := range remote {
-		u, err := newParsedURL(f)
+	tsTLS := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Hi!\n"))
+	}))
+	defer tsTLS.Close()
+	// This silences a TLS handshake error, caused by the dialer just immediately
+	// disconnecting, which we can just ignore.
+	tsTLS.Config.ErrorLog = log.New(ioutil.Discard, "", 0)
+
+	for _, testURL := range []string{ts.URL, tsTLS.URL} {
+		u, err := newParsedURL(testURL)
 		require.NoError(t, err)
-		dialFn, err := makeHTTPDialer(f)
+		dialFn, err := makeHTTPDialer(testURL)
 		require.Nil(t, err)
 
 		addr, err := dialFn(u.Scheme, u.GetHostWithPath())
 		require.NoError(t, err)
 		require.NotNil(t, addr)
 	}
-
 }

--- a/rpc/jsonrpc/client/http_json_client_test.go
+++ b/rpc/jsonrpc/client/http_json_client_test.go
@@ -11,14 +11,13 @@ import (
 )
 
 func TestHTTPClientMakeHTTPDialer(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("Hi!\n"))
-	}))
+	})
+	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	tsTLS := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("Hi!\n"))
-	}))
+	tsTLS := httptest.NewTLSServer(handler)
 	defer tsTLS.Close()
 	// This silences a TLS handshake error, caused by the dialer just immediately
 	// disconnecting, which we can just ignore.


### PR DESCRIPTION
This test relied on connecting to the external site `foo-bar.net`, and (predictably) the site went down and broke all of our CI runs. This changes it to use local HTTP servers instead.