### PR TITLE
RFC 002 Interprocess Communication in Tendermint

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -39,5 +39,6 @@ sections.
 
 - [RFC-000: P2P Roadmap](./rfc-000-p2p-roadmap.rst)
 - [RFC-001: Storage Engines](./rfc-001-storage-engine.rst)
+- [RFC-002: Interprocess Communication](./rfc-002-ipc-ecosystem.md)
 
 <!-- - [RFC-NNN: Title](./rfc-NNN-title.md) -->

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -296,6 +296,12 @@ some advantages over gRPC for our domain. Specifically:
 - It is easy to call JSON-RPC manually from the command-line, which helps with
   a common concern for the RPC service, local debugging and operations.
 
+  Relatedly: JSON is relatively easy for humans to read and write, and it can
+  be easily copied and pasted to share sample queries and debugging results in
+  chat, issue comments, and so on. Ideally, the RPC service will not be used
+  for activities where the costs of a text protocol are important compared to
+  its legibility and manual usability benefits.
+
 - gRPC has an enormous dependency footprint for both clients and servers, and
   many of the features it provides to support security and performance
   (encryption, compression, streaming, etc.) are mostly irrelevant to local

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -308,7 +308,9 @@ some advantages over gRPC for our domain. Specifically:
 - gRPC has an enormous dependency footprint for both clients and servers, and
   many of the features it provides to support security and performance
   (encryption, compression, streaming, etc.) are mostly irrelevant to local
-  use.
+  use. Tendermint already needs to include a gRPC client for the remote signer,
+  but if we can avoid the need for a _client_ to depend on gRPC, that is a win
+  for usability.
 
 - If we intend to migrate light clients off RPC to use P2P entirely, there is
   no advantage to forcing a temporary migration to gRPC along the way; and once

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -178,8 +178,8 @@ interfaces and data structures) just because of the mediation.
 For clients to talk directly to the application, however, there is another
 concern: The consensus node is the ABCI _client_, so it is inconvenient for the
 application to "push" work into the consensus module via ABCI itself.  The
-current implementation works around this by either calling the consensus node's
-RPC service, which exposes an `ABCIQuery` kitchen-sink method that allows the
+current implementation works around this by calling the consensus node's RPC
+service, which exposes an `ABCIQuery` kitchen-sink method that allows the
 application a way to poke ABCI messages in the other direction.
 
 Without this RPC method, you could work around this (at least in principle) by

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -261,7 +261,28 @@ consensus network should use P2P, including the various synchronizations.
 
 ### Options for ABCI Transport
 
+The majority of current usage is in Go, and the majority of that is mediated by
+the Cosmos SDK, which uses the "direct call" interface. There is probably some
+opportunity to clean up the implementation of that code, notably by inverting
+which interface is at the "top" of the abstraction stack (currently it acts
+like an RPC interface, and escape-hatches into the direct call). However, this
+general approach works fine and doesn't need to be fundamentally changed.
 
+For applications _not_ written in Go, the two remaining options are the
+"socket" protocol (another variation on varint-prefiexed protobuf messages over
+an unstructured stream) and gRPC. It would be nice if we could get rid of one
+of these to reduce (unneeded?) optionality, and the "socket" protocol is the
+most obvious choice. gRPC is more complex, but is already widely used in the
+rest of the ecosystem (including the Cosmos SDK).
+
+The main question is whether requiring gRPC imposes an undue burden on the
+authors of applications in languages without good gRPC support. I propose that
+this is not a large constituency -- and if some important use case does arise
+later, it would not be too difficult for that application author to write a
+little proxy (in Go) that bridges the convenient SDK APIs into a simpler
+protocol. **Design principle:** It is better for an uncommon special case to
+carry the burdens of its specialness, than to bake an escape hatch into the
+infrastructure.
 
 ### Options for RPC Transport
 

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -109,11 +109,13 @@ The RPC service is exposed in several ways:
   This transport uses more or less the same JSON-RPC plumbing as the HTTP POST
   handler.
 
