### PR TITLE
evidence: redefine evidence hashing

### DIFF
--- a/test/e2e/networks/simple.toml
+++ b/test/e2e/networks/simple.toml
@@ -1,3 +1,5 @@
+evidence = 5
+
 [node.validator01]
 [node.validator02]
 [node.validator03]

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -20,10 +20,7 @@ import (
 )
 
 // 1 in 11 evidence is light client evidence, the rest is duplicate vote
-// FIXME: Setting to 11 disables light client attack evidence since nodes
-// don't follow a minimum retention height invariant. When we fix this we
-// should use a ratio of 4.
-const lightClientEvidenceRatio = 11
+const lightClientEvidenceRatio = 4
 
 // InjectEvidence takes a running testnet and generates an amount of valid
 // evidence and broadcasts it to a random node through the rpc endpoint `/broadcast_evidence`.
@@ -74,7 +71,7 @@ func InjectEvidence(testnet *e2e.Testnet, amount int) error {
 	duplicateVoteTime := status.SyncInfo.LatestBlockTime
 
 	var ev types.Evidence
-	for i := 0; i < amount; i++ {
+	for i := 1; i <= amount; i++ {
 		if i%lightClientEvidenceRatio == 0 {
 			ev, err = generateLightClientAttackEvidence(
 				privVals, lightEvidenceCommonHeight, valSet, testnet.Name, blockRes.Block.Time,

--- a/test/e2e/tests/block_test.go
+++ b/test/e2e/tests/block_test.go
@@ -38,7 +38,10 @@ func TestBlock_Header(t *testing.T) {
 			resp, err := client.Block(ctx, &block.Header.Height)
 			require.NoError(t, err)
 			require.Equal(t, block, resp.Block,
-				"block mismatch for height %v", block.Header.Height)
+				"block mismatch for height %d", block.Header.Height)
+
+			require.NoError(t, resp.Block.ValidateBasic(),
+				"block at height %d is invalid", block.Header.Height)
 		}
 	})
 }

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -89,9 +89,11 @@ func TestDuplicateVoteEvidenceValidation(t *testing.T) {
 	}
 }
 
-func TestLightClientAttackEvidence(t *testing.T) {
+func TestLightClientAttackEvidenceBasic(t *testing.T) {
 	height := int64(5)
-	voteSet, valSet, privVals := randVoteSet(height, 1, tmproto.PrecommitType, 10, 1)
+	commonHeight := height - 1
+	nValidators := 10
+	voteSet, valSet, privVals := randVoteSet(height, 1, tmproto.PrecommitType, nValidators, 1)
 	header := makeHeaderRandom()
 	header.Height = height
 	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
@@ -105,56 +107,64 @@ func TestLightClientAttackEvidence(t *testing.T) {
 			},
 			ValidatorSet: valSet,
 		},
-		CommonHeight: height - 1,
+		CommonHeight:        commonHeight,
+		TotalVotingPower:    valSet.TotalVotingPower(),
+		Timestamp:           header.Time,
+		ByzantineValidators: valSet.Validators[:nValidators/2],
 	}
 	assert.NotNil(t, lcae.String())
 	assert.NotNil(t, lcae.Hash())
-	// only 7 validators sign
-	differentCommit, err := MakeCommit(blockID, height, 1, voteSet, privVals[:7], defaultVoteTime)
-	require.NoError(t, err)
-	differentEv := &LightClientAttackEvidence{
-		ConflictingBlock: &LightBlock{
-			SignedHeader: &SignedHeader{
-				Header: header,
-				Commit: differentCommit,
-			},
-			ValidatorSet: valSet,
-		},
-		CommonHeight: height - 1,
-	}
-	assert.Equal(t, lcae.Hash(), differentEv.Hash())
-	// different header hash
-	differentHeader := makeHeaderRandom()
-	differentEv = &LightClientAttackEvidence{
-		ConflictingBlock: &LightBlock{
-			SignedHeader: &SignedHeader{
-				Header: differentHeader,
-				Commit: differentCommit,
-			},
-			ValidatorSet: valSet,
-		},
-		CommonHeight: height - 1,
-	}
-	assert.NotEqual(t, lcae.Hash(), differentEv.Hash())
-	// different common height should produce a different header
-	differentEv = &LightClientAttackEvidence{
-		ConflictingBlock: &LightBlock{
-			SignedHeader: &SignedHeader{
-				Header: header,
-				Commit: differentCommit,
-			},
-			ValidatorSet: valSet,
-		},
-		CommonHeight: height - 2,
-	}
-	assert.NotEqual(t, lcae.Hash(), differentEv.Hash())
-	assert.Equal(t, lcae.Height(), int64(4)) // Height should be the common Height
+	assert.Equal(t, lcae.Height(), commonHeight) // Height should be the common Height
 	assert.NotNil(t, lcae.Bytes())
