### PR TITLE
makefile: remove call to tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ build-docker: build-linux
 ###############################################################################
 
 # Build linux binary on other platforms
-build-linux: tools
+build-linux:
 	GOOS=linux GOARCH=amd64 $(MAKE) build
 .PHONY: build-linux
 


### PR DESCRIPTION
Remove mystery `tools` call, which seemed to do nothing other than change our go.mod on Linux

