### PR TITLE
statesync: remove outgoingCalls race condition in dispatcher

### DIFF
--- a/internal/statesync/dispatcher.go
+++ b/internal/statesync/dispatcher.go
@@ -49,13 +49,12 @@ func newDispatcher(requestCh chan<- p2p.Envelope, timeout time.Duration) *dispat
 // in a list, tracks the call and waits for the reactor to pass along the response
 func (d *dispatcher) LightBlock(ctx context.Context, height int64) (*types.LightBlock, types.NodeID, error) {
 	d.mtx.Lock()
-	outgoingCalls := len(d.calls)
-	d.mtx.Unlock()
-
 	// check to see that the dispatcher is connected to at least one peer
-	if d.availablePeers.Len() == 0 && outgoingCalls == 0 {
+	if d.availablePeers.Len() == 0 && len(d.calls) == 0 {
+		d.mtx.Unlock()
 		return nil, "", errNoConnectedPeers
 	}
+	d.mtx.Unlock()
 
 	// fetch the next peer id in the list and request a light block from that
 	// peer

--- a/internal/statesync/dispatcher_test.go
+++ b/internal/statesync/dispatcher_test.go
@@ -49,6 +49,72 @@ func TestDispatcherBasic(t *testing.T) {
 	wg.Wait()
 }
 
+func TestDispatcherReturnsNoBlock(t *testing.T) {
+	ch := make(chan p2p.Envelope, 100)
+	d := newDispatcher(ch, 1*time.Second)
+	peerFromSet := createPeerSet(1)[0]
+	d.addPeer(peerFromSet)
+	doneCh := make(chan struct{})
+
+	go func() {
+		err := d.respond(nil, peerFromSet)
+		require.Nil(t, err)
+		close(doneCh)
+	}()
+
+	lb, peerResult, err := d.LightBlock(context.Background(), 1)
+	<-doneCh
+
+	require.Nil(t, lb)
+	require.Nil(t, err)
+	require.Equal(t, peerFromSet, peerResult)
+}
+
+func TestDispatcherErrorsWhenNoPeers(t *testing.T) {
+	ch := make(chan p2p.Envelope, 100)
+	d := newDispatcher(ch, 1*time.Second)
+
+	lb, peerResult, err := d.LightBlock(context.Background(), 1)
+
+	require.Nil(t, lb)
+	require.Empty(t, peerResult)
+	require.Equal(t, errNoConnectedPeers, err)
+}
+
+func TestDispatcherReturnsBlockOncePeerAvailable(t *testing.T) {
+	ch := make(chan p2p.Envelope, 100)
+	d := newDispatcher(ch, 1*time.Second)
+	peerFromSet := createPeerSet(1)[0]
+	d.addPeer(peerFromSet)
+	ctx := context.Background()
+	wrapped, cancelFunc := context.WithCancel(ctx)
+
+	doneCh := make(chan struct{})
+	go func() {
+		lb, peerResult, err := d.LightBlock(wrapped, 1)
+		require.Nil(t, lb)
+		require.Equal(t, peerFromSet, peerResult)
+		require.Nil(t, err)
+		close(doneCh)
+	}()
+	cancelFunc()
+	<-doneCh
+
+	go func() {
+		lb := &types.LightBlock{}
+		asProto, err := lb.ToProto()
+		require.Nil(t, err)
+		err = d.respond(asProto, peerFromSet)
+		require.Nil(t, err)
+	}()
+
+	lb, peerResult, err := d.LightBlock(context.Background(), 1)
+
+	require.NotNil(t, lb)
+	require.Equal(t, peerFromSet, peerResult)
+	require.Nil(t, err)
+}
+
 func TestDispatcherProviders(t *testing.T) {
 
 	ch := make(chan p2p.Envelope, 100)
@@ -106,6 +172,46 @@ func TestPeerListBasic(t *testing.T) {
 	half++
 	assert.Equal(t, peerSet[half], peerList.Pop(ctx))
 
+}
+
+func TestPeerListBlocksWhenEmpty(t *testing.T) {
+	peerList := newPeerList()
+	assert.Zero(t, peerList.Len())
+	doneCh := make(chan struct{})
+	go func() {
+		peerList.Pop(context.Background())
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+		t.Error("empty peer list should not have returned result")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestEmptyPeerListReturnsWhenContextCancelled(t *testing.T) {
+	peerList := newPeerList()
+	assert.Zero(t, peerList.Len())
+	doneCh := make(chan struct{})
+	ctx := context.Background()
+	wrapped, cancel := context.WithCancel(ctx)
+	go func() {
+		peerList.Pop(wrapped)
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+		t.Error("empty peer list should not have returned result")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case <-doneCh:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("peer list should have returned after context cancelled")
+	}
 }
 
 func TestPeerListConcurrent(t *testing.T) {

--- a/internal/statesync/dispatcher_test.go
+++ b/internal/statesync/dispatcher_test.go
@@ -176,7 +176,7 @@ func TestPeerListBasic(t *testing.T) {
 
 func TestPeerListBlocksWhenEmpty(t *testing.T) {
 	peerList := newPeerList()
-	assert.Zero(t, peerList.Len())
+	require.Zero(t, peerList.Len())
 	doneCh := make(chan struct{})
 	go func() {
 		peerList.Pop(context.Background())
@@ -189,9 +189,9 @@ func TestPeerListBlocksWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestEmptyPeerListReturnsWhenContextCancelled(t *testing.T) {
+func TestEmptyPeerListReturnsWhenContextCanceled(t *testing.T) {
 	peerList := newPeerList()
-	assert.Zero(t, peerList.Len())
+	require.Zero(t, peerList.Len())
 	doneCh := make(chan struct{})
 	ctx := context.Background()
 	wrapped, cancel := context.WithCancel(ctx)
@@ -210,7 +210,7 @@ func TestEmptyPeerListReturnsWhenContextCancelled(t *testing.T) {
 	select {
 	case <-doneCh:
 	case <-time.After(100 * time.Millisecond):
-		t.Error("peer list should have returned after context cancelled")
+		t.Error("peer list should have returned after context canceled")
 	}
 }
 

--- a/internal/statesync/dispatcher_test.go
+++ b/internal/statesync/dispatcher_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +18,7 @@ import (
 )
 
 func TestDispatcherBasic(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
 
 	ch := make(chan p2p.Envelope, 100)
 	closeCh := make(chan struct{})
@@ -50,6 +52,7 @@ func TestDispatcherBasic(t *testing.T) {
 }
 
 func TestDispatcherReturnsNoBlock(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
 	ch := make(chan p2p.Envelope, 100)
 	d := newDispatcher(ch, 1*time.Second)
 	peerFromSet := createPeerSet(1)[0]
@@ -71,6 +74,7 @@ func TestDispatcherReturnsNoBlock(t *testing.T) {
 }
 
 func TestDispatcherErrorsWhenNoPeers(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
 	ch := make(chan p2p.Envelope, 100)
 	d := newDispatcher(ch, 1*time.Second)
 
@@ -82,6 +86,7 @@ func TestDispatcherErrorsWhenNoPeers(t *testing.T) {
 }
 
 func TestDispatcherReturnsBlockOncePeerAvailable(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
 	ch := make(chan p2p.Envelope, 100)
 	d := newDispatcher(ch, 1*time.Second)
 	peerFromSet := createPeerSet(1)[0]
@@ -116,6 +121,7 @@ func TestDispatcherReturnsBlockOncePeerAvailable(t *testing.T) {
 }
 
 func TestDispatcherProviders(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
 
 	ch := make(chan p2p.Envelope, 100)
 	chainID := "state-sync-test"
@@ -144,6 +150,7 @@ func TestDispatcherProviders(t *testing.T) {
 }
 
 func TestPeerListBasic(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
 	peerList := newPeerList()
 	assert.Zero(t, peerList.Len())
 	numPeers := 10
@@ -175,11 +182,14 @@ func TestPeerListBasic(t *testing.T) {
 }
 
 func TestPeerListBlocksWhenEmpty(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
 	peerList := newPeerList()
 	require.Zero(t, peerList.Len())
 	doneCh := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
-		peerList.Pop(context.Background())
+		peerList.Pop(ctx)
 		close(doneCh)
 	}()
 	select {
@@ -190,6 +200,7 @@ func TestPeerListBlocksWhenEmpty(t *testing.T) {
 }
 
 func TestEmptyPeerListReturnsWhenContextCanceled(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
 	peerList := newPeerList()
 	require.Zero(t, peerList.Len())
 	doneCh := make(chan struct{})
@@ -215,6 +226,7 @@ func TestEmptyPeerListReturnsWhenContextCanceled(t *testing.T) {
 }
 
 func TestPeerListConcurrent(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
 	peerList := newPeerList()
 	numPeers := 10
 


### PR DESCRIPTION
This change moves the dispatcher's call to Lock and Unlock the mutex in `LightBlock`. It ensures that the number of outgoing calls and number of peers does not change between the check of outgoing call length and call to the `peerlist`'s `Len` method.

An example interleaving of calls that would cause incorrect behavior exists when there is only 1 peer and it is currently making an outgoing call. If a second thread calls `dispatcher.Remove()` on this peer between `dispatcher.LightBlock`s call to `len(d.calls)` and `d.availablePeers.Len()`, we will incorrectly block in the `d.availablePeers.Pop` method, waiting for a peer that has been removed.

This change also adds tests to the `peerlist` and `dispatcher` to verify specific pieces of the API such as ensuring cancelling the context passed to `peerlist.Pop` will cause the method to return.