### PR TITLE
config/logger: Add mono mode in the tm logger output format.

### DIFF
--- a/cmd/tendermint/commands/root.go
+++ b/cmd/tendermint/commands/root.go
@@ -61,6 +61,8 @@ var RootCmd = &cobra.Command{
 
 		if config.LogFormat == cfg.LogFormatJSON {
 			logger = log.NewTMJSONLogger(log.NewSyncWriter(os.Stdout))
+		} else if config.LogFormat == cfg.LogFormatMono {
+			logger = log.NewTMMonoLogger(log.NewSyncWriter(os.Stdout))
 		}
 
 		logger, err = tmflags.ParseLogLevel(config.LogLevel, logger, cfg.DefaultLogLevel)

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ const (
 
 	// LogFormatPlain is a format for colored text
 	LogFormatPlain = "plain"
+	// LogFormatMono is a format for monochrome text
+	LogFormatMono = "mono"
 	// LogFormatJSON is a format for json output
 	LogFormatJSON = "json"
 
@@ -331,7 +333,7 @@ func (cfg Config) ArePrivValidatorClientSecurityOptionsPresent() bool {
 // returns an error if any check fails.
 func (cfg BaseConfig) ValidateBasic() error {
 	switch cfg.LogFormat {
-	case LogFormatPlain, LogFormatJSON:
+	case LogFormatPlain, LogFormatJSON, LogFormatMono:
 	default:
 		return errors.New("unknown log format (must be 'plain' or 'json')")
 	}

--- a/config/toml.go
+++ b/config/toml.go
@@ -129,7 +129,7 @@ db-dir = "{{ js .BaseConfig.DBPath }}"
 # Output level for logging, including package level options
 log-level = "{{ .BaseConfig.LogLevel }}"
 
-# Output format: 'plain' (colored text) or 'json'
+# Output format: 'plain' (colored text), 'mono' (monochrome text), or 'json'
 log-format = "{{ .BaseConfig.LogFormat }}"
 
 ##### additional base config options #####

--- a/docs/nodes/configuration.md
+++ b/docs/nodes/configuration.md
@@ -80,7 +80,7 @@ db-dir = "data"
 # Output level for logging, including package level options
 log-level = "main:info,state:info,statesync:info,*:error"
 
-# Output format: 'plain' (colored text) or 'json'
+# Output format: 'plain' (colored text), 'mono' (monochrome text), or 'json'
 log-format = "plain"
 
 ##### additional base config options #####

--- a/libs/log/tm_logger.go
+++ b/libs/log/tm_logger.go
@@ -43,6 +43,12 @@ func NewTMLogger(w io.Writer) Logger {
 	return &tmLogger{term.NewLogger(w, NewTMFmtLogger, colorFn)}
 }
 
+// NewTMMonoLogger returns a logger that encodes msg and keyvals to the Writer
+// using go-kit's log as an underlying logger with no color formatter.
+func NewTMMonoLogger(w io.Writer) Logger {
+	return &tmLogger{NewTMFmtLogger(w)}
+}
+
 // NewTMLoggerWithColorFn allows you to provide your own color function. See
 // NewTMLogger for documentation.
 func NewTMLoggerWithColorFn(w io.Writer, colorFn func(keyvals ...interface{}) term.FgBgColor) Logger {


### PR DESCRIPTION
Add mono mode in the tm logger output format. 

Closes #1760