### PR TITLE
Graceful shutdown check in consensus reactor (WIP)

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -196,6 +196,18 @@ func (r *Reactor) OnStart() error {
 // blocking until they all exit, as well as unsubscribing from events and stopping
 // state.
 func (r *Reactor) OnStop() {
+
+	// If the node is commiting the new block, wait until it finished!
+	var c = 0
+	for (r.state.Step == cstypes.RoundStepCommit) && (c < 3) {
+		time.Sleep(time.Second)
+		c++
+	}
+
+	if c == 3 {
+		r.Logger.Error("the 3 secs block commit waiting timeout! The block commit might be failed!")
+	}
+
 	r.unsubscribeFromBroadcastEvents()
 
 	if err := r.state.Stop(); err != nil {


### PR DESCRIPTION
The current consensus reactor will stop mechanism has a chance to cause the data missing with the indexer services. Therefore we introduce a graceful stop if the consensus module is trying to commit the block. The OnStop process will wait for the block commit to finish and then continue the shutdown process. 

Also, tried to adjust the services shutdown order to make sure the stopNonReactorServices be closed after the consensus reactor. 
The indexer gets the block commit info by the eventbus nodule and then updates the indexer. Therefore, if we shut down the eventbus and the indexer services first, the block commit event is not able to emit to the other modules. 

Concerns: Is any reason the core needs to shut down the Non-Reactor services before the other reactors? 
