### PR TITLE
statesync: improve e2e test outcomes

### DIFF
--- a/statesync/snapshots.go
+++ b/statesync/snapshots.go
@@ -178,8 +178,8 @@ func (p *snapshotPool) Ranked() []*snapshot {
 	defer p.Unlock()
 
 	candidates := make([]*snapshot, 0, len(p.snapshots))
-	for _, snapshot := range p.snapshots {
-		candidates = append(candidates, snapshot)
+	for key := range p.snapshots {
+		candidates = append(candidates, p.snapshots[key])
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {

--- a/statesync/syncer.go
+++ b/statesync/syncer.go
@@ -138,7 +138,7 @@ func (s *syncer) RemovePeer(peerID p2p.NodeID) {
 // SyncAny tries to sync any of the snapshots in the snapshot pool, waiting to discover further
 // snapshots if none were found and discoveryTime > 0. It returns the latest state and block commit
 // which the caller must use to bootstrap the node.
-func (s *syncer) SyncAny(discoveryTime time.Duration) (sm.State, *types.Commit, error) {
+func (s *syncer) SyncAny(discoveryTime time.Duration, retryHook func()) (sm.State, *types.Commit, error) {
 	if discoveryTime > 0 {
 		s.logger.Info(fmt.Sprintf("Discovering snapshots for %v", discoveryTime))
 		time.Sleep(discoveryTime)
@@ -161,6 +161,7 @@ func (s *syncer) SyncAny(discoveryTime time.Duration) (sm.State, *types.Commit, 
 			if discoveryTime == 0 {
 				return sm.State{}, nil, errNoSnapshots
 			}
+			retryHook()
 			s.logger.Info(fmt.Sprintf("Discovering snapshots for %v", discoveryTime))
 			time.Sleep(discoveryTime)
 			continue

--- a/statesync/syncer_test.go
+++ b/statesync/syncer_test.go
@@ -175,7 +175,7 @@ func TestSyncer_SyncAny(t *testing.T) {
 		LastBlockAppHash: []byte("app_hash"),
 	}, nil)
 
-	newState, lastCommit, err := rts.syncer.SyncAny(0)
+	newState, lastCommit, err := rts.syncer.SyncAny(0, func() {})
 	require.NoError(t, err)
 
 	wg.Wait()
@@ -201,7 +201,7 @@ func TestSyncer_SyncAny_noSnapshots(t *testing.T) {
 
 	rts := setup(t, nil, nil, stateProvider, 2)
 
-	_, _, err := rts.syncer.SyncAny(0)
+	_, _, err := rts.syncer.SyncAny(0, func() {})
 	require.Equal(t, errNoSnapshots, err)
 }
 
@@ -221,7 +221,7 @@ func TestSyncer_SyncAny_abort(t *testing.T) {
 		Snapshot: toABCI(s), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_ABORT}, nil)
 
-	_, _, err = rts.syncer.SyncAny(0)
+	_, _, err = rts.syncer.SyncAny(0, func() {})
 	require.Equal(t, errAbort, err)
 	rts.conn.AssertExpectations(t)
 }
@@ -260,7 +260,7 @@ func TestSyncer_SyncAny_reject(t *testing.T) {
 		Snapshot: toABCI(s11), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_REJECT}, nil)
 
-	_, _, err = rts.syncer.SyncAny(0)
+	_, _, err = rts.syncer.SyncAny(0, func() {})
 	require.Equal(t, errNoSnapshots, err)
 	rts.conn.AssertExpectations(t)
 }
@@ -295,7 +295,7 @@ func TestSyncer_SyncAny_reject_format(t *testing.T) {
 		Snapshot: toABCI(s11), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_ABORT}, nil)
 
-	_, _, err = rts.syncer.SyncAny(0)
+	_, _, err = rts.syncer.SyncAny(0, func() {})
 	require.Equal(t, errAbort, err)
 	rts.conn.AssertExpectations(t)
 }
@@ -341,7 +341,7 @@ func TestSyncer_SyncAny_reject_sender(t *testing.T) {
 		Snapshot: toABCI(sa), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_REJECT}, nil)
 
-	_, _, err = rts.syncer.SyncAny(0)
+	_, _, err = rts.syncer.SyncAny(0, func() {})
 	require.Equal(t, errNoSnapshots, err)
 	rts.conn.AssertExpectations(t)
 }
