### PR TITLE
Revert "statesync: keep peer despite lightblock query fail (#6692)"

### DIFF
--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -338,6 +338,9 @@ func (r *Reactor) backfill(
 					if lb == nil {
 						r.Logger.Info("backfill: peer didn't have block, fetching from another peer", "height", height)
 						queue.retry(height)
+						// as we are fetching blocks backwards, if this node doesn't have the block it likely doesn't
+						// have any prior ones, thus we remove it from the peer list
+						r.dispatcher.removePeer(peer)
 						continue
 					}
 

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -338,8 +338,8 @@ func (r *Reactor) backfill(
 					if lb == nil {
 						r.Logger.Info("backfill: peer didn't have block, fetching from another peer", "height", height)
 						queue.retry(height)
-						// as we are fetching blocks backwards, if this node doesn't have the block it likely doesn't
-						// have any prior ones, thus we remove it from the peer list
+						// As we are fetching blocks backwards, if this node doesn't have the block it likely doesn't
+						// have any prior ones, thus we remove it from the peer list.
 						r.dispatcher.removePeer(peer)
 						continue
 					}


### PR DESCRIPTION
This reverts commit 50b00dff7191a31b40310cc016a9543892669d67.

This fix was determined to likely not affect correctness and other fixes should instead be pursued.