### PR TITLE
router/statesync: add helpful log messages

### DIFF
--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -1024,8 +1024,13 @@ func (r *Router) NodeInfo() types.NodeInfo {
 // OnStart implements service.Service.
 func (r *Router) OnStart() error {
 	netAddr, _ := r.nodeInfo.NetAddress()
-	r.Logger.Info("node info", "NodeID", r.nodeInfo.NodeID, "Channels", r.nodeInfo.Channels,
-		"ListenAddr", r.nodeInfo.ListenAddr, "NetAddr", netAddr)
+	r.Logger.Info(
+	  "starting router", 
+	  "node_id", r.nodeInfo.NodeID,
+	  "channels", r.nodeInfo.Channels,
+		"listen_addr", r.nodeInfo.ListenAddr,
+		 "net_addr", netAddr,
+		 )
 
 	go r.dialPeers()
 	go r.evictPeers()

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -1023,6 +1023,10 @@ func (r *Router) NodeInfo() types.NodeInfo {
 
 // OnStart implements service.Service.
 func (r *Router) OnStart() error {
+	netAddr, _ := r.nodeInfo.NetAddress()
+	r.Logger.Info("node info", "NodeID", r.nodeInfo.NodeID, "Channels", r.nodeInfo.Channels,
+		"ListenAddr", r.nodeInfo.ListenAddr, "NetAddr", netAddr)
+
 	go r.dialPeers()
 	go r.evictPeers()
 

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -1025,12 +1025,12 @@ func (r *Router) NodeInfo() types.NodeInfo {
 func (r *Router) OnStart() error {
 	netAddr, _ := r.nodeInfo.NetAddress()
 	r.Logger.Info(
-	  "starting router", 
-	  "node_id", r.nodeInfo.NodeID,
-	  "channels", r.nodeInfo.Channels,
+		"starting router",
+		"node_id", r.nodeInfo.NodeID,
+		"channels", r.nodeInfo.Channels,
 		"listen_addr", r.nodeInfo.ListenAddr,
-		 "net_addr", netAddr,
-		 )
+		"net_addr", netAddr,
+	)
 
 	go r.dialPeers()
 	go r.evictPeers()

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -460,10 +460,11 @@ func (r *Reactor) handleSnapshotMessage(envelope p2p.Envelope) error {
 		}
 
 		for _, snapshot := range snapshots {
-			logger.Debug(
+			logger.Info(
 				"advertising snapshot",
 				"height", snapshot.Height,
 				"format", snapshot.Format,
+				"peer", envelope.From,
 			)
 			r.snapshotCh.Out <- p2p.Envelope{
 				To: envelope.From,

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -276,9 +276,6 @@ Does not run any perbutations.
 			defer loadCancel()
 			go func() {
 				err := Load(ctx, cli.testnet, 1)
-				if err != nil {
-					logger.Error(fmt.Sprintf("Transaction load failed: %v", err.Error()))
-				}
 				chLoadResult <- err
 			}()
 


### PR DESCRIPTION
Logs each nodes own `NodeInfo` upon startup so I can see who's trying to connect with who. I think we have a similar message within the switch.

Also moves a log in state sync to info to display which nodes are sending messages. This is to help me narrow down https://github.com/tendermint/tendermint/issues/6704 when it happens


