### PR TITLE
state/indexer: close row after query

### DIFF
--- a/state/indexer/sink/psql/psql.go
+++ b/state/indexer/sink/psql/psql.go
@@ -110,6 +110,7 @@ func (es *EventSink) IndexTxEvents(txr []*abci.TxResult) error {
 		if err != nil {
 			return err
 		}
+		defer r.Close()
 
 		if !r.Next() {
 			return nil


### PR DESCRIPTION

Closes: #6661 

Note: see another error during the events indexing, guess the raw tx size exceeds the limitation?
```
3:17PM ERR failed to index block txs err="pq: index row size 2768 exceeds btree version 4 maximum 2704 for index \"tx_results_tx_result_key\"" height=5205112 module=txindex

