### PR TITLE
goreleaser: downcase archive and binary names (#6029)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-project_name: Tendermint
+project_name: tendermint
 
 env:
   # Require use of Go modules.


### PR DESCRIPTION
before:

```
Tendermint_0.34.3_darwin_amd64.tar.gz

-rw-r--r--  0 runner docker 192329 Jan 19 19:30 CHANGELOG.md
-rw-r--r--  0 runner docker    321 Jan 19 19:30 CHANGELOG_PENDING.md
-rw-r--r--  0 runner docker  11382 Jan 19 19:30 LICENSE
-rw-r--r--  0 runner docker   8165 Jan 19 19:30 README.md
-rwxr-xr-x  0 runner docker 23224320 Jan 19 19:30 tendermint
```

after:

```
tendermint_0.34.3_darwin_amd64.tar.gz

-rw-r--r--  0 runner docker 192329 Jan 19 19:30 CHANGELOG.md
-rw-r--r--  0 runner docker    321 Jan 19 19:30 CHANGELOG_PENDING.md
-rw-r--r--  0 runner docker  11382 Jan 19 19:30 LICENSE
-rw-r--r--  0 runner docker   8165 Jan 19 19:30 README.md
-rwxr-xr-x  0 runner docker 23224320 Jan 19 19:30 tendermint
```
