### PR TITLE
goreleaser: reintroduce arm64 build instructions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
     goarch:
       - amd64
       - arm
+      - arm64
 
 checksum:
   name_template: SHA256SUMS-{{.Version}}.txt


### PR DESCRIPTION
GoReleaser has been updated to automatically ignore darwin/arm64 for versions
of Go < 1.16, so it should be safe to add these release configurations back in.
