### PR TITLE
e2e: slow load processes with longer evidence timeouts

### DIFF
--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -79,7 +79,7 @@ func InjectEvidence(ctx context.Context, testnet *e2e.Testnet, amount int) error
 		return err
 	}
 
-	wctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	wctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	// wait for the node to reach the height above the forged height so that
@@ -110,7 +110,7 @@ func InjectEvidence(ctx context.Context, testnet *e2e.Testnet, amount int) error
 		}
 	}
 
-	wctx, cancel = context.WithTimeout(ctx, 10*time.Second)
+	wctx, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	// wait for the node to reach the height above the forged height so that

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -62,12 +62,8 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 			logger.Info("ending transaction load",
 				"dur_secs", time.Since(started).Seconds(),
 				"txns", success,
-				"rate", rate)
-
-			if rate < 2 {
-				logger.Error("transaction throughput was low",
-					"rate", rate)
-			}
+				"rate", rate,
+				"slow", rate < 1)
 
 			return nil
 		}
@@ -109,7 +105,7 @@ func loadGenerate(ctx context.Context, chTx chan<- types.Tx, size int64) {
 		case chTx <- tx:
 			// sleep for a bit before sending the
 			// next transaction.
-			waitTime := (25 * time.Millisecond) + time.Duration(rand.Int63n(int64(750*time.Millisecond))) // nolint: gosec
+			waitTime := (50 * time.Millisecond) + time.Duration(rand.Int63n(int64(time.Second))) // nolint: gosec
 			timer.Reset(waitTime)
 		}
 


### PR DESCRIPTION
These are mostly the timeouts that I think we're still hitting in CI. 

At this point, the tests (on master) pass on my local machine (which is quite beefy) so I think this is just the first in (perhaps?) a sequence of changes that attempt to change timeouts and load patterns so that the tests pass in CI more reliably. 