### PR TITLE
light: improve timeout functionality

### DIFF
--- a/cmd/tendermint/commands/light.go
+++ b/cmd/tendermint/commands/light.go
@@ -219,7 +219,7 @@ func runProxy(cmd *cobra.Command, args []string) error {
 
 	rpcClient, err := rpchttp.NewWithTimeout(primaryAddr, "/websocket", cfg.WriteTimeout)
 	if err != nil {
-		return fmt.Errorf("http client for %s: %w", primaryAddr, err)
+		return fmt.Errorf("failed to create http client for %s: %w", primaryAddr, err)
 	}
 
 	p := lproxy.Proxy{

--- a/cmd/tendermint/commands/light.go
+++ b/cmd/tendermint/commands/light.go
@@ -206,11 +206,6 @@ func runProxy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	rpcClient, err := rpchttp.New(primaryAddr, "/websocket")
-	if err != nil {
-		return fmt.Errorf("http client for %s: %w", primaryAddr, err)
-	}
-
 	cfg := rpcserver.DefaultConfig()
 	cfg.MaxBodyBytes = config.RPC.MaxBodyBytes
 	cfg.MaxHeaderBytes = config.RPC.MaxHeaderBytes
@@ -220,6 +215,11 @@ func runProxy(cmd *cobra.Command, args []string) error {
 	// See https://github.com/tendermint/tendermint/issues/3435
 	if cfg.WriteTimeout <= config.RPC.TimeoutBroadcastTxCommit {
 		cfg.WriteTimeout = config.RPC.TimeoutBroadcastTxCommit + 1*time.Second
+	}
+
+	rpcClient, err := rpchttp.NewWithTimeout(primaryAddr, "/websocket", cfg.WriteTimeout)
+	if err != nil {
+		return fmt.Errorf("http client for %s: %w", primaryAddr, err)
 	}
 
 	p := lproxy.Proxy{

--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -164,8 +164,8 @@ func (p *http) validatorSet(ctx context.Context, height *int64) (*types.Validato
 				return nil, provider.ErrBadLightBlock{Reason: e}
 
 			default:
-				// If we don't know the error then by default we return a bad light block error and terminate the connection
-				// with the peer
+				// If we don't know the error then by default we return a bad light block error and
+				// terminate the connection with the peer.
 				return nil, provider.ErrBadLightBlock{Reason: e}
 			}
 
@@ -217,8 +217,8 @@ func (p *http) signedHeader(ctx context.Context, height *int64) (*types.SignedHe
 			}
 
 		default:
-			// If we don't know the error then by default we return a bad light block error and terminate the connection
-			// with the peer
+			// If we don't know the error then by default we return a bad light block error and
+			// terminate the connection with the peer.
 			return nil, provider.ErrBadLightBlock{Reason: e}
 		}
 	}

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -507,7 +507,7 @@ func (c *Client) updateLightClientIfNeededTo(ctx context.Context, height *int64)
 		l, err = c.lc.VerifyLightBlockAtHeight(ctx, *height, time.Now())
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to update light client to %d: %w", height, err)
+		return nil, fmt.Errorf("failed to update light client: %w", err)
 	}
 	return l, nil
 }

--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -183,11 +183,8 @@ func (c *Client) Call(
 	}
 
 	httpResponse, err := c.client.Do(httpRequest)
-	if e, ok := err.(*url.Error); ok && e.Timeout() {
-		panic("Hello world")
-	}
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, err
 	}
 
 	defer httpResponse.Body.Close()


### PR DESCRIPTION
This PR makes the following changes:

- Reduces the default timeout and retry attempts from 5 seconds and 10 attempts to 3 seconds and 5 attempts. This reduces the total possible time for a light client request from 200 seconds to just over 50 seconds
- Takes advantage of the RPC error changes to only retry a request when a provider hasn't responded
- Adds a timeout to the light rpc server which is equivalent to the write timeout set in the config


