### PR TITLE
.github: [jepsen] source .bashrc

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -45,4 +45,4 @@ jobs:
         run: ./bin/up --daemon
 
       - name: Run the test
-        run: docker exec -i jepsen-control bash -c 'cd /jepsen/tendermint; lein run test --nemesis ${{ github.event.inputs.nemesis }} --workload ${{ github.event.inputs.workload }} --concurrency ${{ github.event.inputs.concurrency }} --tendermint-url ${{ github.event.inputs.tendermintUrl }} --merkleeyes-url ${{ github.event.inputs.merkleeyesUrl }} --time-limit ${{ github.event.inputs.timeLimit }} ${{ github.event.inputs.dupOrSuperByzValidators }}'
+        run: docker exec -i jepsen-control bash -c 'source /root/.bashrc; cd /jepsen/tendermint; lein run test --nemesis ${{ github.event.inputs.nemesis }} --workload ${{ github.event.inputs.workload }} --concurrency ${{ github.event.inputs.concurrency }} --tendermint-url ${{ github.event.inputs.tendermintUrl }} --merkleeyes-url ${{ github.event.inputs.merkleeyesUrl }} --time-limit ${{ github.event.inputs.timeLimit }} ${{ github.event.inputs.dupOrSuperByzValidators }}'


### PR DESCRIPTION
fixes https://github.com/tendermint/tendermint/runs/1926771645
```
ERROR [2021-02-18 12:16:30,492] main - jepsen.cli Oh jeez, I'm sorry,
Jepsen broke. Here's why:

clojure.lang.ExceptionInfo: throw+: {:dir "/", :private-key-path nil,
:password "root", :username "root", :type :jepsen.control/session-error,
:port 22, :strict-host-key-checking false, :host nil, :sudo nil, :dummy
false, :message "Error opening SSH session. Verify username, password,
and node hostnames are correct.", :session nil}
```
