### PR TITLE
lint: change deprecated linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters:
     # - maligned
     - nakedret
     - prealloc
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - stylecheck


### PR DESCRIPTION
This is a super minor change that silences a warning when running the linter locally. 