### PR TITLE
update outdated comment in state.go

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -62,7 +62,7 @@ func VersionFromProto(v tmstate.Version) Version {
 // including the last validator set and the consensus params.
 // All fields are exposed so the struct can be easily serialized,
 // but none of them should be mutated directly.
-// Instead, use state.Copy().
+// Instead, use state.Copy() or updateState(...).
 // NOTE: not goroutine-safe.
 type State struct {
 	Version Version

--- a/state/state.go
+++ b/state/state.go
@@ -62,7 +62,7 @@ func VersionFromProto(v tmstate.Version) Version {
 // including the last validator set and the consensus params.
 // All fields are exposed so the struct can be easily serialized,
 // but none of them should be mutated directly.
-// Instead, use state.Copy() or state.NextState(...).
+// Instead, use state.Copy().
 // NOTE: not goroutine-safe.
 type State struct {
 	Version Version


### PR DESCRIPTION
I couldn't find any references to `state.NextState(...)`. Looks like `updateState` replaced that function