-  TODO: Three methods, maybe related to event subscription, are _only_ exported
-  via websocket. I think these may be used by the light client for
-  synchronization. In any case, the light client appears to be the only direct
-  consumer of the websocket transport at least within the core repository.
-  Figure out whether that's true.
+  The websocket endpoint also includes three methods that are _only_ exported
+  via websocket, which appear to support event subscription. I'm not sure what
+  is using these, but the likely candidate is the IBC relayer, which acts like
+  a light client and uses the event system to figure out what to synchronize.
+
+  TODO: Figure out what clients are actually using the websocket interface, and
+  which parts of the RPC service they are using _other_ than event subscription.
 
 - gRPC: A subset of queries may be issued in protocol buffer format to the gRPC
   interface described above under (4). As noted, this endpoint is deprecated

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -279,16 +279,17 @@ general approach works fine and doesn't need to be fundamentally changed.
 For applications _not_ written in Go, the two remaining options are the
 "socket" protocol (another variation on varint-prefixed protobuf messages over
 an unstructured stream) and gRPC. It would be nice if we could get rid of one
-of these to reduce (unneeded?) optionality, and the "socket" protocol is the
-most obvious choice. gRPC is more complex, but is already widely used in the
-rest of the ecosystem (including the Cosmos SDK).
+of these to reduce (unneeded?) optionality.
 
-The main question is whether requiring gRPC imposes an undue burden on the
-authors of applications in languages without good gRPC support. I propose that
-this is not a large constituency -- and if some important use case does arise
-later, it would not be too difficult for that application author to write a
-little proxy (in Go) that bridges the convenient SDK APIs into a simpler
-protocol.
+Since both the socket protocol and gRPC depend on protocol buffers, the
+"socket" protocol is the most obvious choice to remove. While gRPC is more
+complex, the set of languages that _have_ protobuf support but _lack_ gRPC
+support is small. Moreover, gRPC is already widely used in the rest of the
+ecosystem (including the Cosmos SDK).
+
+If some use case did arise later that can't work with gRPC, it would not be too
+difficult for that application author to write a little proxy (in Go) that
+bridges the convenient SDK APIs into a simpler protocol than gRPC.
 
 **Design principle:** It is better for an uncommon special case to carry the
 burdens of its specialness, than to bake an escape hatch into the infrastructure.

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -141,17 +141,21 @@ state should talk to the application. Otherwise, such tools would have to bake
 in knowledge about Tendermint (e.g., its interfaces and data structures) that
 they might otherwise not need or care about.
 
-However, this raises another issue: The consensus node is the ABCI client, so
-it is inconvenient for the application to "push" work into the consensus
-module. In theory you could work around this by having the consensus module
-"poll" the application for work that needs done, but that has unsatisfactory
-implications for performance and robustness, as well as being harder to
-understand.
+However, this raises another issue: The consensus node is the ABCI _client_, so
+it is inconvenient for the application to "push" work into the consensus module
+via ABCI itself. Without the Tendermint RPC service, you could work around this
+(at least in principle) by having the consensus module "poll" the application
+for work that needs done, but that has unsatisfactory implications for
+performance and robustness, as well as being harder to understand. When the
+application is compiled into the same binary as the node, the SDK can use the
+RPC methods via a "local" (direct-call) client; otherwise it uses (I think) the
+`ABCIQuery` method of the consensus node's JSON-RPC service.
 
 There has apparently been some discussion about trying to make a more
 bidirectional communication between the consensus node and the application, but
-this issue seems to still be under discussion. TODO: Impact of ABCI++ for this
-question?
+this issue seems to still be under discussion.
+
+TODO: Impact of ABCI++ for this question?
 
 ### Context: RPC Issues
 

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -148,6 +148,17 @@ TODO: Figure out what is going on with the weird pseudo-inheritance service
 interface.  The BaseService type makes sense, but its embeds are more
 complicated.
 
+### Context: Remote Signer Issues
+
+Since the remote signer needs a secure communication channel to exchange keys
+and signatures, and is expected to run truly remotely from the node (i.e., on a
+separate physical server), there is not a whole lot we can do here. We should
+finish the deprecation and removal of the "raw" socket protocol between the
+consensus node and remote signers, but the use of gRPC is appropriate.
+
+The main improvement we can make is to simplify the implementation quite a bit,
+once we no longer need to support both "raw" and gRPC transports.
+
 ### Context: ABCI Issues
 
 In the original design of ABCI, the presumption was that all access to the

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -15,6 +15,9 @@ trustworthy, and usable system, we should document which communication paths
 are essential, which could be removed or reduced in scope, and what we can
 improve for the most important use cases.
 
