### PR TITLE
psql: add documentation and simplify constructor API

### DIFF
--- a/cmd/tendermint/commands/reindex_event.go
+++ b/cmd/tendermint/commands/reindex_event.go
@@ -31,7 +31,7 @@ var ReIndexEventCmd = &cobra.Command{
 	Long: `
 	reindex-event is an offline tooling to re-index block and tx events to the eventsinks,
 	you can run this command when the event store backend dropped/disconnected or you want to replace the backend.
-	The default start-height is 0, meaning the tooling will start reindex from the base block height(inclusive); and the 
+	The default start-height is 0, meaning the tooling will start reindex from the base block height(inclusive); and the
 	default end-height is 0, meaning the tooling will reindex until the latest block height(inclusive). User can omits
 	either or both arguments.
 	`,
@@ -106,7 +106,7 @@ func loadEventSinks(cfg *tmcfg.Config) ([]indexer.EventSink, error) {
 			if conn == "" {
 				return nil, errors.New("the psql connection settings cannot be empty")
 			}
-			es, _, err := psql.NewEventSink(conn, chainID)
+			es, err := psql.NewEventSink(conn, chainID)
 			if err != nil {
 				return nil, err
 			}

--- a/node/setup.go
+++ b/node/setup.go
@@ -115,7 +115,7 @@ loop:
 				return nil, nil, errors.New("the psql connection settings cannot be empty")
 			}
 
-			es, _, err := psql.NewEventSink(conn, chainID)
+			es, err := psql.NewEventSink(conn, chainID)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/state/indexer/indexer_service_test.go
+++ b/state/indexer/indexer_service_test.go
@@ -164,19 +164,16 @@ func setupDB(t *testing.T) (*dockertest.Pool, error) {
 
 	conn := fmt.Sprintf(dsn, user, password, resource.GetPort(port+"/tcp"), dbName)
 
-	if err = pool.Retry(func() error {
-		var err error
-
-		pSink, psqldb, err = psql.NewEventSink(conn, "test-chainID")
-
+	assert.NoError(t, pool.Retry(func() error {
+		sink, err := psql.NewEventSink(conn, "test-chainID")
 		if err != nil {
 			return err
 		}
 
+		pSink = sink
+		psqldb = sink.DB()
 		return psqldb.Ping()
-	}); err != nil {
-		assert.Error(t, err)
-	}
+	}))
 
 	resetDB(t)
 

--- a/state/indexer/sink/psql/psql_test.go
+++ b/state/indexer/sink/psql/psql_test.go
@@ -341,19 +341,14 @@ func setupDB(t *testing.T) (*dockertest.Pool, error) {
 
 	conn := fmt.Sprintf(dsn, user, password, resource.GetPort(port+"/tcp"), dbName)
 
-	if err = pool.Retry(func() error {
-		var err error
-
-		_, db, err = NewEventSink(conn, chainID)
-
+	require.NoError(t, pool.Retry(func() error {
+		sink, err := NewEventSink(conn, chainID)
 		if err != nil {
 			return err
 		}
-
+		db = sink.DB() // set global for test use
 		return db.Ping()
-	}); err != nil {
-		require.NoError(t, err)
-	}
+	}))
 
 	resetDB(t)
 

--- a/state/indexer/sink/sink.go
+++ b/state/indexer/sink/sink.go
@@ -51,7 +51,7 @@ func EventSinksFromConfig(cfg *config.Config, dbProvider config.DBProvider, chai
 				return nil, errors.New("the psql connection settings cannot be empty")
 			}
 
-			es, _, err := psql.NewEventSink(conn, chainID)
+			es, err := psql.NewEventSink(conn, chainID)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Add documentation comments to the psql event sink package, and simplify the
constructor function so that it does not return the SQL database handle.  The
handle is needed for testing, so expose that via a separate method on the
concrete type.

Update the tests and existing usage for the change. This change does not affect
the behaviour of the sink, so there are no functional changes, only syntactic
updates.