### PR TITLE
e2e: relax timeouts

### DIFF
--- a/light/client.go
+++ b/light/client.go
@@ -240,7 +240,7 @@ func NewClientFromTrustedStore(
 
 	// Validate the number of witnesses.
 	if len(c.witnesses) < 1 {
-		return nil, errNoWitnesses{}
+		return nil, ErrNoWitnesses
 	}
 
 	// Verify witnesses are all on the same chain.
@@ -1127,7 +1127,7 @@ func (c *Client) compareFirstHeaderWithWitnesses(ctx context.Context, h *types.S
 	defer c.providerMutex.Unlock()
 
 	if len(c.witnesses) < 1 {
-		return errNoWitnesses{}
+		return ErrNoWitnesses
 	}
 
 	errc := make(chan error, len(c.witnesses))

--- a/light/detector.go
+++ b/light/detector.go
@@ -41,7 +41,7 @@ func (c *Client) detectDivergence(ctx context.Context, primaryTrace []*types.Lig
 	defer c.providerMutex.Unlock()
 
 	if len(c.witnesses) == 0 {
-		return errNoWitnesses{}
+		return ErrNoWitnesses
 	}
 
 	// launch one goroutine per witness to retrieve the light block of the target height

--- a/light/errors.go
+++ b/light/errors.go
@@ -89,14 +89,6 @@ func (e errConflictingHeaders) Error() string {
 		e.Block.Hash(), e.WitnessIndex)
 }
 
-// errNoWitnesses means that there are not enough witnesses connected to
-// continue running the light client.
-type errNoWitnesses struct{}
-
-func (e errNoWitnesses) Error() string {
-	return "no witnesses connected. please reset light client"
-}
-
 // errBadWitness is returned when the witness either does not respond or
 // responds with an invalid header.
 type errBadWitness struct {

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -181,7 +181,9 @@ func (memR *Reactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) {
 	}
 	for _, tx := range msg.Txs {
 		err = memR.mempool.CheckTx(tx, nil, txInfo)
-		if err != nil {
+		if err == ErrTxInCache {
+			memR.Logger.Debug("Tx already exists in cache", "tx", txID(tx))
+		} else if err != nil {
 			memR.Logger.Info("Could not check tx", "tx", txID(tx), "err", err)
 		}
 	}

--- a/test/e2e/runner/perturb.go
+++ b/test/e2e/runner/perturb.go
@@ -66,7 +66,7 @@ func PerturbNode(node *e2e.Node, perturbation e2e.Perturbation) (*rpctypes.Resul
 		return nil, fmt.Errorf("unexpected perturbation %q", perturbation)
 	}
 
-	status, err := waitForNode(node, 0, 10*time.Second)
+	status, err := waitForNode(node, 0, 20*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/runner/start.go
+++ b/test/e2e/runner/start.go
@@ -75,7 +75,7 @@ func Start(testnet *e2e.Testnet) error {
 		if err := execCompose(testnet.Dir, "up", "-d", node.Name); err != nil {
 			return err
 		}
-		status, err := waitForNode(node, node.StartAt, 1*time.Minute)
+		status, err := waitForNode(node, node.StartAt, 3*time.Minute)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -86,7 +86,7 @@ func TestApp_Tx(t *testing.T) {
 		require.NoError(t, err)
 
 		hash := tx.Hash()
-		waitTime := 20 * time.Second
+		waitTime := 30 * time.Second
 		require.Eventuallyf(t, func() bool {
 			txResp, err := client.Tx(ctx, hash, false)
 			return err == nil && bytes.Equal(txResp.Tx, tx)


### PR DESCRIPTION
## Description

Futher relaxes some timeouts that were causing failures.

This PR also removes duplicated light client error and quietens the log message for when duplicate txs are submitted

