### PR TITLE
blockstore: save only the last seen commit

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -477,10 +477,15 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 	}
 
 	// Save seen commit (seen +2/3 precommits for block)
-	// NOTE: we can delete this at a later height
 	pbsc := seenCommit.ToProto()
 	seenCommitBytes := mustEncode(pbsc)
 	if err := batch.Set(seenCommitKey(height), seenCommitBytes); err != nil {
+		panic(err)
+	}
+
+	// remove the previous seen commit that we have just replaced with the
+	// canonical commit
+	if err := batch.Delete(seenCommitKey(height - 1)); err != nil {
 		panic(err)
 	}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -35,8 +35,14 @@ func makeTestCommit(height int64, timestamp time.Time) *types.Commit {
 		Timestamp:        timestamp,
 		Signature:        []byte("Signature"),
 	}}
-	return types.NewCommit(height, 0,
-		types.BlockID{Hash: []byte(""), PartSetHeader: types.PartSetHeader{Hash: []byte(""), Total: 2}}, commitSigs)
+	return types.NewCommit(
+		height,
+		0,
+		types.BlockID{
+			Hash:          crypto.CRandBytes(32),
+			PartSetHeader: types.PartSetHeader{Hash: crypto.CRandBytes(32), Total: 2},
+		},
+		commitSigs)
 }
 
 func makeTxs(height int64) (txs []types.Tx) {
@@ -502,6 +508,45 @@ func TestBlockFetchAtHeight(t *testing.T) {
 	require.Nil(t, blockAtHeightPlus1, "expecting an unsuccessful load of Height()+1")
 	blockAtHeightPlus2 := bs.LoadBlock(bs.Height() + 2)
 	require.Nil(t, blockAtHeightPlus2, "expecting an unsuccessful load of Height()+2")
+}
+
+func TestSeenAndCanonicalCommit(t *testing.T) {
+	bs, _ := freshBlockStore()
+	height := int64(2)
+	loadCommit := func() (interface{}, error) {
+		meta := bs.LoadSeenCommit(height)
+		return meta, nil
+	}
+
+	// Initially no contents.
+	// 1. Requesting for a non-existent blockMeta shouldn't fail
+	res, _, panicErr := doFn(loadCommit)
+	require.Nil(t, panicErr, "a non-existent blockMeta shouldn't cause a panic")
+	require.Nil(t, res, "a non-existent blockMeta should return nil")
+
+	// produce a few blocks and check that the correct seen and cannoncial commits
+	// are persisted.
+	for h := int64(3); h <= 5; h++ {
+		c1 := bs.LoadSeenCommit(h)
+		require.Nil(t, c1)
+		c2 := bs.LoadBlockCommit(h - 1)
+		require.Nil(t, c2)
+		blockCommit := makeTestCommit(h-1, tmtime.Now())
+		block := makeBlock(h, state, blockCommit)
+		partSet := block.MakePartSet(2)
+		seenCommit := makeTestCommit(h, tmtime.Now())
+		bs.SaveBlock(block, partSet, seenCommit)
+		c3 := bs.LoadSeenCommit(h)
+		require.Equal(t, seenCommit.Hash(), c3.Hash())
+		// the previous seen commit should be removed
+		c4 := bs.LoadSeenCommit(h - 1)
+		require.Nil(t, c4)
+		c5 := bs.LoadBlockCommit(h)
+		require.Nil(t, c5)
+		c6 := bs.LoadBlockCommit(h - 1)
+		require.Equal(t, blockCommit.Hash(), c6.Hash())
+	}
+
 }
 
 func doFn(fn func() (interface{}, error)) (res interface{}, err error, panicErr error) {


### PR DESCRIPTION
Closes: #5698

This is probably the least obtrusive way of making this change (the API stays the same and it's easier to revert in a later PR if need be). 

By keeping the height argument we can still theoretically have multiple seen commits but in practice we will always replace the seen commit with the canonical one meaning that we should only ever have one seen commit.


