### PR TITLE
docs: use start command instead of node command

### DIFF
--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -32,7 +32,7 @@ A quick example of a built-in app and Tendermint core in one container.
 
 ```sh
 docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint init
-docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint node --proxy-app=kvstore
+docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint start --proxy-app=kvstore
 ```
 
 ## Local cluster

--- a/docs/app-dev/getting-started.md
+++ b/docs/app-dev/getting-started.md
@@ -64,12 +64,12 @@ before, use:
 
 ```sh
 tendermint init
-tendermint node
+tendermint start
 ```
 
 If you have used Tendermint, you may want to reset the data for a new
 blockchain by running `tendermint unsafe_reset_all`. Then you can run
-`tendermint node` to start Tendermint, and connect to the app. For more
+`tendermint start` to start Tendermint, and connect to the app. For more
 details, see [the guide on using Tendermint](../tendermint-core/using-tendermint.md).
 
 You should see Tendermint making blocks! We can get the status of our
@@ -202,7 +202,7 @@ In another window, reset then start Tendermint:
 
 ```sh
 tendermint unsafe_reset_all
-tendermint node
+tendermint start
 ```
 
 Once again, you can see the blocks streaming by. Let's send some
@@ -277,7 +277,7 @@ In another window, reset and start `tendermint`:
 
 ```sh
 tendermint unsafe_reset_all
-tendermint node
+tendermint start
 ```
 
 Once again, you should see blocks streaming by - but now, our

--- a/docs/architecture/adr-052-tendermint-mode.md
+++ b/docs/architecture/adr-052-tendermint-mode.md
@@ -45,7 +45,7 @@ We would like to suggest a simple Tendermint mode abstraction. These modes will 
 - Configuration, cli command
     - We would like to suggest by introducing `mode` parameter in `config.toml` and cli
     - <span v-pre>`mode = "{{ .BaseConfig.Mode }}"`</span> in `config.toml`
-    - `tendermint node --mode validator`  in cli
+    - `tendermint start --mode validator`  in cli
     - full | validator | seednode (default: "full")
 - RPC modification
     - `host:26657/status`

--- a/docs/introduction/install.md
+++ b/docs/introduction/install.md
@@ -57,7 +57,7 @@ To start a one-node blockchain with a simple in-process application:
 
 ```sh
 tendermint init
-tendermint node --proxy-app=kvstore
+tendermint start --proxy-app=kvstore
 ```
 
 ## Reinstall

--- a/docs/introduction/quick-start.md
+++ b/docs/introduction/quick-start.md
@@ -59,7 +59,7 @@ Configuring a cluster is covered further below.
 Start Tendermint with a simple in-process application:
 
 ```sh
-tendermint node --proxy-app=kvstore
+tendermint start --proxy-app=kvstore
 ```
 
 > Note: `kvstore` is a non persistent app, if you would like to run an application with persistence run `--proxy-app=persistent_kvstore`
