### PR TITLE
tests: Fix TestByzantinePrevoteEquivocation

### DIFF
--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -102,6 +102,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	for nID, s := range rts.states {
 		if s == bzNodeState {
 			bzNodeID = nID
+			break
 		}
 	}
 

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -78,7 +78,7 @@ func setup(t *testing.T, numNodes int, states []*State, size int) *reactorTestSu
 
 		reactor.SetEventBus(state.eventBus)
 
-		blocksSub, err := state.eventBus.Subscribe(context.Background(), testSubscriber, types.EventQueryNewBlock)
+		blocksSub, err := state.eventBus.Subscribe(context.Background(), testSubscriber, types.EventQueryNewBlock, size)
 		require.NoError(t, err)
 
 		rts.states[nodeID] = state


### PR DESCRIPTION
Missed setting the buffer size on the subscription. Note, this doesn't really "fix" this test (a la ref: https://github.com/tendermint/tendermint/pull/5710).

However, I spent a good chunk of time looking at this test with many logs and I'm pretty sure this is mainly due to the fact that none of the nodes get the conflicting vote in time.

closes: #6127