### PR TITLE
.golangci: set locale to US for misspell linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,9 +53,9 @@ issues:
 linters-settings:
   dogsled:
     max-blank-identifiers: 3
-  maligned:
-    suggest-new: true
-  # govet:
-  #   check-shadowing: true
   golint:
     min-confidence: 0
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US


### PR DESCRIPTION
Partially addresses #6030 