### PR TITLE
cleanup: remove redundant error plumbing

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -106,6 +106,7 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
 - [statesync/event] \#6700 Emit statesync status start/end event (@JayT106)
 
 ### IMPROVEMENTS
+
 - [libs/log] Console log formatting changes as a result of \#6534 and \#6589. (@tychoish)
 - [statesync] \#6566 Allow state sync fetchers and request timeout to be configurable. (@alexanderbez)
 - [types] \#6478 Add `block_id` to `newblock` event (@jeebster)
@@ -146,6 +147,7 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
 - [state/privval] \#6578 No GetPubKey retry beyond the proposal/voting window (@JayT106)
 - [rpc] \#6615 Add TotalGasUsed to block_results response (@crypto-facs)
 - [cmd/tendermint/commands] \#6623 replace `$HOME/.some/test/dir` with `t.TempDir` (@tanyabouman)
+- [cleanup] \#6778 Remove redundant error plumbing
 
 ### BUG FIXES
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -106,7 +106,6 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
 - [statesync/event] \#6700 Emit statesync status start/end event (@JayT106)
 
 ### IMPROVEMENTS
-
 - [libs/log] Console log formatting changes as a result of \#6534 and \#6589. (@tychoish)
 - [statesync] \#6566 Allow state sync fetchers and request timeout to be configurable. (@alexanderbez)
 - [types] \#6478 Add `block_id` to `newblock` event (@jeebster)
@@ -147,7 +146,6 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
 - [state/privval] \#6578 No GetPubKey retry beyond the proposal/voting window (@JayT106)
 - [rpc] \#6615 Add TotalGasUsed to block_results response (@crypto-facs)
 - [cmd/tendermint/commands] \#6623 replace `$HOME/.some/test/dir` with `t.TempDir` (@tanyabouman)
-- [cleanup] \#6778 Remove redundant error plumbing
 
 ### BUG FIXES
 

