### PR TITLE
note: add nondeterministic note to events

### DIFF
--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -208,7 +208,7 @@ message ResponseDeliverTx {
   int64          gas_wanted = 5 [json_name = "gas_wanted"];
   int64          gas_used   = 6 [json_name = "gas_used"];
   repeated Event events     = 7
-      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"]; // nondeterministic
   string codespace = 8;
 }
 

--- a/types/block.go
+++ b/types/block.go
@@ -350,6 +350,7 @@ type Header struct {
 	ConsensusHash      tmbytes.HexBytes `json:"consensus_hash"`       // consensus params for current block
 	AppHash            tmbytes.HexBytes `json:"app_hash"`             // state after txs from the previous block
 	// root hash of all results from the txs from the previous block
+	// see `deterministicResponseDeliverTx` to understand which parts of a tx is hashed into here
 	LastResultsHash tmbytes.HexBytes `json:"last_results_hash"`
 
 	// consensus info


### PR DESCRIPTION
## Description

Since events are not hashed into the header they can be non deterministic. Changing an event is not consensus breaking. Will update docs in the spec


