### PR TITLE
rpc: fix evidence test by extending wait time

### DIFF
--- a/rpc/client/evidence_test.go
+++ b/rpc/client/evidence_test.go
@@ -120,7 +120,7 @@ func TestBroadcastEvidence_DuplicateVoteEvidence(t *testing.T) {
 	// previous versions of this test used a shared fixture with
 	// other tests, and in this version we give it a little time
 	// for the node to make progress before running the test
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	chainID := config.ChainID()
 


### PR DESCRIPTION
Occasionally, the node would take longer to produce the first block and therefore the evidence_test.go would fail. This extends the wait time to 100 ms before testing to see that evidence came through

Closes: #6674


