### PR TITLE
backports: mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,7 +11,7 @@ pull_request_rules:
   - name: backport patches to v0.34.x branch
     conditions:
       - base=master
-      - label=backport-to-v0.34.x
+      - label=S:backport-to-v0.34.x
     actions:
       backport:
         branches:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,3 +8,11 @@ pull_request_rules:
         method: squash
         strict: true
         commit_message: title+body
+  - name: backport patches to v0.34.x branch
+    conditions:
+      - base=master
+      - label=backport-to-v0.34.x
+    actions:
+      backport:
+        branches:
+          - v0.34.x

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,7 +289,7 @@ the backport branches have names like `v0.34.x` or `v0.33.x` (literally, `x`; it
 
 As non-breaking changes land on `master`, they should also be backported (cherry-picked) to these backport branches.
 
-We use mergify's backport feature to automatically backport to the needed branch. Depending on which backport branch you need to backport to there will be labels for them. To notify the bot to backport a pull request, mark the pull request with the label `backport-to-<backport_branch>`. Once the original pull request is merged the bot will try to cherry-pick the pull request to the backport branch. If the bot fails to backport, it will open a pull request. The author of the original pull request is responsible for solving the conflicts and merging the pull request.
+We use Mergify's [backport feature](https://mergify.io/features/backports) to automatically backport to the needed branch. Depending on which backport branch you need to backport to there will be labels for them. To notify the bot to backport a pull request, mark the pull request with the label `backport-to-<backport_branch>`. Once the original pull request is merged, the bot will try to cherry-pick the pull request to the backport branch. If the bot fails to backport, it will open a pull request. The author of the original pull request is responsible for solving the conflicts and merging the pull request.
 
 Minor releases don't have release candidates by default, although any tricky changes may merit a release candidate.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,7 +289,7 @@ the backport branches have names like `v0.34.x` or `v0.33.x` (literally, `x`; it
 
 As non-breaking changes land on `master`, they should also be backported (cherry-picked) to these backport branches.
 
-We use mergify's backport feature to automatically backport to the needed branch. Depending on which backport brnach you need to backport to there will be labels for them. To notify the bot to backport a pull request, mark the pr with the label `backport-to-<backport_branch>`. Once the original pull request is merged the bot will try to merge the pull request into the backport branch. If the bot fails to backport, it will open a pull request. The author of the original pull request is responsible for solving the conflicts and merging the pull request.
+We use mergify's backport feature to automatically backport to the needed branch. Depending on which backport branch you need to backport to there will be labels for them. To notify the bot to backport a pull request, mark the pull request with the label `backport-to-<backport_branch>`. Once the original pull request is merged the bot will try to cherry-pick the pull request to the backport branch. If the bot fails to backport, it will open a pull request. The author of the original pull request is responsible for solving the conflicts and merging the pull request.
 
 Minor releases don't have release candidates by default, although any tricky changes may merit a release candidate.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,6 +289,8 @@ the backport branches have names like `v0.34.x` or `v0.33.x` (literally, `x`; it
 
 As non-breaking changes land on `master`, they should also be backported (cherry-picked) to these backport branches.
 
+We use mergify's backport feature to automatically backport to the needed branch. Depending on which backport brnach you need to backport to there will be labels for them. To notify the bot to backport a pull request, mark the pr with the label `backport-to-<backport_branch>`. Once the original pull request is merged the bot will try to merge the pull request into the backport branch. If the bot fails to backport, it will open a pull request. The author of the original pull request is responsible for solving the conflicts and merging the pull request.
+
 Minor releases don't have release candidates by default, although any tricky changes may merit a release candidate.
 
 To create a minor release:


### PR DESCRIPTION
## Decription

Makes the label `backport-to-v0.34.x` handle auto backports


