### PR TITLE
e2e: drop single node hybrid configurations

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -65,7 +65,6 @@ func Generate(r *rand.Rand, opts Options) ([]e2e.Manifest, error) {
 
 		if len(manifest.Nodes) == 1 {
 			if opt["p2p"] == HybridP2PMode {
-				fmt.Println("one")
 				continue
 			}
 		}

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -62,6 +62,13 @@ func Generate(r *rand.Rand, opts Options) ([]e2e.Manifest, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if len(manifest.Nodes) == 1 {
+			if opt["p2p"] == HybridP2PMode {
+				fmt.Println("one")
+				continue
+			}
+		}
 		manifests = append(manifests, manifest)
 	}
 	return manifests, nil


### PR DESCRIPTION
The hybrid e2e test suites are all about testing interoperability
between new and legacy p2p test suites. Single node configurations aren't meaningful in this context. 

Dropping this dimension alone lets us skip 32 test nets.

There are probably other axes that might not make sense to test with single-node confiurations and I'd like to ask you, dear reviewer, if you see any that jump out at you.

For my part, I'm a little bit suspicious of single node various plus the various initial configurations, which are necessarily tested in larger configurations.