### PR TITLE
Add Queue Factory function to support injecting router schedulers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -574,7 +574,7 @@ type P2PConfig struct { //nolint: maligned
 	HandshakeTimeout time.Duration `mapstructure:"handshake-timeout"`
 	DialTimeout      time.Duration `mapstructure:"dial-timeout"`
 
-	// Testing params.		if err := doHandshake(stateStore, state, bl
+	// Testing params.
 	// Force dial to fail
 	TestDialFail bool `mapstructure:"test-dial-fail"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -574,7 +574,7 @@ type P2PConfig struct { //nolint: maligned
 	HandshakeTimeout time.Duration `mapstructure:"handshake-timeout"`
 	DialTimeout      time.Duration `mapstructure:"dial-timeout"`
 
-	// Testing params.
+	// Testing params.		if err := doHandshake(stateStore, state, bl
 	// Force dial to fail
 	TestDialFail bool `mapstructure:"test-dial-fail"`
 }

--- a/node/node.go
+++ b/node/node.go
@@ -611,7 +611,7 @@ func createRouter(
 		privKey,
 		peerManager,
 		[]p2p.Transport{transport},
-		p2p.RouterOptions{QueueType: os.Getenv("TM_P2P_QUEUE")},
+		p2p.RouterOptions{},
 	)
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -611,7 +611,7 @@ func createRouter(
 		privKey,
 		peerManager,
 		[]p2p.Transport{transport},
-		p2p.RouterOptions{},
+		p2p.RouterOptions{QueueType: os.Getenv("TM_P2P_QUEUE")},
 	)
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -52,11 +52,18 @@ import (
 	"github.com/tendermint/tendermint/version"
 )
 
-var useLegacyP2P = true
+var (
+	useLegacyP2P       = true
+	p2pRouterQueueType string
+)
 
 func init() {
 	if v := os.Getenv("TM_LEGACY_P2P"); len(v) > 0 {
 		useLegacyP2P, _ = strconv.ParseBool(v)
+	}
+
+	if v := os.Getenv("TM_P2P_QUEUE"); len(v) > 0 {
+		p2pRouterQueueType = v
 	}
 }
 
@@ -611,7 +618,7 @@ func createRouter(
 		privKey,
 		peerManager,
 		[]p2p.Transport{transport},
-		p2p.RouterOptions{},
+		p2p.RouterOptions{QueueType: p2pRouterQueueType},
 	)
 }
 

--- a/p2p/pqueue.go
+++ b/p2p/pqueue.go
@@ -67,7 +67,6 @@ var _ queue = (*pqScheduler)(nil)
 
 type pqScheduler struct {
 	logger       log.Logger
-	peerID       NodeID
 	metrics      *Metrics
 	size         uint
 	sizes        map[uint]uint // cumulative priority sizes
@@ -84,7 +83,6 @@ type pqScheduler struct {
 
 func newPQScheduler(
 	logger log.Logger,
-	pID NodeID,
 	m *Metrics,
 	chDescs []ChannelDescriptor,
 	enqueueBuf, dequeueBuf, capacity uint,
@@ -110,8 +108,7 @@ func newPQScheduler(
 	heap.Init(&pq)
 
 	return &pqScheduler{
-		logger:       logger.With("peer", pID),
-		peerID:       pID,
+		logger:       logger.With("router", "priorityqueue"),
 		metrics:      m,
 		chDescs:      chDescsCopy,
 		capacity:     capacity,

--- a/p2p/pqueue.go
+++ b/p2p/pqueue.go
@@ -108,7 +108,7 @@ func newPQScheduler(
 	heap.Init(&pq)
 
 	return &pqScheduler{
-		logger:       logger.With("router", "priorityqueue"),
+		logger:       logger.With("router", "scheduler"),
 		metrics:      m,
 		chDescs:      chDescsCopy,
 		capacity:     capacity,

--- a/p2p/queue.go
+++ b/p2p/queue.go
@@ -32,9 +32,7 @@ type fifoQueue struct {
 	closer  *tmsync.Closer
 }
 
-var _ queue = (*fifoQueue)(nil)
-
-func newFIFOQueue(size int) *fifoQueue {
+func newFIFOQueue(size int) queue {
 	return &fifoQueue{
 		queueCh: make(chan Envelope, size),
 		closer:  tmsync.NewCloser(),

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"sync"
 	"time"
 
@@ -228,10 +227,6 @@ func NewRouter(
 	transports []Transport,
 	options RouterOptions,
 ) (*Router, error) {
-
-	if options.QueueType == "" {
-		options.QueueType = os.Getenv("TM_P2P_QUEUE")
-	}
 
 	if err := options.Validate(); err != nil {
 		return nil, err

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -274,9 +274,9 @@ func NewRouter(
 
 func (r *Router) createQueueFactory() (func(int) queue, error) {
 	switch r.options.QueueType {
-	case "fifo":
+	case queueTypeFifo:
 		return newFIFOQueue, nil
-	case "priority":
+	case queueTypePriority:
 		return func(size int) queue {
 			if size%2 != 0 {
 				size++
@@ -286,7 +286,7 @@ func (r *Router) createQueueFactory() (func(int) queue, error) {
 			q.start()
 			return q
 		}, nil
-	case "wdrr":
+	case queueTypeWDRR:
 		return func(size int) queue {
 			if size%2 != 0 {
 				size++
@@ -512,8 +512,7 @@ func (r *Router) acceptPeers(transport Transport) {
 				return
 			}
 
-			queue := newPQScheduler(r.logger, r.metrics, r.chDescs, 0, 0, defaultCapacity)
-			queue.start()
+			queue := r.queueFactory(r.queueBufferDefault)
 
 			r.peerMtx.Lock()
 			r.peerQueues[peerInfo.NodeID] = queue

--- a/p2p/router_init_test.go
+++ b/p2p/router_init_test.go
@@ -1,0 +1,123 @@
+package p2p
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func safeSetEnvVar(t *testing.T, key, value string) func() {
+	t.Helper()
+
+	previous := os.Getenv(key)
+	require.NoError(t, os.Setenv(key, value))
+	require.Equal(t, value, os.Getenv(key))
+	return func() {
+		require.NoError(t, os.Setenv(key, previous))
+		require.Equal(t, previous, os.Getenv(key))
+	}
+}
+
+func TestRouter_ConstructQueueFactory(t *testing.T) {
+	t.Run("ValidateOptionsPopulatesDefaultQueue", func(t *testing.T) {
+		opts := RouterOptions{}
+		require.NoError(t, opts.Validate())
+		require.Equal(t, "fifo", opts.QueueType)
+	})
+	t.Run("EnvironmentConfiguration", func(t *testing.T) {
+		require.Zero(t, os.Getenv("TM_P2P_QUEUE"))
+
+		t.Run("DefaultFifo", func(t *testing.T) {
+			opts := RouterOptions{}
+			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+			require.NoError(t, err)
+			_, ok := r.queueFactory(1).(*fifoQueue)
+			require.True(t, ok)
+		})
+
+		t.Run("ExplictFifo", func(t *testing.T) {
+			defer safeSetEnvVar(t, "TM_P2P_QUEUE", "fifo")()
+
+			opts := RouterOptions{}
+			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+			require.NoError(t, err)
+			_, ok := r.queueFactory(1).(*fifoQueue)
+			require.True(t, ok)
+		})
+
+		t.Run("Priority", func(t *testing.T) {
+			defer safeSetEnvVar(t, "TM_P2P_QUEUE", "priority")()
+
+			opts := RouterOptions{}
+			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+			require.NoError(t, err)
+			q, ok := r.queueFactory(1).(*pqScheduler)
+			require.True(t, ok)
+			defer q.close()
+		})
+
+		t.Run("WDRR", func(t *testing.T) {
+			defer safeSetEnvVar(t, "TM_P2P_QUEUE", "wdrr")()
+
+			opts := RouterOptions{}
+			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+			require.NoError(t, err)
+			q := r.queueFactory(1)
+			_, ok := q.(*wdrrScheduler)
+			require.True(t, ok, "%T", q)
+
+			defer q.close()
+		})
+	})
+	t.Run("ExplicitConfiguration", func(t *testing.T) {
+		t.Run("Default", func(t *testing.T) {
+			require.Zero(t, os.Getenv("TM_P2P_QUEUE"))
+			opts := RouterOptions{}
+			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+			require.NoError(t, err)
+			_, ok := r.queueFactory(1).(*fifoQueue)
+			require.True(t, ok)
+		})
+		t.Run("Fifo", func(t *testing.T) {
+			opts := RouterOptions{QueueType: "fifo"}
+			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+			require.NoError(t, err)
+			_, ok := r.queueFactory(1).(*fifoQueue)
+			require.True(t, ok)
+		})
+		t.Run("Priority", func(t *testing.T) {
+			opts := RouterOptions{QueueType: "priority"}
+			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+			require.NoError(t, err)
+			q, ok := r.queueFactory(1).(*pqScheduler)
+			require.True(t, ok)
+			defer q.close()
+		})
+		t.Run("WDRR", func(t *testing.T) {
+			opts := RouterOptions{QueueType: "wdrr"}
+			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+			require.NoError(t, err)
+			q, ok := r.queueFactory(1).(*wdrrScheduler)
+			require.True(t, ok)
+			defer q.close()
+		})
+	})
+	t.Run("InvalidQueueConfiguration", func(t *testing.T) {
+		t.Run("NonExistant", func(t *testing.T) {
+			opts := RouterOptions{QueueType: "fast"}
+			_, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "fast")
+		})
+		t.Run("InternalsSafe", func(t *testing.T) {
+			r := &Router{}
+			require.Zero(t, r.options.QueueType)
+
+			fn, err := r.createQueueFactory()
+			require.Error(t, err)
+			require.Nil(t, fn)
+		})
+	})
+}

--- a/p2p/router_init_test.go
+++ b/p2p/router_init_test.go
@@ -8,18 +8,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 )
 
-func safeSetEnvVar(t *testing.T, key, value string) func() {
-	t.Helper()
-
-	previous := os.Getenv(key)
-	require.NoError(t, os.Setenv(key, value))
-	require.Equal(t, value, os.Getenv(key))
-	return func() {
-		require.NoError(t, os.Setenv(key, previous))
-		require.Equal(t, previous, os.Getenv(key))
-	}
-}
-
 func TestRouter_ConstructQueueFactory(t *testing.T) {
 	t.Run("ValidateOptionsPopulatesDefaultQueue", func(t *testing.T) {
 		opts := RouterOptions{}

--- a/p2p/router_init_test.go
+++ b/p2p/router_init_test.go
@@ -26,98 +26,49 @@ func TestRouter_ConstructQueueFactory(t *testing.T) {
 		require.NoError(t, opts.Validate())
 		require.Equal(t, "fifo", opts.QueueType)
 	})
-	t.Run("EnvironmentConfiguration", func(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
 		require.Zero(t, os.Getenv("TM_P2P_QUEUE"))
-
-		t.Run("DefaultFifo", func(t *testing.T) {
-			opts := RouterOptions{}
-			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
-			require.NoError(t, err)
-			_, ok := r.queueFactory(1).(*fifoQueue)
-			require.True(t, ok)
-		})
-
-		t.Run("ExplictFifo", func(t *testing.T) {
-			defer safeSetEnvVar(t, "TM_P2P_QUEUE", queueTypeFifo)()
-
-			opts := RouterOptions{}
-			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
-			require.NoError(t, err)
-			_, ok := r.queueFactory(1).(*fifoQueue)
-			require.True(t, ok)
-		})
-
-		t.Run("Priority", func(t *testing.T) {
-			defer safeSetEnvVar(t, "TM_P2P_QUEUE", queueTypePriority)()
-
-			opts := RouterOptions{}
-			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
-			require.NoError(t, err)
-			q, ok := r.queueFactory(1).(*pqScheduler)
-			require.True(t, ok)
-			defer q.close()
-		})
-
-		t.Run("WDRR", func(t *testing.T) {
-			defer safeSetEnvVar(t, "TM_P2P_QUEUE", queueTypeWDRR)()
-
-			opts := RouterOptions{}
-			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
-			require.NoError(t, err)
-			q := r.queueFactory(1)
-			_, ok := q.(*wdrrScheduler)
-			require.True(t, ok, "%T", q)
-
-			defer q.close()
-		})
+		opts := RouterOptions{}
+		r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+		require.NoError(t, err)
+		_, ok := r.queueFactory(1).(*fifoQueue)
+		require.True(t, ok)
 	})
-	t.Run("ExplicitConfiguration", func(t *testing.T) {
-		t.Run("Default", func(t *testing.T) {
-			require.Zero(t, os.Getenv("TM_P2P_QUEUE"))
-			opts := RouterOptions{}
-			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
-			require.NoError(t, err)
-			_, ok := r.queueFactory(1).(*fifoQueue)
-			require.True(t, ok)
-		})
-		t.Run("Fifo", func(t *testing.T) {
-			opts := RouterOptions{QueueType: queueTypeFifo}
-			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
-			require.NoError(t, err)
-			_, ok := r.queueFactory(1).(*fifoQueue)
-			require.True(t, ok)
-		})
-		t.Run("Priority", func(t *testing.T) {
-			opts := RouterOptions{QueueType: queueTypePriority}
-			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
-			require.NoError(t, err)
-			q, ok := r.queueFactory(1).(*pqScheduler)
-			require.True(t, ok)
-			defer q.close()
-		})
-		t.Run("WDRR", func(t *testing.T) {
-			opts := RouterOptions{QueueType: queueTypeWDRR}
-			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
-			require.NoError(t, err)
-			q, ok := r.queueFactory(1).(*wdrrScheduler)
-			require.True(t, ok)
-			defer q.close()
-		})
+	t.Run("Fifo", func(t *testing.T) {
+		opts := RouterOptions{QueueType: queueTypeFifo}
+		r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+		require.NoError(t, err)
+		_, ok := r.queueFactory(1).(*fifoQueue)
+		require.True(t, ok)
 	})
-	t.Run("InvalidQueueConfiguration", func(t *testing.T) {
-		t.Run("NonExistant", func(t *testing.T) {
-			opts := RouterOptions{QueueType: "fast"}
-			_, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "fast")
-		})
-		t.Run("InternalsSafe", func(t *testing.T) {
-			r := &Router{}
-			require.Zero(t, r.options.QueueType)
+	t.Run("Priority", func(t *testing.T) {
+		opts := RouterOptions{QueueType: queueTypePriority}
+		r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+		require.NoError(t, err)
+		q, ok := r.queueFactory(1).(*pqScheduler)
+		require.True(t, ok)
+		defer q.close()
+	})
+	t.Run("WDRR", func(t *testing.T) {
+		opts := RouterOptions{QueueType: queueTypeWDRR}
+		r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+		require.NoError(t, err)
+		q, ok := r.queueFactory(1).(*wdrrScheduler)
+		require.True(t, ok)
+		defer q.close()
+	})
+	t.Run("NonExistant", func(t *testing.T) {
+		opts := RouterOptions{QueueType: "fast"}
+		_, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fast")
+	})
+	t.Run("InternalsSafeWhenUnspecified", func(t *testing.T) {
+		r := &Router{}
+		require.Zero(t, r.options.QueueType)
 
-			fn, err := r.createQueueFactory()
-			require.Error(t, err)
-			require.Nil(t, fn)
-		})
+		fn, err := r.createQueueFactory()
+		require.Error(t, err)
+		require.Nil(t, fn)
 	})
 }

--- a/p2p/router_init_test.go
+++ b/p2p/router_init_test.go
@@ -38,7 +38,7 @@ func TestRouter_ConstructQueueFactory(t *testing.T) {
 		})
 
 		t.Run("ExplictFifo", func(t *testing.T) {
-			defer safeSetEnvVar(t, "TM_P2P_QUEUE", "fifo")()
+			defer safeSetEnvVar(t, "TM_P2P_QUEUE", queueTypeFifo)()
 
 			opts := RouterOptions{}
 			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
@@ -48,7 +48,7 @@ func TestRouter_ConstructQueueFactory(t *testing.T) {
 		})
 
 		t.Run("Priority", func(t *testing.T) {
-			defer safeSetEnvVar(t, "TM_P2P_QUEUE", "priority")()
+			defer safeSetEnvVar(t, "TM_P2P_QUEUE", queueTypePriority)()
 
 			opts := RouterOptions{}
 			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
@@ -59,7 +59,7 @@ func TestRouter_ConstructQueueFactory(t *testing.T) {
 		})
 
 		t.Run("WDRR", func(t *testing.T) {
-			defer safeSetEnvVar(t, "TM_P2P_QUEUE", "wdrr")()
+			defer safeSetEnvVar(t, "TM_P2P_QUEUE", queueTypeWDRR)()
 
 			opts := RouterOptions{}
 			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
@@ -81,14 +81,14 @@ func TestRouter_ConstructQueueFactory(t *testing.T) {
 			require.True(t, ok)
 		})
 		t.Run("Fifo", func(t *testing.T) {
-			opts := RouterOptions{QueueType: "fifo"}
+			opts := RouterOptions{QueueType: queueTypeFifo}
 			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
 			require.NoError(t, err)
 			_, ok := r.queueFactory(1).(*fifoQueue)
 			require.True(t, ok)
 		})
 		t.Run("Priority", func(t *testing.T) {
-			opts := RouterOptions{QueueType: "priority"}
+			opts := RouterOptions{QueueType: queueTypePriority}
 			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
 			require.NoError(t, err)
 			q, ok := r.queueFactory(1).(*pqScheduler)
@@ -96,7 +96,7 @@ func TestRouter_ConstructQueueFactory(t *testing.T) {
 			defer q.close()
 		})
 		t.Run("WDRR", func(t *testing.T) {
-			opts := RouterOptions{QueueType: "wdrr"}
+			opts := RouterOptions{QueueType: queueTypeWDRR}
 			r, err := NewRouter(log.NewNopLogger(), nil, NodeInfo{}, nil, nil, nil, opts)
 			require.NoError(t, err)
 			q, ok := r.queueFactory(1).(*wdrrScheduler)

--- a/p2p/wdrr_queue.go
+++ b/p2p/wdrr_queue.go
@@ -39,7 +39,6 @@ var _ queue = (*wdrrScheduler)(nil)
 // See: https://en.wikipedia.org/wiki/Deficit_round_robin
 type wdrrScheduler struct {
 	logger       log.Logger
-	peerID       NodeID
 	metrics      *Metrics
 	chDescs      []ChannelDescriptor
 	capacity     uint
@@ -58,7 +57,6 @@ type wdrrScheduler struct {
 
 func newWDRRScheduler(
 	logger log.Logger,
-	pID NodeID,
 	m *Metrics,
 	chDescs []ChannelDescriptor,
 	enqueueBuf, dequeueBuf, capacity uint,
@@ -84,8 +82,7 @@ func newWDRRScheduler(
 	}
 
 	return &wdrrScheduler{
-		logger:       logger.With("peer", pID),
-		peerID:       pID,
+		logger:       logger.With("queue", "wdrr"),
 		metrics:      m,
 		capacity:     capacity,
 		chPriorities: chPriorities,

--- a/p2p/wdrr_queue.go
+++ b/p2p/wdrr_queue.go
@@ -239,7 +239,7 @@ func (s *wdrrScheduler) process() {
 			}
 
 		default:
-			// perform the WDRR algorthim
+			// perform the WDRR algorithm
 			for _, chDesc := range s.chDescs {
 				chID := ChannelID(chDesc.ID)
 

--- a/p2p/wdrr_queue_test.go
+++ b/p2p/wdrr_queue_test.go
@@ -23,7 +23,7 @@ func TestWDRRQueue_EqualWeights(t *testing.T) {
 		{ID: 0x06, Priority: 1, MaxSendBytes: 4},
 	}
 
-	peerQueue := newWDRRScheduler(log.NewNopLogger(), NodeID("FFAA"), NopMetrics(), chDescs, 1000, 1000, 120)
+	peerQueue := newWDRRScheduler(log.NewNopLogger(), NopMetrics(), chDescs, 1000, 1000, 120)
 	peerQueue.start()
 
 	totalMsgs := make(map[ChannelID]int)
@@ -119,7 +119,7 @@ func TestWDRRQueue_DecreasingWeights(t *testing.T) {
 		{ID: 0x06, Priority: 1, MaxSendBytes: 4},
 	}
 
-	peerQueue := newWDRRScheduler(log.NewNopLogger(), NodeID("FFAA"), NopMetrics(), chDescs, 0, 6000, 1500)
+	peerQueue := newWDRRScheduler(log.NewNopLogger(), NopMetrics(), chDescs, 0, 6000, 1500)
 	peerQueue.start()
 
 	totalMsgs := make(map[ChannelID]int)

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN go mod download
 COPY . .
 RUN make build && cp build/tendermint /usr/bin/tendermint
 COPY test/e2e/docker/entrypoint* /usr/bin/
+
 # FIXME: Temporarily disconnect maverick node until it is redesigned
 # RUN cd test/e2e && make maverick && cp build/maverick /usr/bin/maverick
 RUN cd test/e2e && make app && cp build/app /usr/bin/app
@@ -27,7 +28,8 @@ RUN cd test/e2e && make app && cp build/app /usr/bin/app
 WORKDIR /tendermint
 VOLUME /tendermint
 ENV TMHOME=/tendermint
-ENV TM_LEGACY_P2P=true
+ENV TM_LEGACY_P2P=false
+ENV TM_P2P_QUEUE="priority"
 
 EXPOSE 26656 26657 26660 6060
 ENTRYPOINT ["/usr/bin/entrypoint"]


### PR DESCRIPTION
This just centralizes how we construct queue instances and avoids using the fifo queue for ingestion and a different queue for outgoing messages. 

It presently defaults to FIFO unless its explicitly overridden, but we may want to use the priority algorithm. 