### PR TITLE
p2p: avoid incoming and outgoing connection race

### DIFF
--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -211,7 +211,7 @@ func TestReactor_AbruptDisconnect(t *testing.T) {
 		Status: p2p.PeerStatusDown,
 		NodeID: rts.nodes[0],
 	}
-	require.NoError(t, rts.network.Nodes[rts.nodes[1]].PeerManager.Disconnected(rts.nodes[0]))
+	rts.network.Nodes[rts.nodes[1]].PeerManager.Disconnected(rts.nodes[0])
 }
 
 func TestReactor_NoBlockResponse(t *testing.T) {

--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -256,11 +256,11 @@ func TestReactorMultiDisconnect(t *testing.T) {
 	// Ensure "disconnecting" the secondary peer from the primary more than once
 	// is handled gracefully.
 
-	require.NoError(t, primary.PeerManager.Disconnected(secondary.NodeID))
+	primary.PeerManager.Disconnected(secondary.NodeID)
 	require.Equal(t, primary.PeerManager.Status(secondary.NodeID), p2p.PeerStatusDown)
 	_, err := primary.PeerManager.TryEvictNext()
 	require.NoError(t, err)
-	require.NoError(t, primary.PeerManager.Disconnected(secondary.NodeID))
+	primary.PeerManager.Disconnected(secondary.NodeID)
 
 	require.Equal(t, primary.PeerManager.Status(secondary.NodeID), p2p.PeerStatusDown)
 	require.Equal(t, secondary.PeerManager.Status(primary.NodeID), p2p.PeerStatusUp)

--- a/p2p/peermanager.go
+++ b/p2p/peermanager.go
@@ -684,7 +684,7 @@ func (m *PeerManager) Accepted(peerID NodeID) error {
 // peer must already be marked as connected. This is separate from Dialed() and
 // Accepted() to allow the router to set up its internal queues before reactors
 // start sending messages.
-func (m *PeerManager) Ready(peerID NodeID) error {
+func (m *PeerManager) Ready(peerID NodeID) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -695,7 +695,6 @@ func (m *PeerManager) Ready(peerID NodeID) error {
 			Status: PeerStatusUp,
 		})
 	}
-	return nil
 }
 
 // EvictNext returns the next peer to evict (i.e. disconnect). If no evictable
@@ -752,7 +751,7 @@ func (m *PeerManager) TryEvictNext() (NodeID, error) {
 
 // Disconnected unmarks a peer as connected, allowing it to be dialed or
 // accepted again as appropriate.
-func (m *PeerManager) Disconnected(peerID NodeID) error {
+func (m *PeerManager) Disconnected(peerID NodeID) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -772,7 +771,6 @@ func (m *PeerManager) Disconnected(peerID NodeID) error {
 	}
 
 	m.dialWaker.Wake()
-	return nil
 }
 
 // Errored reports a peer error, causing the peer to be evicted if it's
@@ -783,7 +781,7 @@ func (m *PeerManager) Disconnected(peerID NodeID) error {
 //
 // FIXME: This will cause the peer manager to immediately try to reconnect to
 // the peer, which is probably not always what we want.
-func (m *PeerManager) Errored(peerID NodeID, err error) error {
+func (m *PeerManager) Errored(peerID NodeID, err error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -792,7 +790,6 @@ func (m *PeerManager) Errored(peerID NodeID, err error) error {
 	}
 
 	m.evictWaker.Wake()
-	return nil
 }
 
 // Advertise returns a list of peer addresses to advertise to a peer.

--- a/p2p/peermanager_test.go
+++ b/p2p/peermanager_test.go
@@ -446,7 +446,7 @@ func TestPeerManager_DialNext_WakeOnDisconnected(t *testing.T) {
 
 	go func() {
 		time.Sleep(200 * time.Millisecond)
-		require.NoError(t, peerManager.Disconnected(a.NodeID))
+		peerManager.Disconnected(a.NodeID)
 	}()
 
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
@@ -558,7 +558,7 @@ func TestPeerManager_TryDialNext_MaxConnectedUpgrade(t *testing.T) {
 
 	// Now, if we disconnect a, we should be allowed to dial d because we have a
 	// free upgrade slot.
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 	dial, err = peerManager.TryDialNext()
 	require.NoError(t, err)
 	require.Equal(t, d, dial)
@@ -567,7 +567,7 @@ func TestPeerManager_TryDialNext_MaxConnectedUpgrade(t *testing.T) {
 	// However, if we disconnect b (such that only c and d are connected), we
 	// should not be allowed to dial e even though there are upgrade slots,
 	// because there are no lower-scored nodes that can be upgraded.
-	require.NoError(t, peerManager.Disconnected(b.NodeID))
+	peerManager.Disconnected(b.NodeID)
 	added, err = peerManager.Add(e)
 	require.NoError(t, err)
 	require.True(t, added)
@@ -979,7 +979,7 @@ func TestPeerManager_Dialed_UpgradeEvenLower(t *testing.T) {
 
 	// In the meanwhile, a disconnects and d connects. d is even lower-scored
 	// than b (1 vs 2), which is currently being upgraded.
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 	added, err = peerManager.Add(d)
 	require.NoError(t, err)
 	require.True(t, added)
@@ -1029,7 +1029,7 @@ func TestPeerManager_Dialed_UpgradeNoEvict(t *testing.T) {
 	require.Equal(t, c, dial)
 
 	// In the meanwhile, b disconnects.
-	require.NoError(t, peerManager.Disconnected(b.NodeID))
+	peerManager.Disconnected(b.NodeID)
 
 	// Once c completes the upgrade of b, there is no longer a need to
 	// evict anything since we're at capacity.
@@ -1198,7 +1198,7 @@ func TestPeerManager_Accepted_Upgrade(t *testing.T) {
 	evict, err := peerManager.TryEvictNext()
 	require.NoError(t, err)
 	require.Equal(t, a.NodeID, evict)
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 
 	// c still cannot get accepted, since it's not scored above b.
 	require.Error(t, peerManager.Accepted(c.NodeID))
@@ -1269,7 +1269,7 @@ func TestPeerManager_Ready(t *testing.T) {
 	require.Equal(t, p2p.PeerStatusDown, peerManager.Status(a.NodeID))
 
 	// Marking a as ready should transition it to PeerStatusUp and send an update.
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 	require.Equal(t, p2p.PeerStatusUp, peerManager.Status(a.NodeID))
 	require.Equal(t, p2p.PeerUpdate{
 		NodeID: a.NodeID,
@@ -1281,7 +1281,7 @@ func TestPeerManager_Ready(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, added)
 	require.Equal(t, p2p.PeerStatusDown, peerManager.Status(b.NodeID))
-	require.NoError(t, peerManager.Ready(b.NodeID))
+	peerManager.Ready(b.NodeID)
 	require.Equal(t, p2p.PeerStatusDown, peerManager.Status(b.NodeID))
 	require.Empty(t, sub.Updates())
 }
@@ -1297,7 +1297,7 @@ func TestPeerManager_EvictNext(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, added)
 	require.NoError(t, peerManager.Accepted(a.NodeID))
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 
 	// Since there are no peers to evict, EvictNext should block until timeout.
 	timeoutCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
@@ -1307,7 +1307,7 @@ func TestPeerManager_EvictNext(t *testing.T) {
 	require.Equal(t, context.DeadlineExceeded, err)
 
 	// Erroring the peer will return it from EvictNext().
-	require.NoError(t, peerManager.Errored(a.NodeID, errors.New("foo")))
+	peerManager.Errored(a.NodeID, errors.New("foo"))
 	evict, err := peerManager.EvictNext(timeoutCtx)
 	require.NoError(t, err)
 	require.Equal(t, a.NodeID, evict)
@@ -1330,12 +1330,12 @@ func TestPeerManager_EvictNext_WakeOnError(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, added)
 	require.NoError(t, peerManager.Accepted(a.NodeID))
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 
 	// Spawn a goroutine to error a peer after a delay.
 	go func() {
 		time.Sleep(200 * time.Millisecond)
-		require.NoError(t, peerManager.Errored(a.NodeID, errors.New("foo")))
+		peerManager.Errored(a.NodeID, errors.New("foo"))
 	}()
 
 	// This will block until peer errors above.
@@ -1362,7 +1362,7 @@ func TestPeerManager_EvictNext_WakeOnUpgradeDialed(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, added)
 	require.NoError(t, peerManager.Accepted(a.NodeID))
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 
 	// Spawn a goroutine to upgrade to b with a delay.
 	go func() {
@@ -1400,7 +1400,7 @@ func TestPeerManager_EvictNext_WakeOnUpgradeAccepted(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, added)
 	require.NoError(t, peerManager.Accepted(a.NodeID))
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 
 	// Spawn a goroutine to upgrade b with a delay.
 	go func() {
@@ -1432,10 +1432,10 @@ func TestPeerManager_TryEvictNext(t *testing.T) {
 
 	// Connecting to a won't evict anything either.
 	require.NoError(t, peerManager.Accepted(a.NodeID))
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 
 	// But if a errors it should be evicted.
-	require.NoError(t, peerManager.Errored(a.NodeID, errors.New("foo")))
+	peerManager.Errored(a.NodeID, errors.New("foo"))
 	evict, err = peerManager.TryEvictNext()
 	require.NoError(t, err)
 	require.Equal(t, a.NodeID, evict)
@@ -1445,7 +1445,7 @@ func TestPeerManager_TryEvictNext(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, evict)
 
-	require.NoError(t, peerManager.Errored(a.NodeID, errors.New("foo")))
+	peerManager.Errored(a.NodeID, errors.New("foo"))
 	evict, err = peerManager.TryEvictNext()
 	require.NoError(t, err)
 	require.Zero(t, evict)
@@ -1461,7 +1461,7 @@ func TestPeerManager_Disconnected(t *testing.T) {
 	defer sub.Close()
 
 	// Disconnecting an unknown peer does nothing.
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 	require.Empty(t, peerManager.Peers())
 	require.Empty(t, sub.Updates())
 
@@ -1470,14 +1470,14 @@ func TestPeerManager_Disconnected(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, added)
 	require.NoError(t, peerManager.Accepted(a.NodeID))
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 	require.Empty(t, sub.Updates())
 
 	// Disconnecting a ready peer sends a status update.
 	_, err = peerManager.Add(a)
 	require.NoError(t, err)
 	require.NoError(t, peerManager.Accepted(a.NodeID))
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 	require.Equal(t, p2p.PeerStatusUp, peerManager.Status(a.NodeID))
 	require.NotEmpty(t, sub.Updates())
 	require.Equal(t, p2p.PeerUpdate{
@@ -1485,7 +1485,7 @@ func TestPeerManager_Disconnected(t *testing.T) {
 		Status: p2p.PeerStatusUp,
 	}, <-sub.Updates())
 
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 	require.Equal(t, p2p.PeerStatusDown, peerManager.Status(a.NodeID))
 	require.NotEmpty(t, sub.Updates())
 	require.Equal(t, p2p.PeerUpdate{
@@ -1499,7 +1499,7 @@ func TestPeerManager_Disconnected(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, a, dial)
 
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 	dial, err = peerManager.TryDialNext()
 	require.NoError(t, err)
 	require.Zero(t, dial)
@@ -1512,7 +1512,7 @@ func TestPeerManager_Errored(t *testing.T) {
 	require.NoError(t, err)
 
 	// Erroring an unknown peer does nothing.
-	require.NoError(t, peerManager.Errored(a.NodeID, errors.New("foo")))
+	peerManager.Errored(a.NodeID, errors.New("foo"))
 	require.Empty(t, peerManager.Peers())
 	evict, err := peerManager.TryEvictNext()
 	require.NoError(t, err)
@@ -1523,19 +1523,19 @@ func TestPeerManager_Errored(t *testing.T) {
 	added, err := peerManager.Add(a)
 	require.NoError(t, err)
 	require.True(t, added)
-	require.NoError(t, peerManager.Errored(a.NodeID, errors.New("foo")))
+	peerManager.Errored(a.NodeID, errors.New("foo"))
 	evict, err = peerManager.TryEvictNext()
 	require.NoError(t, err)
 	require.Zero(t, evict)
 
 	require.NoError(t, peerManager.Accepted(a.NodeID))
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 	evict, err = peerManager.TryEvictNext()
 	require.NoError(t, err)
 	require.Zero(t, evict)
 
 	// However, erroring once connected will evict it.
-	require.NoError(t, peerManager.Errored(a.NodeID, errors.New("foo")))
+	peerManager.Errored(a.NodeID, errors.New("foo"))
 	evict, err = peerManager.TryEvictNext()
 	require.NoError(t, err)
 	require.Equal(t, a.NodeID, evict)
@@ -1560,11 +1560,11 @@ func TestPeerManager_Subscribe(t *testing.T) {
 	require.NoError(t, peerManager.Accepted(a.NodeID))
 	require.Empty(t, sub.Updates())
 
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 	require.NotEmpty(t, sub.Updates())
 	require.Equal(t, p2p.PeerUpdate{NodeID: a.NodeID, Status: p2p.PeerStatusUp}, <-sub.Updates())
 
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 	require.NotEmpty(t, sub.Updates())
 	require.Equal(t, p2p.PeerUpdate{NodeID: a.NodeID, Status: p2p.PeerStatusDown}, <-sub.Updates())
 
@@ -1577,18 +1577,18 @@ func TestPeerManager_Subscribe(t *testing.T) {
 	require.NoError(t, peerManager.Dialed(a))
 	require.Empty(t, sub.Updates())
 
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 	require.NotEmpty(t, sub.Updates())
 	require.Equal(t, p2p.PeerUpdate{NodeID: a.NodeID, Status: p2p.PeerStatusUp}, <-sub.Updates())
 
-	require.NoError(t, peerManager.Errored(a.NodeID, errors.New("foo")))
+	peerManager.Errored(a.NodeID, errors.New("foo"))
 	require.Empty(t, sub.Updates())
 
 	evict, err := peerManager.TryEvictNext()
 	require.NoError(t, err)
 	require.Equal(t, a.NodeID, evict)
 
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 	require.NotEmpty(t, sub.Updates())
 	require.Equal(t, p2p.PeerUpdate{NodeID: a.NodeID, Status: p2p.PeerStatusDown}, <-sub.Updates())
 
@@ -1617,13 +1617,13 @@ func TestPeerManager_Subscribe_Close(t *testing.T) {
 	require.NoError(t, peerManager.Accepted(a.NodeID))
 	require.Empty(t, sub.Updates())
 
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 	require.NotEmpty(t, sub.Updates())
 	require.Equal(t, p2p.PeerUpdate{NodeID: a.NodeID, Status: p2p.PeerStatusUp}, <-sub.Updates())
 
 	// Closing the subscription should not send us the disconnected update.
 	sub.Close()
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 	require.Empty(t, sub.Updates())
 }
 
@@ -1647,7 +1647,7 @@ func TestPeerManager_Subscribe_Broadcast(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, added)
 	require.NoError(t, peerManager.Accepted(a.NodeID))
-	require.NoError(t, peerManager.Ready(a.NodeID))
+	peerManager.Ready(a.NodeID)
 
 	expectUp := p2p.PeerUpdate{NodeID: a.NodeID, Status: p2p.PeerStatusUp}
 	require.NotEmpty(t, s1)
@@ -1660,7 +1660,7 @@ func TestPeerManager_Subscribe_Broadcast(t *testing.T) {
 	// We now close s2. Disconnecting the peer should only send updates
 	// on s1 and s3.
 	s2.Close()
-	require.NoError(t, peerManager.Disconnected(a.NodeID))
+	peerManager.Disconnected(a.NodeID)
 
 	expectDown := p2p.PeerUpdate{NodeID: a.NodeID, Status: p2p.PeerStatusDown}
 	require.NotEmpty(t, s1)

--- a/p2p/pex/reactor.go
+++ b/p2p/pex/reactor.go
@@ -51,8 +51,7 @@ func ChannelDescriptor() conn.ChannelDescriptor {
 		Priority:            1,
 		SendQueueCapacity:   10,
 		RecvMessageCapacity: maxMsgSize,
-
-		MaxSendBytes: 200,
+		MaxSendBytes:        200,
 	}
 }
 

--- a/p2p/router_test.go
+++ b/p2p/router_test.go
@@ -738,7 +738,7 @@ func TestRouter_EvictPeers(t *testing.T) {
 		Status: p2p.PeerStatusUp,
 	})
 
-	require.NoError(t, peerManager.Errored(peerInfo.NodeID, errors.New("boom")))
+	peerManager.Errored(peerInfo.NodeID, errors.New("boom"))
 
 	p2ptest.RequireUpdate(t, sub, p2p.PeerUpdate{
 		NodeID: peerInfo.NodeID,


### PR DESCRIPTION
This is another incremental improvement in the p2p layer to help the e2e tests. 

The intention of this change is that it will avoid a condition where a
peer is trying to connect to you and you're trying to connect to the
peer, and because the connection establishment process isn't entirely
atomic (e.g. we get and release the peer manager and other mutexes a
few times.) I was seeing a lot of cases where a node would end up
without any connections, or the connections would end up churning
frequently. This makes the incoming and outgoing connection
establishment more similar, and (if nothing else) makes the logs much
more clear in my tests.