### PR TITLE
p2p: avoid blocking on the dequeCh

### DIFF
--- a/internal/p2p/pqueue.go
+++ b/internal/p2p/pqueue.go
@@ -257,7 +257,11 @@ func (s *pqScheduler) process() {
 				s.metrics.PeerSendBytesTotal.With(
 					"chID", chIDStr,
 					"peer_id", string(pqEnv.envelope.To)).Add(float64(pqEnv.size))
-				s.dequeueCh <- pqEnv.envelope
+				select {
+				case s.dequeueCh <- pqEnv.envelope:
+				case <-s.closer.Done():
+					return
+				}
 			}
 
 		case <-s.closer.Done():


### PR DESCRIPTION
In some occasions when closing a connection, if the dequeueCh was full, we'd block trying to add an envelope to that channel and thus was not able to close the connection. 

