### PR TITLE
rfc: fix link style

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -37,6 +37,6 @@ sections.
 
 ## Table of Contents
 
-- [RFC-000: P2P Roadmap](./rfc-000.p2p-roadmap.rst)
+- [RFC-000: P2P Roadmap](./rfc-000-p2p-roadmap.rst)
 
-<!-- - [RFC-NNN: Title](./rfc-NNN.title.md) -->
+<!-- - [RFC-NNN: Title](./rfc-NNN-title.md) -->


### PR DESCRIPTION
This is super minor, but chaning this to fix a broken link and to
match the existing style of the ADRs.