### PR TITLE
linter: fix nolintlint warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     # - whitespace
     # - wsl
     # - gocognit
-    - nolintlint
+    # - nolintlint
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     # - whitespace
     # - wsl
     # - gocognit
-    # - nolintlint
+    - nolintlint
 
 issues:
   exclude-rules:

--- a/blockchain/v2/reactor_test.go
+++ b/blockchain/v2/reactor_test.go
@@ -64,14 +64,17 @@ type mockBlockStore struct {
 	blocks map[int64]*types.Block
 }
 
+//nolint:unused
 func (ml *mockBlockStore) Height() int64 {
 	return int64(len(ml.blocks))
 }
 
+//nolint:unused
 func (ml *mockBlockStore) LoadBlock(height int64) *types.Block {
 	return ml.blocks[height]
 }
 
+//nolint:unused
 func (ml *mockBlockStore) SaveBlock(block *types.Block, part *types.PartSet, commit *types.Commit) {
 	ml.blocks[block.Height] = block
 }

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -6,6 +6,6 @@ import (
 
 func Sha256(bytes []byte) []byte {
 	hasher := sha256.New()
-	hasher.Write(bytes) //nolint:errcheck // ignore error
+	hasher.Write(bytes)
 	return hasher.Sum(nil)
 }

--- a/crypto/merkle/proof_value.go
+++ b/crypto/merkle/proof_value.go
@@ -80,7 +80,7 @@ func (op ValueOp) Run(args [][]byte) ([][]byte, error) {
 	}
 	value := args[0]
 	hasher := tmhash.New()
-	hasher.Write(value) //nolint: errcheck // does not error
+	hasher.Write(value)
 	vhash := hasher.Sum(nil)
 
 	bz := new(bytes.Buffer)

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -653,7 +653,7 @@ func newRemoteApp(
 }
 func checksumIt(data []byte) string {
 	h := sha256.New()
-	h.Write(data) //nolint: errcheck // ignore errcheck
+	h.Write(data)
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -941,6 +941,6 @@ func (a *addrBook) hash(b []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	hasher.Write(b) //nolint:errcheck // ignore error
+	hasher.Write(b)
 	return hasher.Sum(nil), nil
 }

--- a/statesync/snapshots.go
+++ b/statesync/snapshots.go
@@ -33,9 +33,9 @@ type snapshot struct {
 func (s *snapshot) Key() snapshotKey {
 	// Hash.Write() never returns an error.
 	hasher := sha256.New()
-	hasher.Write([]byte(fmt.Sprintf("%v:%v:%v", s.Height, s.Format, s.Chunks))) //nolint:errcheck // ignore error
-	hasher.Write(s.Hash)                                                        //nolint:errcheck // ignore error
-	hasher.Write(s.Metadata)                                                    //nolint:errcheck // ignore error
+	hasher.Write([]byte(fmt.Sprintf("%v:%v:%v", s.Height, s.Format, s.Chunks)))
+	hasher.Write(s.Hash)
+	hasher.Write(s.Metadata)
 	var key snapshotKey
 	copy(key[:], hasher.Sum(nil))
 	return key


### PR DESCRIPTION
fixes linter to comply with golangci-lint v1.38 


