### PR TITLE
rpc: revert returning empty block

### DIFF
--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -96,11 +96,12 @@ func (env *Environment) Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.
 		return nil, err
 	}
 
-	block := env.BlockStore.LoadBlock(height)
 	blockMeta := env.BlockStore.LoadBlockMeta(height)
-	if blockMeta == nil || block == nil {
-		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: &types.Block{}}, nil
+	if blockMeta == nil {
+		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: nil}, nil
 	}
+
+	block := env.BlockStore.LoadBlock(height)
 	return &ctypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block}, nil
 }
 


### PR DESCRIPTION
We altered the behavior in an earlier PR where a node returned an empty block instead of nil when the node didn't have it. This slight behavior change messed up with the e2e tests because instead of providing a nil block it was providing a block with a height of 0. This could also be a breaking change in the behavior of clients of the RPC so we've decided to revert the behavior 


