### PR TITLE
commands: add key migration cli

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,10 +24,10 @@ This guide provides instructions for upgrading to specific versions of Tendermin
 
 * Added `--mode` flag and `mode` config variable on `config.toml` for setting Mode of the Node: `full` | `validator` | `seed` (default: `full`)
   [ADR-52](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-052-tendermint-mode.md)
-  
+
 * `BootstrapPeers` has been added as part of the new p2p stack. This will eventually replace
   `Seeds`. Bootstrap peers are connected with on startup if needed for peer discovery. Unlike
-  persistent peers, there's no gaurantee that the node will remain connected with these peers. 
+  persistent peers, there's no gaurantee that the node will remain connected with these peers.
 
 * configuration values starting with `priv-validator-` have moved to the new
   `priv-validator` section, without the `priv-validator-` prefix.
@@ -37,21 +37,21 @@ This guide provides instructions for upgrading to specific versions of Tendermin
 
 ### Key Format Changes
 
-The key names of all tendermint on-disk database keys changes in
-0.35. Upgrading nodes must either re-sync all data run a migration
+The format of all tendermint on-disk database keys changes in
+0.35. Upgrading nodes must either re-sync all data or run a migration
 script provided in this release. The script located in
 `github.com/tendermint/tendermint/scripts/keymigrate/migrate.go`
 provides the function `Migrate(context.Context, db.DB)` which you can
-operationalize as makes sense for your deployment. 
+operationalize as makes sense for your deployment.
 
 For ease of use the `tendermint` command includes a CLI version of the
-migration script, which you can invoke, as in: 
+migration script, which you can invoke, as in:
 
 	tendermint key-migrate
-	
+
 This reads the configuration file as normal and allows the
 `--db-backend` and `--db-dir` flags to change database operations as
-needed. 
+needed.
 
 The migration operation is idempotent and can be run more than once,
 if needed.
@@ -265,8 +265,8 @@ Other user-relevant changes include:
 
 * The old `lite` package was removed; the new light client uses the `light` package.
 * The `Verifier` was broken up into two pieces:
-    * Core verification logic (pure `VerifyX` functions)
-    * `Client` object, which represents the complete light client
+	* Core verification logic (pure `VerifyX` functions)
+	* `Client` object, which represents the complete light client
 * The new light clients stores headers & validator sets as `LightBlock`s
 * The RPC client can be found in the `/rpc` directory.
 * The HTTP(S) proxy is located in the `/proxy` directory.
@@ -398,12 +398,12 @@ Evidence Params has been changed to include duration.
 ### Go API
 
 * `libs/common` has been removed in favor of specific pkgs.
-    * `async`
-    * `service`
-    * `rand`
-    * `net`
-    * `strings`
-    * `cmap`
+	* `async`
+	* `service`
+	* `rand`
+	* `net`
+	* `strings`
+	* `cmap`
 * removal of `errors` pkg
 
 ### RPC Changes
@@ -472,9 +472,9 @@ Prior to the update, suppose your `ResponseDeliverTx` look like:
 ```go
 abci.ResponseDeliverTx{
   Tags: []kv.Pair{
-    {Key: []byte("sender"), Value: []byte("foo")},
-    {Key: []byte("recipient"), Value: []byte("bar")},
-    {Key: []byte("amount"), Value: []byte("35")},
+	{Key: []byte("sender"), Value: []byte("foo")},
+	{Key: []byte("recipient"), Value: []byte("bar")},
+	{Key: []byte("amount"), Value: []byte("35")},
   }
 }
 ```
@@ -493,14 +493,14 @@ the following `Events`:
 ```go
 abci.ResponseDeliverTx{
   Events: []abci.Event{
-    {
-      Type: "transfer",
-      Attributes: kv.Pairs{
-        {Key: []byte("sender"), Value: []byte("foo")},
-        {Key: []byte("recipient"), Value: []byte("bar")},
-        {Key: []byte("amount"), Value: []byte("35")},
-      },
-    }
+	{
+	  Type: "transfer",
+	  Attributes: kv.Pairs{
+		{Key: []byte("sender"), Value: []byte("foo")},
+		{Key: []byte("recipient"), Value: []byte("bar")},
+		{Key: []byte("amount"), Value: []byte("35")},
+	  },
+	}
 }
 ```
 
