### PR TITLE
p2p: enable scheme-less parsing of IPv6 strings

### DIFF
--- a/p2p/address.go
+++ b/p2p/address.go
@@ -24,8 +24,10 @@ var (
 	// reNodeID is a regexp for valid node IDs.
 	reNodeID = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
-	// reHasScheme tries to detect URLs with schemes. It looks for a : before a / (if any).
-	reHasScheme = regexp.MustCompile(`^[^/]+:`)
+	// stringHasScheme tries to detect URLs with schemes. It looks for a : before a / (if any).
+	stringHasScheme = func(str string) bool {
+		return strings.Contains(str, ":/")
+	}
 
 	// reSchemeIsHost tries to detect URLs where the scheme part is instead a
 	// hostname, i.e. of the form "host:80/path" where host: is a hostname.
@@ -95,7 +97,7 @@ func ParseNodeAddress(urlString string) (NodeAddress, error) {
 	// we try to apply a default scheme.
 	url, err := url.Parse(urlString)
 	if (err != nil || url.Scheme == "") &&
-		(!reHasScheme.MatchString(urlString) || reSchemeIsHost.MatchString(urlString)) {
+		(!stringHasScheme(urlString) || reSchemeIsHost.MatchString(urlString)) {
 		url, err = url.Parse(string(defaultProtocol) + "://" + urlString)
 	}
 	if err != nil {

--- a/p2p/address.go
+++ b/p2p/address.go
@@ -26,7 +26,7 @@ var (
 
 	// stringHasScheme tries to detect URLs with schemes. It looks for a : before a / (if any).
 	stringHasScheme = func(str string) bool {
-		return strings.Contains(str, ":/")
+		return strings.Contains(str, "://")
 	}
 
 	// reSchemeIsHost tries to detect URLs where the scheme part is instead a

--- a/p2p/address_test.go
+++ b/p2p/address_test.go
@@ -161,6 +161,16 @@ func TestParseNodeAddress(t *testing.T) {
 			p2p.NodeAddress{Protocol: "memory", NodeID: id},
 			true,
 		},
+		{
+			user + "@[1::]",
+			p2p.NodeAddress{Protocol: "mconn", NodeID: id, Hostname: "1::"},
+			true,
+		},
+		{
+			"mconn://" + user + "@[fd80:b10c::2]:26657",
+			p2p.NodeAddress{Protocol: "mconn", NodeID: id, Hostname: "fd80:b10c::2", Port: 26657},
+			true,
+		},
 
 		// Invalid addresses.
 		{"", p2p.NodeAddress{}, false},


### PR DESCRIPTION
I'm not so well versed with regex so I used `strings.Contains()` instead. If you want a regex based solution then please let me know what I need to add.

Basically, the `reHasScheme` wasn't strict enough when deciding whether something was scheme-less or not hence it was considering scheme-less IPv6 strings (which contain `:`) as having a scheme.

Closes: #6133


