### PR TITLE
use go version 1.16 as minimum version

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1 Generate Tendermint Binary
-FROM golang:1.15-alpine as builder
+FROM golang:1.16-alpine as builder
 RUN apk update && \
     apk upgrade && \
     apk --no-cache add make

--- a/DOCKER/Dockerfile.build_c-amazonlinux
+++ b/DOCKER/Dockerfile.build_c-amazonlinux
@@ -9,7 +9,7 @@ RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &
 RUN yum -y groupinstall "Development Tools"
 RUN yum -y install leveldb-devel which
 
-ENV GOVERSION=1.12.9
+ENV GOVERSION=1.16.5
 
 RUN cd /tmp && \
     wget https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Or [Blockchain](<https://en.wikipedia.org/wiki/Blockchain_(database)>), for shor
 
 [![version](https://img.shields.io/github/tag/tendermint/tendermint.svg)](https://github.com/tendermint/tendermint/releases/latest)
 [![API Reference](https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667)](https://pkg.go.dev/github.com/tendermint/tendermint)
-[![Go version](https://img.shields.io/badge/go-1.15-blue.svg)](https://github.com/moovweb/gvm)
+[![Go version](https://img.shields.io/badge/go-1.16-blue.svg)](https://github.com/moovweb/gvm)
 [![Discord chat](https://img.shields.io/discord/669268347736686612.svg)](https://discord.gg/vcExX9T)
 [![license](https://img.shields.io/github/license/tendermint/tendermint.svg)](https://github.com/tendermint/tendermint/blob/master/LICENSE)
 [![tendermint/tendermint](https://tokei.rs/b1/github/tendermint/tendermint?category=lines)](https://github.com/tendermint/tendermint)
@@ -48,7 +48,7 @@ to notify you of vulnerabilities and fixes in Tendermint Core. You can subscribe
 
 | Requirement | Notes            |
 |-------------|------------------|
-| Go version  | Go1.15 or higher |
+| Go version  | Go1.16 or higher |
 
 ## Documentation
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -80,7 +80,7 @@ will need to change to accommodate these changes. Most notably:
 This release is not compatible with previous blockchains due to changes to
 the encoding format (see "Protocol Buffers," below) and the block header (see "Blockchain Protocol").
 
-Note also that Tendermint 0.34 also requires Go 1.15 or higher.
+Note also that Tendermint 0.34 also requires Go 1.16 or higher.
 
 ### ABCI Changes
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -40,7 +40,7 @@ Verify that you have the latest version of Go installed:
 
 ```bash
 $ go version
-go version go1.15.x darwin/amd64
+go version go1.16.x darwin/amd64
 ```
 
 ## 1.2 Creating a new Go project

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -43,7 +43,7 @@ Verify that you have the latest version of Go installed:
 
 ```bash
 $ go version
-go version go1.15.x darwin/amd64
+go version go1.16.x darwin/amd64
 ```
 
 ## 1.2 Creating a new Go project
@@ -446,7 +446,7 @@ This will populate the `go.mod` with a release number followed by a hash for Ten
 ```go
 module github.com/me/example
 
-go 1.15
+go 1.16
 
 require (
  github.com/dgraph-io/badger v1.6.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tendermint/tendermint
 
-go 1.15
+go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/networks/remote/integration.sh
+++ b/networks/remote/integration.sh
@@ -10,8 +10,8 @@ sudo apt-get upgrade -y
 sudo apt-get install -y jq unzip python-pip software-properties-common make
 
 # get and unpack golang
-curl -O https://dl.google.com/go/go1.15.4.linux-amd64.tar.gz
-tar -xvf go1.15.4.linux-amd64.tar.gz
+curl -O https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz
+tar -xvf go1.16.5.linux-amd64.tar.gz
 
 ## move binary and add to path
 mv go /usr/local

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.16
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.15
+FROM golang:1.16
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y libleveldb-dev librocksdb-dev >/dev/null


### PR DESCRIPTION
Updates the documentation and `go.mod` to use go version `1.16`. `1.16` is currently the latest version of golang and should be preferred. This change also updates the various Dockerfiles used by the project to use `1.16` and updates test scripts as well.

Resolves issue #6641 