### PR TITLE
fastsync/event: emit fastsync status event when switching consensus/fastsync

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -98,6 +98,7 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
   - Applications that do not specify a priority, i.e. zero, will have transactions reaped by the order in which they are received by the node.
   - Transactions are gossiped in FIFO order as they are in `v0`.
 - [config/indexer] \#6411 Introduce support for custom event indexing data sources, specifically PostgreSQL. (@JayT106)
+- [fastsync/event] \#6619 Emit fastsync status event when switching consensus/fastsync (@JayT106)
 
 ### IMPROVEMENTS
 - [libs/log] Console log formatting changes as a result of \#6534 and \#6589. (@tychoish)

--- a/docs/tendermint-core/fast-sync.md
+++ b/docs/tendermint-core/fast-sync.md
@@ -45,3 +45,13 @@ version = "v0"
 
 If we're lagging sufficiently, we should go back to fast syncing, but
 this is an [open issue](https://github.com/tendermint/tendermint/issues/129).
+
+## The Fast Sync event
+When the tendermint blockchain core launches, it might switch to the `fast-sync`
+mode to catch up the states to the current network best height. the core will emits
+a fast-sync event to expose the current status and the sync height. Once it catched
+the network best height, it will switches to the state sync mechanism and then emit
+another event for exposing the fast-sync `complete` status and the state `height`.
+
+The user can query the events by subscribing `EventQueryFastSyncStatus`
+Please check [types](https://pkg.go.dev/github.com/tendermint/tendermint/types?utm_source=godoc#pkg-constants) for the details.

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -305,9 +305,9 @@ conR:
 %+v`, err, r.state, r))
 	}
 
-	d := types.EventDataFastSyncStatus{On: false, Height: state.LastBlockHeight}
+	d := types.EventDataFastSyncStatus{Complete: true, Height: state.LastBlockHeight}
 	if err := r.eventBus.PublishEventFastSyncStatus(d); err != nil {
-		r.Logger.Error("failed to emit the fastsync off event", "err", err)
+		r.Logger.Error("failed to emit the fastsync complete event", "err", err)
 	}
 }
 

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -304,6 +304,11 @@ conS:
 conR:
 %+v`, err, r.state, r))
 	}
+
+	d := types.EventDataFastSyncStatus{On: false, Height: state.LastBlockHeight}
+	if err := r.eventBus.PublishEventFastSyncStatus(d); err != nil {
+		r.Logger.Error("failed to emit the fastsync off event", "err", err)
+	}
 }
 
 // String returns a string representation of the Reactor.

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -260,15 +260,15 @@ func waitForBlockWithUpdatedValsAndValidateIt(
 	wg.Wait()
 }
 