+
+	// maleate evidence to test hash uniqueness
+	testCases := []struct {
+		testName         string
+		malleateEvidence func(*LightClientAttackEvidence)
+	}{
+		{"Different header", func(ev *LightClientAttackEvidence) { ev.ConflictingBlock.Header = makeHeaderRandom() }},
+		{"Different commit", func(ev *LightClientAttackEvidence) {
+			newSigs := append(commit.Signatures[:len(commit.Signatures)-1], NewCommitSigAbsent())
+			newCommit := NewCommit(height, 0, blockID, newSigs)
+			require.NotEqual(t, commit.Hash(), newCommit.Hash())
+			ev.ConflictingBlock.Commit = newCommit
+		}},
+		{"Different common height", func(ev *LightClientAttackEvidence) {
+			ev.CommonHeight = height + 1
+		}},
+		{"Different total voting power", func(ev *LightClientAttackEvidence) { ev.TotalVotingPower *= 2 }},
+		{"Different timestamp", func(ev *LightClientAttackEvidence) { ev.Timestamp = header.Time.Add(1 * time.Hour) }},
+		{"Different byzantine validators", func(ev *LightClientAttackEvidence) {
+			ev.ByzantineValidators = []*Validator{}
+		}},
+	}
+
+	for _, tc := range testCases {
+		lcae := &LightClientAttackEvidence{
+			ConflictingBlock: &LightBlock{
+				SignedHeader: &SignedHeader{
+					Header: header,
+					Commit: commit,
+				},
+				ValidatorSet: valSet,
+			},
+			CommonHeight:        commonHeight,
+			TotalVotingPower:    valSet.TotalVotingPower(),
+			Timestamp:           header.Time,
+			ByzantineValidators: valSet.Validators[:nValidators/2],
+		}
+		hash := lcae.Hash()
+		t.Log(hash)
+		tc.malleateEvidence(lcae)
+		assert.NotEqual(t, hash, lcae.Hash(), tc.testName)
+	}
 }
 
 func TestLightClientAttackEvidenceValidation(t *testing.T) {
 	height := int64(5)
-	voteSet, valSet, privVals := randVoteSet(height, 1, tmproto.PrecommitType, 10, 1)
+	commonHeight := height - 1
+	nValidators := 10
+	voteSet, valSet, privVals := randVoteSet(height, 1, tmproto.PrecommitType, nValidators, 1)
 	header := makeHeaderRandom()
 	header.Height = height
 	header.ValidatorsHash = valSet.Hash()
@@ -169,7 +179,10 @@ func TestLightClientAttackEvidenceValidation(t *testing.T) {
 			},
 			ValidatorSet: valSet,
 		},
-		CommonHeight: height - 1,
+		CommonHeight:        commonHeight,
+		TotalVotingPower:    valSet.TotalVotingPower(),
+		Timestamp:           header.Time,
+		ByzantineValidators: valSet.Validators[:nValidators/2],
 	}
 	assert.NoError(t, lcae.ValidateBasic())
 
@@ -178,15 +191,21 @@ func TestLightClientAttackEvidenceValidation(t *testing.T) {
 		malleateEvidence func(*LightClientAttackEvidence)
 		expectErr        bool
 	}{
-		{"Good DuplicateVoteEvidence", func(ev *LightClientAttackEvidence) {}, false},
+		{"Good LightClientAttackEvidence", func(ev *LightClientAttackEvidence) {}, false},
 		{"Negative height", func(ev *LightClientAttackEvidence) { ev.CommonHeight = -10 }, true},
 		{"Height is greater than divergent block", func(ev *LightClientAttackEvidence) {
 			ev.CommonHeight = height + 1
 		}, true},
+		{"Height is equal to the divergent block", func(ev *LightClientAttackEvidence) {
+			ev.CommonHeight = height
+		}, false},
 		{"Nil conflicting header", func(ev *LightClientAttackEvidence) { ev.ConflictingBlock.Header = nil }, true},
 		{"Nil conflicting blocl", func(ev *LightClientAttackEvidence) { ev.ConflictingBlock = nil }, true},
 		{"Nil validator set", func(ev *LightClientAttackEvidence) {
 			ev.ConflictingBlock.ValidatorSet = &ValidatorSet{}
+		}, true},
+		{"Negative total voting power", func(ev *LightClientAttackEvidence) {
+			ev.TotalVotingPower = -1
 		}, true},
 	}
 	for _, tc := range testCases {
@@ -200,7 +219,10 @@ func TestLightClientAttackEvidenceValidation(t *testing.T) {
 					},
 					ValidatorSet: valSet,
 				},
-				CommonHeight: height - 1,
+				CommonHeight:        commonHeight,
+				TotalVotingPower:    valSet.TotalVotingPower(),
+				Timestamp:           header.Time,
+				ByzantineValidators: valSet.Validators[:nValidators/2],
 			}
 			tc.malleateEvidence(lcae)
 			if tc.expectErr {

--- a/types/light_test.go
+++ b/types/light_test.go
@@ -152,11 +152,13 @@ func TestSignedHeaderValidateBasic(t *testing.T) {
 				Header: tc.shHeader,
 				Commit: tc.shCommit,
 			}
-			assert.Equal(
+			err := sh.ValidateBasic(validSignedHeader.Header.ChainID)
+			assert.Equalf(
 				t,
 				tc.expectErr,
-				sh.ValidateBasic(validSignedHeader.Header.ChainID) != nil,
+				err != nil,
 				"Validate Basic had an unexpected result",
+				err,
 			)
 		})
 	}


### PR DESCRIPTION
See this [comment](https://github.com/tendermint/tendermint/issues/6326#issuecomment-816544708) for a writeup of what was going wrong.

This PR modifies the way we hash the `EvidenceData` struct and the `LightClientAttackEvidence` struct and is thus a breaking change


(I wonder if this works)
Closes: #6326
Closes: #6312

