### PR TITLE
e2e: compile tests

### DIFF
--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         working-directory: test/e2e
         # Run make jobs in parallel, since we can't run steps in parallel.
-        run: make -j2 docker generator runner
+        run: make -j2 docker generator runner tests
 
       - name: Generate testnets
         working-directory: test/e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         working-directory: test/e2e
         # Run two make jobs in parallel, since we can't run steps in parallel.
-        run: make -j2 docker runner
+        run: make -j2 docker runner tests
         if: "env.GIT_DIFF != ''"
 
       - name: Run CI testnet

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,4 +1,4 @@
-all: docker generator runner
+all: docker generator runner tests
 
 docker:
 	docker build --tag tendermint/e2e-node -f docker/Dockerfile ../..
@@ -15,4 +15,7 @@ generator:
 runner:
 	go build -o build/runner ./runner
 
-.PHONY: all app docker generator runner 
+tests:
+	go test -o build/tests ./tests
+
+.PHONY: all app docker generator runner tests

--- a/test/e2e/run-multiple.sh
+++ b/test/e2e/run-multiple.sh
@@ -19,7 +19,7 @@ FAILED=()
 
 for MANIFEST in "$@"; do
 	START=$SECONDS
-	echo "==> Running testnet $MANIFEST..."
+	echo "==> Running testnet: $MANIFEST"
 
 	if ! ./build/runner -f "$MANIFEST"; then
 		echo "==> Testnet $MANIFEST failed, dumping manifest..."

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -63,8 +63,7 @@ func NewCLI() *CLI {
 			lctx, loadCancel := context.WithCancel(ctx)
 			defer loadCancel()
 			go func() {
-				err := Load(lctx, cli.testnet)
-				chLoadResult <- err
+				chLoadResult <- Load(lctx, cli.testnet)
 			}()
 
 			if err := Start(ctx, cli.testnet); err != nil {

--- a/test/e2e/runner/test.go
+++ b/test/e2e/runner/test.go
@@ -15,5 +15,5 @@ func Test(testnet *e2e.Testnet) error {
 		return err
 	}
 
-	return execVerbose("go", "test", "-count", "1", "./tests/...")
+	return execVerbose("./build/tests", "-test.count", "1")
 }

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -3,7 +3,6 @@ package e2e_test
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 
@@ -71,9 +70,6 @@ func loadTestnet(t *testing.T) e2e.Testnet {
 	manifest := os.Getenv("E2E_MANIFEST")
 	if manifest == "" {
 		t.Skip("E2E_MANIFEST not set, not an end-to-end test run")
-	}
-	if !filepath.IsAbs(manifest) {
-		manifest = filepath.Join("..", manifest)
 	}
 
 	testnetCacheMtx.Lock()


### PR DESCRIPTION
This is to avoid the situation where you're changing branches while
running tests, leading to confusing (at best) results.

I don't think this introduces any brittleness that didn't exist
previously (about from where you can run the tests/etc,) and compiling
an extra binary isn't particularly expensive in this context.