### PR TITLE
test: fix flaky router broadcast test

### DIFF
--- a/p2p/router_test.go
+++ b/p2p/router_test.go
@@ -112,6 +112,16 @@ func TestRouter(t *testing.T) {
 		}, (<-channel.In()).Strip())
 	}
 
+	// We now send a broadcast, which we should return back from all peers.
+	channel.Out() <- p2p.Envelope{
+		Broadcast: true,
+		Message:   &TestMessage{Value: "broadcast"},
+	}
+	for i := 0; i < len(peers); i++ {
+		envelope := <-channel.In()
+		require.Equal(t, &TestMessage{Value: "broadcast"}, envelope.Message)
+	}
+
 	// We then submit an error for a peer, and watch it get disconnected.
 	channel.Error() <- p2p.PeerError{
 		PeerID:   peers[0].ID,
@@ -131,18 +141,4 @@ func TestRouter(t *testing.T) {
 		PeerID: peers[0].ID,
 		Status: p2p.PeerStatusUp,
 	}, peerUpdate)
-
-	// We now send a broadcast, which we should return back from all peers.
-	//
-	// FIXME: Temporarily disabled due to a race condition where the router
-	// tries to redial peers[0] before it has registered the disconnection and
-	// thus reject the connection attempt.
-	/*channel.Out() <- p2p.Envelope{
-		Broadcast: true,
-		Message:   &TestMessage{Value: "broadcast"},
-	}
-	for i := 0; i < len(peers); i++ {
-		envelope := <-channel.In()
-		require.Equal(t, &TestMessage{Value: "broadcast"}, envelope.Message)
-	}*/
 }

--- a/p2p/router_test.go
+++ b/p2p/router_test.go
@@ -133,12 +133,16 @@ func TestRouter(t *testing.T) {
 	}, peerUpdate)
 
 	// We now send a broadcast, which we should return back from all peers.
-	channel.Out() <- p2p.Envelope{
+	//
+	// FIXME: Temporarily disabled due to a race condition where the router
+	// tries to redial peers[0] before it has registered the disconnection and
+	// thus reject the connection attempt.
+	/*channel.Out() <- p2p.Envelope{
 		Broadcast: true,
 		Message:   &TestMessage{Value: "broadcast"},
 	}
 	for i := 0; i < len(peers); i++ {
 		envelope := <-channel.In()
 		require.Equal(t, &TestMessage{Value: "broadcast"}, envelope.Message)
-	}
+	}*/
 }


### PR DESCRIPTION
Fixes #6004 by reordering test to avoid race condition. Will redesign router tests to be resistant to this later.