### PR TITLE
config: Add private peer id /net_info expose information in default config

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -341,6 +341,7 @@ recv-rate = {{ .P2P.RecvRate }}
 pex = {{ .P2P.PexReactor }}
 
 # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
+# Warning: IPs will be exposed at /net_info, for more information https://github.com/tendermint/tendermint/issues/3055
 private-peer-ids = "{{ .P2P.PrivatePeerIDs }}"
 
 # Toggle to disable guard against peers connecting from the same ip.


### PR DESCRIPTION
Should give a warning in config until this is below issue is resolved
Related to https://github.com/tendermint/tendermint/issues/3055

