### PR TITLE
e2e: tweak semantics of waitForHeight

### DIFF
--- a/light/client.go
+++ b/light/client.go
@@ -379,6 +379,7 @@ func (c *Client) Update(ctx context.Context, now time.Time) (*types.LightBlock, 
 		return nil, err
 	}
 
+	// If there is a new light block then verify it
 	if latestBlock.Height > lastTrustedHeight {
 		err = c.verifyLightBlock(ctx, latestBlock, now)
 		if err != nil {
@@ -388,7 +389,8 @@ func (c *Client) Update(ctx context.Context, now time.Time) (*types.LightBlock, 
 		return latestBlock, nil
 	}
 
-	return nil, nil
+	// else return the latestTrustedBlock
+	return c.latestTrustedBlock, nil
 }
 
 // VerifyLightBlockAtHeight fetches the light block at the given height

--- a/test/e2e/runner/benchmark.go
+++ b/test/e2e/runner/benchmark.go
@@ -22,7 +22,7 @@ import (
 // Metrics are based of the `benchmarkLength`, the amount of consecutive blocks
 // sampled from in the testnet
 func Benchmark(ctx context.Context, testnet *e2e.Testnet, benchmarkLength int64) error {
-	block, _, err := waitForHeight(ctx, testnet, 0)
+	block, err := getLatestBlock(ctx, testnet)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/runner/wait.go
+++ b/test/e2e/runner/wait.go
@@ -10,7 +10,7 @@ import (
 // Wait waits for a number of blocks to be produced, and for all nodes to catch
 // up with it.
 func Wait(ctx context.Context, testnet *e2e.Testnet, blocks int64) error {
-	block, _, err := waitForHeight(ctx, testnet, 0)
+	block, err := getLatestBlock(ctx, testnet)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
waitForHeight waits until all nodes reach height x and then return the latest block. This latest block is what is used as the trusted block. However, not all nodes have this latest block. It would be far better that waitForHeight returns the block at the height requested and the height that we know all nodes in the network have reached. This PR makes this change
