### PR TITLE
e2e: cleanup on all errors if preserve not specified

### DIFF
--- a/test/e2e/runner/cleanup.go
+++ b/test/e2e/runner/cleanup.go
@@ -11,7 +11,7 @@ import (
 
 // Cleanup removes the Docker Compose containers and testnet directory.
 func Cleanup(testnet *e2e.Testnet) error {
-	err := cleanupDocker()
+	err := cleanupDocker(testnet.Name)
 	if err != nil {
 		return err
 	}
@@ -20,7 +20,7 @@ func Cleanup(testnet *e2e.Testnet) error {
 
 // cleanupDocker removes all E2E resources (with label e2e=True), regardless
 // of testnet.
-func cleanupDocker() error {
+func cleanupDocker(name string) error {
 	logger.Info("Removing Docker containers and networks")
 
 	// GNU xargs requires the -r flag to not run when input is empty, macOS
@@ -28,13 +28,13 @@ func cleanupDocker() error {
 	xargsR := `$(if [[ $OSTYPE == "linux-gnu"* ]]; then echo -n "-r"; fi)`
 
 	err := exec("bash", "-c", fmt.Sprintf(
-		"docker container ls -qa --filter label=e2e | xargs %v docker container rm -f", xargsR))
+		"docker container ls -qa --filter label=\"name=%v\" | xargs %v docker container rm -f", name, xargsR))
 	if err != nil {
 		return err
 	}
 
 	return exec("bash", "-c", fmt.Sprintf(
-		"docker network ls -q --filter label=e2e | xargs %v docker network rm", xargsR))
+		"docker network ls -q --filter label=\"name=%v\"| xargs %v docker network rm", name, xargsR))
 }
 
 // cleanupDir cleans up a testnet directory

--- a/test/e2e/runner/cleanup.go
+++ b/test/e2e/runner/cleanup.go
@@ -11,7 +11,7 @@ import (
 
 // Cleanup removes the Docker Compose containers and testnet directory.
 func Cleanup(testnet *e2e.Testnet) error {
-	err := cleanupDocker(testnet.Name)
+	err := cleanupDocker()
 	if err != nil {
 		return err
 	}
@@ -20,7 +20,7 @@ func Cleanup(testnet *e2e.Testnet) error {
 
 // cleanupDocker removes all E2E resources (with label e2e=True), regardless
 // of testnet.
-func cleanupDocker(name string) error {
+func cleanupDocker() error {
 	logger.Info("Removing Docker containers and networks")
 
 	// GNU xargs requires the -r flag to not run when input is empty, macOS
@@ -28,13 +28,13 @@ func cleanupDocker(name string) error {
 	xargsR := `$(if [[ $OSTYPE == "linux-gnu"* ]]; then echo -n "-r"; fi)`
 
 	err := exec("bash", "-c", fmt.Sprintf(
-		"docker container ls -qa --filter label=\"name=%v\" | xargs %v docker container rm -f", name, xargsR))
+		"docker container ls -qa --filter label=e2e | xargs %v docker container rm -f", xargsR))
 	if err != nil {
 		return err
 	}
 
 	return exec("bash", "-c", fmt.Sprintf(
-		"docker network ls -q --filter label=\"name=%v\"| xargs %v docker network rm", name, xargsR))
+		"docker network ls -q --filter label=e2e | xargs %v docker network rm", xargsR))
 }
 
 // cleanupDir cleans up a testnet directory

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -267,6 +267,8 @@ Does not run any perbutations.
 			if err := Cleanup(cli.testnet); err != nil {
 				return err
 			}
+			defer Cleanup(cli.testnet)
+
 			if err := Setup(cli.testnet); err != nil {
 				return err
 			}
@@ -297,10 +299,6 @@ Does not run any perbutations.
 
 			loadCancel()
 			if err := <-chLoadResult; err != nil {
-				return err
-			}
-
-			if err := Cleanup(cli.testnet); err != nil {
 				return err
 			}
 

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -52,6 +52,9 @@ func NewCLI() *CLI {
 			if err := Cleanup(cli.testnet); err != nil {
 				return err
 			}
+			if !cli.preserve {
+				defer Cleanup(cli.testnet)
+			}
 			if err := Setup(cli.testnet); err != nil {
 				return err
 			}
@@ -102,11 +105,6 @@ func NewCLI() *CLI {
 			}
 			if err := Test(cli.testnet); err != nil {
 				return err
-			}
-			if !cli.preserve {
-				if err := Cleanup(cli.testnet); err != nil {
-					return err
-				}
 			}
 			return nil
 		},

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -54,7 +54,7 @@ func NewCLI() *CLI {
 			}
 			defer func() {
 				if cli.preserve {
-					log.Print("Preserving testnet contents because -preserve=true")
+					logger.Print("Preserving testnet contents because -preserve=true")
 				} else if err := Cleanup(cli.testnet); err != nil {
 					logger.Error("Error cleaning up testnet contents", "err", err)
 				}

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -54,7 +54,7 @@ func NewCLI() *CLI {
 			}
 			defer func() {
 				if cli.preserve {
-					logger.Print("Preserving testnet contents because -preserve=true")
+					logger.Info("Preserving testnet contents because -preserve=true")
 				} else if err := Cleanup(cli.testnet); err != nil {
 					logger.Error("Error cleaning up testnet contents", "err", err)
 				}

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -52,9 +52,13 @@ func NewCLI() *CLI {
 			if err := Cleanup(cli.testnet); err != nil {
 				return err
 			}
-			if !cli.preserve {
-				defer Cleanup(cli.testnet)
-			}
+			defer func() {
+				if cli.preserve {
+					log.Print("Preserving testnet contents because -preserve=true")
+				} else if err := Cleanup(cli.testnet); err != nil {
+					logger.Error("Error cleaning up testnet contents", "err", err)
+				}
+			}()
 			if err := Setup(cli.testnet); err != nil {
 				return err
 			}
@@ -267,7 +271,11 @@ Does not run any perbutations.
 			if err := Cleanup(cli.testnet); err != nil {
 				return err
 			}
-			defer Cleanup(cli.testnet)
+			defer func() {
+				if err := Cleanup(cli.testnet); err != nil {
+					logger.Error("Error cleaning up testnet contents", "err", err)
+				}
+			}()
 
 			if err := Setup(cli.testnet); err != nil {
 				return err


### PR DESCRIPTION
If the e2e tests error, they leave all of the e2e state around including containers and networks etc. 
We should clean this up when the tests shuts down, even if it exits in error.