### PR TITLE
Fix "Unknown Channel" bug on CustomReactors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -28,3 +28,5 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 ### BUG FIXES
 
 - [rpc/jsonrpc/server] \#6191 Correctly unmarshal `RPCRequest` when data is `null` (@melekes)
+
+- [p2p] \#6289 Fix "unknown channels" bug on CustomReactors (@gchaincl)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -28,5 +28,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 ### BUG FIXES
 
 - [rpc/jsonrpc/server] \#6191 Correctly unmarshal `RPCRequest` when data is `null` (@melekes)
-
 - [p2p] \#6289 Fix "unknown channels" bug on CustomReactors (@gchaincl)

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -130,10 +130,15 @@ func newPeer(
 	onPeerError func(Peer, interface{}),
 	options ...PeerOption,
 ) *peer {
+	var channs = make([]byte, 0, len(chDescs))
+	for _, desc := range chDescs {
+		channs = append(channs, desc.ID)
+	}
+
 	p := &peer{
 		peerConn:      pc,
 		nodeInfo:      nodeInfo,
-		channels:      nodeInfo.(DefaultNodeInfo).Channels, // TODO
+		channels:      channs,
 		Data:          cmap.NewCMap(),
 		metricsTicker: time.NewTicker(metricsTickerDuration),
 		metrics:       NopMetrics(),


### PR DESCRIPTION
New Peers are created passing a list of static channels.
When adding a new CustomReactor to NewNode, the new channel(s) used by
that reactor were not passed to the new peers, creating an error when
peers tried to communicate.

Closes #6289


