### PR TITLE
.golangci: remove US spelling linter setting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,5 +57,3 @@ linters-settings:
     min-confidence: 0
   maligned:
     suggest-new: true
-  misspell:
-    locale: US


### PR DESCRIPTION
![](https://media.tenor.com/images/e9c4b3780976ff48d46ca5f2242d40e8/tenor.png)