@@ -134,10 +134,10 @@ tendermint show_node_id --home ./mytestnet/node3
 Finally, from each machine, run:
 
 ```sh
-tendermint node --home ./mytestnet/node0 --proxy-app=kvstore --p2p.persistent-peers="ID1@IP1:26656,ID2@IP2:26656,ID3@IP3:26656,ID4@IP4:26656"
-tendermint node --home ./mytestnet/node1 --proxy-app=kvstore --p2p.persistent-peers="ID1@IP1:26656,ID2@IP2:26656,ID3@IP3:26656,ID4@IP4:26656"
-tendermint node --home ./mytestnet/node2 --proxy-app=kvstore --p2p.persistent-peers="ID1@IP1:26656,ID2@IP2:26656,ID3@IP3:26656,ID4@IP4:26656"
-tendermint node --home ./mytestnet/node3 --proxy-app=kvstore --p2p.persistent-peers="ID1@IP1:26656,ID2@IP2:26656,ID3@IP3:26656,ID4@IP4:26656"
+tendermint start --home ./mytestnet/node0 --proxy-app=kvstore --p2p.persistent-peers="ID1@IP1:26656,ID2@IP2:26656,ID3@IP3:26656,ID4@IP4:26656"
+tendermint start --home ./mytestnet/node1 --proxy-app=kvstore --p2p.persistent-peers="ID1@IP1:26656,ID2@IP2:26656,ID3@IP3:26656,ID4@IP4:26656"
+tendermint start --home ./mytestnet/node2 --proxy-app=kvstore --p2p.persistent-peers="ID1@IP1:26656,ID2@IP2:26656,ID3@IP3:26656,ID4@IP4:26656"
+tendermint start --home ./mytestnet/node3 --proxy-app=kvstore --p2p.persistent-peers="ID1@IP1:26656,ID2@IP2:26656,ID3@IP3:26656,ID4@IP4:26656"
 ```
 
 Note that after the third node is started, blocks will start to stream in

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -127,7 +127,7 @@ definition](https://github.com/tendermint/tendermint/blob/master/types/genesis.g
 To run a Tendermint node, use:
 
 ```bash
-tendermint node
+tendermint start
 ```
 
 By default, Tendermint will try to connect to an ABCI application on
@@ -136,7 +136,7 @@ another window. If you don't, kill Tendermint and run an in-process version of
 the `kvstore` app:
 
 ```bash
-tendermint node --proxy-app=kvstore
+tendermint start --proxy-app=kvstore
 ```
 
 After a few seconds, you should see blocks start streaming in. Note that blocks
@@ -150,10 +150,10 @@ Go, run it in another process, and use the `--proxy-app` flag to specify the
 address of the socket it is listening on, for instance:
 
 ```bash
-tendermint node --proxy-app=/var/run/abci.sock
+tendermint start --proxy-app=/var/run/abci.sock
 ```
 
-You can find out what flags are supported by running `tendermint node --help`.
+You can find out what flags are supported by running `tendermint start --help`.
 
 ## Transactions
 
@@ -270,7 +270,7 @@ transactions or the app hash changes, run Tendermint with this
 additional flag:
 
 ```sh
-tendermint node --consensus.create_empty_blocks=false
+tendermint start --consensus.create_empty_blocks=false
 ```
 
 or set the configuration via the `config.toml` file:
@@ -445,7 +445,7 @@ persistent connections with.
 For example,
 
 ```sh
-tendermint node --p2p.seeds "f9baeaa15fedf5e1ef7448dd60f46c01f1a9e9c4@1.2.3.4:26656,0491d373a8e0fcf1023aaf18c51d6a1d0d4f31bd@5.6.7.8:26656"
+tendermint start --p2p.seeds "f9baeaa15fedf5e1ef7448dd60f46c01f1a9e9c4@1.2.3.4:26656,0491d373a8e0fcf1023aaf18c51d6a1d0d4f31bd@5.6.7.8:26656"
 ```
 
 Alternatively, you can use the `/dial_seeds` endpoint of the RPC to
@@ -465,7 +465,7 @@ maintain a persistent connection with each, you can use the
 stopping Tendermint core instance.
 
 ```sh
-tendermint node --p2p.persistent-peers "429fcf25974313b95673f58d77eacdd434402665@10.11.12.13:26656,96663a3dd0d7b9d17d4c8211b191af259621c693@10.11.12.14:26656"
+tendermint start --p2p.persistent-peers "429fcf25974313b95673f58d77eacdd434402665@10.11.12.13:26656,96663a3dd0d7b9d17d4c8211b191af259621c693@10.11.12.14:26656"
 
 curl 'localhost:26657/dial_peers?persistent=true&peers=\["429fcf25974313b95673f58d77eacdd434402665@10.11.12.13:26656","96663a3dd0d7b9d17d4c8211b191af259621c693@10.11.12.14:26656"\]'
 ```
@@ -543,7 +543,7 @@ Update the `genesis.json` in `~/.tendermint/config`. Copy the genesis
 file and the new `priv_validator_key.json` to the `~/.tendermint/config` on
 a new machine.
 
-Now run `tendermint node` on both machines, and use either
+Now run `tendermint start` on both machines, and use either
 `--p2p.persistent-peers` or the `/dial_peers` to get them to peer up.
 They should start making blocks, and will only continue to do so as long
 as both of them are online.


### PR DESCRIPTION
We changed the cli beforehand to use `start` instead of `node`. This just updates some of the docs to reflect that change


