### PR TITLE
evidence: remove event bus from reactor

### DIFF
--- a/evidence/reactor.go
+++ b/evidence/reactor.go
@@ -55,7 +55,6 @@ type Reactor struct {
 	service.BaseService
 
 	evpool      *Pool
-	eventBus    *types.EventBus
 	evidenceCh  *p2p.Channel
 	peerUpdates *p2p.PeerUpdates
 	closeCh     chan struct{}
@@ -85,11 +84,6 @@ func NewReactor(
 
 	r.BaseService = *service.NewBaseService(logger, "Evidence", r)
 	return r
-}
-
-// SetEventBus implements events.Eventable.
-func (r *Reactor) SetEventBus(b *types.EventBus) {
-	r.eventBus = b
 }
 
 // OnStart starts separate go routines for each p2p Channel and listens for


### PR DESCRIPTION
We don't use the event bus in the evidence reactor nor do I think we will need to. This PR removes it. @alexanderbez perhaps you might have an explanation for why it is there that I've overlooked

