### PR TITLE
.github: clean up PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,7 @@
-## Description
+Please add a description of the changes that this PR introduces and the files that
+are the most critical to review.
 
-_Please add a description of the changes that this PR introduces and the files that
-are the most critical to review._ 
-
-_If this PR fixes an open Issue, please include "Closes #XXX" 
-(where "XXX" is the Issue number) 
-so that GitHub will automatically close the Issue when this PR is merged._
+If this PR fixes an open Issue, please include "Closes #XXX" (where "XXX" is the Issue number) 
+so that GitHub will automatically close the Issue when this PR is merged.
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,8 @@
 _Please add a description of the changes that this PR introduces and the files that
 are the most critical to review._ 
 
-Closes: #XXX
+_If this PR fixes an open Issue, please include "Closes #XXX" 
+(where "XXX" is the Issue number) 
+so that GitHub will automatically close the Issue when this PR is merged._
+
 


### PR DESCRIPTION
I got tired of seeing the literal phrase "Closes #XXX" left in PR bodies. 

Also, this template isn't usually viewed as rendered markdown, so I've removed the markdown formatting and the "Description" heading (which usually gets deleted anyways). 