### PR TITLE
Add a changelog entry for PostgreSQL changes.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -108,6 +108,7 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
 - [fastsync/event] \#6619 Emit fastsync status event when switching consensus/fastsync (@JayT106)
 - [statesync/event] \#6700 Emit statesync status start/end event (@JayT106)
 - [inspect] \#6785 Add a new `inspect` command for introspecting the state and block store of a crashed tendermint node. (@williambanfield)
+- [config/indexer] \#6868 Update the PostgreSQL indexing schema to allow more accurate queries (@creachadair)
 
 ### IMPROVEMENTS
 


### PR DESCRIPTION
A follow-up to #6868.

I accidentally omitted this from the original PR. In adding it here, I remembered why:
There is already an entry for the new PostgreSQL implementation, and this is really
just an update to that still-unreleased feature. 

**Reviewers:** Does it make sense to (1) Skip this entry, and let the original stand?
(2) Replace the original entry with this one? (3) Have both even though this isn't really 
a feature? Or other suggestions as may occur to you.