### PR TITLE
p2p: filter peers by IP address and ID

### DIFF
--- a/p2p/router.go
+++ b/p2p/router.go
@@ -141,6 +141,8 @@ type RouterOptions struct {
 	// milliseconds, and cannot be less than 1 millisecond.
 	IncomingConnectionWindow time.Duration
 
+	// FilterPeerByIP and FilterPeerByID are used by the router to
+	// inject filtering behavior for new incoming connections.
 	FilterPeerByIP func(context.Context, net.IP, uint16) error
 	FilterPeerByID func(context.Context, NodeID) error
 }

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -148,7 +148,7 @@ type RouterOptions struct {
 	// peer.
 	FilterPeerByIP func(context.Context, net.IP, uint16) error
 
-	//FilterPeerByID is used by the router to inject filtering
+	// FilterPeerByID is used by the router to inject filtering
 	// behavior for new incoming connections. The router passes
 	// the NodeID of the node before completing the connection,
 	// but this occurs after the handshake is complete. Filter by

--- a/p2p/router.go
+++ b/p2p/router.go
@@ -141,9 +141,19 @@ type RouterOptions struct {
 	// milliseconds, and cannot be less than 1 millisecond.
 	IncomingConnectionWindow time.Duration
 
-	// FilterPeerByIP and FilterPeerByID are used by the router to
-	// inject filtering behavior for new incoming connections.
+	// FilterPeerByIP is used by the router to inject filtering
+	// behavior for new incoming connections. The router passes
+	// the remote IP of the incoming connection the port number as
+	// arguments. Functions should return an error to reject the
+	// peer.
 	FilterPeerByIP func(context.Context, net.IP, uint16) error
+
+	//FilterPeerByID is used by the router to inject filtering
+	// behavior for new incoming connections. The router passes
+	// the NodeID of the node before completing the connection,
+	// but this occurs after the handshake is complete. Filter by
+	// IP address to filter before the handshake. Functions should
+	// return an error to reject the peer.
 	FilterPeerByID func(context.Context, NodeID) error
 }
 

--- a/p2p/router_filter_test.go
+++ b/p2p/router_filter_test.go
@@ -1,0 +1,34 @@
+package p2p
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/libs/sync"
+)
+
+func TestConnectionFiltering(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := log.TestingLogger()
+
+	filterByIPCount := 0
+	router := &Router{
+		logger:      logger,
+		connTracker: newConnTracker(1, time.Second),
+		options: RouterOptions{
+			FilterPeerByIP: func(ctx context.Context, ip net.IP, port uint16) error {
+				filterByIPCount++
+				return errors.New("mock")
+			},
+		},
+	}
+	require.Equal(t, 0, filterByIPCount)
+	router.openConnection(ctx, &MemoryConnection{logger: logger, closer: sync.NewCloser()})
+	require.Equal(t, 1, filterByIPCount)
+}


### PR DESCRIPTION
Wanted to validate the approach before going to far down. 

I think the real risk here is that an application can put back pressure on the p2p layer which might not be desirable. 