### PR TITLE
psql: close opened rows in tests

### DIFF
--- a/state/indexer/sink/psql/psql_test.go
+++ b/state/indexer/sink/psql/psql_test.go
@@ -293,6 +293,7 @@ func verifyBlock(h int64) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer rows.Close()
 
 	if !rows.Next() {
 		return false, nil
@@ -308,6 +309,7 @@ func verifyBlock(h int64) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer rows.Close()
 
 	return rows.Next(), nil
 }


### PR DESCRIPTION
After #6664, ran a modified version of [dgryski's semgrep rule](https://github.com/dgryski/semgrep-go/blob/master/close-sql-query-rows.yml) on the `psql` code and it found these two unclosed sql rows in tests.

