### PR TITLE
doc: fix typos in /tx_search and /tx.

### DIFF
--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -1042,7 +1042,7 @@ paths:
         - Info
       responses:
         "200":
-          description: List of unconfirmed transactions
+          description: List of transactions
           content:
             application/json:
               schema:
@@ -1132,10 +1132,10 @@ paths:
       tags:
         - Info
       description: |
-        Get a trasasction
+        Get a transaction
       responses:
         "200":
-          description: Get a transaction`
+          description: Get a transaction
           content:
             application/json:
               schema:


### PR DESCRIPTION
Just a few small typos in the descriptions of the /tx_search and /tx endpoints.


