### PR TITLE
e2e: avoid systematic key-type variation

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -24,7 +24,6 @@ var (
 			map[string]string{"initial01": "a", "initial02": "b", "initial03": "c"},
 		},
 		"validators": {"genesis", "initchain"},
-		"keyType":    {types.ABCIPubKeyTypeEd25519, types.ABCIPubKeyTypeSecp256k1},
 	}
 
 	// The following specify randomly chosen values for testnet nodes.
@@ -45,6 +44,7 @@ var (
 	}
 	evidence = uniformChoice{0, 1, 10}
 	txSize   = uniformChoice{1024, 10240} // either 1kb or 10kb
+	keyType  = uniformChoice{types.ABCIPubKeyTypeEd25519, types.ABCIPubKeyTypeSecp256k1}
 )
 
 // Generate generates random testnets using the given RNG.
@@ -90,7 +90,7 @@ func generateTestnet(r *rand.Rand, opt map[string]interface{}) (e2e.Manifest, er
 		Validators:       &map[string]int64{},
 		ValidatorUpdates: map[string]map[string]int64{},
 		Nodes:            map[string]*e2e.ManifestNode{},
-		KeyType:          opt["keyType"].(string),
+		KeyType:          keyType.Choose(r).(string),
 		Evidence:         evidence.Choose(r).(int),
 		QueueType:        opt["queueType"].(string),
 		TxSize:           int64(txSize.Choose(r).(int)),


### PR DESCRIPTION
This is a follow on, potentially, to #6734. 

This change key type, like other tendermint/app configuration,
something that is varried throughout all tests, but not an axsis of
systematic varriance. The key type changes the ABCI protocol, but the
changes are very isolated within tendermint itself, and I don't really
know if there are any kind of systematic interactions between this and
other dimensions.

Having said that, I might be incorrect in this assumption, and I'm
happy to retract this.