@@ -548,9 +548,9 @@ In this case, the WS client will receive an error with description:
   "jsonrpc": "2.0",
   "id": "{ID}#event",
   "error": {
-    "code": -32000,
-    "msg": "Server error",
-    "data": "subscription was canceled (reason: client is not pulling messages fast enough)" // or "subscription was canceled (reason: Tendermint exited)"
+	"code": -32000,
+	"msg": "Server error",
+	"data": "subscription was canceled (reason: client is not pulling messages fast enough)" // or "subscription was canceled (reason: Tendermint exited)"
   }
 }
 
@@ -756,9 +756,9 @@ just the `Data` field set:
 
 ```go
 []ProofOp{
-    ProofOp{
-        Data: <proof bytes>,
-    }
+	ProofOp{
+		Data: <proof bytes>,
+	}
 }
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -27,13 +27,34 @@ This guide provides instructions for upgrading to specific versions of Tendermin
   
 * `BootstrapPeers` has been added as part of the new p2p stack. This will eventually replace
   `Seeds`. Bootstrap peers are connected with on startup if needed for peer discovery. Unlike
-  persistent peers, there's no guarantee that the node will remain connected with these peers. 
+  persistent peers, there's no gaurantee that the node will remain connected with these peers. 
 
 * configuration values starting with `priv-validator-` have moved to the new
   `priv-validator` section, without the `priv-validator-` prefix.
 
 * The fast sync process as well as the blockchain package and service has all
   been renamed to block sync
+
+### Key Format Changes
+
+The key names of all tendermint on-disk database keys changes in
+0.35. Upgrading nodes must either re-sync all data run a migration
+script provided in this release. The script located in
+`github.com/tendermint/tendermint/scripts/keymigrate/migrate.go`
+provides the function `Migrate(context.Context, db.DB)` which you can
+operationalize as makes sense for your deployment. 
+
+For ease of use the `tendermint` command includes a CLI version of the
+migration script, which you can invoke, as in: 
+
+	tendermint key-migrate
+	
+This reads the configuration file as normal and allows the
+`--db-backend` and `--db-dir` flags to change database operations as
+needed. 
+
+The migration operation is idempotent and can be run more than once,
+if needed.
 
 ### CLI Changes
 
@@ -66,7 +87,7 @@ are:
 - `blockchain`
 - `evidence`
 
-Accordingly, the space `node` package was changed to reduce access to
+Accordingly, the `node` package was changed to reduce access to
 tendermint internals: applications that use tendermint as a library
 will need to change to accommodate these changes. Most notably:
 

--- a/cmd/tendermint/commands/key_migrate.go
+++ b/cmd/tendermint/commands/key_migrate.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/scripts/keymigrate"
+)
+
+func MakeKeyMigrateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "key-migrate",
+		Short: "Run Database key migration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+
+			contexts := []string{
+				// this is ordered to put the
+				// (presumably) biggest/most important
+				// subsets first.
+				"blockstore",
+				"state",
+				"peerstore",
+				"tx_index",
+				"evidence",
+				"light",
+			}
+
+			for idx, dbctx := range contexts {
+				logger.Info("beginning a key migration",
+					"dbctx", dbctx,
+					"num", idx+1,
+					"total", len(contexts),
+				)
+
+				db, err := cfg.DefaultDBProvider(&cfg.DBContext{
+					ID:     dbctx,
+					Config: config,
+				})
+
+				if err != nil {
+					return fmt.Errorf("constructing database handle: %w", err)
+				}
+
+				if err = keymigrate.Migrate(ctx, db); err != nil {
+					return fmt.Errorf("running migration for context %q: %w",
+						dbctx, err)
+				}
+			}
+
+			logger.Info("completed database migration successfully")
+
+			return nil
+		},
+	}
+
+	// allow database info to be overridden via cli
+	addDBFlags(cmd)
+
+	return cmd
+}

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -83,7 +83,10 @@ func AddNodeFlags(cmd *cobra.Command) {
 		config.Consensus.CreateEmptyBlocksInterval.String(),
 		"the possible interval between empty blocks")
 
-	// db flags
+	addDBFlags(cmd)
+}
+
+func addDBFlags(cmd *cobra.Command) {
 	cmd.Flags().String(
 		"db-backend",
 		config.DBBackend,

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -28,6 +28,7 @@ func main() {
 		cmd.ShowNodeIDCmd,
 		cmd.GenNodeKeyCmd,
 		cmd.VersionCmd,
+		cmd.MakeKeyMigrateCommand(),
 		debug.DebugCmd,
 		cli.NewCompletionCmd(rootCmd, true),
 	)


### PR DESCRIPTION
This adds a simple CLI around the migration key migration script to facilitate it's use.