### PR TITLE
test/e2e: increase sign/propose tolerances

### DIFF
--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -77,8 +77,12 @@ func TestValidator_Propose(t *testing.T) {
 
 		require.False(t, proposeCount == 0 && expectCount > 0,
 			"node did not propose any blocks (expected %v)", expectCount)
-		require.Less(t, expectCount-proposeCount, 5,
-			"validator missed proposing too many blocks (proposed %v out of %v)", proposeCount, expectCount)
+		if expectCount > 3 {
+			require.GreaterOrEqual(t, proposeCount, 3, "validator didn't propose even 3 blocks")
+		} else {
+			require.Equal(t, proposeCount, expectCount, "validator missed proposing blocks (proposed %v, expected %v)",
+				proposeCount, expectCount)
+		}
 	})
 }
 
@@ -116,8 +120,12 @@ func TestValidator_Sign(t *testing.T) {
 
 		require.False(t, signCount == 0 && expectCount > 0,
 			"validator did not sign any blocks (expected %v)", expectCount)
-		require.Less(t, float64(expectCount-signCount)/float64(expectCount), 0.33,
-			"validator missed signing too many blocks (signed %v out of %v)", signCount, expectCount)
+		if expectCount > 3 {
+			require.GreaterOrEqual(t, signCount, 3, "validator didn't sign even 3 blocks")
+		} else {
+			require.Equal(t, signCount, expectCount, "validator missed signing blocks (signed %v, expected %v)",
+				signCount, expectCount)
+		}
 	})
 }
 


### PR DESCRIPTION
E2E tests often fail because validators miss signing or proposing blocks. Often this is because e.g. there's a lot of disruption in the network or it takes a long time to start up all the nodes.

This changes the test criteria to only check for 3 signed/proposed blocks, rather than a fraction of the expected blocks. This should be enough to catch most issues, apart from performance problems causing nodes to miss signing/proposing, but we may want separate tests for those sorts of things.