### PR TITLE
light: fix deadlock in light tests

### DIFF
--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -233,24 +233,24 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 
 	// two seconds later, the supporting withness should receive the header that can be used
 	// to prove that there was an attack
+	vals := chainKeys[latestHeight].ToValidators(2, 0)
+	newLb := &types.LightBlock{
+		SignedHeader: chainKeys[latestHeight].GenSignedHeader(
+			chainID,
+			proofHeight,
+			bTime.Add(time.Duration(proofHeight+1)*time.Minute), // 12 mins
+			nil,
+			vals,
+			vals,
+			hash("app_hash"),
+			hash("cons_hash"),
+			hash("results_hash"),
+			0, len(chainKeys),
+		),
+		ValidatorSet: vals,
+	}
 	go func() {
 		time.Sleep(2 * time.Second)
-		vals := chainKeys[latestHeight].ToValidators(2, 0)
-		newLb := &types.LightBlock{
-			SignedHeader: chainKeys[latestHeight].GenSignedHeader(
-				chainID,
-				proofHeight,
-				bTime.Add(time.Duration(proofHeight+1)*time.Minute), // 12 mins
-				nil,
-				vals,
-				vals,
-				hash("app_hash"),
-				hash("cons_hash"),
-				hash("results_hash"),
-				0, len(chainKeys),
-			),
-			ValidatorSet: vals,
-		}
 		witness.AddLightBlock(newLb)
 	}()
 

--- a/light/provider/mock/mock.go
+++ b/light/provider/mock/mock.go
@@ -5,13 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/tendermint/tendermint/light/provider"
 	"github.com/tendermint/tendermint/types"
 )
 
 type Mock struct {
-	id               string
+	id string
+
+	mtx              sync.Mutex
 	headers          map[int64]*types.SignedHeader
 	vals             map[int64]*types.ValidatorSet
 	evidenceToReport map[string]types.Evidence // hash => evidence
@@ -53,6 +56,9 @@ func (p *Mock) String() string {
 }
 
 func (p *Mock) LightBlock(_ context.Context, height int64) (*types.LightBlock, error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
 	var lb *types.LightBlock
 
 	if height > p.latestHeight {
@@ -94,6 +100,9 @@ func (p *Mock) HasEvidence(ev types.Evidence) bool {
 }
 
 func (p *Mock) AddLightBlock(lb *types.LightBlock) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
 	if err := lb.ValidateBasic(lb.ChainID); err != nil {
 		panic(fmt.Sprintf("unable to add light block, err: %v", err))
 	}


### PR DESCRIPTION
adds a mutex to the mock provider so that there isn't a data race when running the tests




