### PR TITLE
.github: make core team codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,19 +7,4 @@
 # global owners are only requested if there isn't a more specific
 # codeowner specified below. For this reason, the global codeowners
 # are often repeated in package-level definitions.
-*       @alexanderbez @ebuchman @melekes @tessr
-
-# Overrides for tooling packages
-.github/ @marbar3778 @alexanderbez @ebuchman @melekes @tessr
-DOCKER/ @marbar3778 @alexanderbez @ebuchman @melekes @tessr
-
-# Overrides for core Tendermint packages
-abci/  @marbar3778 @alexanderbez @ebuchman @melekes @tessr
-evidence/ @cmwaters @ebuchman @melekes @tessr
-light/ @cmwaters @melekes @ebuchman @tessr
-
-# Overrides for docs
-*.md @marbar3778 @alexanderbez @ebuchman @melekes @tessr
-docs/ @marbar3778 @alexanderbez @ebuchman @melekes @tessr
-
-
+*       @alexanderbez @cmwaters @ebuchman @marbar3778 @tessr @tychoish


### PR DESCRIPTION
Expanding the list of people who can sign off on PRs. 
(And effectively backporting some changes from master.)