### PR TITLE
Fix and clarify breaks from case clauses.

### DIFF
--- a/crypto/merkle/proof.go
+++ b/crypto/merkle/proof.go
@@ -204,7 +204,10 @@ func (spn *ProofNode) FlattenAunts() [][]byte {
 		case spn.Right != nil:
 			innerHashes = append(innerHashes, spn.Right.Hash)
 		default:
-			break
+			// FIXME(fromberger): Per the documentation above, exactly one of
+			// these fields should be set. If that is true, this should probably
+			// be a panic since it violates the invariant. If not, when can it
+			// be OK to have no siblings? Does this occur at the leaves?
 		}
 		spn = spn.Parent
 	}

--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -385,7 +385,7 @@ func (m *PeerManager) prunePeers() error {
 		peerID := ranked[i].ID
 		switch {
 		case m.store.Size() <= int(m.options.MaxPeers):
-			break
+			return nil
 		case m.dialing[peerID]:
 		case m.connected[peerID]:
 		default:

--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -186,6 +186,7 @@ func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query) ([]int64,
 
 	// fetch matching heights
 	results = make([]int64, 0, len(filteredHeights))
+heights:
 	for _, hBz := range filteredHeights {
 		h := int64FromBytes(hBz)
 
@@ -199,7 +200,7 @@ func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query) ([]int64,
 
 		select {
 		case <-ctx.Done():
-			break
+			break heights
 
 		default:
 		}
@@ -240,7 +241,7 @@ func (idx *BlockerIndexer) matchRange(
 	}
 	defer it.Close()
 
-LOOP:
+iter:
 	for ; it.Valid(); it.Next() {
 		var (
 			eventValue string
@@ -260,7 +261,7 @@ LOOP:
 		if _, ok := qr.AnyBound().(int64); ok {
 			v, err := strconv.ParseInt(eventValue, 10, 64)
 			if err != nil {
-				continue LOOP
+				continue iter
 			}
 
 			include := true
@@ -279,7 +280,7 @@ LOOP:
 
 		select {
 		case <-ctx.Done():
-			break
+			break iter
 
 		default:
 		}
@@ -372,12 +373,13 @@ func (idx *BlockerIndexer) match(
 		}
 		defer it.Close()
 
+	iterExists:
 		for ; it.Valid(); it.Next() {
 			tmpHeights[string(it.Value())] = it.Value()
 
 			select {
 			case <-ctx.Done():
-				break
+				break iterExists
 
 			default:
 			}
@@ -399,6 +401,7 @@ func (idx *BlockerIndexer) match(
 		}
 		defer it.Close()
 
+	iterContains:
 		for ; it.Valid(); it.Next() {
 			eventValue, err := parseValueFromEventKey(it.Key())
 			if err != nil {
@@ -411,7 +414,7 @@ func (idx *BlockerIndexer) match(
 
 			select {
 			case <-ctx.Done():
-				break
+				break iterContains
 
 			default:
 			}


### PR DESCRIPTION
The beginnings of a fix for #6780.

File list:

    % staticcheck -checks SA4011 ./... | cut -d: -f-2

This change is intended to be semantics-preserving, at least for the intended
semantics of the code. It is NOT strictly behaviour-preserving, however.
Specifically: On some inputs, these loops may have run longer than they were
intended to, prior to this change.

There is one case where I was not sure how to resolve the ambiguity.
This is flagged as FIXME in the commit.
