### PR TITLE
p2p/pex: cleanup to pex internals and peerManager interface

### DIFF
--- a/p2p/peermanager.go
+++ b/p2p/peermanager.go
@@ -684,7 +684,7 @@ func (m *PeerManager) Accepted(peerID NodeID) error {
 // peer must already be marked as connected. This is separate from Dialed() and
 // Accepted() to allow the router to set up its internal queues before reactors
 // start sending messages.
-func (m *PeerManager) Ready(peerID NodeID) error {
+func (m *PeerManager) Ready(peerID NodeID) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -695,7 +695,6 @@ func (m *PeerManager) Ready(peerID NodeID) error {
 			Status: PeerStatusUp,
 		})
 	}
-	return nil
 }
 
 // EvictNext returns the next peer to evict (i.e. disconnect). If no evictable
@@ -752,7 +751,7 @@ func (m *PeerManager) TryEvictNext() (NodeID, error) {
 
 // Disconnected unmarks a peer as connected, allowing it to be dialed or
 // accepted again as appropriate.
-func (m *PeerManager) Disconnected(peerID NodeID) error {
+func (m *PeerManager) Disconnected(peerID NodeID) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -772,7 +771,6 @@ func (m *PeerManager) Disconnected(peerID NodeID) error {
 	}
 
 	m.dialWaker.Wake()
-	return nil
 }
 
 // Errored reports a peer error, causing the peer to be evicted if it's
@@ -783,7 +781,7 @@ func (m *PeerManager) Disconnected(peerID NodeID) error {
 //
 // FIXME: This will cause the peer manager to immediately try to reconnect to
 // the peer, which is probably not always what we want.
-func (m *PeerManager) Errored(peerID NodeID, err error) error {
+func (m *PeerManager) Errored(peerID NodeID, err error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -792,7 +790,6 @@ func (m *PeerManager) Errored(peerID NodeID, err error) error {
 	}
 
 	m.evictWaker.Wake()
-	return nil
 }
 
 // Advertise returns a list of peer addresses to advertise to a peer.

--- a/p2p/pex/reactor.go
+++ b/p2p/pex/reactor.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tendermint/tendermint/libs/clist"
 	"github.com/tendermint/tendermint/libs/log"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	"github.com/tendermint/tendermint/libs/service"
@@ -24,7 +23,7 @@ var (
 // See https://github.com/tendermint/tendermint/issues/6371
 const (
 	// the minimum time one peer can send another request to the same peer
-	minReceiveRequestInterval = 300 * time.Millisecond
+	minReceiveRequestInterval = 100 * time.Millisecond
 
 	// the maximum amount of addresses that can be included in a response
 	maxAddresses uint16 = 100
@@ -78,7 +77,7 @@ type ReactorV2 struct {
 	closeCh     chan struct{}
 
 	// list of available peers to loop through and send peer requests to
-	availablePeers *clist.CList
+	availablePeers map[p2p.NodeID]struct{}
 
 	mtx sync.RWMutex
 
@@ -120,7 +119,7 @@ func NewReactorV2(
 		pexCh:                pexCh,
 		peerUpdates:          peerUpdates,
 		closeCh:              make(chan struct{}),
-		availablePeers:       clist.New(),
+		availablePeers:       make(map[p2p.NodeID]struct{}),
 		requestsSent:         make(map[p2p.NodeID]struct{}),
 		lastReceivedRequests: make(map[p2p.NodeID]time.Time),
 	}
@@ -387,11 +386,17 @@ func (r *ReactorV2) handleMessage(chID p2p.ChannelID, envelope p2p.Envelope) (er
 // send a request for addresses.
 func (r *ReactorV2) processPeerUpdate(peerUpdate p2p.PeerUpdate) {
 	r.Logger.Debug("received PEX peer update", "peer", peerUpdate.NodeID, "status", peerUpdate.Status)
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
 	switch peerUpdate.Status {
 	case p2p.PeerStatusUp:
-		r.availablePeers.PushBack(peerUpdate.NodeID)
+		r.availablePeers[peerUpdate.NodeID] = struct{}{}
 	case p2p.PeerStatusDown:
-		r.removePeer(peerUpdate.NodeID)
+		delete(r.availablePeers, peerUpdate.NodeID)
+		delete(r.requestsSent, peerUpdate.NodeID)
+		delete(r.lastReceivedRequests, peerUpdate.NodeID)
 	default:
 	}
 }
@@ -407,14 +412,18 @@ func (r *ReactorV2) waitUntilNextRequest() <-chan time.Time {
 func (r *ReactorV2) sendRequestForPeers() {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
-	peer := r.availablePeers.Front()
-	if peer == nil {
+	if len(r.availablePeers) == 0 {
 		// no peers are available
 		r.Logger.Debug("no available peers to send request to, waiting...")
 		r.nextRequestTime = time.Now().Add(noAvailablePeersWaitPeriod)
 		return
 	}
-	peerID := peer.Value.(p2p.NodeID)
+	var peerID p2p.NodeID
+
+	// use range to get a random peer.
+	for peerID = range r.availablePeers {
+		break
+	}
 
 	// The node accommodates for both pex systems
 	if r.isLegacyPeer(peerID) {
@@ -429,9 +438,10 @@ func (r *ReactorV2) sendRequestForPeers() {
 		}
 	}
 
-	// remove the peer from the available peers list and mark it in the requestsSent map
-	r.availablePeers.Remove(peer)
-	peer.DetachPrev()
+	// remove the peer from the abvailable peers list and mark it in the requestsSent map
+	// WAT(tychoish): do we actually want to do this? doesn't this
+	// just make churn?
+	delete(r.availablePeers, peerID)
 	r.requestsSent[peerID] = struct{}{}
 
 	r.calculateNextRequestTime()
@@ -462,7 +472,7 @@ func (r *ReactorV2) calculateNextRequestTime() {
 	// in. For example if we have 10 peers and we can't send a message to the
 	// same peer every 500ms, then we can send a request every 50ms. In practice
 	// we use a safety margin of 2, ergo 100ms
-	peers := tmmath.MinInt(r.availablePeers.Len(), 50)
+	peers := tmmath.MinInt(len(r.availablePeers), 50)
 	baseTime := minReceiveRequestInterval
 	if peers > 0 {
 		baseTime = minReceiveRequestInterval * 2 / time.Duration(peers)
@@ -482,20 +492,6 @@ func (r *ReactorV2) calculateNextRequestTime() {
 	// NOTE: As ratio is always >= 1, discovery ratio is >= 1. Therefore we don't need to worry
 	// about the next request time being less than the minimum time
 	r.nextRequestTime = time.Now().Add(baseTime * time.Duration(r.discoveryRatio))
-}
-
-func (r *ReactorV2) removePeer(id p2p.NodeID) {
-	for e := r.availablePeers.Front(); e != nil; e = e.Next() {
-		if e.Value == id {
-			r.availablePeers.Remove(e)
-			e.DetachPrev()
-			break
-		}
-	}
-	r.mtx.Lock()
-	defer r.mtx.Unlock()
-	delete(r.requestsSent, id)
-	delete(r.lastReceivedRequests, id)
 }
 
 func (r *ReactorV2) markPeerRequest(peer p2p.NodeID) error {
@@ -521,7 +517,8 @@ func (r *ReactorV2) markPeerResponse(peer p2p.NodeID) error {
 	delete(r.requestsSent, peer)
 	// attach to the back of the list so that the peer can be used again for
 	// future requests
-	r.availablePeers.PushBack(peer)
+
+	r.availablePeers[peer] = struct{}{}
 	return nil
 }
 

--- a/p2p/pex/reactor_test.go
+++ b/p2p/pex/reactor_test.go
@@ -668,6 +668,7 @@ func (r *reactorTestSuite) requireNumberOfPeers(
 	nodeIndex, numPeers int,
 	waitPeriod time.Duration,
 ) {
+	t.Helper()
 	require.Eventuallyf(t, func() bool {
 		actualNumPeers := len(r.network.Nodes[r.nodes[nodeIndex]].PeerManager.Peers())
 		return actualNumPeers >= numPeers

--- a/test/e2e/networks/simple.toml
+++ b/test/e2e/networks/simple.toml
@@ -1,5 +1,11 @@
+disable_legacy_p2p = true
+
 [node.validator01]
+    disable_legacy_p2p = true
 [node.validator02]
+    disable_legacy_p2p = true
 [node.validator03]
+    disable_legacy_p2p = true
 [node.validator04]
+    disable_legacy_p2p = true
 


### PR DESCRIPTION
This is a cleanup as a fresh take on https://github.com/tendermint/tendermint/pull/6470

- pex: remove clist for map/set
- p2p: clean up peer manager interface and routePeer refactor

Please add a description of the changes that this PR introduces and the files that
are the most critical to review.

If this PR fixes an open Issue, please include "Closes #XXX" (where "XXX" is the Issue number) 
so that GitHub will automatically close the Issue when this PR is merged.