### PR TITLE
e2e: run tests in fewer groups

### DIFF
--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         p2p: ['legacy', 'new', 'hybrid']
-        group: ['00', '01', '02']
+        group: ['00', '01']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -35,7 +35,7 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 3 -d networks/nightly/${{ matrix.p2p }} -p ${{ matrix.p2p }} 
+        run: ./build/generator -g 2 -d networks/nightly/${{ matrix.p2p }} -p ${{ matrix.p2p }} 
 
       - name: Run ${{ matrix.p2p }} p2p testnets in group ${{ matrix.group }}
         working-directory: test/e2e

--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         p2p: ['legacy', 'new', 'hybrid']
-        group: ['00', '01', '02', '03']
+        group: ['00', '01', '02']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -35,7 +35,7 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 4 -d networks/nightly/${{ matrix.p2p }} -p ${{ matrix.p2p }} 
+        run: ./build/generator -g 3 -d networks/nightly/${{ matrix.p2p }} -p ${{ matrix.p2p }} 
 
       - name: Run ${{ matrix.p2p }} p2p testnets in group ${{ matrix.group }}
         working-directory: test/e2e


### PR DESCRIPTION
Now that there are fewer total test cases (64 down from 288), it makes
sense to reduce the amount of seperate executions. 

Previously we all of the tests into 3 p2p-based groups (96 networks
each), and then split each of those runs into 4 groups of 24 cases
each. This means that the total run finishes in about 50 minutes,
which is nice for responsiveness. 

The downside is that because the docker images aren't fanned out to
machines, each group execution run has to build the docker image
`3x<groups>` number of times, which can become a significant portion
of the total test time. 

This patch pushes us to two groups, (e.g. about 11 tests per group)
which reduces the per-run overhead by half, and also the total runtime
should halve as well. We could go down to a single group, and maybe we
will once things become more reliable.