### PR TITLE
node: implement ADR-52 Tendermint Mode (reopened)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -43,6 +43,8 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### FEATURES
 
+- [config] Add `--mode` flag and config variable. See [ADR-52](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-052-tendermint-mode.md)
+
 ### IMPROVEMENTS
 
 - [crypto/ed25519] \#5632 Adopt zip215 `ed25519` verification. (@marbar3778)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,7 +17,10 @@ This guide provides instructions for upgrading to specific versions of Tendermin
 * `fast_sync = "v1"` is no longer supported. Please use `v2` instead.
 
 * All config parameters are now hyphen-case (also known as kebab-case) instead of snake_case. Before restarting the node make sure
-  you have updated all the variables in your `config.toml` file. 
+  you have updated all the variables in your `config.toml` file.
+
+* Added `--mode` flag and `Mode` config variable on `config.toml` for setting Mode of the Node: `fullnode` | `validator` | `seednode` (default: `fullnode`)
+  [ADR-52](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-052-tendermint-mode.md)
 
 ### CLI Changes
 
@@ -30,7 +33,7 @@ This guide provides instructions for upgrading to specific versions of Tendermin
   $ tendermint gen_node_key > $TMHOME/config/node_key.json
   ```
 
-* CLI commands and flags are all now hyphen-case instead of snake_case. 
+* CLI commands and flags are all now hyphen-case instead of snake_case.
   Make sure to adjust any scripts that calls a cli command with snake_casing
 ## v0.34.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,7 +19,7 @@ This guide provides instructions for upgrading to specific versions of Tendermin
 * All config parameters are now hyphen-case (also known as kebab-case) instead of snake_case. Before restarting the node make sure
   you have updated all the variables in your `config.toml` file.
 
-* Added `--mode` flag and `Mode` config variable on `config.toml` for setting Mode of the Node: `fullnode` | `validator` | `seednode` (default: `fullnode`)
+* Added `--mode` flag and `mode` config variable on `config.toml` for setting Mode of the Node: `fullnode` | `validator` | `seednode` (default: `fullnode`)
   [ADR-52](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-052-tendermint-mode.md)
 
 ### CLI Changes

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -25,7 +25,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("moniker", config.Moniker, "node name")
 
 	// mode flags
-	cmd.Flags().String("mode", config.Mode, "Mode of Node (fullnode | validator | seednode )")
+	cmd.Flags().String("mode", config.Mode, "node mode (fullnode | validator | seednode )")
 
 	// priv val flags
 	cmd.Flags().String(

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -105,9 +105,6 @@ func NewRunNodeCmd(nodeProvider nm.Provider) *cobra.Command {
 		Use:     "start",
 		Aliases: []string{"node", "run"},
 		Short:   "Run the tendermint node",
-		Long: `Run the tendermint node
-
-need to set "--mode validator" to run the node as validator`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := checkGenesisHash(config); err != nil {
 				return err

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -24,6 +24,9 @@ func AddNodeFlags(cmd *cobra.Command) {
 	// bind flags
 	cmd.Flags().String("moniker", config.Moniker, "node name")
 
+	// mode flags
+	cmd.Flags().String("mode", config.Mode, "Mode of Node (fullnode | validator | seednode )")
+
 	// priv val flags
 	cmd.Flags().String(
 		"priv-validator-laddr",
@@ -102,6 +105,9 @@ func NewRunNodeCmd(nodeProvider nm.Provider) *cobra.Command {
 		Use:     "start",
 		Aliases: []string{"node", "run"},
 		Short:   "Run the tendermint node",
+		Long: `Run the tendermint node
+
+need to set "--mode validator" to run the node as validator`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := checkGenesisHash(config); err != nil {
 				return err

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -25,7 +25,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("moniker", config.Moniker, "node name")
 
 	// mode flags
-	cmd.Flags().String("mode", config.Mode, "node mode (fullnode | validator | seednode )")
+	cmd.Flags().String("mode", config.Mode, "node mode (fullnode | validator | seednode)")
 
 	// priv val flags
 	cmd.Flags().String(

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -104,7 +104,9 @@ func testnetFiles(cmd *cobra.Command, args []string) error {
 		)
 	}
 
+	// set mode to validator for testnet
 	config := cfg.DefaultConfig()
+	config.Mode = cfg.ModeValidator
 
 	// overwrite default config if set and valid
 	if configFile != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -345,7 +345,7 @@ func (cfg BaseConfig) ValidateBasic() error {
 	switch cfg.Mode {
 	case ModeFullNode, ModeValidator, ModeSeedNode:
 	default:
-		return fmt.Errorf("unknown mode: %v". cfg.Mode)
+		return fmt.Errorf("unknown mode: %v", cfg.Mode)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -345,7 +345,7 @@ func (cfg BaseConfig) ValidateBasic() error {
 	switch cfg.Mode {
 	case ModeFullNode, ModeValidator, ModeSeedNode:
 	default:
-		return errors.New("unknown mode (must be 'fullnode' or 'validator' or 'seednode')")
+		return fmt.Errorf("unknown mode: %v". cfg.Mode)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -174,6 +174,7 @@ type BaseConfig struct { //nolint: maligned
 	// * seednode
 	//   - only P2P, PEX Reactor
 	//   - No priv_validator_key.json, priv_validator_state.json
+	//   - It automatically set seed-mode to true
 	Mode string `mapstructure:"mode"`
 
 	// If this node is many blocks behind the tip of the chain, FastSync
@@ -585,6 +586,7 @@ type P2PConfig struct { //nolint: maligned
 	// peers. If another node asks it for addresses, it responds and disconnects.
 	//
 	// Does not work if the peer-exchange reactor is disabled.
+	// automatically set true if Mode of the node is seednode
 	SeedMode bool `mapstructure:"seed-mode"`
 
 	// Comma separated list of peer IDs to keep private (will not be gossiped to

--- a/config/toml.go
+++ b/config/toml.go
@@ -99,6 +99,7 @@ moniker = "{{ .BaseConfig.Moniker }}"
 # * seednode
 #   - only P2P, PEX Reactor
 #   - No priv_validator_key.json, priv_validator_state.json
+#   - It automatically set seed-mode to true
 mode = "{{ .BaseConfig.Mode }}"
 
 # If this node is many blocks behind the tip of the chain, FastSync
@@ -322,6 +323,7 @@ pex = {{ .P2P.PexReactor }}
 # peers. If another node asks it for addresses, it responds and disconnects.
 #
 # Does not work if the peer-exchange reactor is disabled.
+# automatically set true if Mode of the node is seednode
 seed-mode = {{ .P2P.SeedMode }}
 
 # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)

--- a/config/toml.go
+++ b/config/toml.go
@@ -88,6 +88,19 @@ proxy-app = "{{ .BaseConfig.ProxyApp }}"
 # A custom human readable name for this node
 moniker = "{{ .BaseConfig.Moniker }}"
 
+# Mode of Node: fullnode | validator | seednode (default: "fullnode")
+# Default value is fullnode, so you need to set it to "validator" if you want to run the node as validator
+# * fullnode (default)
+#   - all reactors
+#   - No priv_validator_key.json, priv_validator_state.json
+# * validator
+#   - all reactors
+#   - with priv_validator_key.json, priv_validator_state.json
+# * seednode
+#   - only P2P, PEX Reactor
+#   - No priv_validator_key.json, priv_validator_state.json
+mode = "{{ .BaseConfig.Mode }}"
+
 # If this node is many blocks behind the tip of the chain, FastSync
 # allows them to catchup quickly by downloading blocks in parallel
 # and verifying their commits

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -89,7 +89,7 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	consensusState := NewState(config.Consensus, state.Copy(), blockExec, blockStore, mempool, evpool)
 	consensusState.SetLogger(logger)
 	consensusState.SetEventBus(eventBus)
-	if privValidator != nil {
+	if privValidator != nil && privValidator != (*privval.FilePV)(nil) {
 		consensusState.SetPrivValidator(privValidator)
 	}
 	// END OF COPY PASTE

--- a/docs/architecture/adr-052-tendermint-mode.md
+++ b/docs/architecture/adr-052-tendermint-mode.md
@@ -7,9 +7,9 @@
 
 ## Context
 
-- Fullnode mode: fullnode mode does not have the capability to become a validator. 
+- Fullnode mode: fullnode mode does not have the capability to become a validator.
 - Validator mode : this mode is exactly same as existing state machine behavior. sync without voting on consensus, and participate consensus when fully synced
-- Seed mode : lightweight seed mode maintaining an address book, p2p like [TenderSeed](https://gitlab.com/polychainlabs/tenderseed)
+- Seednode mode : lightweight seed node mode maintaining an address book, p2p like [TenderSeed](https://gitlab.com/polychainlabs/tenderseed)
 
 ## Decision
 
@@ -24,6 +24,7 @@ We would like to suggest a simple Tendermint mode abstraction. These modes will 
           - evidence
           - blockchain
           - p2p/pex
+          - statesync
         - rpc (safe connections only)
         - *~~no privValidator(priv_validator_key.json, priv_validator_state.json)~~*
     - validator
@@ -33,10 +34,11 @@ We would like to suggest a simple Tendermint mode abstraction. These modes will 
           - consensus
           - evidence
           - blockchain
-          - p2p/pex
+          - p2p/pex
+          - statesync
         - rpc (safe connections only)
         - with privValidator(priv_validator_key.json, priv_validator_state.json)
-    - seed
+    - seednode
         - switch, transport
         - reactor
            - p2p/pex
@@ -44,17 +46,17 @@ We would like to suggest a simple Tendermint mode abstraction. These modes will 
     - We would like to suggest by introducing `mode` parameter in `config.toml` and cli
     - <span v-pre>`mode = "{{ .BaseConfig.Mode }}"`</span> in `config.toml`
     - `tendermint node --mode validator`  in cli
-    - fullnode | validator | seed (default: "fullnode")
+    - fullnode | validator | seednode (default: "fullnode")
 - RPC modification
     - `host:26657/status`
         - return empty `validator_info` when fullnode mode
-    - no rpc server in seed mode
+    - no rpc server in seednode
 - Where to modify in codebase
     - Add  switch for `config.Mode` on `node/node.go:DefaultNewNode`
     - If `config.Mode==validator`, call default `NewNode` (current logic)
     - If `config.Mode==fullnode`, call `NewNode` with `nil` `privValidator` (do not load or generation)
         - Need to add exception routine for `nil` `privValidator` to related functions
-    - If `config.Mode==seed`, call `NewSeedNode` (seed version of `node/node.go:NewNode`)
+    - If `config.Mode==seednode`, call `NewSeedNode` (seed node version of `node/node.go:NewNode`)
         - Need to add exception routine for `nil` `reactor`, `component` to related functions
 
 ## Status

--- a/docs/nodes/configuration.md
+++ b/docs/nodes/configuration.md
@@ -41,6 +41,19 @@ moniker = "anonymous"
 # and verifying their commits
 fast-sync = true
 
+# Mode of Node: fullnode | validator | seednode
+# Default value is fullnode, so you need to set it to "validator" if you want to run the node as validator
+# * fullnode (default)
+#   - all reactors
+#   - No priv_validator_key.json, priv_validator_state.json
+# * validator
+#   - all reactors
+#   - with priv_validator_key.json, priv_validator_state.json
+# * seednode
+#   - only P2P, PEX Reactor
+#   - No priv_validator_key.json, priv_validator_state.json
+mode = "fullnode"
+
 # Database backend: goleveldb | cleveldb | boltdb | rocksdb | badgerdb
 # * goleveldb (github.com/syndtr/goleveldb - most popular implementation)
 #   - pure go

--- a/docs/nodes/configuration.md
+++ b/docs/nodes/configuration.md
@@ -52,6 +52,7 @@ fast-sync = true
 # * seednode
 #   - only P2P, PEX Reactor
 #   - No priv_validator_key.json, priv_validator_state.json
+#   - It automatically set seed-mode to true
 mode = "fullnode"
 
 # Database backend: goleveldb | cleveldb | boltdb | rocksdb | badgerdb
@@ -259,6 +260,7 @@ pex = true
 # peers. If another node asks it for addresses, it responds and disconnects.
 #
 # Does not work if the peer-exchange reactor is disabled.
+# automatically set true if Mode of the node is seednode
 seed-mode = false
 
 # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)

--- a/docs/nodes/validators.md
+++ b/docs/nodes/validators.md
@@ -56,7 +56,7 @@ The validator will only talk to the sentry that are provided, the sentry nodes w
 
 When initializing nodes there are five parameters in the `config.toml` that may need to be altered.
 
-- `mode:` (fullnode | validator | seednode) Mode of node, Default value is fullnode so you need to set it to `validator` if you want to run the node as validator, When set to `fullnode`, the privValidator is disabled. When set to `seednode`, only p2p and pex reactor are used.
+- `mode:` (fullnode | validator | seednode) Mode of node (default: 'fullnode'). If you want to run the node as validator, change it to 'validator'.
 - `pex:` boolean. This turns the peer exchange reactor on or off for a node. When `pex=false`, only the `persistent-peers` list is available for connection.
 - `persistent-peers:` a comma separated list of `nodeID@ip:port` values that define a list of peers that are expected to be online at all times. This is necessary at first startup because by setting `pex=false` the node will not be able to join the network.
 - `unconditional-peer-ids:` comma separated list of nodeID's. These nodes will be connected to no matter the limits of inbound and outbound peers. This is useful for when sentry nodes have full address books.
@@ -76,7 +76,7 @@ When initializing nodes there are five parameters in the `config.toml` that may 
 | addr-book-strict         | false                      |
 | double-sign-check-height | 10                         |
 
-To run the node as validator must set `mode=validator`, The validator node should have `pex=false` so it does not gossip to the entire network. The persistent peers will be your sentry nodes. Private peers can be left empty as the validator is not trying to hide who it is communicating with. Setting unconditional peers is optional for a validator because they will not have a full address books.
+To run the node as validator ensure `mode=validator`. The validator node should have `pex=false` so it does not gossip to the entire network. The persistent peers will be your sentry nodes. Private peers can be left empty as the validator is not trying to hide who it is communicating with. Setting unconditional peers is optional for a validator because they will not have a full address books.
 
 #### Sentry Node Configuration
 

--- a/docs/nodes/validators.md
+++ b/docs/nodes/validators.md
@@ -56,6 +56,7 @@ The validator will only talk to the sentry that are provided, the sentry nodes w
 
 When initializing nodes there are five parameters in the `config.toml` that may need to be altered.
 
+- `mode:` (fullnode | validator | seednode) Mode of node, Default value is fullnode so you need to set it to `validator` if you want to run the node as validator, When set to `fullnode`, the privValidator is disabled. When set to `seednode`, only p2p and pex reactor are used.
 - `pex:` boolean. This turns the peer exchange reactor on or off for a node. When `pex=false`, only the `persistent-peers` list is available for connection.
 - `persistent-peers:` a comma separated list of `nodeID@ip:port` values that define a list of peers that are expected to be online at all times. This is necessary at first startup because by setting `pex=false` the node will not be able to join the network.
 - `unconditional-peer-ids:` comma separated list of nodeID's. These nodes will be connected to no matter the limits of inbound and outbound peers. This is useful for when sentry nodes have full address books.
@@ -67,6 +68,7 @@ When initializing nodes there are five parameters in the `config.toml` that may 
 
 | Config Option            | Setting                    |
 | ------------------------ | -------------------------- |
+| mode                     | validator                  |
 | pex                      | false                      |
 | persistent-peers         | list of sentry nodes       |
 | private-peer-ids         | none                       |
@@ -74,12 +76,13 @@ When initializing nodes there are five parameters in the `config.toml` that may 
 | addr-book-strict         | false                      |
 | double-sign-check-height | 10                         |
 
-The validator node should have `pex=false` so it does not gossip to the entire network. The persistent peers will be your sentry nodes. Private peers can be left empty as the validator is not trying to hide who it is communicating with. Setting unconditional peers is optional for a validator because they will not have a full address books.
+To run the node as validator must set `mode=validator`, The validator node should have `pex=false` so it does not gossip to the entire network. The persistent peers will be your sentry nodes. Private peers can be left empty as the validator is not trying to hide who it is communicating with. Setting unconditional peers is optional for a validator because they will not have a full address books.
 
 #### Sentry Node Configuration
 
 | Config Option          | Setting                                       |
 | ---------------------- | --------------------------------------------- |
+| mode                   | fullnode                                      |
 | pex                    | true                                          |
 | persistent-peers       | validator node, optionally other sentry nodes |
 | private-peer-ids       | validator node ID                             |

--- a/networks/remote/integration.sh
+++ b/networks/remote/integration.sh
@@ -124,7 +124,7 @@ Restart=on-failure
 User={{service}}
 Group={{service}}
 PermissionsStartOnly=true
-ExecStart=/usr/bin/tendermint node --proxy-app=kvstore --p2p.persistent-peers=$id0@$ip0:26656,$id1@$ip1:26656,$id2@$ip2:26656,$id3@$ip3:26656
+ExecStart=/usr/bin/tendermint node --mode validator --proxy-app=kvstore --p2p.persistent-peers=$id0@$ip0:26656,$id1@$ip1:26656,$id2@$ip2:26656,$id3@$ip3:26656
 ExecReload=/bin/kill -HUP \$MAINPID
 KillSignal=SIGTERM
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -522,6 +522,29 @@ func TestNodeNewNodeCustomReactors(t *testing.T) {
 	assert.Equal(t, customBlockchainReactor, n.Switch().Reactor("BLOCKCHAIN"))
 }
 
+func TestNodeNewSeedNode(t *testing.T) {
+	config := cfg.ResetTestRoot("node_new_node_custom_reactors_test")
+	config.Mode = cfg.ModeSeedNode
+	defer os.RemoveAll(config.RootDir)
+
+	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
+	require.NoError(t, err)
+
+	n, err := NewSeedNode(config,
+		nodeKey,
+		DefaultGenesisDocProviderFunc(config),
+		DefaultDBProvider,
+		log.TestingLogger(),
+	)
+	require.NoError(t, err)
+
+	err = n.Start()
+	require.NoError(t, err)
+
+	assert.False(t, n.config.P2P.SeedMode)
+	assert.True(t, n.pexReactor.IsRunning())
+}
+
 func state(nVals int, height int64) (sm.State, dbm.DB, []types.PrivValidator) {
 	privVals := make([]types.PrivValidator, nVals)
 	vals := make([]types.GenesisValidator, nVals)

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"time"
 
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
@@ -49,7 +50,14 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 	if val := validatorAtHeight(latestUncommittedHeight()); val != nil {
 		votingPower = val.VotingPower
 	}
-
+	validatorInfo := ctypes.ValidatorInfo{}
+	if env.PubKey != nil {
+		validatorInfo = ctypes.ValidatorInfo{
+			Address:     env.PubKey.Address(),
+			PubKey:      env.PubKey,
+			VotingPower: votingPower,
+		}
+	}
 	result := &ctypes.ResultStatus{
 		NodeInfo: env.P2PTransport.NodeInfo(),
 		SyncInfo: ctypes.SyncInfo{
@@ -63,22 +71,32 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 			EarliestBlockTime:   time.Unix(0, earliestBlockTimeNano),
 			CatchingUp:          env.ConsensusReactor.WaitSync(),
 		},
-		ValidatorInfo: ctypes.ValidatorInfo{
-			Address:     env.PubKey.Address(),
-			PubKey:      env.PubKey,
-			VotingPower: votingPower,
-		},
+		ValidatorInfo: validatorInfo,
 	}
 
 	return result, nil
 }
 
 func validatorAtHeight(h int64) *types.Validator {
-	vals, err := env.StateStore.LoadValidators(h)
+	valsWithH, err := env.StateStore.LoadValidators(h)
 	if err != nil {
 		return nil
 	}
+	if env.PubKey == nil {
+		return nil
+	}
 	privValAddress := env.PubKey.Address()
-	_, val := vals.GetByAddress(privValAddress)
+
+	// If we're still at height h, search in the current validator set.
+	lastBlockHeight, vals := env.ConsensusState.GetValidators()
+	if lastBlockHeight == h {
+		for _, val := range vals {
+			if bytes.Equal(val.Address, privValAddress) {
+				return val
+			}
+		}
+	}
+
+	_, val := valsWithH.GetByAddress(privValAddress)
 	return val
 }

--- a/test/app/test.sh
+++ b/test/app/test.sh
@@ -96,7 +96,7 @@ function counter_over_grpc_grpc() {
     kill -9 $pid_counter $pid_tendermint
 }
 
-case "$1" in
+case "$1" in 
     "kvstore_over_socket")
     kvstore_over_socket
     ;;

--- a/test/app/test.sh
+++ b/test/app/test.sh
@@ -17,7 +17,7 @@ function kvstore_over_socket(){
     echo "Starting kvstore_over_socket"
     abci-cli kvstore > /dev/null &
     pid_kvstore=$!
-    tendermint start > tendermint.log &
+    tendermint start --mode validator > tendermint.log &
     pid_tendermint=$!
     sleep 5
 
@@ -32,7 +32,7 @@ function kvstore_over_socket_reorder(){
     rm -rf $TMHOME
     tendermint init
     echo "Starting kvstore_over_socket_reorder (ie. start tendermint first)"
-    tendermint start > tendermint.log &
+    tendermint start --mode validator > tendermint.log &
     pid_tendermint=$!
     sleep 2
     abci-cli kvstore > /dev/null &
@@ -52,7 +52,7 @@ function counter_over_socket() {
     echo "Starting counter_over_socket"
     abci-cli counter --serial > /dev/null &
     pid_counter=$!
-    tendermint start > tendermint.log &
+    tendermint start --mode validator > tendermint.log &
     pid_tendermint=$!
     sleep 5
 
@@ -68,7 +68,7 @@ function counter_over_grpc() {
     echo "Starting counter_over_grpc"
     abci-cli counter --serial --abci grpc > /dev/null &
     pid_counter=$!
-    tendermint start --abci grpc > tendermint.log &
+    tendermint start --mode validator --abci grpc > tendermint.log &
     pid_tendermint=$!
     sleep 5
 
@@ -86,7 +86,7 @@ function counter_over_grpc_grpc() {
     pid_counter=$!
     sleep 1
     GRPC_PORT=36656
-    tendermint start --abci grpc --rpc.grpc-laddr tcp://localhost:$GRPC_PORT > tendermint.log &
+    tendermint start --mode validator --abci grpc --rpc.grpc-laddr tcp://localhost:$GRPC_PORT > tendermint.log &
     pid_tendermint=$!
     sleep 5
 
@@ -96,7 +96,7 @@ function counter_over_grpc_grpc() {
     kill -9 $pid_counter $pid_tendermint
 }
 
-case "$1" in 
+case "$1" in
     "kvstore_over_socket")
     kvstore_over_socket
     ;;

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -25,20 +25,22 @@ validator04 = 100
 validator05 = 50
 
 [node.seed01]
-mode = "seed"
+mode = "seednode"
 seeds = ["seed02"]
 
 [node.seed02]
-mode = "seed"
+mode = "seednode"
 seeds = ["seed01"]
 
 [node.validator01]
+mode = "validator"
 seeds = ["seed01"]
 snapshot_interval = 5
 perturb = ["disconnect"]
 misbehaviors = { 1018 = "double-prevote" }
 
 [node.validator02]
+mode = "validator"
 seeds = ["seed02"]
 database = "boltdb"
 abci_protocol = "tcp"
@@ -47,6 +49,7 @@ persist_interval = 0
 perturb = ["restart"]
 
 [node.validator03]
+mode = "validator"
 seeds = ["seed01"]
 database = "badgerdb"
 # FIXME: should be grpc, disabled due to https://github.com/tendermint/tendermint/issues/5439
@@ -57,6 +60,7 @@ retain_blocks = 3
 perturb = ["kill"]
 
 [node.validator04]
+mode = "validator"
 persistent_peers = ["validator01"]
 database = "rocksdb"
 abci_protocol = "builtin"
@@ -64,6 +68,7 @@ perturb = ["pause"]
 
 [node.validator05]
 start_at = 1005 # Becomes part of the validator set at 1010
+mode = "validator"
 seeds = ["seed02"]
 database = "cleveldb"
 fast_sync = "v0"
@@ -74,7 +79,7 @@ perturb = ["kill", "pause", "disconnect", "restart"]
 
 [node.full01]
 start_at = 1010
-mode = "full"
+mode = "fullnode"
 # FIXME: should be v2, disabled due to flake
 fast_sync = "v0"
 persistent_peers = ["validator01", "validator02", "validator03", "validator04", "validator05"]
@@ -83,7 +88,7 @@ perturb = ["restart"]
 
 [node.full02]
 start_at = 1015
-mode = "full"
+mode = "fullnode"
 # FIXME: should be v2, disabled due to flake
 fast_sync = "v0"
 state_sync = true

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -58,7 +58,7 @@ type Manifest struct {
 
 // ManifestNode represents a node in a testnet manifest.
 type ManifestNode struct {
-	// Mode specifies the type of node: "validator", "full", or "seed". Defaults to
+	// Mode specifies the type of node: "validator", "fullnode", or "seednode". Defaults to
 	// "validator". Full nodes do not get a signing key (a dummy key is generated),
 	// and seed nodes run in seed mode with the PEX reactor enabled.
 	Mode string `toml:"mode"`

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -33,8 +33,8 @@ type Perturbation string
 
 const (
 	ModeValidator Mode = "validator"
-	ModeFull      Mode = "full"
-	ModeSeed      Mode = "seed"
+	ModeFull      Mode = "fullnode"
+	ModeSeed      Mode = "seednode"
 
 	ProtocolBuiltin Protocol = "builtin"
 	ProtocolFile    Protocol = "file"

--- a/test/e2e/runner/rpc.go
+++ b/test/e2e/runner/rpc.go
@@ -67,6 +67,9 @@ func waitForHeight(testnet *e2e.Testnet, height int64) (*types.Block, *types.Blo
 
 // waitForNode waits for a node to become available and catch up to the given block height.
 func waitForNode(node *e2e.Node, height int64, timeout time.Duration) (*rpctypes.ResultStatus, error) {
+	if node.Mode == e2e.ModeSeed {
+		return nil, nil
+	}
 	client, err := node.Client()
 	if err != nil {
 		return nil, err

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -246,6 +246,7 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg.P2P.AddrBookStrict = false
 	cfg.DBBackend = node.Database
 	cfg.StateSync.DiscoveryTime = 5 * time.Second
+	cfg.Mode = string(node.Mode)
 
 	switch node.ABCIProtocol {
 	case e2e.ProtocolUNIX:


### PR DESCRIPTION
## Description

Implementation spec of [Tendermint Mode ADR-52](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-052-tendermint-mode.md) by B-Harvest

Add Tendermint mode 
- Add `--mode` flag on `tendermint node` and `mode` on `config.toml` 
- [ `fullnode`, `validator`, `seednode` ]
- default is `fullnode`, except testnet

Refs
- [ADR-52](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-052-tendermint-mode.md)
- https://github.com/tendermint/tendermint/pull/4302
- https://github.com/tendermint/tendermint/issues/2237
- https://github.com/tendermint/tendermint/pull/5212

* [x]  Wrote tests
* [x]  Updated CHANGELOG_PENDING.md
* [x]  Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
* [x]  Updated relevant documentation (docs/) and code comments
* [x]  Re-reviewed Files changed in the Github PR explorer
* [ ]  Applied Appropriate Labels

----

reopened the PR https://github.com/tendermint/tendermint/pull/5212
Since the last commit of the previous PR, added the following commits according to the review
- merge latest Master branch
- [add upgrading.md](https://github.com/tendermint/tendermint/pull/5212#pullrequestreview-557358054), 
- [seednode automatically set seed_mode to true](https://github.com/tendermint/tendermint/pull/5212#discussion_r547500390)
- [simplify addReactor logic](https://github.com/tendermint/tendermint/pull/5212#discussion_r547507067)

