### PR TITLE
light: fix early erroring

### DIFF
--- a/light/client.go
+++ b/light/client.go
@@ -239,7 +239,7 @@ func NewClientFromTrustedStore(
 	}
 
 	// Validate the number of witnesses.
-	if len(c.witnesses) < 1 {
+	if len(c.witnesses) == 0 {
 		return nil, ErrNoWitnesses
 	}
 
@@ -1129,7 +1129,7 @@ func (c *Client) compareFirstHeaderWithWitnesses(ctx context.Context, h *types.S
 	c.providerMutex.Lock()
 	defer c.providerMutex.Unlock()
 
-	if len(c.witnesses) < 1 {
+	if len(c.witnesses) == 0 {
 		return ErrNoWitnesses
 	}
 
@@ -1171,7 +1171,7 @@ and remove witness. Otherwise, use the different primary`, e.WitnessIndex), "wit
 
 	// remove witnesses that have misbehaved
 	if err := c.removeWitnesses(witnessesToRemove); err != nil {
-		return err
+		c.logger.Error("failed to remove witnesses", "err", err, "witnessesToRemove", witnessesToRemove)
 	}
 
 	return nil

--- a/light/client.go
+++ b/light/client.go
@@ -1046,7 +1046,7 @@ func (c *Client) findNewPrimary(ctx context.Context, height int64, remove bool) 
 	c.providerMutex.Lock()
 	defer c.providerMutex.Unlock()
 
-	if len(c.witnesses) < 1 {
+	if len(c.witnesses) == 0 {
 		return nil, ErrNoWitnesses
 	}
 
@@ -1119,7 +1119,7 @@ func (c *Client) findNewPrimary(ctx context.Context, height int64, remove bool) 
 
 	// remove witnesses marked as bad. Removal is done in descending order
 	if err := c.removeWitnesses(witnessesToRemove); err != nil {
-		return nil, err
+		c.logger.Error("failed to remove witnesses", "err", err, "witnessesToRemove", witnessesToRemove)
 	}
 
 	return nil, lastError

--- a/light/client.go
+++ b/light/client.go
@@ -1001,14 +1001,14 @@ func (c *Client) lightBlockFromPrimary(ctx context.Context, height int64) (*type
 
 	case provider.ErrNoResponse, provider.ErrLightBlockNotFound, provider.ErrHeightTooHigh:
 		// we find a new witness to replace the primary
-		c.logger.Debug("error from light block request from primary, replacing...",
+		c.logger.Info("error from light block request from primary, replacing...",
 			"error", err, "height", height, "primary", c.primary)
 		return c.findNewPrimary(ctx, height, false)
 
 	default:
 		// The light client has most likely received either provider.ErrUnreliableProvider or provider.ErrBadLightBlock
 		// These errors mean that the light client should drop the primary and try with another provider instead
-		c.logger.Error("error from light block request from primary, removing...",
+		c.logger.Info("error from light block request from primary, removing...",
 			"error", err, "height", height, "primary", c.primary)
 		return c.findNewPrimary(ctx, height, true)
 	}


### PR DESCRIPTION
It seems the light client was erroring out when it had `<= 1` witnesses when it should be `< 1`. This corrects this. 