### PR TITLE
statesync: pre-populate reactor peer list

### DIFF
--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -982,7 +982,7 @@ func (r *Reactor) waitForEnoughPeers(ctx context.Context, numPeers int) {
 		}
 
 		// log something about once a minute
-		if iterCount%60000 == 0 {
+		if iterCount%300 == 0 {
 			r.Logger.Info("waiting for enough peers to sync",
 				"required", numPeers,
 				"current", lastCount,

--- a/node/node.go
+++ b/node/node.go
@@ -696,6 +696,18 @@ func (n *nodeImpl) OnStart() error {
 			n.eventBus.Logger.Error("failed to emit the statesync start event", "err", err)
 		}
 
+		if n.config.P2P.UseLegacy {
+			pl := n.sw.Peers().List()
+			peers := make([]types.NodeID, 0, len(pl))
+			for _, p := range pl {
+				peers = append(peers, p.ID())
+			}
+
+			n.stateSyncReactor.InitPeers(peers)
+		} else {
+			n.stateSyncReactor.InitPeers(n.peerManager.Peers())
+		}
+
 		// FIXME: We shouldn't allow state sync to silently error out without
 		// bubbling up the error and gracefully shutting down the rest of the node
 		go func() {


### PR DESCRIPTION
This is my last theory for the week about our observed initialization
hang. Want to let it bake over the weekend.