### PR TITLE
e2e: more consistent node selection during tests

### DIFF
--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -417,16 +417,6 @@ func (t Testnet) ArchiveNodes() []*Node {
 	return nodes
 }
 
-// RandomNode returns a random non-seed node.
-func (t Testnet) RandomNode() *Node {
-	for {
-		node := t.Nodes[rand.Intn(len(t.Nodes))]
-		if node.Mode != ModeSeed {
-			return node
-		}
-	}
-}
-
 // IPv6 returns true if the testnet is an IPv6 network.
 func (t Testnet) IPv6() bool {
 	return t.IP.IP.To4() == nil

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -33,7 +33,7 @@ func InjectEvidence(testnet *e2e.Testnet, amount int) error {
 	var targetNode *e2e.Node
 
 	for i := 0; i < len(testnet.Nodes)-1; i++ {
-		targetNode = testnet.Nodes[rand.Intn(len(testnet.Nodes))]
+		targetNode = testnet.Nodes[rand.Intn(len(testnet.Nodes))] // nolint: gosec
 		if targetNode.Mode == e2e.ModeSeed {
 			targetNode = nil
 			continue

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -29,7 +30,21 @@ const lightClientEvidenceRatio = 4
 // DuplicateVoteEvidence.
 func InjectEvidence(testnet *e2e.Testnet, amount int) error {
 	// select a random node
-	targetNode := testnet.RandomNode()
+	var targetNode *e2e.Node
+
+	for i := 0; i < len(testnet.Nodes)-1; i++ {
+		targetNode = testnet.Nodes[rand.Intn(len(testnet.Nodes))]
+		if targetNode.Mode == e2e.ModeSeed {
+			targetNode = nil
+			continue
+		}
+
+		break
+	}
+
+	if targetNode == nil {
+		return errors.New("could not find node to inject evidence into")
+	}
 
 	logger.Info(fmt.Sprintf("Injecting evidence through %v (amount: %d)...", targetNode.Name, amount))
 


### PR DESCRIPTION
In the transaction load generator, the e2e test harness previously distributed load randomly to hosts, which was a source of test non-determinism. This change distributes the load generation to the different nodes in the set in a round robin fashion, to produce more reliable results, but does not otherwise change the behavior of the test harness. 