### PR TITLE
logging: print string instead of callback

### DIFF
--- a/libs/service/service.go
+++ b/libs/service/service.go
@@ -136,7 +136,7 @@ func (bs *BaseService) Start() error {
 			atomic.StoreUint32(&bs.started, 0)
 			return ErrAlreadyStopped
 		}
-		bs.Logger.Info(fmt.Sprintf("Starting %v service", bs.name), "impl", bs.impl)
+		bs.Logger.Info(fmt.Sprintf("Starting %v service", bs.name), "impl", bs.impl.String())
 		err := bs.impl.OnStart()
 		if err != nil {
 			// revert flag


### PR DESCRIPTION
## Description

Fixes marshaling error in sdk

closes https://github.com/cosmos/cosmos-sdk/issues/8578

the output stays the same, we are avoiding the passing of the callback because sdk uses typed logging. 