### PR TITLE
mempool: don't return an error on checktx with the same tx

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -277,11 +277,13 @@ func (mem *CListMempool) CheckTx(tx types.Tx, cb func(*abci.Response), txInfo Tx
 		// so we only record the sender for txs still in the mempool.
 		if e, ok := mem.txsMap.Load(TxKey(tx)); ok {
 			memTx := e.(*clist.CElement).Value.(*mempoolTx)
-			memTx.senders.LoadOrStore(txInfo.SenderID, true)
+			_, loaded := memTx.senders.LoadOrStore(txInfo.SenderID, true)
 			// TODO: consider punishing peer for dups,
 			// its non-trivial since invalid txs can become valid,
 			// but they can spam the same tx with little cost to them atm.
-			return ErrTxInCache
+			if loaded {
+				return ErrTxInCache
+			}
 		}
 
 		mem.logger.Debug("tx exists already in cache", "tx_hash", tx.Hash())

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -281,9 +281,11 @@ func (mem *CListMempool) CheckTx(tx types.Tx, cb func(*abci.Response), txInfo Tx
 			// TODO: consider punishing peer for dups,
 			// its non-trivial since invalid txs can become valid,
 			// but they can spam the same tx with little cost to them atm.
+			return ErrTxInCache
 		}
 
-		return ErrTxInCache
+		mem.logger.Debug("tx exists already in cache", "tx_hash", tx.Hash())
+		return nil
 	}
 
 	ctx := context.Background()

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -190,9 +190,7 @@ func TestMempoolUpdate(t *testing.T) {
 		err := mempool.Update(1, []types.Tx{[]byte{0x01}}, abciResponses(1, abci.CodeTypeOK), nil, nil)
 		require.NoError(t, err)
 		err = mempool.CheckTx([]byte{0x01}, nil, TxInfo{})
-		if assert.Error(t, err) {
-			assert.Equal(t, ErrTxInCache, err)
-		}
+		assert.NoError(t, err)
 	}
 
 	// 2. Removes valid txs from the mempool
@@ -245,15 +243,11 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 
 		// a must be added to the cache
 		err = mempool.CheckTx(a, nil, TxInfo{})
-		if assert.Error(t, err) {
-			assert.Equal(t, ErrTxInCache, err)
-		}
+		assert.NoError(t, err)
 
 		// b must remain in the cache
 		err = mempool.CheckTx(b, nil, TxInfo{})
-		if assert.Error(t, err) {
-			assert.Equal(t, ErrTxInCache, err)
-		}
+		assert.NoError(t, err)
 	}
 
 	// 2. An invalid transaction must remain in the cache
@@ -266,11 +260,6 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 
 		err := mempool.CheckTx(a, nil, TxInfo{})
 		require.NoError(t, err)
-
-		err = mempool.CheckTx(a, nil, TxInfo{})
-		if assert.Error(t, err) {
-			assert.Equal(t, ErrTxInCache, err)
-		}
 	}
 }
 

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -190,7 +190,7 @@ func TestMempoolUpdate(t *testing.T) {
 		err := mempool.Update(1, []types.Tx{[]byte{0x01}}, abciResponses(1, abci.CodeTypeOK), nil, nil)
 		require.NoError(t, err)
 		err = mempool.CheckTx([]byte{0x01}, nil, TxInfo{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	// 2. Removes valid txs from the mempool
@@ -243,11 +243,11 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 
 		// a must be added to the cache
 		err = mempool.CheckTx(a, nil, TxInfo{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// b must remain in the cache
 		err = mempool.CheckTx(b, nil, TxInfo{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	// 2. An invalid transaction must remain in the cache

--- a/test/app/counter_test.sh
+++ b/test/app/counter_test.sh
@@ -109,14 +109,7 @@ if [[ $APPEND_TX_CODE != 0 ]]; then
 	exit 1
 fi
 
-
-echo "... sending tx. expect error"
-
-# second time should get rejected by the mempool (return error and non-zero code)
-sendTx $TX true
-
-
-echo "... sending tx. expect no error"
+echo "... sending new tx. expect no error"
 
 # now, TX=01 should pass, with no error
 TX=01


### PR DESCRIPTION
I have been seeing this error being logged repeatedly in the e2e tests. AFAIK, there's nothing wrong with multiple peers sending the same tx to the same node.

```
E[2021-03-03|10:04:05.373] checktx failed for tx module=mempool peer=539ffc12a0ac78970dab31ae8cdcfdd4285b2162 tx=74B08D5A229A9E907F1586DB4D7835ED20F5F9BE40042ABEF09F7AA9B11B0088 err="tx already exists in cache"
``` 

Since we track senders, I've left it to returning the error if the same sender sends the same tx, otherwise it just logs it as `Debug`.

cc: @alexanderbez, @melekes