--- a/abci/types/messages.go
+++ b/abci/types/messages.go
@@ -15,11 +15,7 @@ const (
 func WriteMessage(msg proto.Message, w io.Writer) error {
 	protoWriter := protoio.NewDelimitedWriter(w)
 	_, err := protoWriter.WriteMsg(msg)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // ReadMessage reads a varint length-delimited protobuf message.

--- a/privval/signer_listener_endpoint.go
+++ b/privval/signer_listener_endpoint.go
@@ -142,8 +142,7 @@ func (sl *SignerListenerEndpoint) ensureConnection(maxWait time.Duration) error 
 	// block until connected or timeout
 	sl.Logger.Info("SignerListener: Blocking for connection")
 	sl.triggerConnect()
-	err := sl.WaitConnection(sl.connectionAvailableCh, maxWait)
-	return err
+	return sl.WaitConnection(sl.connectionAvailableCh, maxWait)
 }
 
 func (sl *SignerListenerEndpoint) acceptNewConnection() (net.Conn, error) {

--- a/privval/signer_listener_endpoint.go
+++ b/privval/signer_listener_endpoint.go
@@ -143,11 +143,7 @@ func (sl *SignerListenerEndpoint) ensureConnection(maxWait time.Duration) error 
 	sl.Logger.Info("SignerListener: Blocking for connection")
 	sl.triggerConnect()
 	err := sl.WaitConnection(sl.connectionAvailableCh, maxWait)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (sl *SignerListenerEndpoint) acceptNewConnection() (net.Conn, error) {

--- a/state/indexer/sink/psql/psql_test.go
+++ b/state/indexer/sink/psql/psql_test.go
@@ -256,11 +256,7 @@ func verifyTimeStamp(tb string) error {
 	if rows.Next() {
 		var ts string
 		err = rows.Scan(&ts)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 
 	return errors.New("no result")

--- a/state/indexer/sink/psql/psql_test.go
+++ b/state/indexer/sink/psql/psql_test.go
@@ -255,8 +255,7 @@ func verifyTimeStamp(tb string) error {
 
 	if rows.Next() {
 		var ts string
-		err = rows.Scan(&ts)
-		return err
+		return rows.Scan(&ts)
 	}
 
 	return errors.New("no result")

--- a/state/store.go
+++ b/state/store.go
@@ -661,6 +661,5 @@ func (store dbStore) saveConsensusParamsInfo(
 		return err
 	}
 
-	err = batch.Set(consensusParamsKey(nextHeight), bz)
-	return err
+	return batch.Set(consensusParamsKey(nextHeight), bz)
 }

--- a/state/store.go
+++ b/state/store.go
@@ -662,9 +662,5 @@ func (store dbStore) saveConsensusParamsInfo(
 	}
 
 	err = batch.Set(consensusParamsKey(nextHeight), bz)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/test/e2e/runner/cleanup.go
+++ b/test/e2e/runner/cleanup.go
@@ -15,8 +15,7 @@ func Cleanup(testnet *e2e.Testnet) error {
 	if err != nil {
 		return err
 	}
-	err = cleanupDir(testnet.Dir)
-	return err
+	return cleanupDir(testnet.Dir)
 }
 
 // cleanupDocker removes all E2E resources (with label e2e=True), regardless
@@ -67,6 +66,5 @@ func cleanupDir(dir string) error {
 		return err
 	}
 
-	err = os.RemoveAll(dir)
-	return err
+	return os.RemoveAll(dir)
 }

--- a/test/e2e/runner/cleanup.go
+++ b/test/e2e/runner/cleanup.go
@@ -16,10 +16,7 @@ func Cleanup(testnet *e2e.Testnet) error {
 		return err
 	}
 	err = cleanupDir(testnet.Dir)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // cleanupDocker removes all E2E resources (with label e2e=True), regardless
@@ -39,11 +36,7 @@ func cleanupDocker() error {
 
 	err = exec("bash", "-c", fmt.Sprintf(
 		"docker network ls -q --filter label=e2e | xargs %v docker network rm", xargsR))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // cleanupDir cleans up a testnet directory
@@ -75,9 +68,5 @@ func cleanupDir(dir string) error {
 	}
 
 	err = os.RemoveAll(dir)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/test/e2e/runner/cleanup.go
+++ b/test/e2e/runner/cleanup.go
@@ -33,9 +33,8 @@ func cleanupDocker() error {
 		return err
 	}
 
-	err = exec("bash", "-c", fmt.Sprintf(
+	return exec("bash", "-c", fmt.Sprintf(
 		"docker network ls -q --filter label=e2e | xargs %v docker network rm", xargsR))
-	return err
 }
 
 // cleanupDir cleans up a testnet directory

--- a/test/e2e/runner/wait.go
+++ b/test/e2e/runner/wait.go
@@ -21,10 +21,7 @@ func Wait(testnet *e2e.Testnet, blocks int64) error {
 func WaitUntil(testnet *e2e.Testnet, height int64) error {
 	logger.Info(fmt.Sprintf("Waiting for all nodes to reach height %v...", height))
 	_, err := waitForAllNodes(testnet, height, waitingTime(len(testnet.Nodes)))
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // waitingTime estimates how long it should take for a node to reach the height.

--- a/test/fuzz/rpc/jsonrpc/server/handler.go
+++ b/test/fuzz/rpc/jsonrpc/server/handler.go
@@ -59,6 +59,5 @@ func Fuzz(data []byte) int {
 
 func outputJSONIsSlice(input []byte) bool {
 	slice := []interface{}{}
-	err := json.Unmarshal(input, &slice)
-	return err == nil
+	return json.Unmarshal(input, &slice) == nil
 }

--- a/types/node_key.go
+++ b/types/node_key.go
@@ -34,10 +34,7 @@ func (nodeKey NodeKey) SaveAs(filePath string) error {
 		return err
 	}
 	err = ioutil.WriteFile(filePath, jsonBytes, 0600)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // LoadOrGenNodeKey attempts to load the NodeKey from the given filePath. If

--- a/types/node_key.go
+++ b/types/node_key.go
@@ -33,8 +33,7 @@ func (nodeKey NodeKey) SaveAs(filePath string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filePath, jsonBytes, 0600)
-	return err
+	return ioutil.WriteFile(filePath, jsonBytes, 0600)
 }
 
 // LoadOrGenNodeKey attempts to load the NodeKey from the given filePath. If


### PR DESCRIPTION
Fixes #6479 and related cases.

This is a mostly-automated fixup using Comby (https://comby.dev) to reduce lexically-obvious redundant error checks. No functional changes are intended.

Slightly ironically, the original presenting case from #6479 is now gone, but the pattern remains elsewhere in the repository.