### PR TITLE
fix: make p2p evidence_pending test not timing dependent

### DIFF
--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -382,10 +382,10 @@ func TestReactorBroadcastEvidence_Pending(t *testing.T) {
 		require.NoError(t, rts.pools[secondary.NodeID].AddEvidence(evList[i]))
 	}
 
-	rts.start(t)
-
 	// the secondary should have half the evidence as pending
 	require.Equal(t, numEvidence/2, int(rts.pools[secondary.NodeID].Size()))
+
+	rts.start(t)
 
 	// adding the secondary node back in node back in
 	require.NoError(t, primary.PeerManager.Add(secondary.NodeAddress))

--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -387,19 +387,6 @@ func TestReactorBroadcastEvidence_Pending(t *testing.T) {
 
 	rts.start(t)
 
-	// adding the secondary node back in node back in
-	require.NoError(t, primary.PeerManager.Add(secondary.NodeAddress))
-
-	startAt := time.Now()
-	for {
-		if time.Since(startAt) > time.Second {
-			require.Fail(t, "could not reconnect the secondary in less than a second")
-		}
-		if primary.PeerManager.Status(secondary.NodeID) == p2p.PeerStatusUp {
-			break
-		}
-	}
-
 	// The secondary reactor should have received all the evidence ignoring the
 	// already pending evidence.
 	rts.waitForEvidence(t, evList, secondary.NodeID)


### PR DESCRIPTION
this fixes a timing-dependent assertion in the current test which is
failing inconsistently (but, I think, particularly in CI.)