### PR TITLE
mempool: use regular map with mutex for mempool transaction senders

### DIFF
--- a/mempool/bench_test.go
+++ b/mempool/bench_test.go
@@ -2,6 +2,7 @@ package mempool
 
 import (
 	"encoding/binary"
+	"math"
 	"sync/atomic"
 	"testing"
 
@@ -83,11 +84,11 @@ func BenchmarkCheckDuplicateTx(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tx := make([]byte, 8)
 		binary.BigEndian.PutUint64(tx, uint64(i))
-		if err := mempool.CheckTx(tx, nil, TxInfo{}); err != nil {
+		if err := mempool.CheckTx(tx, nil, TxInfo{SenderID: math.MaxUint16}); err != nil {
 			b.Fatal(err)
 		}
 
-		if err := mempool.CheckTx(tx, nil, TxInfo{}); err == nil {
+		if err := mempool.CheckTx(tx, nil, TxInfo{SenderID: math.MaxUint16}); err == nil {
 			b.Fatal("tx should be duplicate")
 		}
 	}

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -369,7 +369,7 @@ func (r *Reactor) broadcastTxRoutine(peerID p2p.NodeID, closer *tmsync.Closer) {
 		// NOTE: Transaction batching was disabled due to:
 		// https://github.com/tendermint/tendermint/issues/5796
 
-		if _, ok := memTx.senders.Load(peerMempoolID); !ok {
+		if !memTx.HasSender(peerMempoolID) {
 			// Send the mempool tx to the corresponding peer. Note, the peer may be
 			// behind and thus would not be able to process the mempool tx correctly.
 			r.mempoolCh.Out <- p2p.Envelope{


### PR DESCRIPTION
The senders map is only used for checking duplicated senders, so we can
use a regular map with mutex instead of sync.Map to reduce the overhead.

Benchmark result:

```
name                old time/op    new time/op    delta
Reap-8                 401µs ± 0%     389µs ± 0%   -3.17%  (p=0.000 n=10+9)
CheckTx-8             1.79µs ± 4%    1.61µs ± 5%  -10.27%  (p=0.000 n=10+10)
ParallelCheckTx-8     2.18µs ± 1%    2.00µs ± 1%   -8.15%  (p=0.000 n=10+10)
CheckDuplicateTx-8    2.19µs ± 3%    1.93µs ± 3%  -12.09%  (p=0.000 n=10+10)
CacheInsertTime-8      309ns ± 2%     308ns ± 3%     ~     (p=0.725 n=10+10)
CacheRemoveTime-8      262ns ± 1%     263ns ± 0%   +0.63%  (p=0.001 n=10+9)

name                old alloc/op   new alloc/op   delta
Reap-8                 486kB ± 0%     486kB ± 0%     ~     (all equal)
CheckTx-8             1.52kB ± 0%    1.27kB ± 0%  -16.67%  (p=0.000 n=10+10)
ParallelCheckTx-8     1.53kB ± 0%    1.28kB ± 0%  -16.28%  (p=0.000 n=10+10)
CheckDuplicateTx-8    1.57kB ± 0%    1.28kB ± 0%  -18.48%  (p=0.000 n=9+10)
CacheInsertTime-8      80.0B ± 0%     80.0B ± 0%     ~     (all equal)
CacheRemoveTime-8      0.00B          0.00B          ~     (all equal)

name                old allocs/op  new allocs/op  delta
Reap-8                 10.0k ± 0%     10.0k ± 0%     ~     (all equal)
CheckTx-8               32.0 ± 0%      28.0 ± 0%  -12.50%  (p=0.000 n=10+10)
ParallelCheckTx-8       32.0 ± 0%      28.0 ± 0%  -12.50%  (p=0.000 n=10+10)
CheckDuplicateTx-8      35.0 ± 0%      28.0 ± 0%  -20.00%  (p=0.000 n=10+10)
CacheInsertTime-8       2.00 ± 0%      2.00 ± 0%     ~     (all equal)
CacheRemoveTime-8       0.00           0.00          ~     (all equal)
```

Fixes #6471