### PR TITLE
ci: disable codecov patch status check

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,7 +6,7 @@ coverage:
     project:
       default:
         threshold: 20%
-    patch: on
+    patch: off
     changes: off
 
 github_checks:


### PR DESCRIPTION
This should avoid the red x.