### PR TITLE
p2p: reduce buffering on channels

### DIFF
--- a/internal/blockchain/v0/reactor.go
+++ b/internal/blockchain/v0/reactor.go
@@ -32,7 +32,7 @@ var (
 				ID:                  byte(BlockchainChannel),
 				Priority:            5,
 				SendQueueCapacity:   1000,
-				RecvBufferCapacity:  50 * 4096,
+				RecvBufferCapacity:  1024,
 				RecvMessageCapacity: bc.MaxMsgSize,
 
 				MaxSendBytes: 100,

--- a/internal/blockchain/v2/reactor.go
+++ b/internal/blockchain/v2/reactor.go
@@ -583,7 +583,7 @@ func (r *BlockchainReactor) GetChannels() []*p2p.ChannelDescriptor {
 			ID:                  BlockchainChannel,
 			Priority:            5,
 			SendQueueCapacity:   2000,
-			RecvBufferCapacity:  50 * 4096,
+			RecvBufferCapacity:  1024,
 			RecvMessageCapacity: bc.MaxMsgSize,
 		},
 	}

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -33,8 +33,8 @@ var (
 			MsgType: new(tmcons.Message),
 			Descriptor: &p2p.ChannelDescriptor{
 				ID:                  byte(StateChannel),
-				Priority:            6,
-				SendQueueCapacity:   100,
+				Priority:            8,
+				SendQueueCapacity:   64,
 				RecvMessageCapacity: maxMsgSize,
 
 				MaxSendBytes: 12000,
@@ -47,9 +47,9 @@ var (
 				// stuff. Once we gossip the whole block there is nothing left to send
 				// until next height or round.
 				ID:                  byte(DataChannel),
-				Priority:            10,
-				SendQueueCapacity:   100,
-				RecvBufferCapacity:  50 * 4096,
+				Priority:            12,
+				SendQueueCapacity:   64,
+				RecvBufferCapacity:  512,
 				RecvMessageCapacity: maxMsgSize,
 
 				MaxSendBytes: 40000,
@@ -59,9 +59,9 @@ var (
 			MsgType: new(tmcons.Message),
 			Descriptor: &p2p.ChannelDescriptor{
 				ID:                  byte(VoteChannel),
-				Priority:            7,
-				SendQueueCapacity:   100,
-				RecvBufferCapacity:  100 * 100,
+				Priority:            10,
+				SendQueueCapacity:   64,
+				RecvBufferCapacity:  128,
 				RecvMessageCapacity: maxMsgSize,
 
 				MaxSendBytes: 150,
@@ -71,9 +71,9 @@ var (
 			MsgType: new(tmcons.Message),
 			Descriptor: &p2p.ChannelDescriptor{
 				ID:                  byte(VoteSetBitsChannel),
-				Priority:            1,
-				SendQueueCapacity:   2,
-				RecvBufferCapacity:  1024,
+				Priority:            5,
+				SendQueueCapacity:   8,
+				RecvBufferCapacity:  128,
 				RecvMessageCapacity: maxMsgSize,
 
 				MaxSendBytes: 50,

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -18,7 +18,7 @@ import (
 	"github.com/tendermint/tendermint/libs/service"
 )
 
-const queueBufferDefault = 4096
+const queueBufferDefault = 32
 
 // ChannelID is an arbitrary channel ID.
 type ChannelID uint16

--- a/node/setup.go
+++ b/node/setup.go
@@ -696,7 +696,7 @@ func createPEXReactorV2(
 	router *p2p.Router,
 ) (*pex.ReactorV2, error) {
 
-	channel, err := router.OpenChannel(pex.ChannelDescriptor(), &protop2p.PexMessage{}, 4096)
+	channel, err := router.OpenChannel(pex.ChannelDescriptor(), &protop2p.PexMessage{}, 128)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is draft, and mostly to do a nightly e2e run, but generally, I
think having smaller buffers in each reactor/channel will mean that
there will be fewer stale messages.