### PR TITLE
e2e: fix perturbation of seed nodes

### DIFF
--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -27,6 +27,7 @@ validator05 = 50
 [node.seed01]
 mode = "seed"
 seeds = ["seed02"]
+perturb = ["restart"]
 
 [node.seed02]
 mode = "seed"

--- a/test/e2e/runner/perturb.go
+++ b/test/e2e/runner/perturb.go
@@ -66,6 +66,12 @@ func PerturbNode(node *e2e.Node, perturbation e2e.Perturbation) (*rpctypes.Resul
 		return nil, fmt.Errorf("unexpected perturbation %q", perturbation)
 	}
 
+	// seed nodes do not have an RPC endpoint exposed so we cannot assert that
+	// the node recovered. All we can do is hope.
+	if node.Mode == e2e.ModeSeed {
+		return nil, nil
+	}
+
 	status, err := waitForNode(node, 0, 10*time.Second)
 	if err != nil {
 		return nil, err

--- a/test/e2e/runner/perturb.go
+++ b/test/e2e/runner/perturb.go
@@ -66,7 +66,7 @@ func PerturbNode(node *e2e.Node, perturbation e2e.Perturbation) (*rpctypes.Resul
 		return nil, fmt.Errorf("unexpected perturbation %q", perturbation)
 	}
 
-	// seed nodes do not have an RPC endpoint exposed so we cannot assert that
+	// Seed nodes do not have an RPC endpoint exposed so we cannot assert that
 	// the node recovered. All we can do is hope.
 	if node.Mode == e2e.ModeSeed {
 		return nil, nil


### PR DESCRIPTION
seeds nodes don't run an RPC so unfortunately when we tried to check the status of the node the testnet was panicking (because status was nil). 

This PR corrects this