### PR TITLE
p2p: tighten up and test Transport API

### DIFF
--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -39,7 +39,7 @@ type reactorTestSuite struct {
 func setup(t *testing.T, cfg *cfg.MempoolConfig, logger log.Logger, chBuf uint) *reactorTestSuite {
 	t.Helper()
 
-	pID := make([]byte, 16)
+	pID := make([]byte, 20)
 	_, err := rng.Read(pID)
 	require.NoError(t, err)
 
@@ -313,7 +313,7 @@ func TestReactorNoBroadcastToSender(t *testing.T) {
 func TestMempoolIDsBasic(t *testing.T) {
 	ids := newMempoolIDs()
 
-	peerID, err := p2p.NewNodeID("00ffaa")
+	peerID, err := p2p.NewNodeID("0011223344556677889900112233445566778899")
 	require.NoError(t, err)
 
 	ids.ReserveForPeer(peerID)
@@ -399,7 +399,7 @@ func TestDontExhaustMaxActiveIDs(t *testing.T) {
 		}
 	}()
 
-	peerID, err := p2p.NewNodeID("00ffaa")
+	peerID, err := p2p.NewNodeID("0011223344556677889900112233445566778899")
 	require.NoError(t, err)
 
 	// ensure the reactor does not panic (i.e. exhaust active IDs)
@@ -427,7 +427,7 @@ func TestMempoolIDsPanicsIfNodeRequestsOvermaxActiveIDs(t *testing.T) {
 	// 0 is already reserved for UnknownPeerID
 	ids := newMempoolIDs()
 
-	peerID, err := p2p.NewNodeID("00ffaa")
+	peerID, err := p2p.NewNodeID("0011223344556677889900112233445566778899")
 	require.NoError(t, err)
 
 	for i := 0; i < maxActiveIDs-1; i++ {

--- a/p2p/key.go
+++ b/p2p/key.go
@@ -22,11 +22,8 @@ type NodeID string
 
 // NewNodeID returns a lowercased (normalized) NodeID.
 func NewNodeID(nodeID string) (NodeID, error) {
-	if _, err := NodeID(nodeID).Bytes(); err != nil {
-		return NodeID(""), err
-	}
-
-	return NodeID(strings.ToLower(nodeID)), nil
+	n := NodeID(strings.ToLower(nodeID))
+	return n, n.Validate()
 }
 
 // NodeIDFromPubKey returns the noe ID corresponding to the given PubKey. It's

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -1475,12 +1475,12 @@ func (p *peer) processMessages() {
 			p.onError(err)
 			return
 		}
-		reactor, ok := p.reactors[chID]
+		reactor, ok := p.reactors[byte(chID)]
 		if !ok {
 			p.onError(fmt.Errorf("unknown channel %v", chID))
 			return
 		}
-		reactor.Receive(chID, p, msg)
+		reactor.Receive(byte(chID), p, msg)
 	}
 }
 
@@ -1555,7 +1555,7 @@ func (p *peer) Send(chID byte, msgBytes []byte) bool {
 	} else if !p.hasChannel(chID) {
 		return false
 	}
-	res, err := p.conn.SendMessage(chID, msgBytes)
+	res, err := p.conn.SendMessage(ChannelID(chID), msgBytes)
 	if err == io.EOF {
 		return false
 	} else if err != nil {
@@ -1580,7 +1580,7 @@ func (p *peer) TrySend(chID byte, msgBytes []byte) bool {
 	} else if !p.hasChannel(chID) {
 		return false
 	}
-	res, err := p.conn.TrySendMessage(chID, msgBytes)
+	res, err := p.conn.TrySendMessage(ChannelID(chID), msgBytes)
 	if err == io.EOF {
 		return false
 	} else if err != nil {

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -629,6 +629,8 @@ func (r *Router) OnStart() error {
 }
 
 // OnStop implements service.Service.
+//
+// FIXME: This needs to close transports as well.
 func (r *Router) OnStop() {
 	// Collect all active queues, so we can wait for them to close.
 	queues := []queue{}

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -536,8 +536,8 @@ func (r *Router) receivePeer(peerID NodeID, conn Connection) error {
 		}
 
 		r.channelMtx.RLock()
-		queue, ok := r.channelQueues[ChannelID(chID)]
-		messageType := r.channelMessages[ChannelID(chID)]
+		queue, ok := r.channelQueues[chID]
+		messageType := r.channelMessages[chID]
 		r.channelMtx.RUnlock()
 		if !ok {
 			r.logger.Error("dropping message for unknown channel", "peer", peerID, "channel", chID)
@@ -558,8 +558,7 @@ func (r *Router) receivePeer(peerID NodeID, conn Connection) error {
 		}
 
 		select {
-		// FIXME: ReceiveMessage() should return ChannelID.
-		case queue.enqueue() <- Envelope{channelID: ChannelID(chID), From: peerID, Message: msg}:
+		case queue.enqueue() <- Envelope{channelID: chID, From: peerID, Message: msg}:
 			r.logger.Debug("received message", "peer", peerID, "message", msg)
 		case <-queue.closed():
 			r.logger.Error("channel closed, dropping message", "peer", peerID, "channel", chID)
@@ -580,8 +579,7 @@ func (r *Router) sendPeer(peerID NodeID, conn Connection, queue queue) error {
 				continue
 			}
 
-			// FIXME: SendMessage() should take ChannelID.
-			_, err = conn.SendMessage(byte(envelope.channelID), bz)
+			_, err = conn.SendMessage(envelope.channelID, bz)
 			if err != nil {
 				return err
 			}

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -293,10 +293,10 @@ func (r *Router) acceptPeers(transport Transport) {
 		// FIXME: The old P2P stack supported ABCI-based IP address filtering via
 		// /p2p/filter/addr/<ip> queries, do we want to implement this here as well?
 		// Filtering by node ID is probably better.
-		conn, err := transport.Accept(ctx)
+		conn, err := transport.Accept()
 		switch err {
 		case nil:
-		case ErrTransportClosed{}, io.EOF, context.Canceled:
+		case io.EOF:
 			r.logger.Debug("stopping accept routine", "transport", transport)
 			return
 		default:

--- a/p2p/router_test.go
+++ b/p2p/router_test.go
@@ -50,8 +50,7 @@ func TestRouter(t *testing.T) {
 	logger := log.TestingLogger()
 	network := p2p.NewMemoryNetwork(logger)
 	nodeInfo, privKey := generateNode()
-	transport, err := network.CreateTransport(nodeInfo.NodeID)
-	require.NoError(t, err)
+	transport := network.CreateTransport(nodeInfo.NodeID)
 	defer transport.Close()
 	chID := p2p.ChannelID(1)
 
@@ -62,8 +61,7 @@ func TestRouter(t *testing.T) {
 		peerManager, err := p2p.NewPeerManager(dbm.NewMemDB(), p2p.PeerManagerOptions{})
 		require.NoError(t, err)
 		peerInfo, peerKey := generateNode()
-		peerTransport, err := network.CreateTransport(peerInfo.NodeID)
-		require.NoError(t, err)
+		peerTransport := network.CreateTransport(peerInfo.NodeID)
 		defer peerTransport.Close()
 		peerRouter, err := p2p.NewRouter(
 			logger.With("peerID", i),

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -669,8 +669,7 @@ func (sw *Switch) IsPeerPersistent(na *NetAddress) bool {
 func (sw *Switch) acceptRoutine() {
 	for {
 		var peerNodeInfo NodeInfo
-		ctx := context.Background()
-		c, err := sw.transport.Accept(ctx)
+		c, err := sw.transport.Accept()
 		if err == nil {
 			// NOTE: The legacy MConn transport did handshaking in Accept(),
 			// which was asynchronous and avoided head-of-line-blocking.

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -706,7 +706,7 @@ func (et errorTransport) Protocols() []Protocol {
 	return []Protocol{"error"}
 }
 
-func (et errorTransport) Accept(context.Context) (Connection, error) {
+func (et errorTransport) Accept() (Connection, error) {
 	return nil, et.acceptErr
 }
 func (errorTransport) Dial(context.Context, Endpoint) (Connection, error) {

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -31,11 +31,10 @@ type Transport interface {
 	// MemoryTransport starts listening via MemoryNetwork.CreateTransport().
 	Endpoints() []Endpoint
 
-	// Accept waits for the next inbound connection on a listening endpoint. Returns
-	// io.EOF if the transport is closed.
-	//
-	// FIXME: This can't take a context, since net.Listener doesn't.
-	Accept(context.Context) (Connection, error)
+	// Accept waits for the next inbound connection on a listening endpoint, blocking
+	// until either a connection is available or the transport is closed. On closure,
+	// io.EOF is returned and further Accept calls are futile.
+	Accept() (Connection, error)
 
 	// Dial creates an outbound connection to an endpoint.
 	Dial(context.Context, Endpoint) (Connection, error)

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -73,14 +73,14 @@ type Connection interface {
 
 	// ReceiveMessage returns the next message received on the connection,
 	// blocking until one is available. Returns io.EOF if closed.
-	ReceiveMessage() (chID byte, msg []byte, err error)
+	ReceiveMessage() (ChannelID, []byte, error)
 
 	// SendMessage sends a message on the connection. Returns io.EOF if closed.
 	//
 	// FIXME: For compatibility with the legacy P2P stack, it returns an
 	// additional boolean false if the message timed out waiting to be accepted
 	// into the send buffer. This should be removed.
-	SendMessage(chID byte, msg []byte) (bool, error)
+	SendMessage(ChannelID, []byte) (bool, error)
 
 	// TrySendMessage is a non-blocking version of SendMessage that returns
 	// immediately if the message buffer is full. It returns true if the message
@@ -88,7 +88,7 @@ type Connection interface {
 	//
 	// FIXME: This method is here for backwards-compatibility with the legacy
 	// P2P stack and should be removed.
-	TrySendMessage(chID byte, msg []byte) (bool, error)
+	TrySendMessage(ChannelID, []byte) (bool, error)
 
 	// LocalEndpoint returns the local endpoint for the connection.
 	LocalEndpoint() Endpoint
@@ -104,7 +104,7 @@ type Connection interface {
 	// FIXME: This only exists for backwards-compatibility with the current
 	// MConnection implementation. There should really be a separate Flush()
 	// method, but there is no easy way to synchronously flush pending data with
-	// the current MConnection structure.
+	// the current MConnection code.
 	FlushClose() error
 
 	// Status returns the current connection status.
@@ -114,9 +114,9 @@ type Connection interface {
 
 // Endpoint represents a transport connection endpoint, either local or remote.
 //
-// Endpoints are not necessarily networked (see e.g. MemoryTransport which uses
-// in-memory communication), but all networked endpoints must use IP as the
-// underlying transport protocol to allow e.g. IP address filtering.
+// Endpoints are not necessarily networked (see e.g. MemoryTransport) but all
+// networked endpoints must use IP as the underlying transport protocol to allow
+// e.g. IP address filtering. Either IP or Path (or both) must be set.
 type Endpoint struct {
 	// Protocol specifies the transport protocol.
 	Protocol Protocol

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -33,6 +33,8 @@ type Transport interface {
 
 	// Accept waits for the next inbound connection on a listening endpoint. Returns
 	// io.EOF if the transport is closed.
+	//
+	// FIXME: This can't take a context, since net.Listener doesn't.
 	Accept(context.Context) (Connection, error)
 
 	// Dial creates an outbound connection to an endpoint.

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/p2p/conn"
@@ -149,15 +148,7 @@ func (e Endpoint) PeerAddress(nodeID NodeID) PeerAddress {
 
 // String formats the endpoint as a URL string.
 func (e Endpoint) String() string {
-	if e.IP == nil {
-		return fmt.Sprintf("%s:%s", e.Protocol, e.Path)
-	}
-	s := fmt.Sprintf("%s://%s", e.Protocol, e.IP)
-	if e.Port > 0 {
-		s += strconv.Itoa(int(e.Port))
-	}
-	s += e.Path
-	return s
+	return e.PeerAddress("").String()
 }
 
 // Validate validates the endpoint.
@@ -165,10 +156,16 @@ func (e Endpoint) Validate() error {
 	switch {
 	case e.Protocol == "":
 		return errors.New("endpoint has no protocol")
+
+	case len(e.IP) > 0 && e.IP.To16() == nil:
+		return fmt.Errorf("invalid IP address %v", e.IP)
+
 	case e.Port > 0 && len(e.IP) == 0:
 		return fmt.Errorf("endpoint has port %v but no IP", e.Port)
+
 	case len(e.IP) == 0 && e.Path == "":
 		return errors.New("endpoint has neither path nor IP")
+
 	default:
 		return nil
 	}

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -25,15 +25,18 @@ type Transport interface {
 	// uses this to pick a transport for an Endpoint.
 	Protocols() []Protocol
 
-	// Accept waits for the next inbound connection on a listening endpoint. If
-	// the transport is closed, io.EOF is returned.
+	// Endpoints returns the local endpoints the transport is listening on, if any.
+	//
+	// How to listen is transport-dependent, e.g. MConnTransport uses Listen() while
+	// MemoryTransport starts listening via MemoryNetwork.CreateTransport().
+	Endpoints() []Endpoint
+
+	// Accept waits for the next inbound connection on a listening endpoint. Returns
+	// io.EOF if the transport is closed.
 	Accept(context.Context) (Connection, error)
 
 	// Dial creates an outbound connection to an endpoint.
 	Dial(context.Context, Endpoint) (Connection, error)
-
-	// Endpoints returns the local endpoints the transport is listening on, if any.
-	Endpoints() []Endpoint
 
 	// Close stops accepting new connections, but does not close active connections.
 	Close() error

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -114,6 +114,13 @@ type Connection interface {
 	// Status returns the current connection status.
 	// FIXME: Only here for compatibility with the current Peer code.
 	Status() conn.ConnectionStatus
+
+	// Stringer is used to display the connection, e.g. in logs.
+	//
+	// Without this, the logger may use reflection to access and display
+	// internal fields. These can be written to concurrently, which can trigger
+	// the race detector or even cause a panic.
+	fmt.Stringer
 }
 
 // Endpoint represents a transport connection endpoint, either local or remote.

--- a/p2p/transport_mconn.go
+++ b/p2p/transport_mconn.go
@@ -151,12 +151,6 @@ func (m *MConnTransport) Accept() (Connection, error) {
 
 // Dial implements Transport.
 func (m *MConnTransport) Dial(ctx context.Context, endpoint Endpoint) (Connection, error) {
-	select {
-	case <-m.closeCh:
-		return nil, errors.New("transport is closed")
-	default:
-	}
-
 	if err := m.validateEndpoint(endpoint); err != nil {
 		return nil, err
 	}

--- a/p2p/transport_mconn.go
+++ b/p2p/transport_mconn.go
@@ -126,7 +126,7 @@ func (m *MConnTransport) Listen(endpoint Endpoint) error {
 }
 
 // Accept implements Transport.
-func (m *MConnTransport) Accept(ctx context.Context) (Connection, error) {
+func (m *MConnTransport) Accept() (Connection, error) {
 	if m.listener == nil {
 		return nil, errors.New("transport is not listening")
 	}
@@ -136,8 +136,6 @@ func (m *MConnTransport) Accept(ctx context.Context) (Connection, error) {
 		select {
 		case <-m.closeCh:
 			return nil, io.EOF
-		case <-ctx.Done():
-			return nil, ctx.Err()
 		default:
 			return nil, err
 		}

--- a/p2p/transport_mconn.go
+++ b/p2p/transport_mconn.go
@@ -84,7 +84,7 @@ func (m *MConnTransport) Listen(endpoint Endpoint) error {
 	if m.listener != nil {
 		return errors.New("transport is already listening")
 	}
-	endpoint, err := m.normalizeEndpoint(endpoint)
+	endpoint, err := m.normalizeEndpoint(endpoint, false)
 	if err != nil {
 		return fmt.Errorf("invalid MConn listen endpoint %q: %w", endpoint, err)
 	}
@@ -132,7 +132,7 @@ func (m *MConnTransport) Accept(ctx context.Context) (Connection, error) {
 
 // Dial implements Transport.
 func (m *MConnTransport) Dial(ctx context.Context, endpoint Endpoint) (Connection, error) {
-	endpoint, err := m.normalizeEndpoint(endpoint)
+	endpoint, err := m.normalizeEndpoint(endpoint, true)
 	if err != nil {
 		return nil, err
 	}
@@ -174,8 +174,10 @@ func (m *MConnTransport) Close() error {
 	return err
 }
 
-// normalizeEndpoint normalizes and validates an endpoint.
-func (m *MConnTransport) normalizeEndpoint(endpoint Endpoint) (Endpoint, error) {
+// normalizeEndpoint normalizes and validates an endpoint. If setPort is true,
+// the port will be normalized to 26657 if 0 (port 0 is useful to listen on
+// random ports).
+func (m *MConnTransport) normalizeEndpoint(endpoint Endpoint, setPort bool) (Endpoint, error) {
 	if err := endpoint.Validate(); err != nil {
 		return Endpoint{}, err
 	}
@@ -188,7 +190,7 @@ func (m *MConnTransport) normalizeEndpoint(endpoint Endpoint) (Endpoint, error) 
 	if endpoint.Path != "" {
 		return Endpoint{}, fmt.Errorf("endpoint cannot have path (got %q)", endpoint.Path)
 	}
-	if endpoint.Port == 0 {
+	if endpoint.Port == 0 && setPort {
 		endpoint.Port = 26657
 	}
 	return endpoint, nil

--- a/p2p/transport_mconn.go
+++ b/p2p/transport_mconn.go
@@ -118,6 +118,11 @@ func (m *MConnTransport) Listen(endpoint Endpoint) error {
 		return err
 	}
 	if m.options.MaxAcceptedConnections > 0 {
+		// FIXME: This will establish the inbound connection but simply hang it
+		// until another connection is released. It would probably be better to
+		// return an error to the remote peer or close the connection. This is
+		// also a DoS vector since the connection will take up kernel resources.
+		// This was just carried over from the legacy P2P stack.
 		listener = netutil.LimitListener(listener, int(m.options.MaxAcceptedConnections))
 	}
 	m.listener = listener

--- a/p2p/transport_mconn.go
+++ b/p2p/transport_mconn.go
@@ -285,13 +285,16 @@ func (c *mConnConnection) Handshake(
 		}
 		c.mconn = mconn
 		c.logger = mconn.Logger
+		if err = c.mconn.Start(); err != nil {
+			return NodeInfo{}, nil, err
+		}
 		return peerInfo, peerKey, nil
 	}
 }
 
 // handshake is a helper for Handshake, simplifying error handling so we can
-// keep context handling and panic recovery in Handshake. It returns the
-// handshaked MConnection and does not modify the mConnConnection.
+// keep context handling and panic recovery in Handshake. It returns an
+// unstarted but handshaked MConnection, to avoid concurrent field writes.
 func (c *mConnConnection) handshake(
 	ctx context.Context,
 	nodeInfo NodeInfo,
@@ -334,9 +337,6 @@ func (c *mConnConnection) handshake(
 		c.mConnConfig,
 	)
 	mconn.SetLogger(c.logger.With("peer", c.RemoteEndpoint().PeerAddress(peerInfo.NodeID)))
-	if err = mconn.Start(); err != nil {
-		return nil, NodeInfo{}, nil, err
-	}
 
 	return mconn, peerInfo, secretConn.RemotePubKey(), nil
 }

--- a/p2p/transport_mconn.go
+++ b/p2p/transport_mconn.go
@@ -118,7 +118,7 @@ func (m *MConnTransport) Listen(endpoint Endpoint) error {
 		return err
 	}
 	if m.options.MaxAcceptedConnections > 0 {
-		listener = netutil.LimitListener(m.listener, int(m.options.MaxAcceptedConnections))
+		listener = netutil.LimitListener(listener, int(m.options.MaxAcceptedConnections))
 	}
 	m.listener = listener
 

--- a/p2p/transport_mconn_test.go
+++ b/p2p/transport_mconn_test.go
@@ -14,7 +14,7 @@ import (
 // Most tests are done via the test suite in transport_test.go, we register a
 // transport factory here to get tested by the suite.
 func init() {
-	transportFactories["mconn"] = func(t *testing.T) p2p.Transport {
+	testTransports["mconn"] = func(t *testing.T) p2p.Transport {
 		transport := p2p.NewMConnTransport(
 			log.TestingLogger(),
 			conn.DefaultMConnConfig(),

--- a/p2p/transport_mconn_test.go
+++ b/p2p/transport_mconn_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/tendermint/tendermint/p2p/conn"
 )
 
-// Most tests are done via the test suite in transport_test.go, we register a
-// transport factory here to get tested by the suite.
+// Transports are mainly tested by common tests in transport_test.go, we
+// register a transport factory here to get included in those tests.
 func init() {
 	testTransports["mconn"] = func(t *testing.T) p2p.Transport {
 		transport := p2p.NewMConnTransport(

--- a/p2p/transport_mconn_test.go
+++ b/p2p/transport_mconn_test.go
@@ -18,7 +18,7 @@ func init() {
 		transport := p2p.NewMConnTransport(
 			log.TestingLogger(),
 			conn.DefaultMConnConfig(),
-			[]*p2p.ChannelDescriptor{},
+			[]*p2p.ChannelDescriptor{{ID: byte(chID), Priority: 1}},
 			p2p.MConnTransportOptions{},
 		)
 		err := transport.Listen(p2p.Endpoint{

--- a/p2p/transport_mconn_test.go
+++ b/p2p/transport_mconn_test.go
@@ -1,0 +1,37 @@
+package p2p_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/p2p/conn"
+)
+
+// Most tests are done via the test suite in transport_test.go, we register a
+// transport factory here to get tested by the suite.
+func init() {
+	transportFactories["mconn"] = func(t *testing.T) p2p.Transport {
+		transport := p2p.NewMConnTransport(
+			log.TestingLogger(),
+			conn.DefaultMConnConfig(),
+			[]*p2p.ChannelDescriptor{},
+			p2p.MConnTransportOptions{},
+		)
+		err := transport.Listen(p2p.Endpoint{
+			Protocol: p2p.MConnProtocol,
+			IP:       net.IPv4(127, 0, 0, 1),
+			Port:     0, // assign a random port
+		})
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			require.NoError(t, transport.Close())
+		})
+
+		return transport
+	}
+}

--- a/p2p/transport_mconn_test.go
+++ b/p2p/transport_mconn_test.go
@@ -1,9 +1,12 @@
 package p2p_test
 
 import (
+	"io"
 	"net"
 	"testing"
+	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/libs/log"
@@ -33,5 +36,173 @@ func init() {
 		})
 
 		return transport
+	}
+}
+
+func TestMConnTransport_AcceptBeforeListen(t *testing.T) {
+	transport := p2p.NewMConnTransport(
+		log.TestingLogger(),
+		conn.DefaultMConnConfig(),
+		[]*p2p.ChannelDescriptor{{ID: byte(chID), Priority: 1}},
+		p2p.MConnTransportOptions{
+			MaxAcceptedConnections: 2,
+		},
+	)
+	t.Cleanup(func() {
+		_ = transport.Close()
+	})
+
+	_, err := transport.Accept()
+	require.Error(t, err)
+	require.NotEqual(t, io.EOF, err) // io.EOF should be returned after Close()
+}
+
+func TestMConnTransport_AcceptMaxAcceptedConnections(t *testing.T) {
+	transport := p2p.NewMConnTransport(
+		log.TestingLogger(),
+		conn.DefaultMConnConfig(),
+		[]*p2p.ChannelDescriptor{{ID: byte(chID), Priority: 1}},
+		p2p.MConnTransportOptions{
+			MaxAcceptedConnections: 2,
+		},
+	)
+	t.Cleanup(func() {
+		_ = transport.Close()
+	})
+	err := transport.Listen(p2p.Endpoint{
+		Protocol: p2p.MConnProtocol,
+		IP:       net.IPv4(127, 0, 0, 1),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.Endpoints())
+	endpoint := transport.Endpoints()[0]
+
+	// Start a goroutine to just accept any connections.
+	acceptCh := make(chan p2p.Connection, 10)
+	go func() {
+		for {
+			conn, err := transport.Accept()
+			if err != nil {
+				return
+			}
+			acceptCh <- conn
+		}
+	}()
+
+	// The first two connections should be accepted just fine.
+	dial1, err := transport.Dial(ctx, endpoint)
+	require.NoError(t, err)
+	defer dial1.Close()
+	accept1 := <-acceptCh
+	defer accept1.Close()
+	require.Equal(t, dial1.LocalEndpoint(), accept1.RemoteEndpoint())
+
+	dial2, err := transport.Dial(ctx, endpoint)
+	require.NoError(t, err)
+	defer dial2.Close()
+	accept2 := <-acceptCh
+	defer accept2.Close()
+	require.Equal(t, dial2.LocalEndpoint(), accept2.RemoteEndpoint())
+
+	// The third connection will be dialed successfully, but the accept should
+	// not go through.
+	dial3, err := transport.Dial(ctx, endpoint)
+	require.NoError(t, err)
+	defer dial3.Close()
+	select {
+	case <-acceptCh:
+		require.Fail(t, "unexpected accept")
+	case <-time.After(time.Second):
+	}
+
+	// However, once either of the other connections are closed, the accept
+	// goes through.
+	require.NoError(t, accept1.Close())
+	accept3 := <-acceptCh
+	defer accept3.Close()
+	require.Equal(t, dial3.LocalEndpoint(), accept3.RemoteEndpoint())
+}
+
+func TestMConnTransport_Listen(t *testing.T) {
+	testcases := []struct {
+		endpoint p2p.Endpoint
+		ok       bool
+	}{
+		// Valid v4 and v6 addresses, with mconn and tcp protocols.
+		{p2p.Endpoint{Protocol: p2p.MConnProtocol, IP: net.IPv4zero}, true},
+		{p2p.Endpoint{Protocol: p2p.MConnProtocol, IP: net.IPv4(127, 0, 0, 1)}, true},
+		{p2p.Endpoint{Protocol: p2p.MConnProtocol, IP: net.IPv6zero}, true},
+		{p2p.Endpoint{Protocol: p2p.MConnProtocol, IP: net.IPv6loopback}, true},
+		{p2p.Endpoint{Protocol: p2p.TCPProtocol, IP: net.IPv4zero}, true},
+
+		// Invalid endpoints.
+		{p2p.Endpoint{}, false},
+		{p2p.Endpoint{Protocol: p2p.MConnProtocol, Path: "foo"}, false},
+		{p2p.Endpoint{Protocol: p2p.MConnProtocol, IP: net.IPv4zero, Path: "foo"}, false},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.endpoint.String(), func(t *testing.T) {
+			t.Cleanup(leaktest.Check(t))
+
+			transport := p2p.NewMConnTransport(
+				log.TestingLogger(),
+				conn.DefaultMConnConfig(),
+				[]*p2p.ChannelDescriptor{{ID: byte(chID), Priority: 1}},
+				p2p.MConnTransportOptions{},
+			)
+			t.Cleanup(func() {
+				_ = transport.Close()
+			})
+
+			// Transport should not listen on any endpoints yet.
+			require.Empty(t, transport.Endpoints())
+
+			// Start listening, and check any expected errors.
+			err := transport.Listen(tc.endpoint)
+			if !tc.ok {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Start a goroutine to just accept any connections.
+			go func() {
+				for {
+					conn, err := transport.Accept()
+					if err != nil {
+						return
+					}
+					defer func() {
+						_ = conn.Close()
+					}()
+				}
+			}()
+
+			// Check the endpoint.
+			endpoints := transport.Endpoints()
+			require.Len(t, endpoints, 1)
+			endpoint := endpoints[0]
+
+			require.Equal(t, p2p.MConnProtocol, endpoint.Protocol)
+			if tc.endpoint.IP.IsUnspecified() {
+				require.True(t, endpoint.IP.IsUnspecified(),
+					"expected unspecified IP, got %v", endpoint.IP)
+			} else {
+				require.True(t, tc.endpoint.IP.Equal(endpoint.IP),
+					"expected %v, got %v", tc.endpoint.IP, endpoint.IP)
+			}
+			require.NotZero(t, endpoint.Port)
+			require.Empty(t, endpoint.Path)
+
+			// Dialing the endpoint should work.
+			conn, err := transport.Dial(ctx, endpoint)
+			require.NoError(t, err)
+			require.NoError(t, conn.Close())
+
+			// Trying to listen again should error.
+			err = transport.Listen(tc.endpoint)
+			require.Error(t, err)
+		})
 	}
 }

--- a/p2p/transport_memory.go
+++ b/p2p/transport_memory.go
@@ -178,37 +178,6 @@ func (t *MemoryTransport) Dial(ctx context.Context, endpoint Endpoint) (Connecti
 	}
 }
 
-// DialAccept is a convenience function that dials a peer MemoryTransport and
-// returns both ends of the connection (A to B and B to A).
-func (t *MemoryTransport) DialAccept(
-	ctx context.Context,
-	peer *MemoryTransport,
-) (Connection, Connection, error) {
-	endpoints := peer.Endpoints()
-	if len(endpoints) == 0 {
-		return nil, nil, fmt.Errorf("peer %q not listening on any endpoints", peer.nodeID)
-	}
-
-	acceptCh := make(chan Connection, 1)
-	errCh := make(chan error, 1)
-	go func() {
-		conn, err := peer.Accept(ctx)
-		errCh <- err
-		acceptCh <- conn
-	}()
-
-	outConn, err := t.Dial(ctx, endpoints[0])
-	if err != nil {
-		return nil, nil, err
-	}
-	inConn, err := <-acceptCh, <-errCh
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return outConn, inConn, nil
-}
-
 // Close implements Transport.
 func (t *MemoryTransport) Close() error {
 	t.network.RemoveTransport(t.nodeID)

--- a/p2p/transport_memory.go
+++ b/p2p/transport_memory.go
@@ -174,8 +174,6 @@ func (t *MemoryTransport) Dial(ctx context.Context, endpoint Endpoint) (Connecti
 	select {
 	case peer.acceptCh <- inConn:
 		return outConn, nil
-	case <-t.closeCh:
-		return nil, io.EOF
 	case <-peer.closeCh:
 		return nil, io.EOF
 	case <-ctx.Done():

--- a/p2p/transport_memory.go
+++ b/p2p/transport_memory.go
@@ -78,6 +78,11 @@ func (n *MemoryNetwork) RemoveTransport(id NodeID) {
 	}
 }
 
+// Size returns the number of transports in the network.
+func (n *MemoryNetwork) Size() int {
+	return len(n.transports)
+}
+
 // MemoryTransport is an in-memory transport that uses buffered Go channels to
 // communicate between endpoints. It is primarily meant for testing.
 //

--- a/p2p/transport_memory.go
+++ b/p2p/transport_memory.go
@@ -130,15 +130,13 @@ func (t *MemoryTransport) Endpoints() []Endpoint {
 }
 
 // Accept implements Transport.
-func (t *MemoryTransport) Accept(ctx context.Context) (Connection, error) {
+func (t *MemoryTransport) Accept() (Connection, error) {
 	select {
 	case conn := <-t.acceptCh:
 		t.logger.Info("accepted connection", "remote", conn.RemoteEndpoint().Path)
 		return conn, nil
 	case <-t.closeCh:
 		return nil, io.EOF
-	case <-ctx.Done():
-		return nil, ctx.Err()
 	}
 }
 

--- a/p2p/transport_memory_test.go
+++ b/p2p/transport_memory_test.go
@@ -10,26 +10,23 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 )
 
-// Most tests are done via the test suite in transport_test.go, we register a
-// transport factory here to get tested by the suite.
+// Transports are mainly tested by common tests in transport_test.go, we
+// register a transport factory here to get included in those tests.
 func init() {
-	var (
-		network *p2p.MemoryNetwork // shared by transports in the same test
-		i       byte               // incrementing transport ID
-	)
+	var network *p2p.MemoryNetwork // shared by transports in the same test
 
 	testTransports["memory"] = func(t *testing.T) p2p.Transport {
 		if network == nil {
 			network = p2p.NewMemoryNetwork(log.TestingLogger())
 		}
+		i := byte(network.Size())
 		nodeID, err := p2p.NewNodeID(hex.EncodeToString(bytes.Repeat([]byte{i<<4 + i}, 20)))
 		require.NoError(t, err)
 		transport := network.CreateTransport(nodeID)
-		i++
 
 		t.Cleanup(func() {
 			require.NoError(t, transport.Close())
-			network, i = nil, 0 // set up new memory network per test
+			network = nil // set up a new memory network for the next test
 		})
 
 		return transport

--- a/p2p/transport_memory_test.go
+++ b/p2p/transport_memory_test.go
@@ -13,17 +13,14 @@ import (
 func TestMemoryTransport(t *testing.T) {
 	ctx := context.Background()
 	network := p2p.NewMemoryNetwork(log.TestingLogger())
-	a, err := network.CreateTransport("0a")
-	require.NoError(t, err)
-	b, err := network.CreateTransport("0b")
-	require.NoError(t, err)
-	c, err := network.CreateTransport("0c")
-	require.NoError(t, err)
+	a := network.CreateTransport("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	b := network.CreateTransport("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	c := network.CreateTransport("cccccccccccccccccccccccccccccccccccccccc")
 
 	// Dialing a missing endpoint should fail.
-	_, err = a.Dial(ctx, p2p.Endpoint{
+	_, err := a.Dial(ctx, p2p.Endpoint{
 		Protocol: p2p.MemoryProtocol,
-		Path:     "foo",
+		Path:     "dddddddddddddddddddddddddddddddddddddddd",
 	})
 	require.Error(t, err)
 

--- a/p2p/transport_memory_test.go
+++ b/p2p/transport_memory_test.go
@@ -1,7 +1,9 @@
 package p2p_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"io"
 	"testing"
 
@@ -9,6 +11,32 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/p2p"
 )
+
+// Most tests are done via the test suite in transport_test.go, we register a
+// transport factory here to get tested by the suite.
+func init() {
+	var (
+		network *p2p.MemoryNetwork // shared by transports in the same test
+		i       byte               // incrementing transport ID
+	)
+
+	transportFactories["memory"] = func(t *testing.T) p2p.Transport {
+		if network == nil {
+			network = p2p.NewMemoryNetwork(log.TestingLogger())
+		}
+		nodeID, err := p2p.NewNodeID(hex.EncodeToString(bytes.Repeat([]byte{i<<4 + i}, 20)))
+		require.NoError(t, err)
+		transport := network.CreateTransport(nodeID)
+		i++
+
+		t.Cleanup(func() {
+			require.NoError(t, transport.Close())
+			network, i = nil, 0 // set up new memory network per test
+		})
+
+		return transport
+	}
+}
 
 func TestMemoryTransport(t *testing.T) {
 	ctx := context.Background()

--- a/p2p/transport_memory_test.go
+++ b/p2p/transport_memory_test.go
@@ -2,9 +2,7 @@ package p2p_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,7 +18,7 @@ func init() {
 		i       byte               // incrementing transport ID
 	)
 
-	transportFactories["memory"] = func(t *testing.T) p2p.Transport {
+	testTransports["memory"] = func(t *testing.T) p2p.Transport {
 		if network == nil {
 			network = p2p.NewMemoryNetwork(log.TestingLogger())
 		}
@@ -36,113 +34,4 @@ func init() {
 
 		return transport
 	}
-}
-
-func TestMemoryTransport(t *testing.T) {
-	ctx := context.Background()
-	network := p2p.NewMemoryNetwork(log.TestingLogger())
-	a := network.CreateTransport("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-	b := network.CreateTransport("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-	c := network.CreateTransport("cccccccccccccccccccccccccccccccccccccccc")
-
-	// Dialing a missing endpoint should fail.
-	_, err := a.Dial(ctx, p2p.Endpoint{
-		Protocol: p2p.MemoryProtocol,
-		Path:     "dddddddddddddddddddddddddddddddddddddddd",
-	})
-	require.Error(t, err)
-
-	// Dialing and accepting a→b and a→c should work.
-	aToB, bToA, err := a.DialAccept(ctx, b)
-	require.NoError(t, err)
-	defer aToB.Close()
-	defer bToA.Close()
-
-	aToC, cToA, err := a.DialAccept(ctx, c)
-	require.NoError(t, err)
-	defer aToC.Close()
-	defer cToA.Close()
-
-	// Send and receive a message both ways a→b and b→a
-	sent, err := aToB.SendMessage(1, []byte{0x01})
-	require.NoError(t, err)
-	require.True(t, sent)
-
-	ch, msg, err := bToA.ReceiveMessage()
-	require.NoError(t, err)
-	require.EqualValues(t, 1, ch)
-	require.EqualValues(t, []byte{0x01}, msg)
-
-	sent, err = bToA.SendMessage(1, []byte{0x02})
-	require.NoError(t, err)
-	require.True(t, sent)
-
-	ch, msg, err = aToB.ReceiveMessage()
-	require.NoError(t, err)
-	require.EqualValues(t, 1, ch)
-	require.EqualValues(t, []byte{0x02}, msg)
-
-	// Send and receive a message both ways a→c and c→a
-	sent, err = aToC.SendMessage(1, []byte{0x03})
-	require.NoError(t, err)
-	require.True(t, sent)
-
-	ch, msg, err = cToA.ReceiveMessage()
-	require.NoError(t, err)
-	require.EqualValues(t, 1, ch)
-	require.EqualValues(t, []byte{0x03}, msg)
-
-	sent, err = cToA.SendMessage(1, []byte{0x04})
-	require.NoError(t, err)
-	require.True(t, sent)
-
-	ch, msg, err = aToC.ReceiveMessage()
-	require.NoError(t, err)
-	require.EqualValues(t, 1, ch)
-	require.EqualValues(t, []byte{0x04}, msg)
-
-	// If we close aToB, sending and receiving on either end will error.
-	err = aToB.Close()
-	require.NoError(t, err)
-
-	_, err = aToB.SendMessage(1, []byte{0x05})
-	require.Equal(t, io.EOF, err)
-
-	_, _, err = aToB.ReceiveMessage()
-	require.Equal(t, io.EOF, err)
-
-	_, err = bToA.SendMessage(1, []byte{0x06})
-	require.Equal(t, io.EOF, err)
-
-	_, _, err = bToA.ReceiveMessage()
-	require.Equal(t, io.EOF, err)
-
-	// We can still send aToC.
-	sent, err = aToC.SendMessage(1, []byte{0x07})
-	require.NoError(t, err)
-	require.True(t, sent)
-
-	ch, msg, err = cToA.ReceiveMessage()
-	require.NoError(t, err)
-	require.EqualValues(t, 1, ch)
-	require.EqualValues(t, []byte{0x07}, msg)
-
-	// If we close the c transport, it will no longer accept connections,
-	// but we can still use the open connection.
-	endpoint := c.Endpoints()[0]
-	err = c.Close()
-	require.NoError(t, err)
-	require.Empty(t, c.Endpoints())
-
-	_, err = a.Dial(ctx, endpoint)
-	require.Error(t, err)
-
-	sent, err = aToC.SendMessage(1, []byte{0x08})
-	require.NoError(t, err)
-	require.True(t, sent)
-
-	ch, msg, err = cToA.ReceiveMessage()
-	require.NoError(t, err)
-	require.EqualValues(t, 1, ch)
-	require.EqualValues(t, []byte{0x08}, msg)
 }

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -110,6 +110,12 @@ func TestTransport_DialEndpoints(t *testing.T) {
 		_, err = a.Dial(ctx, noProtocol)
 		require.Error(t, err)
 
+		// Dialing with invalid protocol should error.
+		fooProtocol := endpoint
+		fooProtocol.Protocol = "foo"
+		_, err = a.Dial(ctx, fooProtocol)
+		require.Error(t, err)
+
 		// Tests for networked endpoints (with IP).
 		if len(endpoint.IP) > 0 {
 			for _, tc := range ipTestCases {

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -1,0 +1,140 @@
+package p2p
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoint_PeerAddress(t *testing.T) {
+	var (
+		ip4    = []byte{1, 2, 3, 4}
+		ip4in6 = net.IPv4(1, 2, 3, 4)
+		ip6    = []byte{0xb1, 0x0c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+	)
+
+	testcases := []struct {
+		endpoint Endpoint
+		expect   PeerAddress
+	}{
+		// Valid endpoints.
+		{
+			Endpoint{Protocol: "tcp", IP: ip4, Port: 8080, Path: "path"},
+			PeerAddress{Protocol: "tcp", Hostname: "1.2.3.4", Port: 8080, Path: "path"},
+		},
+		{
+			Endpoint{Protocol: "tcp", IP: ip4in6, Port: 8080, Path: "path"},
+			PeerAddress{Protocol: "tcp", Hostname: "1.2.3.4", Port: 8080, Path: "path"},
+		},
+		{
+			Endpoint{Protocol: "tcp", IP: ip6, Port: 8080, Path: "path"},
+			PeerAddress{Protocol: "tcp", Hostname: "b10c::1", Port: 8080, Path: "path"},
+		},
+		{
+			Endpoint{Protocol: "memory", Path: "foo"},
+			PeerAddress{Protocol: "memory", Path: "foo"},
+		},
+
+		// Partial (invalid) endpoints.
+		{Endpoint{}, PeerAddress{}},
+		{Endpoint{Protocol: "tcp"}, PeerAddress{Protocol: "tcp"}},
+		{Endpoint{IP: net.IPv4(1, 2, 3, 4)}, PeerAddress{Hostname: "1.2.3.4"}},
+		{Endpoint{Port: 8080}, PeerAddress{}},
+		{Endpoint{Path: "path"}, PeerAddress{Path: "path"}},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.endpoint.String(), func(t *testing.T) {
+			// Without NodeID.
+			expect := tc.expect
+			require.Equal(t, expect, tc.endpoint.PeerAddress(""))
+
+			// With NodeID.
+			expect.NodeID = NodeID("b10c")
+			require.Equal(t, expect, tc.endpoint.PeerAddress(expect.NodeID))
+		})
+	}
+}
+
+func TestEndpoint_String(t *testing.T) {
+	var (
+		ip4    = []byte{1, 2, 3, 4}
+		ip4in6 = net.IPv4(1, 2, 3, 4)
+		ip6    = []byte{0xb1, 0x0c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+	)
+
+	testcases := []struct {
+		endpoint Endpoint
+		expect   string
+	}{
+		// Non-networked endpoints.
+		{Endpoint{Protocol: "memory", Path: "foo"}, "memory:foo"},
+		{Endpoint{Protocol: "memory", Path: "👋"}, "memory:👋"},
+
+		// IPv4 endpoints.
+		{Endpoint{Protocol: "tcp", IP: ip4}, "tcp://1.2.3.4"},
+		{Endpoint{Protocol: "tcp", IP: ip4in6}, "tcp://1.2.3.4"},
+		{Endpoint{Protocol: "tcp", IP: ip4, Port: 8080}, "tcp://1.2.3.4:8080"},
+		{Endpoint{Protocol: "tcp", IP: ip4, Port: 8080, Path: "/path"}, "tcp://1.2.3.4:8080/path"},
+		{Endpoint{Protocol: "tcp", IP: ip4, Path: "path/👋"}, "tcp://1.2.3.4/path/%F0%9F%91%8B"},
+
+		// IPv6 endpoints.
+		{Endpoint{Protocol: "tcp", IP: ip6}, "tcp://b10c::1"},
+		{Endpoint{Protocol: "tcp", IP: ip6, Port: 8080}, "tcp://[b10c::1]:8080"},
+		{Endpoint{Protocol: "tcp", IP: ip6, Port: 8080, Path: "/path"}, "tcp://[b10c::1]:8080/path"},
+		{Endpoint{Protocol: "tcp", IP: ip6, Path: "path/👋"}, "tcp://b10c::1/path/%F0%9F%91%8B"},
+
+		// Partial (invalid) endpoints.
+		{Endpoint{}, ""},
+		{Endpoint{Protocol: "tcp"}, "tcp:"},
+		{Endpoint{IP: []byte{1, 2, 3, 4}}, "1.2.3.4"},
+		{Endpoint{IP: []byte{0xb1, 0x0c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}}, "b10c::1"},
+		{Endpoint{Port: 8080}, ""},
+		{Endpoint{Path: "foo"}, "/foo"},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.expect, func(t *testing.T) {
+			require.Equal(t, tc.expect, tc.endpoint.String())
+		})
+	}
+}
+
+func TestEndpoint_Validate(t *testing.T) {
+	var (
+		ip4    = []byte{1, 2, 3, 4}
+		ip4in6 = net.IPv4(1, 2, 3, 4)
+		ip6    = []byte{0xb1, 0x0c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+	)
+
+	testcases := []struct {
+		endpoint    Endpoint
+		expectValid bool
+	}{
+		// Valid endpoints.
+		{Endpoint{Protocol: "tcp", IP: ip4}, true},
+		{Endpoint{Protocol: "tcp", IP: ip4in6}, true},
+		{Endpoint{Protocol: "tcp", IP: ip6}, true},
+		{Endpoint{Protocol: "tcp", IP: ip4, Port: 8008}, true},
+		{Endpoint{Protocol: "tcp", IP: ip4, Port: 8080, Path: "path"}, true},
+		{Endpoint{Protocol: "memory", Path: "path"}, true},
+
+		// Invalid endpoints.
+		{Endpoint{}, false},
+		{Endpoint{IP: ip4}, false},
+		{Endpoint{Protocol: "tcp", IP: []byte{1, 2, 3}}, false},
+		{Endpoint{Protocol: "tcp", Port: 8080, Path: "path"}, false},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.endpoint.String(), func(t *testing.T) {
+			err := tc.endpoint.Validate()
+			if tc.expectValid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -580,8 +580,8 @@ func dialAccept(t *testing.T, a, b p2p.Transport) (p2p.Connection, p2p.Connectio
 	require.NoError(t, <-errCh)
 
 	t.Cleanup(func() {
-		require.NoError(t, dialConn.Close())
-		require.NoError(t, acceptConn.Close())
+		_ = dialConn.Close()
+		_ = acceptConn.Close()
 	})
 
 	return dialConn, acceptConn

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
@@ -251,10 +250,7 @@ func TestConnection_Handshake(t *testing.T) {
 		bKey := ed25519.GenPrivKey()
 		bInfo := p2p.NodeInfo{NodeID: p2p.NodeIDFromPubKey(bKey.PubKey())}
 
-		var wg sync.WaitGroup
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
 			// Must use assert due to goroutine.
 			peerInfo, peerKey, err := ba.Handshake(ctx, bInfo, bKey)
 			if assert.NoError(t, err) {
@@ -267,8 +263,6 @@ func TestConnection_Handshake(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, bInfo, peerInfo)
 		require.Equal(t, bKey.PubKey(), peerKey)
-
-		wg.Wait()
 	})
 }
 

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -51,13 +51,13 @@ func TestTransport_AcceptClose(t *testing.T) {
 			errCh <- a.Close()
 		}()
 
-		_, err := a.Accept(ctx)
+		_, err := a.Accept()
 		require.Error(t, err)
 		require.Equal(t, io.EOF, err)
 		require.NoError(t, <-errCh)
 
 		// Closed transport should return error immediately.
-		_, err = a.Accept(ctx)
+		_, err = a.Accept()
 		require.Error(t, err)
 		require.Equal(t, io.EOF, err)
 	})
@@ -87,7 +87,7 @@ func TestTransport_DialEndpoints(t *testing.T) {
 		// Spawn a goroutine to simply accept any connections until closed.
 		go func() {
 			for {
-				conn, err := a.Accept(ctx)
+				conn, err := a.Accept()
 				if err != nil {
 					return
 				}
@@ -568,7 +568,7 @@ func dialAccept(t *testing.T, a, b p2p.Transport) (p2p.Connection, p2p.Connectio
 	acceptCh := make(chan p2p.Connection, 1)
 	errCh := make(chan error, 1)
 	go func() {
-		conn, err := b.Accept(ctx)
+		conn, err := b.Accept()
 		errCh <- err
 		acceptCh <- conn
 	}()

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -1,11 +1,120 @@
-package p2p
+package p2p_test
 
 import (
+	"context"
 	"net"
+	"sync"
 	"testing"
 
+	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/libs/bytes"
+	"github.com/tendermint/tendermint/p2p"
 )
+
+// transportFactory is used to set up transports for tests.
+type transportFactory func(t *testing.T) p2p.Transport
+
+var (
+	// ctx is a convenience context, to avoid creating it in tests.
+	ctx = context.Background()
+
+	// transportFactories contains registered transports for testTransports().
+	transportFactories = map[string]transportFactory{}
+)
+
+// testTransports is a test helper that runs a test against all
+// transports registered in transportFactories.
+func testTransports(t *testing.T, tester func(*testing.T, transportFactory)) {
+	t.Helper()
+	for name, transportFactory := range transportFactories {
+		transportFactory := transportFactory
+		t.Run(name, func(t *testing.T) {
+			defer leaktest.Check(t)
+			tester(t, transportFactory)
+		})
+	}
+}
+
+// dialAccept is a helper that dials b from a and returns both sides of the
+// connection.
+func dialAccept(t *testing.T, a, b p2p.Transport) (p2p.Connection, p2p.Connection) {
+	t.Helper()
+
+	endpoints := b.Endpoints()
+	require.NotEmpty(t, endpoints, "peer not listening on any endpoints")
+
+	acceptCh := make(chan p2p.Connection, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := b.Accept(ctx)
+		errCh <- err
+		acceptCh <- conn
+	}()
+
+	dialConn, err := a.Dial(ctx, endpoints[0])
+	require.NoError(t, err)
+
+	acceptConn := <-acceptCh
+	require.NoError(t, <-errCh)
+
+	return dialConn, acceptConn
+}
+
+func TestTransport_DialAcceptHandshake(t *testing.T) {
+	testTransports(t, func(t *testing.T, newTransport transportFactory) {
+		a := newTransport(t)
+		b := newTransport(t)
+
+		ab, ba := dialAccept(t, a, b)
+
+		// Both ends should have corresponding endpoints.
+		require.NotEmpty(t, ab.LocalEndpoint())
+		require.NotEmpty(t, ba.LocalEndpoint())
+		require.Equal(t, ab.LocalEndpoint(), ba.RemoteEndpoint())
+		require.Equal(t, ab.RemoteEndpoint(), ba.LocalEndpoint())
+
+		// We should be able to handshake.
+		aKey := ed25519.GenPrivKey()
+		aInfo := p2p.NodeInfo{
+			NodeID:          p2p.NodeIDFromPubKey(aKey.PubKey()),
+			ProtocolVersion: p2p.NewProtocolVersion(1, 2, 3),
+			ListenAddr:      "listenaddr",
+			Network:         "network",
+			Version:         "1.2.3",
+			Channels:        bytes.HexBytes([]byte{0xf0, 0x0f}),
+			Moniker:         "moniker",
+			Other: p2p.NodeInfoOther{
+				TxIndex:    "txindex",
+				RPCAddress: "rpc.domain.com",
+			},
+		}
+		bKey := ed25519.GenPrivKey()
+		bInfo := p2p.NodeInfo{NodeID: p2p.NodeIDFromPubKey(bKey.PubKey())}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// must use assert due to goroutine
+			peerInfo, peerKey, err := ba.Handshake(ctx, bInfo, bKey)
+			if assert.NoError(t, err) {
+				assert.Equal(t, aInfo, peerInfo)
+				assert.Equal(t, aKey.PubKey(), peerKey)
+			}
+		}()
+
+		peerInfo, peerKey, err := ab.Handshake(ctx, aInfo, aKey)
+		require.NoError(t, err)
+		require.Equal(t, bInfo, peerInfo)
+		require.Equal(t, bKey.PubKey(), peerKey)
+
+		wg.Wait()
+	})
+}
 
 func TestEndpoint_PeerAddress(t *testing.T) {
 	var (
@@ -15,33 +124,33 @@ func TestEndpoint_PeerAddress(t *testing.T) {
 	)
 
 	testcases := []struct {
-		endpoint Endpoint
-		expect   PeerAddress
+		endpoint p2p.Endpoint
+		expect   p2p.PeerAddress
 	}{
 		// Valid endpoints.
 		{
-			Endpoint{Protocol: "tcp", IP: ip4, Port: 8080, Path: "path"},
-			PeerAddress{Protocol: "tcp", Hostname: "1.2.3.4", Port: 8080, Path: "path"},
+			p2p.Endpoint{Protocol: "tcp", IP: ip4, Port: 8080, Path: "path"},
+			p2p.PeerAddress{Protocol: "tcp", Hostname: "1.2.3.4", Port: 8080, Path: "path"},
 		},
 		{
-			Endpoint{Protocol: "tcp", IP: ip4in6, Port: 8080, Path: "path"},
-			PeerAddress{Protocol: "tcp", Hostname: "1.2.3.4", Port: 8080, Path: "path"},
+			p2p.Endpoint{Protocol: "tcp", IP: ip4in6, Port: 8080, Path: "path"},
+			p2p.PeerAddress{Protocol: "tcp", Hostname: "1.2.3.4", Port: 8080, Path: "path"},
 		},
 		{
-			Endpoint{Protocol: "tcp", IP: ip6, Port: 8080, Path: "path"},
-			PeerAddress{Protocol: "tcp", Hostname: "b10c::1", Port: 8080, Path: "path"},
+			p2p.Endpoint{Protocol: "tcp", IP: ip6, Port: 8080, Path: "path"},
+			p2p.PeerAddress{Protocol: "tcp", Hostname: "b10c::1", Port: 8080, Path: "path"},
 		},
 		{
-			Endpoint{Protocol: "memory", Path: "foo"},
-			PeerAddress{Protocol: "memory", Path: "foo"},
+			p2p.Endpoint{Protocol: "memory", Path: "foo"},
+			p2p.PeerAddress{Protocol: "memory", Path: "foo"},
 		},
 
 		// Partial (invalid) endpoints.
-		{Endpoint{}, PeerAddress{}},
-		{Endpoint{Protocol: "tcp"}, PeerAddress{Protocol: "tcp"}},
-		{Endpoint{IP: net.IPv4(1, 2, 3, 4)}, PeerAddress{Hostname: "1.2.3.4"}},
-		{Endpoint{Port: 8080}, PeerAddress{}},
-		{Endpoint{Path: "path"}, PeerAddress{Path: "path"}},
+		{p2p.Endpoint{}, p2p.PeerAddress{}},
+		{p2p.Endpoint{Protocol: "tcp"}, p2p.PeerAddress{Protocol: "tcp"}},
+		{p2p.Endpoint{IP: net.IPv4(1, 2, 3, 4)}, p2p.PeerAddress{Hostname: "1.2.3.4"}},
+		{p2p.Endpoint{Port: 8080}, p2p.PeerAddress{}},
+		{p2p.Endpoint{Path: "path"}, p2p.PeerAddress{Path: "path"}},
 	}
 	for _, tc := range testcases {
 		tc := tc
@@ -51,7 +160,7 @@ func TestEndpoint_PeerAddress(t *testing.T) {
 			require.Equal(t, expect, tc.endpoint.PeerAddress(""))
 
 			// With NodeID.
-			expect.NodeID = NodeID("b10c")
+			expect.NodeID = p2p.NodeID("b10c")
 			require.Equal(t, expect, tc.endpoint.PeerAddress(expect.NodeID))
 		})
 	}
@@ -65,33 +174,33 @@ func TestEndpoint_String(t *testing.T) {
 	)
 
 	testcases := []struct {
-		endpoint Endpoint
+		endpoint p2p.Endpoint
 		expect   string
 	}{
 		// Non-networked endpoints.
-		{Endpoint{Protocol: "memory", Path: "foo"}, "memory:foo"},
-		{Endpoint{Protocol: "memory", Path: "👋"}, "memory:👋"},
+		{p2p.Endpoint{Protocol: "memory", Path: "foo"}, "memory:foo"},
+		{p2p.Endpoint{Protocol: "memory", Path: "👋"}, "memory:👋"},
 
 		// IPv4 endpoints.
-		{Endpoint{Protocol: "tcp", IP: ip4}, "tcp://1.2.3.4"},
-		{Endpoint{Protocol: "tcp", IP: ip4in6}, "tcp://1.2.3.4"},
-		{Endpoint{Protocol: "tcp", IP: ip4, Port: 8080}, "tcp://1.2.3.4:8080"},
-		{Endpoint{Protocol: "tcp", IP: ip4, Port: 8080, Path: "/path"}, "tcp://1.2.3.4:8080/path"},
-		{Endpoint{Protocol: "tcp", IP: ip4, Path: "path/👋"}, "tcp://1.2.3.4/path/%F0%9F%91%8B"},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip4}, "tcp://1.2.3.4"},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip4in6}, "tcp://1.2.3.4"},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip4, Port: 8080}, "tcp://1.2.3.4:8080"},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip4, Port: 8080, Path: "/path"}, "tcp://1.2.3.4:8080/path"},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip4, Path: "path/👋"}, "tcp://1.2.3.4/path/%F0%9F%91%8B"},
 
 		// IPv6 endpoints.
-		{Endpoint{Protocol: "tcp", IP: ip6}, "tcp://b10c::1"},
-		{Endpoint{Protocol: "tcp", IP: ip6, Port: 8080}, "tcp://[b10c::1]:8080"},
-		{Endpoint{Protocol: "tcp", IP: ip6, Port: 8080, Path: "/path"}, "tcp://[b10c::1]:8080/path"},
-		{Endpoint{Protocol: "tcp", IP: ip6, Path: "path/👋"}, "tcp://b10c::1/path/%F0%9F%91%8B"},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip6}, "tcp://b10c::1"},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip6, Port: 8080}, "tcp://[b10c::1]:8080"},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip6, Port: 8080, Path: "/path"}, "tcp://[b10c::1]:8080/path"},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip6, Path: "path/👋"}, "tcp://b10c::1/path/%F0%9F%91%8B"},
 
 		// Partial (invalid) endpoints.
-		{Endpoint{}, ""},
-		{Endpoint{Protocol: "tcp"}, "tcp:"},
-		{Endpoint{IP: []byte{1, 2, 3, 4}}, "1.2.3.4"},
-		{Endpoint{IP: []byte{0xb1, 0x0c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}}, "b10c::1"},
-		{Endpoint{Port: 8080}, ""},
-		{Endpoint{Path: "foo"}, "/foo"},
+		{p2p.Endpoint{}, ""},
+		{p2p.Endpoint{Protocol: "tcp"}, "tcp:"},
+		{p2p.Endpoint{IP: []byte{1, 2, 3, 4}}, "1.2.3.4"},
+		{p2p.Endpoint{IP: []byte{0xb1, 0x0c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}}, "b10c::1"},
+		{p2p.Endpoint{Port: 8080}, ""},
+		{p2p.Endpoint{Path: "foo"}, "/foo"},
 	}
 	for _, tc := range testcases {
 		tc := tc
@@ -109,22 +218,22 @@ func TestEndpoint_Validate(t *testing.T) {
 	)
 
 	testcases := []struct {
-		endpoint    Endpoint
+		endpoint    p2p.Endpoint
 		expectValid bool
 	}{
 		// Valid endpoints.
-		{Endpoint{Protocol: "tcp", IP: ip4}, true},
-		{Endpoint{Protocol: "tcp", IP: ip4in6}, true},
-		{Endpoint{Protocol: "tcp", IP: ip6}, true},
-		{Endpoint{Protocol: "tcp", IP: ip4, Port: 8008}, true},
-		{Endpoint{Protocol: "tcp", IP: ip4, Port: 8080, Path: "path"}, true},
-		{Endpoint{Protocol: "memory", Path: "path"}, true},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip4}, true},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip4in6}, true},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip6}, true},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip4, Port: 8008}, true},
+		{p2p.Endpoint{Protocol: "tcp", IP: ip4, Port: 8080, Path: "path"}, true},
+		{p2p.Endpoint{Protocol: "memory", Path: "path"}, true},
 
 		// Invalid endpoints.
-		{Endpoint{}, false},
-		{Endpoint{IP: ip4}, false},
-		{Endpoint{Protocol: "tcp", IP: []byte{1, 2, 3}}, false},
-		{Endpoint{Protocol: "tcp", Port: 8080, Path: "path"}, false},
+		{p2p.Endpoint{}, false},
+		{p2p.Endpoint{IP: ip4}, false},
+		{p2p.Endpoint{Protocol: "tcp", IP: []byte{1, 2, 3}}, false},
+		{p2p.Endpoint{Protocol: "tcp", Port: 8080, Path: "path"}, false},
 	}
 	for _, tc := range testcases {
 		tc := tc


### PR DESCRIPTION
This tightens up the new P2P `Transport` API and infrastructure, fixes a bunch of bugs and inconsistencies, and adds tests.
