### PR TITLE
RPC: mark grpc as deprecated

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,6 +23,7 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
   - [rpc] \#6610 Add MaxPeerBlockHeight into /status rpc call (@JayT106)
   - [libs/CList] \#6626 Automatically detach the prev/next elements in Remove function (@JayT106)
   - [fastsync/rpc] \#6620 Add TotalSyncedTime & RemainingTime to SyncInfo in /status RPC  (@JayT106)
+  - [rpc/grpc] \#6725 Mark gRPC in the RPC layer as deprecated.
 
 - Apps
   - [ABCI] \#6408 Change the `key` and `value` fields from `[]byte` to `string` in the `EventAttribute` type. (@alexanderbez)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -74,6 +74,10 @@ will need to change to accommodate these changes. Most notably:
   longer exported and have been replaced with `node.New` and
   `node.NewDefault` which provide more functional interfaces.
 
+### RPC changes
+
+Mark gRPC in the RPC layer as deprecated and to be removed in 0.36.
+
 ## v0.34.0
 
 **Upgrading to Tendermint 0.34 requires a blockchain restart.**

--- a/config/config.go
+++ b/config/config.go
@@ -446,6 +446,7 @@ type RPCConfig struct {
 
 	// TCP or UNIX socket address for the gRPC server to listen on
 	// NOTE: This server only supports /broadcast_tx_commit
+	// Deprecated: gRPC  in the RPC layer of Tendermint will be deprecated in 0.36
 	GRPCListenAddress string `mapstructure:"grpc-laddr"`
 
 	// Maximum number of simultaneous connections.
@@ -453,6 +454,7 @@ type RPCConfig struct {
 	// If you want to accept a larger number than the default, make sure
 	// you increase your OS limits.
 	// 0 - unlimited.
+	// Deprecated: gRPC  in the RPC layer of Tendermint will be deprecated in 0.36.
 	GRPCMaxOpenConnections int `mapstructure:"grpc-max-open-connections"`
 
 	// Activate unsafe RPC commands like /dial-persistent-peers and /unsafe-flush-mempool

--- a/config/config.go
+++ b/config/config.go
@@ -446,7 +446,7 @@ type RPCConfig struct {
 
 	// TCP or UNIX socket address for the gRPC server to listen on
 	// NOTE: This server only supports /broadcast_tx_commit
-	// Deprecated: gRPC  in the RPC layer of Tendermint will be deprecated in 0.36
+	// Deprecated: gRPC in the RPC layer of Tendermint will be removed in 0.36.
 	GRPCListenAddress string `mapstructure:"grpc-laddr"`
 
 	// Maximum number of simultaneous connections.
@@ -454,7 +454,7 @@ type RPCConfig struct {
 	// If you want to accept a larger number than the default, make sure
 	// you increase your OS limits.
 	// 0 - unlimited.
-	// Deprecated: gRPC  in the RPC layer of Tendermint will be deprecated in 0.36.
+	// Deprecated: gRPC in the RPC layer of Tendermint will be removed in 0.36.
 	GRPCMaxOpenConnections int `mapstructure:"grpc-max-open-connections"`
 
 	// Activate unsafe RPC commands like /dial-persistent-peers and /unsafe-flush-mempool

--- a/config/toml.go
+++ b/config/toml.go
@@ -200,6 +200,7 @@ cors-allowed-headers = [{{ range .RPC.CORSAllowedHeaders }}{{ printf "%q, " . }}
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
+# Deprecated gRPC  in the RPC layer of Tendermint will be deprecated in 0.36.
 grpc-laddr = "{{ .RPC.GRPCListenAddress }}"
 
 # Maximum number of simultaneous connections.
@@ -209,6 +210,7 @@ grpc-laddr = "{{ .RPC.GRPCListenAddress }}"
 # 0 - unlimited.
 # Should be < {ulimit -Sn} - {MaxNumInboundPeers} - {MaxNumOutboundPeers} - {N of wal, db and other open files}
 # 1024 - 40 - 10 - 50 = 924 = ~900
+# Deprecated gRPC  in the RPC layer of Tendermint will be deprecated in 0.36.
 grpc-max-open-connections = {{ .RPC.GRPCMaxOpenConnections }}
 
 # Activate unsafe RPC commands like /dial-seeds and /unsafe-flush-mempool

--- a/rpc/grpc/api.go
+++ b/rpc/grpc/api.go
@@ -17,6 +17,7 @@ func (bapi *broadcastAPI) Ping(ctx context.Context, req *RequestPing) (*Response
 	return &ResponsePing{}, nil
 }
 
+// `Deprecated: gRPC  in the RPC layer of Tendermint will be deprecated in 0.36`
 func (bapi *broadcastAPI) BroadcastTx(ctx context.Context, req *RequestBroadcastTx) (*ResponseBroadcastTx, error) {
 	// NOTE: there's no way to get client's remote address
 	// see https://stackoverflow.com/questions/33684570/session-and-remote-ip-address-in-grpc-go

--- a/rpc/grpc/api.go
+++ b/rpc/grpc/api.go
@@ -17,7 +17,7 @@ func (bapi *broadcastAPI) Ping(ctx context.Context, req *RequestPing) (*Response
 	return &ResponsePing{}, nil
 }
 
-// `Deprecated: gRPC  in the RPC layer of Tendermint will be deprecated in 0.36`
+// Deprecated: gRPC  in the RPC layer of Tendermint will be removed in 0.36.
 func (bapi *broadcastAPI) BroadcastTx(ctx context.Context, req *RequestBroadcastTx) (*ResponseBroadcastTx, error) {
 	// NOTE: there's no way to get client's remote address
 	// see https://stackoverflow.com/questions/33684570/session-and-remote-ip-address-in-grpc-go

--- a/rpc/grpc/client_server.go
+++ b/rpc/grpc/client_server.go
@@ -18,7 +18,7 @@ type Config struct {
 // StartGRPCServer starts a new gRPC BroadcastAPIServer using the given
 // net.Listener.
 // NOTE: This function blocks - you may want to call it in a go-routine.
-// Deprecated: gRPC  in the RPC layer of Tendermint will be deprecated in 0.36
+// Deprecated: gRPC  in the RPC layer of Tendermint will be removed in 0.36
 func StartGRPCServer(env *core.Environment, ln net.Listener) error {
 	grpcServer := grpc.NewServer()
 	RegisterBroadcastAPIServer(grpcServer, &broadcastAPI{env: env})

--- a/rpc/grpc/client_server.go
+++ b/rpc/grpc/client_server.go
@@ -18,6 +18,7 @@ type Config struct {
 // StartGRPCServer starts a new gRPC BroadcastAPIServer using the given
 // net.Listener.
 // NOTE: This function blocks - you may want to call it in a go-routine.
+// Deprecated: gRPC  in the RPC layer of Tendermint will be deprecated in 0.36
 func StartGRPCServer(env *core.Environment, ln net.Listener) error {
 	grpcServer := grpc.NewServer()
 	RegisterBroadcastAPIServer(grpcServer, &broadcastAPI{env: env})


### PR DESCRIPTION
## Description

Mark gRPC as deprecated in the RPC layer. 

closes #6718 

