### PR TITLE
ci: tweak code coverage settings

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,27 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch: on
+    changes: off
+
+github_checks:
+  annotations: false
+
+comment:
+  layout: "diff, files"
+  behavior: default
+  require_changes: no
+  require_base: no
+  require_head: yes
+
+ignore:
+  - "docs"
+  - "DOCKER"
+  - "scripts"
+  - "**/*.pb.go"
+  - "libs/pubsub/query/query.peg.go"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     project:
       default:
-        threshold: 1%
+        threshold: 20%
     patch: on
     changes: off
 

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -12,12 +12,7 @@ coverage:
 github_checks:
   annotations: false
 
-comment:
-  layout: "diff, files"
-  behavior: default
-  require_changes: no
-  require_base: no
-  require_head: yes
+comment: false
 
 ignore:
   - "docs"
@@ -25,3 +20,6 @@ ignore:
   - "scripts"
   - "**/*.pb.go"
   - "libs/pubsub/query/query.peg.go"
+  - "*.md"
+  - "*.rst"
+  - "*.yml"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -121,3 +121,7 @@ jobs:
       - run: |
           cat ./*profile.out | grep -v "mode: atomic" >> coverage.txt
         if: env.GIT_DIFF
+      - uses: codecov/codecov-action@v2.0.3
+        with:
+          file: ./coverage.txt
+        if: env.GIT_DIFF


### PR DESCRIPTION
I think what removing it did was just change the way the data got reported to the service, and what I really want to do is remove the comment on the PR, and avoid red x'es, which it looks like this patch will do. 