### PR TITLE
docs/security: add preallocated list of security vulnerability names

### DIFF
--- a/docs/security/vulnerability-names.md
+++ b/docs/security/vulnerability-names.md
@@ -1,0 +1,70 @@
+---
+order: false
+---
+
+# Vulnerability names
+
+Pre-Stargate, Tendermint and Cosmos vulnerabilities used "color" names (e.g. Mulberry, Periwinkle). 
+However, these names were not used in order; post-Stargate, we're introducing a new naming scheme
+which uses names of _bugs_ (get it?) and will be used in-order.
+
+Here is a list of pre-allocated vulnerability names, to be crossed-out as they are used.
+Hopefully we don't make it all the way through the list!
+
+Alderfly
+Aphid
+Ant
+Bedbug
+Beetle
+Bookworm
+Bumblebee
+Butterfly
+Caterpillar
+Cicada
+Centipede
+Cockroach
+Cranefly
+Cricket
+Damselfly 
+Dragonfly
+Earthworm
+Earwig
+Flea 
+Firefly
+Gnat
+Grasshopper
+Hornet
+Horsefly
+Jumpingbean
+Katydid
+Lacewing 
+Ladybug
+Leafroller
+Locust
+Louse
+Maggot
+Mantis 
+Mealybug
+Midge
+Mite
+Mosquito
+Moth
+Palmerworm
+Parasite
+Sawfly
+Scarab
+Silkworm
+Silverfish
+Skeletonizer
+Slug
+Sphinx
+Stinkbug
+Termite
+Thrip
+Viceroy
+Walkingstick
+Wasp
+Weevil
+Whitefly 
+Yellowjacket 
+


### PR DESCRIPTION
I'm also going to add the retros for all previous security incidents to this directory - I'd like to have them somewhere more central than the Cosmos Forum, where they currently live. 
