### PR TITLE
e2e: split out nightly tests

### DIFF
--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        p2p: ['legacy', 'new', 'split']
+        p2p: ['legacy', 'new', 'hybrid']
         group: ['00', '01', '02', '03']
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        p2p: ['legacy', 'new', 'split']
         group: ['00', '01', '02', '03']
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -34,22 +35,12 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 4 -d networks/nightly/legacy -p legacy
-        run: ./build/generator -g 4 -d networks/nightly/new -p new
-        run: ./build/generator -g 4 -d networks/nightly/split -p split
+        run: ./build/generator -g 4 -d networks/nightly/{{ matrix.p2p }} -p {{ matrix.p2p }} 
 
-      - name: Run legacy p2p testnets in group ${{ matrix.group }}
+      - name: Run {{ matrix.p2p }} p2p testnets in group ${{ matrix.group }}
         working-directory: test/e2e
-        run: ./run-multiple.sh networks/nightly/legacy/*-group${{ matrix.group
+        run: ./run-multiple.sh networks/nightly/{{ matrix.p2p }}/*-group${{ matrix.group
         }}-*.toml
-        
-      - name: Run new p2p testnets in group ${{ matrix.group }}
-        working-directory: test/e2e
-        run: ./run-multiple.sh networks/nightly/new/*-group${{ matrix.group }}-*.toml
-        
-      - name: Run split p2p testnets in group ${{ matrix.group }}
-        working-directory: test/e2e
-        run: ./run-multiple.sh networks/nightly/split/*-group${{ matrix.group }}-*.toml
 
   e2e-nightly-fail-2:
     needs: e2e-nightly-test-2

--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -34,11 +34,22 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 4 -d networks/nightly
+        run: ./build/generator -g 4 -d networks/nightly/legacy -p legacy
+        run: ./build/generator -g 4 -d networks/nightly/new -p new
+        run: ./build/generator -g 4 -d networks/nightly/split -p split
 
-      - name: Run testnets in group ${{ matrix.group }}
+      - name: Run legacy p2p testnets in group ${{ matrix.group }}
         working-directory: test/e2e
-        run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
+        run: ./run-multiple.sh networks/nightly/legacy/*-group${{ matrix.group
+        }}-*.toml
+        
+      - name: Run new p2p testnets in group ${{ matrix.group }}
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks/nightly/new/*-group${{ matrix.group }}-*.toml
+        
+      - name: Run split p2p testnets in group ${{ matrix.group }}
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks/nightly/split/*-group${{ matrix.group }}-*.toml
 
   e2e-nightly-fail-2:
     needs: e2e-nightly-test-2

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -16,7 +16,7 @@ var (
 	testnetCombinations = map[string][]interface{}{
 		"topology":      {"single", "quad", "large"},
 		"ipv6":          {false, true},
-		"p2p":           {NewP2PMode, LegacyP2PMode, SplitP2PMode},
+		"p2p":           {NewP2PMode, LegacyP2PMode, HybridP2PMode},
 		"queueType":     {"priority"}, // "fifo", "wdrr"
 		"initialHeight": {0, 1000},
 		"initialState": {
@@ -51,10 +51,10 @@ var (
 func Generate(r *rand.Rand, opts Options) ([]e2e.Manifest, error) {
 	manifests := []e2e.Manifest{}
 	switch opts.P2P {
-	case NewP2PMode, LegacyP2PMode, SplitP2PMode:
+	case NewP2PMode, LegacyP2PMode, HybridP2PMode:
 		testnetCombinations["p2p"] = []interface{}{opts.P2P}
 	default:
-		testnetCombinations["p2p"] = []interface{}{NewP2PMode, LegacyP2PMode, SplitP2PMode}
+		testnetCombinations["p2p"] = []interface{}{NewP2PMode, LegacyP2PMode, HybridP2PMode}
 	}
 
 	for _, opt := range combinations(testnetCombinations) {
@@ -76,7 +76,7 @@ type P2PMode string
 const (
 	NewP2PMode    P2PMode = "new"
 	LegacyP2PMode P2PMode = "legacy"
-	SplitP2PMode  P2PMode = "split"
+	HybridP2PMode P2PMode = "hybrid"
 	// mixed means that all combination are generated
 	MixedP2PMode P2PMode = "mixed"
 )
@@ -102,7 +102,7 @@ func generateTestnet(r *rand.Rand, opt map[string]interface{}) (e2e.Manifest, er
 		manifest.DisableLegacyP2P = true
 	case LegacyP2PMode:
 		manifest.DisableLegacyP2P = false
-	case SplitP2PMode:
+	case HybridP2PMode:
 		manifest.DisableLegacyP2P = false
 		p2pNodeFactor = 2
 	default:

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -65,7 +65,7 @@ func NewCLI() *CLI {
 	_ = cli.root.MarkPersistentFlagRequired("dir")
 	cli.root.PersistentFlags().IntP("groups", "g", 0, "Number of groups")
 	cli.root.PersistentFlags().StringP("p2p", "p", string(MixedP2PMode),
-		"P2P typology to be generated [\"new\", \"legacy\", \"split\" or \"mixed\" ]")
+		"P2P typology to be generated [\"new\", \"legacy\", \"hybrid\" or \"mixed\" ]")
 
 	return cli
 }

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -45,25 +45,38 @@ func NewCLI() *CLI {
 			if err != nil {
 				return err
 			}
-			return cli.generate(dir, groups)
+			p2pMode, err := cmd.Flags().GetString("p2p")
+			if err != nil {
+				return err
+			}
+			var opts Options
+			switch p2pMode {
+			case "new", "legacy", "split", "mixed":
+				opts = Options{P2P: P2PMode(p2pMode)}
+			default:
+				return fmt.Errorf("p2p mode must be either new, legacy, split or mixed got %s", p2pMode)
+			}
+
+			return cli.generate(dir, groups, opts)
 		},
 	}
 
 	cli.root.PersistentFlags().StringP("dir", "d", "", "Output directory for manifests")
 	_ = cli.root.MarkPersistentFlagRequired("dir")
 	cli.root.PersistentFlags().IntP("groups", "g", 0, "Number of groups")
+	cli.root.PersistentFlags().StringP("p2p", "p", "mixed", "P2P typology to be generated. Can be \"new\", \"legacy\" or \"split\". Use \"mixed\" for combinations of all flavours")
 
 	return cli
 }
 
 // generate generates manifests in a directory.
-func (cli *CLI) generate(dir string, groups int) error {
+func (cli *CLI) generate(dir string, groups int, opts Options) error {
 	err := os.MkdirAll(dir, 0755)
 	if err != nil {
 		return err
 	}
 
-	manifests, err := Generate(rand.New(rand.NewSource(randomSeed)))
+	manifests, err := Generate(rand.New(rand.NewSource(randomSeed)), opts)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -64,7 +64,8 @@ func NewCLI() *CLI {
 	cli.root.PersistentFlags().StringP("dir", "d", "", "Output directory for manifests")
 	_ = cli.root.MarkPersistentFlagRequired("dir")
 	cli.root.PersistentFlags().IntP("groups", "g", 0, "Number of groups")
-	cli.root.PersistentFlags().StringP("p2p", "p", "mixed", "P2P typology to be generated. Can be \"new\", \"legacy\" or \"split\". Use \"mixed\" for combinations of all flavours")
+	cli.root.PersistentFlags().StringP("p2p", "p", string(MixedP2PMode),
+		"P2P typology to be generated [\"new\", \"legacy\", \"split\" or \"mixed\" ]")
 
 	return cli
 }


### PR DESCRIPTION
Added a flag to the e2e generator which specifies which p2p system to use. Then I updated the nightly workflow so that a separate job is run for each p2p system