### PR TITLE
docs/tutorials: fix sample code

### DIFF
--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -336,7 +336,6 @@ Put the following code into the "main.go" file:
 package main
 
 import (
- "errors"
  "flag"
  "fmt"
  "os"
@@ -410,7 +409,7 @@ func newTendermint(app abci.Application, configFile string) (*nm.Node, error) {
  // create logger
  logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
  var err error
- logger, err = tmflags.ParseLogLevel(config.LogLevel, logger, cfg.DefaultLogLevel())
+ logger, err = tmflags.ParseLogLevel(config.LogLevel, logger, cfg.DefaultLogLevel)
  if err != nil {
   return nil, fmt.Errorf("failed to parse log level: %w", err)
  }


### PR DESCRIPTION
The following code in "Creating a built-in application in Go" had a small bug that prevented the application from being built, so we fixed it.

- unused import errors
- `cfg.DefaultLogLevel` is not function
