### PR TITLE
P2P: remove incompatible peers from address book to avoid repeated failures

### DIFF
--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -697,6 +697,12 @@ func (sw *Switch) acceptRoutine() {
 					sw.addrBook.AddOurAddress(&addr)
 				}
 
+				if err.IsIncompatible() {
+					// Remove the given address from the address book to avoid dialing in the future.
+					addr := err.Addr()
+					sw.addrBook.RemoveAddress(&addr)
+				}
+
 				sw.Logger.Info(
 					"Inbound Peer rejected",
 					"err", err,
@@ -823,6 +829,11 @@ func (sw *Switch) addOutboundPeerWithConfig(
 				sw.addrBook.AddOurAddress(addr)
 
 				return err
+			}
+
+			if e.IsIncompatible() {
+				// Remove the given address from the address book to avoid dialing in the future.
+				sw.addrBook.RemoveAddress(addr)
 			}
 		}
 


### PR DESCRIPTION
On dialling, or accepting connection from incompatible peers (TM version, or chainID mismatch), remove from address book as so to not indefinitely redial.

Closes #6245


