### PR TITLE
e2e: fix looping problem while waiting for testnet

### DIFF
--- a/test/e2e/runner/rpc.go
+++ b/test/e2e/runner/rpc.go
@@ -43,7 +43,7 @@ func waitForHeight(testnet *e2e.Testnet, height int64) (*types.Block, *types.Blo
 			if err != nil {
 				continue
 			}
-			if result.Block != nil && (maxResult == nil || result.Block.Height >= maxResult.Block.Height) {
+			if result.Block != nil && (maxResult == nil || result.Block.Height > maxResult.Block.Height) {
 				maxResult = result
 				lastIncrease = time.Now()
 			}


### PR DESCRIPTION
`waitForHeight` can get stuck in an infinite loop because the max result gets updated when the result is equal or greater when it should be strictly greater. This means when a chain is not making progress and is stuck on the same height it will never timeout

