### PR TITLE
ci: skip coverage for non-go changes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,6 @@
 name: Test Coverage
 on:
   pull_request:
-    paths:
-      - "**.go"
-      - "!test/"
   push:
     paths:
       - "**.go"
@@ -56,6 +53,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.go
+            "!test/"
             go.mod
             go.sum
       - name: install

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,11 +3,11 @@ on:
   pull_request:
     paths:
       - "**.go"
-      - "!test"
+      - "!test/"
   push:
     paths:
       - "**.go"
-      - "!test"
+      - "!test/"
     branches:
       - master
       - release/**

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
       - "**.go"
       - "!test"
   push:
+    paths:
+      - "**.go"
+      - "!test"
     branches:
       - master
       - release/**

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Test Coverage
 on:
   pull_request:
+    paths:
+      - "**.go"
+      - "!test"
   push:
     branches:
       - master


### PR DESCRIPTION
The spirit of my change is that we shouldn't run golang coverage tests unless go source files (outside of the test package, which are generally integration tests).

Any failures uncovered in these cases (e.g. docs, fuzzer/e2e test changes) wouldn't be appropriate to fix in the context of these PRs, and don't provide useful/actionable feedback.