+This document proposes a variety of possible improvements of varying size and
+scope. Specific design proposals should get their own documentation.
+
 
 ## Background
 

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -62,13 +62,6 @@ A remote signer communicates with the consensus node in one of two ways:
    standard encrypted gRPC HTTP/2 stub as the transport. In this mode, the
    remote signer is the server and the consensus node is the client.
 
-TODO: It's not clear to me how meaningfully a remote signer is really isolated
-by this mechanism. The consensus node has to be on a shared network with the
-remote signer, so a compromise of the consensus node from the public network
-leaves the attacker able to communicate with the remote signer anyway. It does
-raise the bar by a constant factor -- now you also have to compromise the
-remote signer too -- but it's not actually isolated in the gRPC configuration.
-
 
 ### ABCI Transport
 

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -280,9 +280,12 @@ authors of applications in languages without good gRPC support. I propose that
 this is not a large constituency -- and if some important use case does arise
 later, it would not be too difficult for that application author to write a
 little proxy (in Go) that bridges the convenient SDK APIs into a simpler
-protocol. **Design principle:** It is better for an uncommon special case to
-carry the burdens of its specialness, than to bake an escape hatch into the
-infrastructure.
+protocol.
+
+**Design principle:** It is better for an uncommon special case to carry the
+burdens of its specialness, than to bake an escape hatch into the infrastructure.
+
+**Recommendation:** We should deprecate and remove the socket protocol.
 
 ### Options for RPC Transport
 

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -39,13 +39,36 @@ The Tendermint state replication engine has a complex IPC footprint.
    The gRPC interface to the consensus node has been deprecated and is slated
    for removal in the forthcoming Tendermint v0.36 release.
 
+5. Consensus nodes may optionally communicate with a "remote signer" that holds
+   a validator key and can provide public keys and signatures to the consensus
+   node. One of the stated goals of this configuration is to allow the signer
+   to be run on a private network, separate from the consensus node, so that a
+   compromise of the consensus node from the public network would be less
+   likely to expose validator keys.
 
-## Discussion
+## Discussion: Transport Mechanisms
 
-TODO: What about the verifier/signer? I think this is maybe baked into the
-consensus node.  Can/does it run separately?  If so, how does it communicate
-with the consensus node?  Does an application ever talk directly to the
-verifier/signer?
+### Remote Signer Transport
+
+A remote signer communicates with the consensus node in one of two ways:
+
+1. "Raw": Using a TCP or Unix-domain socket which carries varint-prefixed
+   protocol buffer messages. In this mode, the consensus node is the server,
+   and the remote signer is the client.
+
+   This mode has been deprecated, and is intended to be removed.
+
+2. gRPC: This mode uses the same protobuf messages as "Raw" node, but uses a
+   standard encrypted gRPC HTTP/2 stub as the transport. In this mode, the
+   remote signer is the server and the consensus node is the client.
+
+TODO: It's not clear to me how meaningfully a remote signer is really isolated
+by this mechanism. The consensus node has to be on a shared network with the
+remote signer, so a compromise of the consensus node from the public network
+leaves the attacker able to communicate with the remote signer anyway. It does
+raise the bar by a constant factor -- now you also have to compromise the
+remote signer too -- but it's not actually isolated in the gRPC configuration.
+
 
 ### ABCI Transport
 

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -239,11 +239,17 @@ Having the RPC server still makes sense for local bootstrapping and operations,
 but can be further simplified. Here are some specific proposals:
 
 - Remove the HTTP GET interface entirely.
+
 - Simplify JSON-RPC plumbing to remove unnecessary reflection and wrapping.
+
 - Remove the gRPC interface (this is already planned for v0.36).
+
 - Separate the websocket interface from the rest of the RPC service, and
   restrict it to only event subscription.
-  - Eventually: Remove the websocket interface entirely.
+
+  Eventually we should try to emove the websocket interface entirely, but we
+  will need to revisit that (probably in a new RFC) once we've done some of the
+  easier things.
 
 These changes would preserve the ability of operators to issue queries with
 curl (but would require using JSON-RPC instead of URI parameters). That would

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -392,13 +392,15 @@ The following outlines some ideas at a high level:
   synchronization, but work is already in progress to handle that concern via
   the P2P layer. Once that's done, event subscription could be separated.
 
