### PR TITLE
e2e: tweak sleep for pertubations

### DIFF
--- a/test/e2e/runner/perturb.go
+++ b/test/e2e/runner/perturb.go
@@ -16,7 +16,7 @@ func Perturb(testnet *e2e.Testnet) error {
 			if err != nil {
 				return err
 			}
-			time.Sleep(5 * time.Second) // give network some time to recover between each
+			time.Sleep(15 * time.Second) // give network some time to recover between each
 		}
 	}
 	return nil
@@ -42,6 +42,7 @@ func PerturbNode(node *e2e.Node, perturbation e2e.Perturbation) (*rpctypes.Resul
 		if err := execCompose(testnet.Dir, "kill", "-s", "SIGKILL", node.Name); err != nil {
 			return nil, err
 		}
+		time.Sleep(2 * time.Second)
 		if err := execCompose(testnet.Dir, "start", node.Name); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This tweaks sleeps around pertubations, based on a theory that our
tests with "kill" pertubations restart the nodes fast enough the peers
haven't marked it down when it tries to reconnect. In my local test
runs, this clears out *most* of the test failures that I've seen,
except for one evidence-related test-harness problem (which should be
handled separately.)