### PR TITLE
p2p: message queue alternative w/ priority queue

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -52,11 +52,18 @@ import (
 	"github.com/tendermint/tendermint/version"
 )
 
-var useLegacyP2P = true
+var (
+	useLegacyP2P       = true
+	p2pRouterQueueType string
+)
 
 func init() {
 	if v := os.Getenv("TM_LEGACY_P2P"); len(v) > 0 {
 		useLegacyP2P, _ = strconv.ParseBool(v)
+	}
+
+	if v := os.Getenv("TM_P2P_QUEUE"); len(v) > 0 {
+		p2pRouterQueueType = v
 	}
 }
 
@@ -611,7 +618,7 @@ func createRouter(
 		privKey,
 		peerManager,
 		[]p2p.Transport{transport},
-		p2p.RouterOptions{},
+		p2p.RouterOptions{QueueType: p2pRouterQueueType},
 	)
 }
 

--- a/p2p/pqueue.go
+++ b/p2p/pqueue.go
@@ -139,6 +139,7 @@ func (s *pqScheduler) closed() <-chan struct{} {
 	return s.closer.Done()
 }
 
+// start starts non-blocking process that starts the priority queue scheduler.
 func (s *pqScheduler) start() {
 	go s.process()
 }

--- a/p2p/pqueue.go
+++ b/p2p/pqueue.go
@@ -67,7 +67,6 @@ var _ queue = (*pqScheduler)(nil)
 
 type pqScheduler struct {
 	logger       log.Logger
-	peerID       NodeID
 	metrics      *Metrics
 	size         uint
 	sizes        map[uint]uint // cumulative priority sizes
@@ -84,7 +83,6 @@ type pqScheduler struct {
 
 func newPQScheduler(
 	logger log.Logger,
-	pID NodeID,
 	m *Metrics,
 	chDescs []ChannelDescriptor,
 	enqueueBuf, dequeueBuf, capacity uint,
@@ -110,8 +108,7 @@ func newPQScheduler(
 	heap.Init(&pq)
 
 	return &pqScheduler{
-		logger:       logger.With("peer", pID),
-		peerID:       pID,
+		logger:       logger.With("router", "scheduler"),
 		metrics:      m,
 		chDescs:      chDescsCopy,
 		capacity:     capacity,

--- a/p2p/pqueue.go
+++ b/p2p/pqueue.go
@@ -246,7 +246,7 @@ func (s *pqScheduler) process() {
 
 			// dequeue
 
-			if s.pq.Len() > 0 {
+			for s.pq.Len() > 0 {
 				pqEnv = heap.Pop(s.pq).(*pqEnvelope)
 				s.size -= pqEnv.size
 

--- a/p2p/pqueue.go
+++ b/p2p/pqueue.go
@@ -1,0 +1,280 @@
+package p2p
+
+import (
+	"container/heap"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/tendermint/tendermint/libs/log"
+	tmsync "github.com/tendermint/tendermint/libs/sync"
+)
+
+// pqEnvelope defines a wrapper around an Envelope with priority to be inserted
+// into a priority queue used for Envelope scheduling.
+type pqEnvelope struct {
+	envelope  Envelope
+	priority  uint
+	size      uint
+	timestamp time.Time
+
+	index int
+}
+
+// priorityQueue defines a type alias for a priority queue implementation.
+type priorityQueue []*pqEnvelope
+
+func (pq priorityQueue) get(i int) *pqEnvelope { return pq[i] }
+func (pq priorityQueue) Len() int              { return len(pq) }
+
+func (pq priorityQueue) Less(i, j int) bool {
+	// if both elements have the same priority, prioritize based on most recent
+	if pq[i].priority == pq[j].priority {
+		return pq[i].timestamp.After(pq[j].timestamp)
+	}
+
+	// otherwise, pick the pqEnvelope with the higher priority
+	return pq[i].priority > pq[j].priority
+}
+
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *priorityQueue) Push(x interface{}) {
+	n := len(*pq)
+	pqEnv := x.(*pqEnvelope)
+	pqEnv.index = n
+	*pq = append(*pq, pqEnv)
+}
+
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	pqEnv := old[n-1]
+	old[n-1] = nil
+	pqEnv.index = -1
+	*pq = old[:n-1]
+	return pqEnv
+}
+
+// Assert the priority queue scheduler implements the queue interface at
+// compile-time.
+var _ queue = (*pqScheduler)(nil)
+
+type pqScheduler struct {
+	logger       log.Logger
+	peerID       NodeID
+	metrics      *Metrics
+	size         uint
+	sizes        map[uint]uint // cumulative priority sizes
+	pq           *priorityQueue
+	chDescs      []ChannelDescriptor
+	capacity     uint
+	chPriorities map[ChannelID]uint
+
+	enqueueCh chan Envelope
+	dequeueCh chan Envelope
+	closer    *tmsync.Closer
+	done      *tmsync.Closer
+}
+
+func newPQScheduler(
+	logger log.Logger,
+	pID NodeID,
+	m *Metrics,
+	chDescs []ChannelDescriptor,
+	enqueueBuf, dequeueBuf, capacity uint,
+) *pqScheduler {
+
+	// copy each ChannelDescriptor and sort them by ascending channel priority
+	chDescsCopy := make([]ChannelDescriptor, len(chDescs))
+	copy(chDescsCopy, chDescs)
+	sort.Slice(chDescsCopy, func(i, j int) bool { return chDescsCopy[i].Priority < chDescsCopy[j].Priority })
+
+	var (
+		chPriorities = make(map[ChannelID]uint)
+		sizes        = make(map[uint]uint)
+	)
+
+	for _, chDesc := range chDescsCopy {
+		chID := ChannelID(chDesc.ID)
+		chPriorities[chID] = uint(chDesc.Priority)
+		sizes[uint(chDesc.Priority)] = 0
+	}
+
+	pq := make(priorityQueue, 0)
+	heap.Init(&pq)
+
+	return &pqScheduler{
+		logger:       logger.With("peer", pID),
+		peerID:       pID,
+		metrics:      m,
+		chDescs:      chDescsCopy,
+		capacity:     capacity,
+		chPriorities: chPriorities,
+		pq:           &pq,
+		sizes:        sizes,
+		enqueueCh:    make(chan Envelope, enqueueBuf),
+		dequeueCh:    make(chan Envelope, dequeueBuf),
+		closer:       tmsync.NewCloser(),
+		done:         tmsync.NewCloser(),
+	}
+}
+
+func (s *pqScheduler) enqueue() chan<- Envelope {
+	return s.enqueueCh
+}
+
+func (s *pqScheduler) dequeue() <-chan Envelope {
+	return s.dequeueCh
+}
+
+func (s *pqScheduler) close() {
+	s.closer.Close()
+	<-s.done.Done()
+}
+
+func (s *pqScheduler) closed() <-chan struct{} {
+	return s.closer.Done()
+}
+
+func (s *pqScheduler) start() {
+	go s.process()
+}
+
+// process starts a block process where we listen for Envelopes to enqueue. If
+// there is sufficient capacity, it will be enqueued into the priority queue,
+// otherwise, we attempt to dequeue enough elements from the priority queue to
+// make room for the incoming Envelope by dropping lower priority elements. If
+// there isn't sufficient capacity at lower priorities for the incoming Envelope,
+// it is dropped.
+//
+// After we attempt to enqueue the incoming Envelope, if the priority queue is
+// non-empty, we pop the top Envelope and send it on the dequeueCh.
+func (s *pqScheduler) process() {
+	defer s.done.Close()
+
+	for {
+		select {
+		case e := <-s.enqueueCh:
+			chIDStr := strconv.Itoa(int(e.channelID))
+			pqEnv := &pqEnvelope{
+				envelope:  e,
+				size:      uint(proto.Size(e.Message)),
+				priority:  s.chPriorities[e.channelID],
+				timestamp: time.Now().UTC(),
+			}
+
+			// enqueue
+
+			// Check if we have sufficient capacity to simply enqueue the incoming
+			// Envelope.
+			if s.size+pqEnv.size <= s.capacity {
+				// enqueue the incoming Envelope
+				s.push(pqEnv)
+			} else {
+				// There is not sufficient capacity to simply enqueue the incoming
+				// Envelope. So we have to attempt to make room for it by dropping lower
+				// priority Envelopes or drop the incoming Envelope otherwise.
+				var total uint
+
+				for i := 0; i < len(s.chDescs) && uint(s.chDescs[i].Priority) < pqEnv.priority && total < pqEnv.size; i++ {
+					total += s.sizes[uint(s.chDescs[i].Priority)]
+				}
+
+				if total >= pqEnv.size {
+					// There is room for the incoming Envelope, so we drop as many lower
+					// priority Envelopes as we need to.
+					var (
+						canEnqueue bool
+						tmpSize    = s.size
+						i          = s.pq.Len() - 1
+					)
+
+					// Drop lower priority Envelopes until sufficient capacity exists for
+					// the incoming Envelope
+					for i >= 0 && !canEnqueue {
+						pqEnvTmp := s.pq.get(i)
+
+						if pqEnvTmp.priority < pqEnv.priority {
+							if tmpSize+pqEnv.size <= s.capacity {
+								canEnqueue = true
+							} else {
+								pqEnvTmpChIDStr := strconv.Itoa(int(pqEnvTmp.envelope.channelID))
+								s.metrics.PeerQueueDroppedMsgs.With("ch_id", pqEnvTmpChIDStr).Add(1)
+								s.logger.Debug(
+									"dropped envelope",
+									"ch_id", pqEnvTmpChIDStr,
+									"priority", pqEnvTmp.priority,
+									"msg_size", pqEnvTmp.size,
+									"capacity", s.capacity,
+								)
+
+								// dequeue/drop from the priority queue
+								heap.Remove(s.pq, pqEnvTmp.index)
+
+								// update the size tracker
+								tmpSize -= pqEnvTmp.size
+
+								// start from the end again
+								i = s.pq.Len() - 1
+							}
+						} else {
+							i--
+						}
+					}
+
+					// enqueue the incoming Envelope
+					s.push(pqEnv)
+				} else {
+					// There is not sufficient capacity to drop lower priority Envelopes,
+					// so we drop the incoming Envelope.
+					s.metrics.PeerQueueDroppedMsgs.With("ch_id", chIDStr).Add(1)
+					s.logger.Debug(
+						"dropped envelope",
+						"ch_id", chIDStr,
+						"priority", pqEnv.priority,
+						"msg_size", pqEnv.size,
+						"capacity", s.capacity,
+					)
+				}
+			}
+
+			// dequeue
+
+			if s.pq.Len() > 0 {
+				pqEnv = heap.Pop(s.pq).(*pqEnvelope)
+				s.size -= pqEnv.size
+
+				// deduct the Envelope size from all the relevant cumulative sizes
+				for i := 0; i < len(s.chDescs) && pqEnv.priority <= uint(s.chDescs[i].Priority); i++ {
+					s.sizes[uint(s.chDescs[i].Priority)] -= pqEnv.size
+				}
+
+				s.dequeueCh <- pqEnv.envelope
+			}
+
+		case <-s.closer.Done():
+			return
+		}
+	}
+}
+
+func (s *pqScheduler) push(pqEnv *pqEnvelope) {
+	chIDStr := strconv.Itoa(int(pqEnv.envelope.channelID))
+
+	// enqueue the incoming Envelope
+	heap.Push(s.pq, pqEnv)
+	s.size += pqEnv.size
+	s.metrics.PeerQueueMsgSize.With("ch_id", chIDStr).Set(float64(pqEnv.size))
+
+	// Update the cumulative sizes by adding the Envelope's size to every
+	// priority less than or equal to it.
+	for i := 0; i < len(s.chDescs) && pqEnv.priority <= uint(s.chDescs[i].Priority); i++ {
+		s.sizes[uint(s.chDescs[i].Priority)] += pqEnv.size
+	}
+}

--- a/p2p/queue.go
+++ b/p2p/queue.go
@@ -32,9 +32,7 @@ type fifoQueue struct {
 	closer  *tmsync.Closer
 }
 
-var _ queue = (*fifoQueue)(nil)
-
-func newFIFOQueue(size int) *fifoQueue {
+func newFIFOQueue(size int) queue {
 	return &fifoQueue{
 		queueCh: make(chan Envelope, size),
 		closer:  tmsync.NewCloser(),

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -450,7 +450,7 @@ func (r *Router) acceptPeers(transport Transport) {
 				return
 			}
 
-			queue := newWDRRScheduler(r.logger, peerInfo.NodeID, r.metrics, r.chDescs, 10000, 10000, defaultCapacity)
+			queue := newPQScheduler(r.logger, peerInfo.NodeID, r.metrics, r.chDescs, 0, 0, defaultCapacity)
 			queue.start()
 
 			r.peerMtx.Lock()
@@ -528,7 +528,7 @@ func (r *Router) dialPeers() {
 				return
 			}
 
-			queue := newWDRRScheduler(r.logger, peerID, r.metrics, r.chDescs, 10000, 10000, defaultCapacity)
+			queue := newPQScheduler(r.logger, peerID, r.metrics, r.chDescs, 0, 0, defaultCapacity)
 			queue.start()
 
 			r.peerMtx.Lock()

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -124,10 +124,29 @@ type RouterOptions struct {
 	// HandshakeTimeout is the timeout for handshaking with a peer. 0 means
 	// no timeout.
 	HandshakeTimeout time.Duration
+
+	// QueueType must be "wdrr" (Weighed Deficit Round Robin),
+	// "priority", or FIFO. Defaults to FIFO.
+	QueueType string
 }
+
+const (
+	queueTypeFifo     = "fifo"
+	queueTypePriority = "priority"
+	queueTypeWDRR     = "wdrr"
+)
 
 // Validate validates router options.
 func (o *RouterOptions) Validate() error {
+	switch o.QueueType {
+	case "":
+		o.QueueType = queueTypeFifo
+	case queueTypeFifo, queueTypeWDRR, queueTypePriority:
+		// pass
+	default:
+		return fmt.Errorf("queue type %q is not supported", o.QueueType)
+	}
+
 	return nil
 }
 
@@ -184,9 +203,10 @@ type Router struct {
 	protocolTransports map[Protocol]Transport
 	stopCh             chan struct{} // signals Router shutdown
 
-	peerMtx    sync.RWMutex
-	peerQueues map[NodeID]queue // outbound messages per peer for all channels
-
+	peerMtx            sync.RWMutex
+	peerQueues         map[NodeID]queue // outbound messages per peer for all channels
+	queueFactory       func(int) queue
+	queueBufferDefault int
 	// FIXME: We don't strictly need to use a mutex for this if we seal the
 	// channels on router start. This depends on whether we want to allow
 	// dynamic channels in the future.
@@ -207,6 +227,7 @@ func NewRouter(
 	transports []Transport,
 	options RouterOptions,
 ) (*Router, error) {
+
 	if err := options.Validate(); err != nil {
 		return nil, err
 	}
@@ -225,8 +246,15 @@ func NewRouter(
 		channelQueues:      map[ChannelID]queue{},
 		channelMessages:    map[ChannelID]proto.Message{},
 		peerQueues:         map[NodeID]queue{},
+		queueBufferDefault: 4096,
 	}
 	router.BaseService = service.NewBaseService(logger, "router", router)
+
+	qf, err := router.createQueueFactory()
+	if err != nil {
+		return nil, err
+	}
+	router.queueFactory = qf
 
 	for _, transport := range transports {
 		for _, protocol := range transport.Protocols() {
@@ -237,6 +265,35 @@ func NewRouter(
 	}
 
 	return router, nil
+}
+
+func (r *Router) createQueueFactory() (func(int) queue, error) {
+	switch r.options.QueueType {
+	case queueTypeFifo:
+		return newFIFOQueue, nil
+	case queueTypePriority:
+		return func(size int) queue {
+			if size%2 != 0 {
+				size++
+			}
+
+			q := newPQScheduler(r.logger, r.metrics, r.chDescs, uint(size)/2, uint(size)/2, defaultCapacity)
+			q.start()
+			return q
+		}, nil
+	case queueTypeWDRR:
+		return func(size int) queue {
+			if size%2 != 0 {
+				size++
+			}
+
+			q := newWDRRScheduler(r.logger, r.metrics, r.chDescs, uint(size)/2, uint(size)/2, defaultCapacity)
+			q.start()
+			return q
+		}, nil
+	default:
+		return nil, fmt.Errorf("cannot construct queue of type %q", r.options.QueueType)
+	}
 }
 
 // AddChannelDescriptors adds a set of ChannelDescriptors to the reactor. Note,
@@ -255,17 +312,7 @@ func (r *Router) AddChannelDescriptors(chDescs []*ChannelDescriptor) {
 // which internally makes the inbound, outbound, and error channel buffered.
 func (r *Router) OpenChannel(id ChannelID, messageType proto.Message, size int) (*Channel, error) {
 	if size == 0 {
-		size = 4096
-	}
-
-	queue := newFIFOQueue(size)
-	outCh := make(chan Envelope, size)
-	errCh := make(chan PeerError, size)
-	channel := NewChannel(id, messageType, queue.dequeue(), outCh, errCh)
-
-	var wrapper Wrapper
-	if w, ok := messageType.(Wrapper); ok {
-		wrapper = w
+		size = r.queueBufferDefault
 	}
 
 	r.channelMtx.Lock()
@@ -273,6 +320,16 @@ func (r *Router) OpenChannel(id ChannelID, messageType proto.Message, size int) 
 
 	if _, ok := r.channelQueues[id]; ok {
 		return nil, fmt.Errorf("channel %v already exists", id)
+	}
+
+	queue := r.queueFactory(size)
+	outCh := make(chan Envelope, size)
+	errCh := make(chan PeerError, size)
+	channel := NewChannel(id, messageType, queue.dequeue(), outCh, errCh)
+
+	var wrapper Wrapper
+	if w, ok := messageType.(Wrapper); ok {
+		wrapper = w
 	}
 
 	r.channelQueues[id] = queue
@@ -450,8 +507,7 @@ func (r *Router) acceptPeers(transport Transport) {
 				return
 			}
 
-			queue := newPQScheduler(r.logger, peerInfo.NodeID, r.metrics, r.chDescs, 0, 0, defaultCapacity)
-			queue.start()
+			queue := r.queueFactory(r.queueBufferDefault)
 
 			r.peerMtx.Lock()
 			r.peerQueues[peerInfo.NodeID] = queue
@@ -528,19 +584,13 @@ func (r *Router) dialPeers() {
 				return
 			}
 
-			queue := newPQScheduler(r.logger, peerID, r.metrics, r.chDescs, 0, 0, defaultCapacity)
-			queue.start()
-
-			r.peerMtx.Lock()
-			r.peerQueues[peerID] = queue
-			r.peerMtx.Unlock()
-
+			peerQueue := r.getOrMakeQueue(peerID)
 			defer func() {
 				r.peerMtx.Lock()
 				delete(r.peerQueues, peerID)
 				r.peerMtx.Unlock()
 
-				queue.close()
+				peerQueue.close()
 
 				if err := r.peerManager.Disconnected(peerID); err != nil {
 					r.logger.Error("failed to disconnect peer", "peer", address, "err", err)
@@ -552,9 +602,22 @@ func (r *Router) dialPeers() {
 				return
 			}
 
-			r.routePeer(peerID, conn, queue)
+			r.routePeer(peerID, conn, peerQueue)
 		}()
 	}
+}
+
+func (r *Router) getOrMakeQueue(peerID NodeID) queue {
+	r.peerMtx.Lock()
+	defer r.peerMtx.Unlock()
+
+	if peerQueue, ok := r.peerQueues[peerID]; ok {
+		return peerQueue
+	}
+
+	peerQueue := r.queueFactory(r.queueBufferDefault)
+	r.peerQueues[peerID] = peerQueue
+	return peerQueue
 }
 
 // dialPeer connects to a peer by dialing it.

--- a/p2p/router_init_test.go
+++ b/p2p/router_init_test.go
@@ -1,0 +1,62 @@
+package p2p
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func TestRouter_ConstructQueueFactory(t *testing.T) {
+	t.Run("ValidateOptionsPopulatesDefaultQueue", func(t *testing.T) {
+		opts := RouterOptions{}
+		require.NoError(t, opts.Validate())
+		require.Equal(t, "fifo", opts.QueueType)
+	})
+	t.Run("Default", func(t *testing.T) {
+		require.Zero(t, os.Getenv("TM_P2P_QUEUE"))
+		opts := RouterOptions{}
+		r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+		require.NoError(t, err)
+		_, ok := r.queueFactory(1).(*fifoQueue)
+		require.True(t, ok)
+	})
+	t.Run("Fifo", func(t *testing.T) {
+		opts := RouterOptions{QueueType: queueTypeFifo}
+		r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+		require.NoError(t, err)
+		_, ok := r.queueFactory(1).(*fifoQueue)
+		require.True(t, ok)
+	})
+	t.Run("Priority", func(t *testing.T) {
+		opts := RouterOptions{QueueType: queueTypePriority}
+		r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+		require.NoError(t, err)
+		q, ok := r.queueFactory(1).(*pqScheduler)
+		require.True(t, ok)
+		defer q.close()
+	})
+	t.Run("WDRR", func(t *testing.T) {
+		opts := RouterOptions{QueueType: queueTypeWDRR}
+		r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+		require.NoError(t, err)
+		q, ok := r.queueFactory(1).(*wdrrScheduler)
+		require.True(t, ok)
+		defer q.close()
+	})
+	t.Run("NonExistant", func(t *testing.T) {
+		opts := RouterOptions{QueueType: "fast"}
+		_, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fast")
+	})
+	t.Run("InternalsSafeWhenUnspecified", func(t *testing.T) {
+		r := &Router{}
+		require.Zero(t, r.options.QueueType)
+
+		fn, err := r.createQueueFactory()
+		require.Error(t, err)
+		require.Nil(t, fn)
+	})
+}

--- a/p2p/router_test.go
+++ b/p2p/router_test.go
@@ -97,7 +97,15 @@ func TestRouter_Channel(t *testing.T) {
 	// Set up a router with no transports (so no peers).
 	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
-	router, err := p2p.NewRouter(log.TestingLogger(), p2p.NopMetrics(), selfInfo, selfKey, peerManager, nil, p2p.RouterOptions{})
+	router, err := p2p.NewRouter(
+		log.TestingLogger(),
+		p2p.NopMetrics(),
+		selfInfo,
+		selfKey,
+		peerManager,
+		nil,
+		p2p.RouterOptions{},
+	)
 	require.NoError(t, err)
 
 	require.NoError(t, router.Start())

--- a/p2p/wdrr_queue.go
+++ b/p2p/wdrr_queue.go
@@ -39,7 +39,6 @@ var _ queue = (*wdrrScheduler)(nil)
 // See: https://en.wikipedia.org/wiki/Deficit_round_robin
 type wdrrScheduler struct {
 	logger       log.Logger
-	peerID       NodeID
 	metrics      *Metrics
 	chDescs      []ChannelDescriptor
 	capacity     uint
@@ -58,7 +57,6 @@ type wdrrScheduler struct {
 
 func newWDRRScheduler(
 	logger log.Logger,
-	pID NodeID,
 	m *Metrics,
 	chDescs []ChannelDescriptor,
 	enqueueBuf, dequeueBuf, capacity uint,
@@ -84,8 +82,7 @@ func newWDRRScheduler(
 	}
 
 	return &wdrrScheduler{
-		logger:       logger.With("peer", pID),
-		peerID:       pID,
+		logger:       logger.With("queue", "wdrr"),
 		metrics:      m,
 		capacity:     capacity,
 		chPriorities: chPriorities,
@@ -242,7 +239,7 @@ func (s *wdrrScheduler) process() {
 			}
 
 		default:
-			// perform the WDRR algorthim
+			// perform the WDRR algorithm
 			for _, chDesc := range s.chDescs {
 				chID := ChannelID(chDesc.ID)
 

--- a/p2p/wdrr_queue_test.go
+++ b/p2p/wdrr_queue_test.go
@@ -23,7 +23,7 @@ func TestWDRRQueue_EqualWeights(t *testing.T) {
 		{ID: 0x06, Priority: 1, MaxSendBytes: 4},
 	}
 
-	peerQueue := newWDRRScheduler(log.NewNopLogger(), NodeID("FFAA"), NopMetrics(), chDescs, 1000, 1000, 120)
+	peerQueue := newWDRRScheduler(log.NewNopLogger(), NopMetrics(), chDescs, 1000, 1000, 120)
 	peerQueue.start()
 
 	totalMsgs := make(map[ChannelID]int)
@@ -119,7 +119,7 @@ func TestWDRRQueue_DecreasingWeights(t *testing.T) {
 		{ID: 0x06, Priority: 1, MaxSendBytes: 4},
 	}
 
-	peerQueue := newWDRRScheduler(log.NewNopLogger(), NodeID("FFAA"), NopMetrics(), chDescs, 0, 6000, 1500)
+	peerQueue := newWDRRScheduler(log.NewNopLogger(), NopMetrics(), chDescs, 0, 6000, 1500)
 	peerQueue.start()
 
 	totalMsgs := make(map[ChannelID]int)

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN cd test/e2e && make app && cp build/app /usr/bin/app
 WORKDIR /tendermint
 VOLUME /tendermint
 ENV TMHOME=/tendermint
-ENV TM_LEGACY_P2P=false
+ENV TM_LEGACY_P2P=true
 ENV TM_P2P_QUEUE="priority"
 
 EXPOSE 26656 26657 26660 6060

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN go mod download
 COPY . .
 RUN make build && cp build/tendermint /usr/bin/tendermint
 COPY test/e2e/docker/entrypoint* /usr/bin/
+
 # FIXME: Temporarily disconnect maverick node until it is redesigned
 # RUN cd test/e2e && make maverick && cp build/maverick /usr/bin/maverick
 RUN cd test/e2e && make app && cp build/app /usr/bin/app
@@ -27,7 +28,8 @@ RUN cd test/e2e && make app && cp build/app /usr/bin/app
 WORKDIR /tendermint
 VOLUME /tendermint
 ENV TMHOME=/tendermint
-ENV TM_LEGACY_P2P=true
+ENV TM_LEGACY_P2P=false
+ENV TM_P2P_QUEUE="priority"
 
 EXPOSE 26656 26657 26660 6060
 ENTRYPOINT ["/usr/bin/entrypoint"]


### PR DESCRIPTION
An alternative implementation with a priority queue and dequeuing immediately after enqueueing. **Better** results compared to the WDRR scheduler.

Note: We still experience https://github.com/tendermint/tendermint/issues/6208, but it's not clear if its the scheduler implementation(s) or the consensus reactor refactor.