### PR TITLE
bytes: clean up and simplify encoding of HexBytes

### DIFF
--- a/libs/bytes/bytes.go
+++ b/libs/bytes/bytes.go
@@ -35,6 +35,13 @@ func (bz HexBytes) MarshalJSON() ([]byte, error) {
 	hex.Encode(buf[1:], []byte(bz))
 	buf[0] = '"'
 	buf[size-1] = '"'
+
+	// Ensure letter digits are capitalized.
+	for i := 1; i < size-1; i++ {
+		if buf[i] >= 'a' && buf[i] <= 'f' {
+			buf[i] = 'A' + (buf[i] - 'a')
+		}
+	}
 	return buf, nil
 }
 

--- a/libs/bytes/bytes.go
+++ b/libs/bytes/bytes.go
@@ -27,7 +27,7 @@ func (bz *HexBytes) Unmarshal(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaler interface.  The encoding is a JSON
+// MarshalJSON implements the json.Marshaler interface. The encoding is a JSON
 // quoted string of hexadecimal digits.
 func (bz HexBytes) MarshalJSON() ([]byte, error) {
 	size := hex.EncodedLen(len(bz)) + 2 // +2 for quotation marks

--- a/libs/bytes/bytes.go
+++ b/libs/bytes/bytes.go
@@ -27,15 +27,15 @@ func (bz *HexBytes) Unmarshal(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaler interface. The hex bytes is a
-// quoted hexadecimal encoded string.
+// MarshalJSON implements the json.Marshaler interface.  The encoding is a JSON
+// quoted string of hexadecimal digits.
 func (bz HexBytes) MarshalJSON() ([]byte, error) {
-	s := strings.ToUpper(hex.EncodeToString(bz))
-	jbz := make([]byte, len(s)+2)
-	jbz[0] = '"'
-	copy(jbz[1:], s)
-	jbz[len(jbz)-1] = '"'
-	return jbz, nil
+	size := hex.EncodedLen(len(bz)) + 2 // +2 for quotation marks
+	buf := make([]byte, size)
+	hex.Encode(buf[1:], []byte(bz))
+	buf[0] = '"'
+	buf[size-1] = '"'
+	return buf, nil
 }
 
 // UnmarshalJSON implements the json.Umarshaler interface.

--- a/libs/bytes/bytes_test.go
+++ b/libs/bytes/bytes_test.go
@@ -37,6 +37,7 @@ func TestJSONMarshal(t *testing.T) {
 		{[]byte(``), `{"B1":"","B2":""}`},
 		{[]byte(`a`), `{"B1":"YQ==","B2":"61"}`},
 		{[]byte(`abc`), `{"B1":"YWJj","B2":"616263"}`},
+		{[]byte("\x1a\x2b\x3c"), `{"B1":"Gis8","B2":"1A2B3C"}`},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
As written, the encoding step unnecessarily made and moved multiple copies of
the encoded representation. Reduce this to a single allocation and encode the
data in-place so that a shift is no longer required.

No functional changes.
