### PR TITLE
Update DOCKER/README.md to make init succeed

### DIFF
--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -31,7 +31,7 @@ To get started developing applications, see the [application developers guide](h
 A quick example of a built-in app and Tendermint core in one container.
 
 ```sh
-docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint init
+docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint init validator
 docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint start --proxy-app=kvstore
 ```
 


### PR DESCRIPTION
A node type is required for `tendermint init`. I added the same mentionned on https://docs.tendermint.com/master/introduction/quick-start.html#initialization

Following the current doc on docker hub we face the following error message:

```
$ docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint init
ERROR: must specify a node type: tendermint init [validator|full|seed]
```