-func ensureFastSyncStatus(msg tmpubsub.Message, on bool, height int64) {
+func ensureFastSyncStatus(msg tmpubsub.Message, complete bool, height int64) {
 	status, ok := msg.Data().(types.EventDataFastSyncStatus)
 	if !ok {
 		panic(fmt.Sprintf("expected a EventDataFastSyncStatus, got %T. Wrong subscription channel?",
 			msg.Data()))
 	}
 
-	if status.On != on {
-		panic(fmt.Sprintf("expected on %v, got %v", on, status.On))
+	if status.Complete != complete {
+		panic(fmt.Sprintf("expected on %v, got %v", complete, status.Complete))
 	}
 
 	if status.Height != height {
@@ -311,7 +311,7 @@ func TestReactorBasic(t *testing.T) {
 		// wait till everyone makes the consensus switch
 		go func(s types.Subscription) {
 			msg := <-s.Out()
-			ensureFastSyncStatus(msg, false, 0)
+			ensureFastSyncStatus(msg, true, 0)
 			wg.Done()
 		}(sub)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -664,7 +664,7 @@ func (n *nodeImpl) OnStart() error {
 		}
 
 		err = startStateSync(n.stateSyncReactor, bcR, n.consensusReactor, n.stateSyncProvider,
-			n.config.StateSync, n.config.FastSyncMode, n.stateStore, n.blockStore, state)
+			n.config.StateSync, n.config.FastSyncMode, n.stateStore, n.blockStore, state, n.eventBus)
 		if err != nil {
 			return fmt.Errorf("failed to start state sync: %w", err)
 		}
@@ -1029,7 +1029,7 @@ func (n *nodeImpl) NodeInfo() types.NodeInfo {
 // startStateSync starts an asynchronous state sync process, then switches to fast sync mode.
 func startStateSync(ssR *statesync.Reactor, bcR cs.FastSyncReactor, conR *cs.Reactor,
 	stateProvider statesync.StateProvider, config *cfg.StateSyncConfig, fastSync bool,
-	stateStore sm.Store, blockStore *store.BlockStore, state sm.State) error {
+	stateStore sm.Store, blockStore *store.BlockStore, state sm.State, eventbus *types.EventBus) error {
 	ssR.Logger.Info("starting state sync...")
 
 	if stateProvider == nil {
@@ -1071,6 +1071,12 @@ func startStateSync(ssR *statesync.Reactor, bcR cs.FastSyncReactor, conR *cs.Rea
 				ssR.Logger.Error("failed to switch to fast sync", "err", err)
 				return
 			}
+
+			d := types.EventDataFastSyncStatus{On: true, Height: state.LastBlockHeight}
+			if err := eventbus.PublishEventFastSyncStatus(d); err != nil {
+				ssR.Logger.Error("failed to emit the fastsync on event", "err", err)
+			}
+
 		} else {
 			conR.SwitchToConsensus(state, true)
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -1072,9 +1072,9 @@ func startStateSync(ssR *statesync.Reactor, bcR cs.FastSyncReactor, conR *cs.Rea
 				return
 			}
 
-			d := types.EventDataFastSyncStatus{On: true, Height: state.LastBlockHeight}
+			d := types.EventDataFastSyncStatus{Complete: false, Height: state.LastBlockHeight}
 			if err := eventbus.PublishEventFastSyncStatus(d); err != nil {
-				ssR.Logger.Error("failed to emit the fastsync on event", "err", err)
+				ssR.Logger.Error("failed to emit the fastsync starting event", "err", err)
 			}
 
 		} else {

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -153,6 +153,10 @@ func (b *EventBus) PublishEventValidBlock(data EventDataRoundState) error {
 	return b.Publish(EventValidBlockValue, data)
 }
 
+func (b *EventBus) PublishEventFastSyncStatus(data EventDataFastSyncStatus) error {
+	return b.Publish(EventFastSyncStatusValue, data)
+}
+
 // PublishEventTx publishes tx event with events from Result. Note it will add
 // predefined keys (EventTypeKey, TxHashKey). Existing events with the same keys
 // will be overwritten.
@@ -227,6 +231,10 @@ func (b *EventBus) PublishEventLock(data EventDataRoundState) error {
 
 func (b *EventBus) PublishEventValidatorSetUpdates(data EventDataValidatorSetUpdates) error {
 	return b.Publish(EventValidatorSetUpdatesValue, data)
+}
+
+func (b *EventBus) PublishEventFastSyncUpdate(data EventDataValidatorSetUpdates) error {
+	return b.Publish(EventFastSyncStatusValue, data)
 }
 
 //-----------------------------------------------------------------------------
@@ -306,5 +314,9 @@ func (NopEventBus) PublishEventLock(data EventDataRoundState) error {
 }
 
 func (NopEventBus) PublishEventValidatorSetUpdates(data EventDataValidatorSetUpdates) error {
+	return nil
+}
+
+func (NopEventBus) PublishEventFastSyncStatus(data EventDataFastSyncStatus) error {
 	return nil
 }

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -233,10 +233,6 @@ func (b *EventBus) PublishEventValidatorSetUpdates(data EventDataValidatorSetUpd
 	return b.Publish(EventValidatorSetUpdatesValue, data)
 }
 
-func (b *EventBus) PublishEventFastSyncUpdate(data EventDataValidatorSetUpdates) error {
-	return b.Publish(EventFastSyncStatusValue, data)
-}
-
 //-----------------------------------------------------------------------------
 type NopEventBus struct{}
 

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -370,6 +370,8 @@ func TestEventBusPublish(t *testing.T) {
 	require.NoError(t, err)
 	err = eventBus.PublishEventValidatorSetUpdates(EventDataValidatorSetUpdates{})
 	require.NoError(t, err)
+	err = eventBus.PublishEventFastSyncStatus(EventDataFastSyncStatus{})
+	require.NoError(t, err)
 
 	select {
 	case <-done:
@@ -476,9 +478,11 @@ var events = []string{
 	EventRelockValue,
 	EventTimeoutWaitValue,
 	EventVoteValue,
+	EventFastSyncStatusValue,
 }
 
 func randEventValue() string {
+
 	return events[mrand.Intn(len(events))]
 }
 
@@ -494,7 +498,8 @@ var queries = []tmpubsub.Query{
 	EventQueryLock,
 	EventQueryRelock,
 	EventQueryTimeoutWait,
-	EventQueryVote}
+	EventQueryVote,
+	EventQueryFastSyncStatus}
 
 func randQuery() tmpubsub.Query {
 	return queries[mrand.Intn(len(queries))]

--- a/types/events.go
+++ b/types/events.go
@@ -173,8 +173,8 @@ type EventDataValidatorSetUpdates struct {
 }
 
 type EventDataFastSyncStatus struct {
-	On     bool  `json:"on"`
-	Height int64 `json:"height"`
+	Complete bool  `json:"complete"`
+	Height   int64 `json:"height"`
 }
 
 // PUBSUB

--- a/types/events.go
+++ b/types/events.go
@@ -27,6 +27,7 @@ const (
 	// These are used for testing the consensus state machine.
 	// They can also be used to build real-time consensus visualizers.
 	EventCompleteProposalValue = "CompleteProposal"
+	EventFastSyncStatusValue   = "FastSyncStatus"
 	EventLockValue             = "Lock"
 	EventNewRoundValue         = "NewRound"
 	EventNewRoundStepValue     = "NewRoundStep"
@@ -100,6 +101,7 @@ func init() {
 	tmjson.RegisterType(EventDataVote{}, "tendermint/event/Vote")
 	tmjson.RegisterType(EventDataValidatorSetUpdates{}, "tendermint/event/ValidatorSetUpdates")
 	tmjson.RegisterType(EventDataString(""), "tendermint/event/ProposalString")
+	tmjson.RegisterType(EventDataFastSyncStatus{}, "tendermint/event/FastSyncStatus")
 }
 
 // Most event messages are basic types (a block, a transaction)
@@ -170,6 +172,11 @@ type EventDataValidatorSetUpdates struct {
 	ValidatorUpdates []*Validator `json:"validator_updates"`
 }
 
+type EventDataFastSyncStatus struct {
+	On     bool  `json:"on"`
+	Height int64 `json:"height"`
+}
+
 // PUBSUB
 
 const (
@@ -207,6 +214,7 @@ var (
 	EventQueryValidatorSetUpdates = QueryForEvent(EventValidatorSetUpdatesValue)
 	EventQueryValidBlock          = QueryForEvent(EventValidBlockValue)
 	EventQueryVote                = QueryForEvent(EventVoteValue)
+	EventQueryFastSyncStatus      = QueryForEvent(EventFastSyncStatusValue)
 )
 
 func EventQueryTxFor(tx Tx) tmpubsub.Query {

--- a/types/events.go
+++ b/types/events.go
@@ -27,17 +27,19 @@ const (
 	// These are used for testing the consensus state machine.
 	// They can also be used to build real-time consensus visualizers.
 	EventCompleteProposalValue = "CompleteProposal"
-	EventFastSyncStatusValue   = "FastSyncStatus"
-	EventLockValue             = "Lock"
-	EventNewRoundValue         = "NewRound"
-	EventNewRoundStepValue     = "NewRoundStep"
-	EventPolkaValue            = "Polka"
-	EventRelockValue           = "Relock"
-	EventTimeoutProposeValue   = "TimeoutPropose"
-	EventTimeoutWaitValue      = "TimeoutWait"
-	EventUnlockValue           = "Unlock"
-	EventValidBlockValue       = "ValidBlock"
-	EventVoteValue             = "Vote"
+	// The FastSyncStatus event will be emitted when the node switching
+	// state sync mechanism between the consensus reactor and the fastsync reactor.
+	EventFastSyncStatusValue = "FastSyncStatus"
+	EventLockValue           = "Lock"
+	EventNewRoundValue       = "NewRound"
+	EventNewRoundStepValue   = "NewRoundStep"
+	EventPolkaValue          = "Polka"
+	EventRelockValue         = "Relock"
+	EventTimeoutProposeValue = "TimeoutPropose"
+	EventTimeoutWaitValue    = "TimeoutWait"
+	EventUnlockValue         = "Unlock"
+	EventValidBlockValue     = "ValidBlock"
+	EventVoteValue           = "Vote"
 )
 
 // Pre-populated ABCI Tendermint-reserved events
@@ -172,6 +174,8 @@ type EventDataValidatorSetUpdates struct {
 	ValidatorUpdates []*Validator `json:"validator_updates"`
 }
 
+// EventDataFastSyncStatus shows the fastsync status and the
+// height when the node state sync mechanism changes.
 type EventDataFastSyncStatus struct {
 	Complete bool  `json:"complete"`
 	Height   int64 `json:"height"`


### PR DESCRIPTION
closes #2498 
solves part of #3365

Note: difficult to test the event emit in SwitchToFastSync part, might need to change `stateSyncReactor` to an interface in the `nodeImpl` struct   
