### PR TITLE
e2e: skip assertions for stateless nodes

### DIFF
--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -17,9 +17,6 @@ import (
 // Tests that any initial state given in genesis has made it into the app.
 func TestApp_InitialState(t *testing.T) {
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Stateless() {
-			return
-		}
 		if len(node.Testnet.InitialState) == 0 {
 			return
 		}
@@ -39,10 +36,6 @@ func TestApp_InitialState(t *testing.T) {
 // block and the node sync status.
 func TestApp_Hash(t *testing.T) {
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode == e2e.ModeSeed {
-			return
-		}
-
 		client, err := node.Client()
 		require.NoError(t, err)
 		info, err := client.ABCIInfo(ctx)
@@ -64,10 +57,6 @@ func TestApp_Hash(t *testing.T) {
 // Tests that we can set a value and retrieve it.
 func TestApp_Tx(t *testing.T) {
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode == e2e.ModeSeed {
-			return
-		}
-
 		client, err := node.Client()
 		require.NoError(t, err)
 
@@ -104,6 +93,5 @@ func TestApp_Tx(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, key, string(abciResp.Response.Key))
 		assert.Equal(t, value, string(abciResp.Response.Value))
-
 	})
 }

--- a/test/e2e/tests/block_test.go
+++ b/test/e2e/tests/block_test.go
@@ -13,10 +13,6 @@ import (
 func TestBlock_Header(t *testing.T) {
 	blocks := fetchBlockChain(t)
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode == e2e.ModeSeed {
-			return
-		}
-
 		client, err := node.Client()
 		require.NoError(t, err)
 		status, err := client.Status(ctx)
@@ -55,10 +51,6 @@ func TestBlock_Header(t *testing.T) {
 // Tests that the node contains the expected block range.
 func TestBlock_Range(t *testing.T) {
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode == e2e.ModeSeed {
-			return
-		}
-
 		client, err := node.Client()
 		require.NoError(t, err)
 		status, err := client.Status(ctx)

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -30,8 +30,9 @@ var (
 	blocksCacheMtx  = sync.Mutex{}
 )
 
-// testNode runs tests for testnet nodes. The callback function is given a
-// single node to test, running as a subtest in parallel with other subtests.
+// testNode runs tests for testnet nodes. The callback function is
+// given a single stateful node to test, running as a subtest in
+// parallel with other subtests.
 //
 // The testnet manifest must be given as the envvar E2E_MANIFEST. If not set,
 // these tests are skipped so that they're not picked up during normal unit
@@ -51,6 +52,11 @@ func testNode(t *testing.T, testFunc func(*testing.T, e2e.Node)) {
 
 	for _, node := range nodes {
 		node := *node
+
+		if node.Stateless() {
+			continue
+		}
+
 		t.Run(node.Name, func(t *testing.T) {
 			t.Parallel()
 			testFunc(t, node)

--- a/test/e2e/tests/net_test.go
+++ b/test/e2e/tests/net_test.go
@@ -14,11 +14,6 @@ func TestNet_Peers(t *testing.T) {
 	t.SkipNow()
 
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		// Seed nodes shouldn't necessarily mesh with the entire network.
-		if node.Mode == e2e.ModeSeed {
-			return
-		}
-
 		client, err := node.Client()
 		require.NoError(t, err)
 		netInfo, err := client.NetInfo(ctx)

--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -14,10 +14,6 @@ import (
 // scheduled validator updates.
 func TestValidator_Sets(t *testing.T) {
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode == e2e.ModeSeed {
-			return
-		}
-
 		client, err := node.Client()
 		require.NoError(t, err)
 		status, err := client.Status(ctx)


### PR DESCRIPTION
This is mostly as a proposal, I'm not neccessarily committed to the
change as such. Some of this is just centralizing "skips" more
clearly. Additionally this doesn't run application tests for light
clients, which are effectively just proxied to another node in the
network.

I think this is a fine change:

- the use case of the go light client is pretty narrow, and probably
  more commonly used in its embedded form, either for statesync or as
  part of an application.

- the e2e test framework makes simple calls against light client RPC
  endpoints to ensure that the node has started. I think we can be
  confident that the light client RPC system *works* from a "smoke
  test perspective," and I don't think we should use the e2e tests to
  do exhaustive testing at this level. 
  
- the assertions that we skip were largely proxied to other nodes, and
  we're also still making those requests directly to the other nodes,
  but without the extra intermediate that can timeout or cause a
  failure that's difficult to tracedown and can be an artifact of the
  test infrastructure.