### PR TITLE
linter: linter checks non-ASCII identifiers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,7 @@ linters:
     # - wsl
     # - gocognit
     - nolintlint
+    - asciicheck
 
 issues:
   exclude-rules:


### PR DESCRIPTION
Enabled the ASCII check linter
https://github.com/tdakkota/asciicheck

Closes #2801
