### PR TITLE
node/state: graceful shutdown in the consensus state

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -92,6 +92,7 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
 - [privval] \#6240 Add `context.Context` to privval interface.
 - [rpc] \#6265 set cache control in http-rpc response header (@JayT106)
 - [statesync] \#6378 Retry requests for snapshots and add a minimum discovery time (5s) for new snapshots.
+- [node/state] \#6370 graceful shutdown in the consensus reactor (@JayT106)
 
 ### BUG FIXES
 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -122,9 +122,6 @@ type Reactor struct {
 	// this dedicated channel,stateCloseCh, is necessary in order to avoid data races.
 	stateCloseCh chan struct{}
 	closeCh      chan struct{}
-
-	// Use the newHeightCh to listen the new height event.
-	newHeightCh chan int64
 }
 
 // NewReactor returns a reference to a new consensus reactor, which implements
@@ -155,7 +152,6 @@ func NewReactor(
 		peerUpdates:   peerUpdates,
 		stateCloseCh:  make(chan struct{}),
 		closeCh:       make(chan struct{}),
-		newHeightCh:   make(chan int64),
 	}
 	r.BaseService = *service.NewBaseService(logger, "Consensus", r)
 
@@ -200,18 +196,6 @@ func (r *Reactor) OnStart() error {
 // blocking until they all exit, as well as unsubscribing from events and stopping
 // state.
 func (r *Reactor) OnStop() {
-
-	// If the node is committing the new block, wait until it finished!
-
-	if r.state.GetRoundState().Step == cstypes.RoundStepCommit {
-		select {
-		case <-r.newHeightCh:
-		case <-time.After(3 * time.Second):
-			r.Logger.Error("the 3 secs block commit waiting timeout! The block commit might be failed!")
-		}
-	}
-
-	close(r.newHeightCh)
 
 	r.unsubscribeFromBroadcastEvents()
 
@@ -385,6 +369,10 @@ func (r *Reactor) subscribeToBroadcastEvents() {
 		types.EventNewRoundStep,
 		func(data tmevents.EventData) {
 			r.broadcastNewRoundStepMessage(data.(*cstypes.RoundState))
+			select {
+			case r.state.onStopCh <- data.(*cstypes.RoundState):
+			default:
+			}
 		},
 	)
 	if err != nil {
@@ -411,23 +399,6 @@ func (r *Reactor) subscribeToBroadcastEvents() {
 	)
 	if err != nil {
 		r.Logger.Error("failed to add listener for events", "err", err)
-	}
-
-	err = r.state.evsw.AddListenerForEvent(
-		listenerIDConsensus,
-		types.EventRoundStepNewHeight,
-		func(data tmevents.EventData) {
-			select {
-			case r.newHeightCh <- data.(int64):
-				r.Logger.Debug("new height: %v", data.(int64))
-			default:
-				r.Logger.Debug("new height: default")
-			}
-		},
-	)
-
-	if err != nil {
-		r.Logger.Error("failed to add listener for the event EventRoundStepNewHeight", "err", err)
 	}
 }
 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -196,6 +196,18 @@ func (r *Reactor) OnStart() error {
 // blocking until they all exit, as well as unsubscribing from events and stopping
 // state.
 func (r *Reactor) OnStop() {
+
+	// If the node is committing the new block, wait until it finished!
+	var c = 0
+	for (r.state.Step == cstypes.RoundStepCommit) && (c < 3) {
+		time.Sleep(time.Second)
+		c++
+	}
+
+	if c == 3 {
+		r.Logger.Error("the 3 secs block commit waiting timeout! The block commit might be failed!")
+	}
+
 	r.unsubscribeFromBroadcastEvents()
 
 	if err := r.state.Stop(); err != nil {

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -202,7 +202,8 @@ func (r *Reactor) OnStart() error {
 func (r *Reactor) OnStop() {
 
 	// If the node is committing the new block, wait until it finished!
-	if r.state.Step == cstypes.RoundStepCommit {
+
+	if r.state.GetRoundState().Step == cstypes.RoundStepCommit {
 		select {
 		case <-r.newHeightCh:
 		case <-time.After(3 * time.Second):

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -469,7 +469,7 @@ func (h *Handshaker) replayBlocks(
 			assertAppHashEqualsOneFromBlock(appHash, block)
 		}
 
-		if i == finalBlock {
+		if i == finalBlock && !mutateState {
 			// We emit events for the index services at the final block due to the sync issue when
 			// the node shutdown during the block committing status.
 			blockExec := sm.NewBlockExecutor(

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -476,13 +476,13 @@ func (h *Handshaker) replayBlocks(
 				h.stateStore, h.logger, proxyApp.Consensus(), emptyMempool{}, sm.EmptyEvidencePool{})
 			blockExec.SetEventBus(h.eventBus)
 			appHash, err = sm.ExecCommitBlock(
-				blockExec, proxyApp.Consensus(), block, h.logger, h.stateStore, h.genDoc.InitialHeight)
+				blockExec, proxyApp.Consensus(), block, h.logger, h.stateStore, h.genDoc.InitialHeight, state)
 			if err != nil {
 				return nil, err
 			}
 		} else {
 			appHash, err = sm.ExecCommitBlock(
-				nil, proxyApp.Consensus(), block, h.logger, h.stateStore, h.genDoc.InitialHeight)
+				nil, proxyApp.Consensus(), block, h.logger, h.stateStore, h.genDoc.InitialHeight, state)
 			if err != nil {
 				return nil, err
 			}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1674,6 +1674,7 @@ func (cs *State) finalizeCommit(height int64) {
 
 	// NewHeightStep!
 	cs.updateToState(stateCopy)
+	cs.evsw.FireEvent(types.EventRoundStepNewHeight, height)
 
 	fail.Fail() // XXX
 

--- a/node/node.go
+++ b/node/node.go
@@ -1435,7 +1435,6 @@ func (n *Node) OnStart() error {
 
 // OnStop stops the Node. It implements service.Service.
 func (n *Node) OnStop() {
-	n.BaseService.OnStop()
 
 	n.Logger.Info("Stopping Node")
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -565,6 +565,7 @@ func ExecCommitBlock(
 		return nil, err
 	}
 
+	// the BlockExecutor condition is using for the final block replay process.
 	if be != nil {
 		abciValUpdates := abciResponses.EndBlock.ValidatorUpdates
 		err = validateValidatorUpdates(abciValUpdates, s.ConsensusParams.Validator)

--- a/state/execution.go
+++ b/state/execution.go
@@ -221,16 +221,6 @@ func (blockExec *BlockExecutor) ApplyBlock(
 	return state, retainHeight, nil
 }
 
-func (blockExec *BlockExecutor) FireEvents(
-	logger log.Logger,
-	eventBus types.BlockEventPublisher,
-	block *types.Block,
-	abciResponses *tmstate.ABCIResponses,
-	validatorUpdates []*types.Validator) {
-	fireEvents(
-		logger, eventBus, block, abciResponses, validatorUpdates)
-}
-
 // Commit locks the mempool, runs the ABCI Commit message, and updates the
 // mempool.
 // It returns the result of calling abci.Commit (the AppHash) and the height to retain (if any).
@@ -588,7 +578,7 @@ func ExecCommitBlock(
 			return nil, err
 		}
 
-		be.FireEvents(be.logger, be.eventBus, block, abciResponses, validatorUpdates)
+		fireEvents(be.logger, be.eventBus, block, abciResponses, validatorUpdates)
 	}
 
 	// Commit block, get hash back

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -100,7 +100,7 @@ func TestBeginBlockValidators(t *testing.T) {
 		// block for height 2
 		block, _ := state.MakeBlock(2, makeTxs(2), lastCommit, nil, state.Validators.GetProposer().Address)
 
-		_, err = sm.ExecCommitBlock(proxyApp.Consensus(), block, log.TestingLogger(), stateStore, 1)
+		_, err = sm.ExecCommitBlock(nil, proxyApp.Consensus(), block, log.TestingLogger(), stateStore, 1)
 		require.Nil(t, err, tc.desc)
 
 		// -> app receives a list of validators with a bool indicating if they signed

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -100,7 +100,7 @@ func TestBeginBlockValidators(t *testing.T) {
 		// block for height 2
 		block, _ := state.MakeBlock(2, makeTxs(2), lastCommit, nil, state.Validators.GetProposer().Address)
 
-		_, err = sm.ExecCommitBlock(nil, proxyApp.Consensus(), block, log.TestingLogger(), stateStore, 1)
+		_, err = sm.ExecCommitBlock(nil, proxyApp.Consensus(), block, log.TestingLogger(), stateStore, 1, state)
 		require.Nil(t, err, tc.desc)
 
 		// -> app receives a list of validators with a bool indicating if they signed

--- a/types/events.go
+++ b/types/events.go
@@ -25,17 +25,18 @@ const (
 	// Internal consensus events.
 	// These are used for testing the consensus state machine.
 	// They can also be used to build real-time consensus visualizers.
-	EventCompleteProposal = "CompleteProposal"
-	EventLock             = "Lock"
-	EventNewRound         = "NewRound"
-	EventNewRoundStep     = "NewRoundStep"
-	EventPolka            = "Polka"
-	EventRelock           = "Relock"
-	EventTimeoutPropose   = "TimeoutPropose"
-	EventTimeoutWait      = "TimeoutWait"
-	EventUnlock           = "Unlock"
-	EventValidBlock       = "ValidBlock"
-	EventVote             = "Vote"
+	EventCompleteProposal   = "CompleteProposal"
+	EventLock               = "Lock"
+	EventNewRound           = "NewRound"
+	EventNewRoundStep       = "NewRoundStep"
+	EventPolka              = "Polka"
+	EventRelock             = "Relock"
+	EventTimeoutPropose     = "TimeoutPropose"
+	EventTimeoutWait        = "TimeoutWait"
+	EventUnlock             = "Unlock"
+	EventValidBlock         = "ValidBlock"
+	EventVote               = "Vote"
+	EventRoundStepNewHeight = "RoundStepNewHeight"
 )
 
 // ENCODING / DECODING

--- a/types/events.go
+++ b/types/events.go
@@ -25,18 +25,17 @@ const (
 	// Internal consensus events.
 	// These are used for testing the consensus state machine.
 	// They can also be used to build real-time consensus visualizers.
-	EventCompleteProposal   = "CompleteProposal"
-	EventLock               = "Lock"
-	EventNewRound           = "NewRound"
-	EventNewRoundStep       = "NewRoundStep"
-	EventPolka              = "Polka"
-	EventRelock             = "Relock"
-	EventTimeoutPropose     = "TimeoutPropose"
-	EventTimeoutWait        = "TimeoutWait"
-	EventUnlock             = "Unlock"
-	EventValidBlock         = "ValidBlock"
-	EventVote               = "Vote"
-	EventRoundStepNewHeight = "RoundStepNewHeight"
+	EventCompleteProposal = "CompleteProposal"
+	EventLock             = "Lock"
+	EventNewRound         = "NewRound"
+	EventNewRoundStep     = "NewRoundStep"
+	EventPolka            = "Polka"
+	EventRelock           = "Relock"
+	EventTimeoutPropose   = "TimeoutPropose"
+	EventTimeoutWait      = "TimeoutWait"
+	EventUnlock           = "Unlock"
+	EventValidBlock       = "ValidBlock"
+	EventVote             = "Vote"
 )
 
 // ENCODING / DECODING


### PR DESCRIPTION
The current consensus reactor will stop mechanism has a chance to cause the data missing with the indexer services. Therefore we introduce a graceful stop if the consensus module is trying to commit the block. The OnStop process will wait for the block commit to finish and then continue the shutdown process.

Also, emit the index services-related events when the node replays the final block.

Closes:#5002
Might solves:#5851
