### PR TITLE
mempool: add duplicate transaction and parallel checktx benchmarks

### DIFF
--- a/mempool/bench_test.go
+++ b/mempool/bench_test.go
@@ -52,7 +52,7 @@ func BenchmarkCheckDuplicateTx(b *testing.B) {
 	mempool, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
-	mempool.config.Size = 100000000000
+	mempool.config.Size = 1000000
 
 	for i := 0; i < b.N; i++ {
 		tx := make([]byte, 8)

--- a/mempool/bench_test.go
+++ b/mempool/bench_test.go
@@ -1,6 +1,7 @@
 package mempool
 
 import (
+	"context"
 	"encoding/binary"
 	"testing"
 
@@ -43,6 +44,46 @@ func BenchmarkCheckTx(b *testing.B) {
 		if err := mempool.CheckTx(tx, nil, TxInfo{}); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func BenchmarkParallelCheckTx(b *testing.B) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLocalClientCreator(app)
+	mempool, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	mempool.config.Size = 100000000
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	counter := make(chan int, 1000)
+	go func() {
+		num := 0
+		for {
+			num++
+			select {
+			case counter <- num:
+			case <-ctx.Done():
+				close(counter)
+				return
+			}
+		}
+
+	}()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				tx := make([]byte, 8)
+				binary.BigEndian.PutUint64(tx, uint64(<-counter))
+				if err := mempool.CheckTx(tx, nil, TxInfo{}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
 	}
 }
 

--- a/mempool/bench_test.go
+++ b/mempool/bench_test.go
@@ -1,7 +1,6 @@
 package mempool
 
 import (
-	"context"
 	"encoding/binary"
 	"testing"
 
@@ -55,23 +54,12 @@ func BenchmarkParallelCheckTx(b *testing.B) {
 
 	mempool.config.Size = 100000000
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	counter := make(chan int, 1000)
-	go func() {
-		num := 0
-		for {
-			num++
-			select {
-			case counter <- num:
-			case <-ctx.Done():
-				close(counter)
-				return
-			}
-		}
-
-	}()
-
+	txCt := 500000000
+	counter := make(chan int, txCt)
+	for i := 0; i < txCt; i++ {
+		counter <- i
+	}
+	close(counter)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.RunParallel(func(pb *testing.PB) {


### PR DESCRIPTION
This should resolve #2122, and adds a benchmark for adding a duplicate
Tx to the mempool, as described in the intial ticket. I think this
benchmark, see blow, shows that there isn't an additional overhead for
adding a duplicate transaction relative to adding a transaction in
general.


```bash 
$ go test -benchmem -bench=. -run="Bench.*" ./mempool

goos: linux                                                          
goarch: amd64
pkg: github.com/tendermint/tendermint/mempool
cpu: Intel(R) Core(TM) i7-4820K CPU @ 3.70GHz
BenchmarkReap-8                     1220           1001954 ns/op          485781 B/op      10001 allocs/op
BenchmarkCheckTx-8                262141              5363 ns/op            1553 B/op         32 allocs/op
BenchmarkCheckDuplicateTx-8       179866              6014 ns/op            1538 B/op         33 allocs/op
BenchmarkCacheInsertTime-8       1547768               802.8 ns/op            84 B/op          2 allocs/op
BenchmarkCacheRemoveTime-8       1942242               638.7 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/tendermint/tendermint/mempool        10.716s
```