### PR TITLE
Revert "e2e: releases nightly (#5906)"

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         group: ['00', '01', '02', '03']
-          # todo: expand to multiple versions after 0.35 release
-        branch: ['master', 'v0.34.x']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -23,8 +21,6 @@ jobs:
           go-version: '1.15'
 
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ matrix.branch}}
 
       - name: Build
         working-directory: test/e2e


### PR DESCRIPTION
This reverts commit 64961e22673a796782b0db54dab7fd06bd3aa7b4, to see if it will make the workflow dispatch trigger reappear. 

(Apologies for testing our tooling on master, but given that we're looking at branch funkiness, I think it's necessary.)