-Separating parts of the existing RPC service is not without cost: It would
-require additional connection endpoints, for example. In return, though, it
-would become easier to reduce transport options (we only need one per
-interface), and for operators to independently control access to sensitive
-data. Considering the viability and implications of these ideas is beyond the
-scope of this RFC, but they are documented here since they follow from the
-background we have already discussed.
+Separating parts of the existing RPC service is not without cost: It might
+require additional connection endpoints, for example, though it is also not too
+difficult for multiple otherwise-independent services to share a connection.
+
+In return, though, it would become easier to reduce transport options and for
+operators to independently control access to sensitive data. Considering the
+viability and implications of these ideas is beyond the scope of this RFC, but
+they are documented here since they follow from the background we have already
+discussed.
 
 ## References
 

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -277,7 +277,7 @@ like an RPC interface, and escape-hatches into the direct call). However, this
 general approach works fine and doesn't need to be fundamentally changed.
 
 For applications _not_ written in Go, the two remaining options are the
-"socket" protocol (another variation on varint-prefiexed protobuf messages over
+"socket" protocol (another variation on varint-prefixed protobuf messages over
 an unstructured stream) and gRPC. It would be nice if we could get rid of one
 of these to reduce (unneeded?) optionality, and the "socket" protocol is the
 most obvious choice. gRPC is more complex, but is already widely used in the

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -66,6 +66,11 @@ two ways:
 - A custom remote procedure protocol built on wire-format protobuf messages
   using a socket (the "socket protocol"): [`abci/server/socket_server.go`][socket-server]
 
+The SDK also provides a [gRPC service][sdk-grpc] accessible from outside the
+application, allowing transactions to be broadcast to the network, look up
+transactions, and simulate transaction costs.
+
+
 ### RPC Transport
 
 The consensus node RPC service allows callers to query consensus parameters
@@ -235,5 +240,6 @@ uses a complex HTTP/2 based transport that is not easily replicated.
 [cosmos-sdk]: https://github.com/cosmos/cosmos-sdk/
 [local-client]: https://github.com/tendermint/tendermint/blob/master/abci/client/local_client.go
 [socket-server]: https://github.com/tendermint/tendermint/blob/master/abci/server/socket_server.go
+[sdk-grpc]: https://pkg.go.dev/github.com/cosmos/cosmos-sdk/types/tx#ServiceServer
 [json-rpc]: https://www.jsonrpc.org/specification
 [adr-57]: https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-057-RPC.md

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -149,10 +149,6 @@ use via curl, but I expect that is mostly ad hoc. Ethan reports that nodes are
 often configured with the ports to the RPC service blocked, which is good for
 security but complicates use by the light client.
 
-TODO: Figure out what is going on with the weird pseudo-inheritance service
-interface.  The BaseService type makes sense, but its embeds are more
-complicated.
-
 ### Context: Remote Signer Issues
 
 Since the remote signer needs a secure communication channel to exchange keys

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -93,10 +93,11 @@ The RPC service is exposed in several ways:
   This transport uses more or less the same JSON-RPC plumbing as the HTTP POST
   handler.
 
-  TODO: There appear to be some methods that are _only_ exported via websocket.
-  Figure out what is going on there and why it's that way. I think these may be
-  here for the same reason as the gRPC subset, viz., to support external
-  clients who could now talk directly to the application.
+  TODO: Three methods, maybe related to event subscription, are _only_ exported
+  via websocket. I think these may be used by the light client for
+  synchronization. In any case, the light client appears to be the only direct
+  consumer of the websocket transport at least within the core repository.
+  Figure out whether that's true.
 
 - gRPC: A subset of queries may be issued in protocol buffer format to the gRPC
   interface described above under (4). As noted, this endpoint is deprecated
@@ -177,10 +178,9 @@ For bootstrapping and operations, the RPC mechanism still makes sense, but can
 be further simplified. Here are some specific proposals:
 
 - Remove the HTTP GET interface entirely.
+- Simplify JSON-RPC plumbing to remove unnecessary reflection and wrapping.
 - Remove the gRPC interface (this is already planned for v0.36).
-- Remove the websocket interface (TODO: are websockets used anymore?)
-- Simplify the JSON-RPC plumbing to remove unnecessary reflection and interface
-  wrapping.
+- Remove the websocket interface (possibly depends on light client changes).
 
 These changes would preserve the ability of operators to issue queries with
 curl (but would require using JSON-RPC instead of URI parameters). That would

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -1,0 +1,239 @@
+# RFC 002: Interprocess Communication (IPC) in Tendermint
+
+## Changelog
+
+- 08-Sep-2021: Initial draft (@creachadair).
+
+
+## Abstract
+
+Communication in Tendermint among consensus nodes, applications, and operator
+tools all use different message formats and transport mechanisms.  In some
+cases there are multiple options. Having all these options complicates both the
+code and the developer experience, and hides bugs. To support a more robust,
+trustworthy, and usable system, we should document which communication paths
+are essential, which could be removed or reduced in scope, and what we can
+improve for the most important use cases.
+
+
+## Background
+
+The Tendermint state replication engine has a complex IPC footprint.
+
+1. Consensus nodes communicate with each other using a networked peer-to-peer
+   message-passing protocol.
+
+2. Consensus nodes communicate with the application whose state is being
+   replicated via the [Application BlockChain Interface (ABCI)][abci].
+
+3. Consensus nodes export a network-accessible [RPC service][rpc-service] to
+   support operations (bootstrapping, debugging) and synchronization of [light clients][light-client].
+   This interface is also used by the [`tendermint` CLI][tm-cli].
+
+4. Consensus nodes export a gRPC service exposing a subset of the methods of
+   the RPC service described by (3). This was intended to simplify the
+   implementation of tools that already use gRPC to communicate with an
+   application (via the Cosmos SDK), and wanted to also talk to the consensus
+   node without implementing yet another RPC protocol.
+
+   The gRPC interface to the consensus node has been deprecated and is slated
+   for removal in the forthcoming Tendermint v0.36 release.
+
+
+## Discussion
+
+TODO: What about the verifier/signer? I think this is maybe baked into the
+consensus node.  Can/does it run separately?  If so, how does it communicate
+with the consensus node?  Does an application ever talk directly to the
+verifier/signer?
+
+### ABCI Transport
+
+In ABCI, the _application_ is the server, and the Tendermint consensus engine
+is the client.  Most applications implement the server using the [Cosmos SDK][cosmos-sdk],
+which handles low-level details of the ABCI interaction and provides a
+higher-level interface to the rest of the application. The SDK is written in Go.
+
+Beneath the SDK, the application communicates with Tendermint core in one of
+two ways:
+
+- In-process direct calls (for applications written in Go and compiled against
+  the Tendermint code).  This is an optimization for the common case where an
+  application is written in Go, to save on the overhead of marshaling and
+  unmarshaling requests and responses within the same process:
+  [`abci/client/local_client.go`][local-client]
+
+- A custom remote procedure protocol built on wire-format protobuf messages
+  using a socket (the "socket protocol"): [`abci/server/socket_server.go`][socket-server]
+
+### RPC Transport
+
+The consensus node RPC service allows callers to query consensus parameters
+(genesis data, transactions, commits), node status (network info, health
+checks), application state (abci_query, abci_info), mempool state, and other
+attributes of the node and its application. The service also provides methods
+allowing transactions and evidence to be injected ("broadcast") into the
+blockchain.
+
+The RPC service is exposed in several ways:
+
+- HTTP GET: Queries may be sent as URI parameters, with method names in the path.
+
+- HTTP POST: Queries may be sent as JSON-RPC request messages in the body of an
+  HTTP POST request.  The server uses a custom implementation of JSON-RPC that
+  is not fully compatible with the [JSON-RPC 2.0 spec][json-rpc], but handles
+  the common cases.
+
+- Websocket: Queries may be sent as JSON-RPC request messages via a websocket.
+  This transport uses more or less the same JSON-RPC plumbing as the HTTP POST
+  handler.
+
+  TODO: There appear to be some methods that are _only_ exported via websocket.
+  Figure out what is going on there and why it's that way. I think these may be
+  here for the same reason as the gRPC subset, viz., to support external
+  clients who could now talk directly to the application.
+
+- gRPC: A subset of queries may be issued in protocol buffer format to the gRPC
+  interface described above under (4). As noted, this endpoint is deprecated
+  and will be removed in v0.36.
+
+### Opportunities for Simplification
+
+**Claim:** There are too many IPC mechanisms.
+
+The preponderance of ABCI usage is via the Cosmos SDK, which means the
+application and the consensus node are compiled together into a single binary,
+and the consensus node calls the ABCI methods of the application directly as Go
+functions.
+
+TODO: What are the remaining use cases for the socket protocol and gRPC? Ethan
+mentioned some cases like web-based explorer UIs and possibly other tools.
+
+As far as I can tell the primary consumers of the multi-headed "RPC service"
+are the light client and the `tendermint` command-line client. There is
+probably some local use via curl, but I expect that is mostly ad hoc. Ethan
+reports that nodes are often configured with the ports to the RPC service
+blocked, which is good for security but complicates use by the light client.
+
+TODO: Figure out what is going on with the weird pseudo-inheritance service
+interface.  The BaseService type makes sense, but its embeds are more
+complicated.
+
+### Context: ABCI Issues
+
+In the original design of ABCI, the presumption was that all access to the
+application would be mediated by the consensus node. This makes sense, since
+outside access could change application state and corrupt the consensus
+process. Of course, even without outside access an application could behave
+nondeterministically, but allowing other programs to send it requests was seen
+as inviting trouble.
+
+Later, however, it was noted that most of the time, tools specific to a
+particular application don't really want to talk to the consensus module
+directly. The application is the "owner" of the state machine the consensus
+engine is replicating, so tools that want to know things about application
+state should talk to the application. Otherwise, such tools would have to bake
+in knowledge about Tendermint (e.g., its interfaces and data structures) that
+they might otherwise not need or care about.
+
+However, this raises another issue: The consensus node is the ABCI client, so
+it is inconvenient for the application to "push" work into the consensus
+module. In theory you could work around this by having the consensus module
+"poll" the application for work that needs done, but that has unsatisfactory
+implications for performance and robustness, as well as being harder to
+understand.
+
+There has apparently been some discussion about trying to make a more
+bidirectional communication between the consensus node and the application, but
+this issue seems to still be under discussion. TODO: Impact of ABCI++ for this
+question?
+
+### Context: RPC Issues
+
+The RPC system serves several masters, and has a complex surface area. I
+believe there are some improvements that can be exposed by separating some of
+these concerns.
+
+For light clients, some work is already underway to move toward using P2P
+message passing rather than RPC to synchronize light client state with the rest
+of the network.  Because of the way light client synchronization interacts with
+event logging, this is not as simple as just swapping out the transport: More
+details of the event system will need to be made visible via P2P, and that in
+turn has some implications for fault tolerance (in particular, I think the
+ability of a badly-behaved client to DDoS the network without punishment is a
+concern). However, once this work is done, it should in principle be possible
+to remove the dependency of light clients on the RPC service.
+
+For bootstrapping and operations, the RPC mechanism still makes sense, but can
+be further simplified. Here are some specific proposals:
+
+- Remove the HTTP GET interface entirely.
+- Remove the gRPC interface (this is already planned for v0.36).
+- Remove the websocket interface (TODO: are websockets used anymore?)
+- Simplify the JSON-RPC plumbing to remove unnecessary reflection and interface
+  wrapping.
+
+These changes would preserve the ability of operators to issue queries with
+curl (but would require using JSON-RPC instead of URI parameters). That would
+be a little less user-friendly, but for a use case that should not be that
+prevalent.
+
+These changes would also preserve compatibility with existing JSON-RPC based
+code paths like the `tendermint` CLI and the light client (even ahead of
+further work to remove that dependency).
+
+**Design goal:** An operator should be able to disable non-local access to the
+RPC server on any node in the network without impairing the ability of the
+network to function for service of state replication, including light clients.
+
+**Design principle:** Any communication required to operate the network should use P2P.
+
+### Options for RPC Transport
+
+[ADR 057][adr-57] proposes using gRPC for the Tendermint RPC implementation.
+This is still possible, but if we are able to simplify and decouple the
+concerns as described above, I do not think it should be necessary.
+
+While JSON-RPC is not the best possible RPC protocol for all situations, it has
+some advantages over gRPC for our domain. Specifically:
+
+- It is easy to call JSON-RPC manually from the command-line, which helps with
+  a common concern for the RPC service, local debugging and operations.
+
+- gRPC has an enormous dependency footprint for both clients and servers, and
+  many of the features it provides to support security and performance
+  (encryption, compression, streaming, etc.) are mostly irrelevant to local
+  use.
+
+- If we intend to migrate light clients off RPC to use P2P entirely, there is
+  no advantage to forcing a temporary migration to gRPC along the way; and once
+  the light client is not dependent on the RPC service, the efficiency of the
+  protocol is much less important.
+
+- We can still get the benefits of generated data types using protocol buffers, even
+  without using gRPC:
+
+  - Protobuf defines a standard JSON encoding for all message types so
+    languages with protobuf support do not need to worry about type mapping
+    oddities.
+
+  - Using JSON means that even languages _without_ good protobuf support can
+    implement the protocol with a bit more work, and I expect this situation to
+    be rare.
+
+Even if a language lacks a good standard JSON-RPC mechanism, the protocol is
+lightweight and can be implemented by simple send/receive over TCP or
+Unix-domain sockets with no need for code generation, encryption, etc. gRPC
+uses a complex HTTP/2 based transport that is not easily replicated.
+
+## References
+
+[abci]: https://github.com/tendermint/spec/tree/95cf253b6df623066ff7cd4074a94e7a3f147c7a/spec/abci
+[rpc-service]: https://docs.tendermint.com/master/rpc/
+[light-client]: https://docs.tendermint.com/master/tendermint-core/light-client.html
+[tm-cli]: https://github.com/tendermint/tendermint/tree/master/cmd/tendermint
+[cosmos-sdk]: https://github.com/cosmos/cosmos-sdk/
+[local-client]: https://github.com/tendermint/tendermint/blob/master/abci/client/local_client.go
+[socket-server]: https://github.com/tendermint/tendermint/blob/master/abci/server/socket_server.go
+[json-rpc]: https://www.jsonrpc.org/specification
+[adr-57]: https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-057-RPC.md

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -135,14 +135,19 @@ application and the consensus node are compiled together into a single binary,
 and the consensus node calls the ABCI methods of the application directly as Go
 functions.
 
-TODO: What are the remaining use cases for the socket protocol and gRPC? Ethan
-mentioned some cases like web-based explorer UIs and possibly other tools.
+We also need a true IPC transport to support ABCI applications _not_ written in
+Go.  There are also several known applications written in Rust, for example
+(including [Anoma](https://github.com/anoma/anoma), Penumbra,
+[Oasis](https://github.com/oasisprotocol/oasis-core), Twilight, and
+[Nomic](https://github.com/nomic-io/nomic)). Ideally we will have at most one
+such transport "built-in": More esoteric cases can be handled by a custom proxy.
+Pragmatically, gRPC is probably the right choice here.
 
-As far as I can tell the primary consumers of the multi-headed "RPC service"
-are the light client and the `tendermint` command-line client. There is
-probably some local use via curl, but I expect that is mostly ad hoc. Ethan
-reports that nodes are often configured with the ports to the RPC service
-blocked, which is good for security but complicates use by the light client.
+The primary consumers of the multi-headed "RPC service" today are the light
+client and the `tendermint` command-line client. There is probably some local
+use via curl, but I expect that is mostly ad hoc. Ethan reports that nodes are
+often configured with the ports to the RPC service blocked, which is good for
+security but complicates use by the light client.
 
 TODO: Figure out what is going on with the weird pseudo-inheritance service
 interface.  The BaseService type makes sense, but its embeds are more

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -195,7 +195,9 @@ further work to remove that dependency).
 RPC server on any node in the network without impairing the ability of the
 network to function for service of state replication, including light clients.
 
-**Design principle:** Any communication required to operate the network should use P2P.
+**Design principle:** All communication required to implement and monitor the
+consensus network should use P2P, including the various synchronizations.
+
 
 ### Options for RPC Transport
 


### PR DESCRIPTION
Communication in Tendermint among consensus nodes, applications, and operator tools all use different message formats and transport mechanisms.  In some cases there are multiple options. Having all these options complicates both the code and the developer experience, and hides bugs. To support a more robust, trustworthy, and usable system, we should document which communication paths are essential, which could be removed or reduced in scope, and what we can improve for the most important use cases.
