### PR TITLE
e2e: cleanup node start function

### DIFF
--- a/test/e2e/runner/start.go
+++ b/test/e2e/runner/start.go
@@ -9,6 +9,9 @@ import (
 )
 
 func Start(testnet *e2e.Testnet) error {
+	if len(testnet.Nodes) == 0 {
+		return fmt.Errorf("no nodes in testnet")
+	}
 
 	// Nodes are already sorted by name. Sort them by name then startAt,
 	// which gives the overall order startAt, mode, name.
@@ -29,9 +32,7 @@ func Start(testnet *e2e.Testnet) error {
 	sort.SliceStable(nodeQueue, func(i, j int) bool {
 		return nodeQueue[i].StartAt < nodeQueue[j].StartAt
 	})
-	if len(nodeQueue) == 0 {
-		return fmt.Errorf("no nodes in testnet")
-	}
+
 	if nodeQueue[0].StartAt > 0 {
 		return fmt.Errorf("no initial nodes in testnet")
 	}
@@ -93,10 +94,10 @@ func Start(testnet *e2e.Testnet) error {
 			}
 		}
 
-		logger.Info(fmt.Sprintf("Starting node %v at height %v...", node.Name, node.StartAt))
-		if _, _, err := waitForHeight(testnet, node.StartAt); err != nil {
-			return err
-		}
+		logger.Info("Starting catch up node",
+			"node", node.Name,
+			"height", node.StartAt)
+
 		if err := execCompose(testnet.Dir, "up", "-d", node.Name); err != nil {
 			return err
 		}

--- a/test/e2e/runner/start.go
+++ b/test/e2e/runner/start.go
@@ -94,9 +94,7 @@ func Start(testnet *e2e.Testnet) error {
 			}
 		}
 
-		logger.Info("Starting catch up node",
-			"node", node.Name,
-			"height", node.StartAt)
+		logger.Info("Starting catch up node", "node", node.Name, "height", node.StartAt)
 
 		if err := execCompose(testnet.Dir, "up", "-d", node.Name); err != nil {
 			return err


### PR DESCRIPTION
I realized after my last commit that my change made a following line of code a bit redundant.

(alternatively my last change was redunadnt to the existing code.)

I took this oppertunity to make some minor cleanups and logging changes to the node changes which I hope will make tests a bit more clear.