@@ -364,7 +364,7 @@ func TestSyncer_SyncAny_abciError(t *testing.T) {
 		Snapshot: toABCI(s), AppHash: []byte("app_hash"),
 	}).Once().Return(nil, errBoom)
 
-	_, _, err = rts.syncer.SyncAny(0)
+	_, _, err = rts.syncer.SyncAny(0, func() {})
 	require.True(t, errors.Is(err, errBoom))
 	rts.conn.AssertExpectations(t)
 }

--- a/test/e2e/app/snapshots.go
+++ b/test/e2e/app/snapshots.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -88,7 +87,7 @@ func (s *SnapshotStore) Create(state *State) (abci.Snapshot, error) {
 	if err != nil {
 		return abci.Snapshot{}, err
 	}
-	hash := sha256.Sum256(bz)
+	hash := hashItems(state.Values)
 	snapshot := abci.Snapshot{
 		Height: state.Height,
 		Format: 1,
@@ -111,10 +110,9 @@ func (s *SnapshotStore) Create(state *State) (abci.Snapshot, error) {
 func (s *SnapshotStore) List() ([]*abci.Snapshot, error) {
 	s.RLock()
 	defer s.RUnlock()
-	snapshots := []*abci.Snapshot{}
-	for _, snapshot := range s.metadata {
-		s := snapshot // copy to avoid pointer to range variable
-		snapshots = append(snapshots, &s)
+	snapshots := make([]*abci.Snapshot, len(s.metadata))
+	for idx := range s.metadata {
+		snapshots[idx] = &s.metadata[idx]
 	}
 	return snapshots, nil
 }

--- a/test/e2e/app/snapshots.go
+++ b/test/e2e/app/snapshots.go
@@ -87,11 +87,10 @@ func (s *SnapshotStore) Create(state *State) (abci.Snapshot, error) {
 	if err != nil {
 		return abci.Snapshot{}, err
 	}
-	hash := hashItems(state.Values)
 	snapshot := abci.Snapshot{
 		Height: state.Height,
 		Format: 1,
-		Hash:   hash[:],
+		Hash:   hashItems(state.Values),
 		Chunks: byteChunks(bz),
 	}
 	err = ioutil.WriteFile(filepath.Join(s.dir, fmt.Sprintf("%v.json", state.Height)), bz, 0644)

--- a/test/e2e/networks/simple.toml
+++ b/test/e2e/networks/simple.toml
@@ -1,5 +1,27 @@
-[node.validator01]
-[node.validator02]
-[node.validator03]
-[node.validator04]
+shinitial_height = 10
 
+[validators]
+  validator01 = 55
+  validator02 = 78
+  validator03 = 32
+
+[validator_update]
+  [validator_update.1010]
+    validator02 = 94
+
+[node.validator01]
+    fast_sync = "v0"
+    state_sync = false
+    snapshot_interval = 2
+
+[node.validator02]
+    fast_sync = "v0"
+    state_sync = false
+    snapshot_interval = 2
+
+[node.validator03]
+    start_at = 15
+    fast_sync = ""
+    state_sync = true
+    persist_interval = 2
+    snapshot_interval = 2


### PR DESCRIPTION
I believe that this, in my testing seems to help the e2e state-sync
tests complete more reliably, by fixing some potential, range-related
slice building, as well as the way the test app hashes snapshots. 

Additionally, and I'm not sure if we want to do this, but I added this
hook to the reactor that re-sends the request for snapshots during the
retry. This helps in tests prevent systems from getting stuck, but I
think in reality, it might create more traffic, and operators would
just restart a state-syncing node to get a similar effect.