### PR TITLE
light: fix net_info call on light rpc

### DIFF
--- a/light/proxy/routes.go
+++ b/light/proxy/routes.go
@@ -69,10 +69,10 @@ func makeStatusFunc(c *lrpc.Client) rpcStatusFunc {
 	}
 }
 
-type rpcNetInfoFunc func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.ResultNetInfo, error)
+type rpcNetInfoFunc func(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error)
 
 func makeNetInfoFunc(c *lrpc.Client) rpcNetInfoFunc {
-	return func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.ResultNetInfo, error) {
+	return func(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error) {
 		return c.NetInfo(ctx.Context())
 	}
 }


### PR DESCRIPTION
Whilst poking around the light client, I realised that the `/net_info` endpoint ends up panicking the light client rpc server. Did a sneaky git blame and it looks like this bugs been around for 2 years.

I've tested this locally to make sure that the endpoint is working now
