### PR TITLE
e2e: increase retain height

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -51,7 +51,7 @@ var (
 	nodeStateSyncs        = uniformChoice{e2e.StateSyncDisabled, e2e.StateSyncP2P, e2e.StateSyncRPC}
 	nodePersistIntervals  = uniformChoice{0, 1, 5}
 	nodeSnapshotIntervals = uniformChoice{0, 3}
-	nodeRetainBlocks      = uniformChoice{0, int(e2e.EvidenceAgeHeight), int(e2e.EvidenceAgeHeight) + 5}
+	nodeRetainBlocks      = uniformChoice{0, 2 * int(e2e.EvidenceAgeHeight), 4 * int(e2e.EvidenceAgeHeight)}
 	nodePerturbations     = probSetChoice{
 		"disconnect": 0.1,
 		"pause":      0.1,

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -53,7 +53,7 @@ persist_interval = 3
 perturb = ["kill"]
 privval_protocol = "grpc"
 block_sync = "v0"
-retain_blocks = 7
+retain_blocks = 10
 
 [node.validator04]
 abci_protocol = "builtin"
@@ -79,7 +79,7 @@ start_at = 1010
 block_sync = "v0"
 persistent_peers = ["validator01", "validator02", "validator03", "validator04"]
 perturb = ["restart"]
-retain_blocks = 7
+retain_blocks = 10
 state_sync = "rpc"
 
 [node.light01]


### PR DESCRIPTION
To avoid the state provider requesting a block that a peer no longer has, I've increased the retain height to at least twice the evidence age (14)