### PR TITLE
Update terraform config

### DIFF
--- a/networks/remote/terraform/cluster/main.tf
+++ b/networks/remote/terraform/cluster/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
 resource "digitalocean_tag" "cluster" {
   name = "${var.name}"
 }

--- a/networks/remote/terraform/cluster/variables.tf
+++ b/networks/remote/terraform/cluster/variables.tf
@@ -4,13 +4,13 @@ variable "name" {
 
 variable "regions" {
   description = "Regions to launch in"
-  type = "list"
+  type = list
   default = ["AMS3", "FRA1", "LON1", "NYC3", "SFO2", "SGP1", "TOR1"]
 }
 
 variable "ssh_key" {
   description = "SSH key filename to copy to the nodes"
-  type = "string"
+  type = string
 }
 
 variable "instance_size" {

--- a/networks/remote/terraform/main.tf
+++ b/networks/remote/terraform/main.tf
@@ -1,5 +1,14 @@
 #Terraform Configuration
 
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
 variable "DO_API_TOKEN" {
   description = "DigitalOcean Access Token"
 }
@@ -11,7 +20,7 @@ variable "TESTNET_NAME" {
 
 variable "SSH_KEY_FILE" {
   description = "SSH public key file to be used on the nodes"
-  type = "string"
+  type = string
 }
 
 variable "SERVERS" {


### PR DESCRIPTION
I tried terraform with network/remote config, but got these errors:

```
The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Invalid quoted type constraints
│ 
│   on main.tf line 14, in variable "SSH_KEY_FILE":
│   14:   type = "string"
│ 
│

│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider
│ hashicorp/digitalocean: provider registry registry.terraform.io does not have
│ a provider named registry.terraform.io/hashicorp/digitalocean
│ 
│ Did you intend to use digitalocean/digitalocean? If so, you must specify that
│ source address in each module which requires that provider. To see which
│ modules are currently depending on hashicorp/digitalocean, run the following
│ command:
│     terraform providers
```

In this PR, I fixed these errors, and the `terraform init` works fine.