### PR TITLE
e2e: adjust tx load

### DIFF
--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -68,9 +68,9 @@ func Load(ctx context.Context, testnet *e2e.Testnet, multiplier int) error {
 // loadGenerate generates jobs until the context is canceled
 func loadGenerate(ctx context.Context, chTx chan<- types.Tx, multiplier int, size int64) {
 	for i := 0; i < math.MaxInt64; i++ {
-		// We keep generating the same 1000 keys over and over, with different values.
+		// We keep generating the same 100 keys over and over, with different values.
 		// This gives a reasonable load without putting too much data in the app.
-		id := i % 1000
+		id := i % 100
 
 		bz := make([]byte, size)
 		_, err := rand.Read(bz)
@@ -81,7 +81,8 @@ func loadGenerate(ctx context.Context, chTx chan<- types.Tx, multiplier int, siz
 
 		select {
 		case chTx <- tx:
-			time.Sleep(time.Millisecond * time.Duration(int(size)/multiplier))
+			sqrtSize := int(math.Sqrt(float64(size)))
+			time.Sleep(10 * time.Millisecond * time.Duration(sqrtSize/multiplier))
 
 		case <-ctx.Done():
 			close(chTx)

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -61,9 +61,6 @@ func NewCLI() *CLI {
 			defer loadCancel()
 			go func() {
 				err := Load(ctx, cli.testnet, 1)
-				if err != nil {
-					logger.Error(fmt.Sprintf("Transaction load failed: %v", err.Error()))
-				}
 				chLoadResult <- err
 			}()
 
@@ -95,9 +92,9 @@ func NewCLI() *CLI {
 
 			loadCancel()
 			if err := <-chLoadResult; err != nil {
-				return err
+				return fmt.Errorf("transaction load failed: %w", err)
 			}
-			if err := Wait(cli.testnet, 8); err != nil { // wait for network to settle before tests
+			if err := Wait(cli.testnet, 5); err != nil { // wait for network to settle before tests
 				return err
 			}
 			if err := Test(cli.testnet); err != nil {


### PR DESCRIPTION
In #6659, variable tx size was introduced. The frequency of txs sent to a node was adjusted to be inversely proportional to the size of the tx. However, after looking at the nightlies, I saw that in some one node testnets where the tx size was 10kb the frequency was so low that occasionally no txs were submitted and this caused a few testnets to error out. This tweaks the frequency to prevent this from happening


