### PR TITLE
test: fix TestSwitchAcceptRoutine by ignoring spurious error

### DIFF
--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -642,8 +642,7 @@ func TestSwitchAcceptRoutine(t *testing.T) {
 	require.NoError(t, err)
 	// check conn is closed
 	one := make([]byte, 1)
-	err = conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
-	require.NoError(t, err)
+	_ = conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
 	_, err = conn.Read(one)
 	assert.Error(t, err)
 	assert.Equal(t, cfg.MaxNumInboundPeers, sw.Peers().Size())


### PR DESCRIPTION
Another fix for `TestSwitchAcceptRoutine` following from #6000, since the `SetDeadline()` call also errors when the connection has been closed.