### PR TITLE
p2p: fix using custom channels

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,3 +24,5 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### BUG FIXES
 
+- [p2p/node] \#6339 Fix bug with using custom channels (@cmwaters)
+

--- a/node/node.go
+++ b/node/node.go
@@ -152,6 +152,14 @@ func CustomReactors(reactors map[string]p2p.Reactor) Option {
 				n.sw.RemoveReactor(name, existingReactor)
 			}
 			n.sw.AddReactor(name, reactor)
+			// register the new channels to the nodeInfo
+			for _, chDesc := range reactor.GetChannels() {
+				// these functions only error when the channel is already
+				// registered. This may be the case when we are replacing
+				// existing reactors so we can ignore these
+				_ = n.nodeInfo.(p2p.DefaultNodeInfo).AddChannel(chDesc.ID)
+				_ = n.transport.AddChannel(chDesc.ID)
+			}
 		}
 	}
 }

--- a/p2p/mock/reactor.go
+++ b/p2p/mock/reactor.go
@@ -8,6 +8,8 @@ import (
 
 type Reactor struct {
 	p2p.BaseReactor
+
+	Channels []*conn.ChannelDescriptor
 }
 
 func NewReactor() *Reactor {
@@ -17,7 +19,7 @@ func NewReactor() *Reactor {
 	return r
 }
 
-func (r *Reactor) GetChannels() []*conn.ChannelDescriptor            { return []*conn.ChannelDescriptor{} }
+func (r *Reactor) GetChannels() []*conn.ChannelDescriptor            { return r.Channels }
 func (r *Reactor) AddPeer(peer p2p.Peer)                             {}
 func (r *Reactor) RemovePeer(peer p2p.Peer, reason interface{})      {}
 func (r *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {}

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -245,6 +245,18 @@ func (info DefaultNodeInfo) ToProto() *tmp2p.DefaultNodeInfo {
 	return dni
 }
 
+// AddChannel checks if the nodeInfo doesn't already contain the channel before
+// appending it
+func (info DefaultNodeInfo) AddChannel(chId byte) error {
+	for _, ch := range info.Channels {
+		if ch == chId {
+			return fmt.Errorf("channel %v already exists", chId)
+		}
+	}
+	info.Channels = append(info.Channels, chId)
+	return nil
+}
+
 func DefaultNodeInfoFromToProto(pb *tmp2p.DefaultNodeInfo) (DefaultNodeInfo, error) {
 	if pb == nil {
 		return DefaultNodeInfo{}, errors.New("nil node info")

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -1,11 +1,12 @@
 package p2p
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"reflect"
 
-	"github.com/tendermint/tendermint/libs/bytes"
+	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	tmstrings "github.com/tendermint/tendermint/libs/strings"
 	tmp2p "github.com/tendermint/tendermint/proto/tendermint/p2p"
 	"github.com/tendermint/tendermint/version"
@@ -85,9 +86,9 @@ type DefaultNodeInfo struct {
 
 	// Check compatibility.
 	// Channels are HexBytes so easier to read as JSON
-	Network  string         `json:"network"`  // network/chain ID
-	Version  string         `json:"version"`  // major.minor.revision
-	Channels bytes.HexBytes `json:"channels"` // channels this node knows about
+	Network  string           `json:"network"`  // network/chain ID
+	Version  string           `json:"version"`  // major.minor.revision
+	Channels tmbytes.HexBytes `json:"channels"` // channels this node knows about
 
 	// ASCIIText fields
 	Moniker string               `json:"moniker"` // arbitrary moniker
@@ -222,6 +223,10 @@ func (info DefaultNodeInfo) NetAddress() (*NetAddress, error) {
 	return NewNetAddressString(idAddr)
 }
 
+func (info DefaultNodeInfo) HasChannel(chID byte) bool {
+	return bytes.Contains(info.Channels, []byte{chID})
+}
+
 func (info DefaultNodeInfo) ToProto() *tmp2p.DefaultNodeInfo {
 
 	dni := new(tmp2p.DefaultNodeInfo)
@@ -243,18 +248,6 @@ func (info DefaultNodeInfo) ToProto() *tmp2p.DefaultNodeInfo {
 	}
 
 	return dni
-}
-
-// AddChannel checks if the nodeInfo doesn't already contain the channel before
-// appending it
-func (info DefaultNodeInfo) AddChannel(chID byte) error {
-	for _, ch := range info.Channels {
-		if ch == chID {
-			return fmt.Errorf("channel %v already exists", chID)
-		}
-	}
-	info.Channels = append(info.Channels, chID)
-	return nil
 }
 
 func DefaultNodeInfoFromToProto(pb *tmp2p.DefaultNodeInfo) (DefaultNodeInfo, error) {

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -247,13 +247,13 @@ func (info DefaultNodeInfo) ToProto() *tmp2p.DefaultNodeInfo {
 
 // AddChannel checks if the nodeInfo doesn't already contain the channel before
 // appending it
-func (info DefaultNodeInfo) AddChannel(chId byte) error {
+func (info DefaultNodeInfo) AddChannel(chID byte) error {
 	for _, ch := range info.Channels {
-		if ch == chId {
-			return fmt.Errorf("channel %v already exists", chId)
+		if ch == chID {
+			return fmt.Errorf("channel %v already exists", chID)
 		}
 	}
-	info.Channels = append(info.Channels, chId)
+	info.Channels = append(info.Channels, chID)
 	return nil
 }
 

--- a/p2p/node_info_test.go
+++ b/p2p/node_info_test.go
@@ -102,7 +102,8 @@ func TestNodeInfoCompatible(t *testing.T) {
 	assert.NoError(t, ni1.CompatibleWith(ni2))
 
 	// add another channel; still compatible
-	ni2.Channels = []byte{newTestChannel, testCh}
+	ni2.Channels = append(ni2.Channels, newTestChannel)
+	assert.True(t, ni2.HasChannel(newTestChannel))
 	assert.NoError(t, ni1.CompatibleWith(ni2))
 
 	// wrong NodeInfo type is not compatible

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -130,15 +130,10 @@ func newPeer(
 	onPeerError func(Peer, interface{}),
 	options ...PeerOption,
 ) *peer {
-	var channs = make([]byte, 0, len(chDescs))
-	for _, desc := range chDescs {
-		channs = append(channs, desc.ID)
-	}
-
 	p := &peer{
 		peerConn:      pc,
 		nodeInfo:      nodeInfo,
-		channels:      channs,
+		channels:      nodeInfo.(DefaultNodeInfo).Channels,
 		Data:          cmap.NewCMap(),
 		metricsTicker: time.NewTicker(metricsTickerDuration),
 		metrics:       NopMetrics(),

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -261,10 +261,17 @@ func (mt *MultiplexTransport) Listen(addr NetAddress) error {
 	return nil
 }
 
-// AddChannel registers a channel to nodeInfo. This will be broadcaster to peers
-// to make them aware of what channels are open
-func (mt *MultiplexTransport) AddChannel(chID byte) error {
-	return mt.nodeInfo.(DefaultNodeInfo).AddChannel(chID)
+// AddChannel registers a channel to nodeInfo.
+// NOTE: NodeInfo must be of type DefaultNodeInfo else channels won't be updated
+// This is a bit messy at the moment but is cleaned up in the following version
+// when NodeInfo changes from an interface to a concrete type
+func (mt *MultiplexTransport) AddChannel(chID byte) {
+	if ni, ok := mt.nodeInfo.(DefaultNodeInfo); ok {
+		if !ni.HasChannel(chID) {
+			ni.Channels = append(ni.Channels, chID)
+		}
+		mt.nodeInfo = ni
+	}
 }
 
 func (mt *MultiplexTransport) acceptPeers() {

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -261,6 +261,12 @@ func (mt *MultiplexTransport) Listen(addr NetAddress) error {
 	return nil
 }
 
+// AddChannel registers a channel to nodeInfo. This will be broadcaster to peers
+// to make them aware of what channels are open
+func (mt *MultiplexTransport) AddChannel(chID byte) error {
+	return mt.nodeInfo.(DefaultNodeInfo).AddChannel(chID)
+}
+
 func (mt *MultiplexTransport) acceptPeers() {
 	for {
 		c, err := mt.listener.Accept()

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -621,6 +621,21 @@ func TestTransportHandshake(t *testing.T) {
 	}
 }
 
+func TestTransportAddChannel(t *testing.T) {
+	mt := newMultiplexTransport(
+		emptyNodeInfo(),
+		NodeKey{
+			PrivKey: ed25519.GenPrivKey(),
+		},
+	)
+	testChannel := byte(0x01)
+
+	mt.AddChannel(testChannel)
+	if !mt.nodeInfo.(DefaultNodeInfo).HasChannel(testChannel) {
+		t.Errorf("missing added channel %v. Got %v", testChannel, mt.nodeInfo.(DefaultNodeInfo).Channels)
+	}
+}
+
 // create listener
 func testSetupMultiplexTransport(t *testing.T) *MultiplexTransport {
 	var (


### PR DESCRIPTION
Previously, we were supporting custom reactors but weren't adding the channel of the custom reactor to the nodeInfo, this means nodes were not able to broadcast that they could receive messages to this custom reactor. 

#6297 attempted to fix this but in fact was replacing the peers available channels that the node received in the handshake with its own channels (thus it would think that it all its peers have the same channel that it does). Trudging through this I could see why it was confusing because `peerConfig` is actually information about the node itself not the peer. 

I tried to find a way to still allow using custom reactors without doing any breaking changes hence I'm not particularly happy with this fix but I can't really think of a better solution. 

Closes: #6338


