### PR TITLE
docs: fix graceful shutdown in go built-in example

### DIFF
--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -388,7 +388,6 @@ func main() {
  c := make(chan os.Signal, 1)
  signal.Notify(c, os.Interrupt, syscall.SIGTERM)
  <-c
- os.Exit(0)
 }
 
 func newTendermint(app abci.Application, configFile string) (*nm.Node, error) {
@@ -564,7 +563,6 @@ defer func() {
 c := make(chan os.Signal, 1)
 signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 <-c
-os.Exit(0)
 ```
 
 ## 1.5 Getting Up and Running


### PR DESCRIPTION
``` go
func main() {
 /* ... */
 node.Start()
 defer func() { // defer for graceful shutdown
  node.Stop()
  node.Wait()
 }()

 c := make(chan os.Signal, 1)
 signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 <-c
 os.Exit(0) // node.Stop() & node.Wait() aren't called, because os.Exit(0) terminates the process immediately
}
```