### PR TITLE
consensus: remove logic to unlock block on 2/3 prevote for nil

### DIFF
--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -647,8 +647,15 @@ func ensureNewUnlock(t *testing.T, unlockCh <-chan tmpubsub.Message, height int6
 }
 
 func ensureLock(t *testing.T, lockCh <-chan tmpubsub.Message, height int64, round int32) {
+	t.Helper()
 	ensureNewEvent(t, lockCh, height, round, ensureTimeout,
 		"Timeout expired while waiting for LockValue event")
+}
+
+func ensureRelock(t *testing.T, relockCh <-chan tmpubsub.Message, height int64, round int32) {
+	t.Helper()
+	ensureNewEvent(t, relockCh, height, round, ensureTimeout,
+		"Timeout expired while waiting for RelockValue event")
 }
 
 func ensureProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID) {

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -512,15 +512,6 @@ func ensureNoNewRoundStep(t *testing.T, stepCh <-chan tmpubsub.Message) {
 		"We should be stuck waiting, not receiving NewRoundStep event")
 }
 
-func ensureNoNewUnlock(t *testing.T, unlockCh <-chan tmpubsub.Message) {
-	t.Helper()
-	ensureNoNewEvent(
-		t,
-		unlockCh,
-		ensureTimeout,
-		"We should be stuck waiting, not receiving Unlock event")
-}
-
 func ensureNoNewTimeout(t *testing.T, stepCh <-chan tmpubsub.Message, timeout int64) {
 	t.Helper()
 	timeoutDuration := time.Duration(timeout*10) * time.Nanosecond
@@ -638,12 +629,6 @@ func ensureNewBlockHeader(t *testing.T, blockCh <-chan tmpubsub.Message, height 
 			t.Fatalf("expected header %X, got %X", blockHash, blockHeaderEvent.Header.Hash())
 		}
 	}
-}
-
-func ensureNewUnlock(t *testing.T, unlockCh <-chan tmpubsub.Message, height int64, round int32) {
-	t.Helper()
-	ensureNewEvent(t, unlockCh, height, round, ensureTimeout,
-		"Timeout expired while waiting for NewUnlock event")
 }
 
 func ensureLock(t *testing.T, lockCh <-chan tmpubsub.Message, height int64, round int32) {

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -647,10 +647,9 @@ func ensureNewUnlock(t *testing.T, unlockCh <-chan tmpubsub.Message, height int6
 }
 
 func ensureLock(t *testing.T, lockCh <-chan tmpubsub.Message, height int64, round int32) {
-	ensureNewEvent(lockCh, height, round, ensureTimeout,
+	ensureNewEvent(t, lockCh, height, round, ensureTimeout,
 		"Timeout expired while waiting for LockValue event")
 }
-
 
 func ensureProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID) {
 	t.Helper()

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -522,7 +522,7 @@ func ensureNoNewTimeout(t *testing.T, stepCh <-chan tmpubsub.Message, timeout in
 		"We should be stuck waiting, not receiving NewTimeout event")
 }
 
-func ensureNewEvent(t *testing.T, ch <-chan tmpubsub.Message, height int64, round int32, timeout time.Duration, errorMessage string) { //nolint: lll
+func ensureNewEvent(t *testing.T, ch <-chan tmpubsub.Message, height int64, round int32, timeout time.Duration, errorMessage string) { // nolint: lll
 	t.Helper()
 	select {
 	case <-time.After(timeout):

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -622,6 +622,7 @@ func ensureNewUnlock(unlockCh <-chan tmpubsub.Message, height int64, round int32
 	ensureNewEvent(unlockCh, height, round, ensureTimeout,
 		"Timeout expired while waiting for NewUnlock event")
 }
+
 func ensureLock(lockCh <-chan tmpubsub.Message, height int64, round int32) {
 	ensureNewEvent(lockCh, height, round, ensureTimeout,
 		"Timeout expired while waiting for LockValue event")

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -622,6 +622,10 @@ func ensureNewUnlock(unlockCh <-chan tmpubsub.Message, height int64, round int32
 	ensureNewEvent(unlockCh, height, round, ensureTimeout,
 		"Timeout expired while waiting for NewUnlock event")
 }
+func ensureLock(lockCh <-chan tmpubsub.Message, height int64, round int32) {
+	ensureNewEvent(lockCh, height, round, ensureTimeout,
+		"Timeout expired while waiting for LockValue event")
+}
 
 func ensureProposal(proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID) {
 	select {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1409,21 +1409,7 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 
 	// +2/3 prevoted nil.
 	if len(blockID.Hash) == 0 {
-		/*
-					               if cs.LockedBlock == nil {
-			                       logger.Debug("precommit step; +2/3 prevoted for nil")
-			               } else {
-			                       logger.Debug("precommit step; +2/3 prevoted for nil; unlocking")
-			                       cs.LockedRound = -1
-			                       cs.LockedBlock = nil
-			                       cs.LockedBlockParts = nil
-
-			                       if err := cs.eventBus.PublishEventUnlock(cs.RoundStateEvent()); err != nil {
-			                               logger.Error("failed publishing event unlock", "err", err)
-			                       }
-			               }
-		*/
-
+		logger.Debug("precommit step; +2/3 prevoted for nil")
 		cs.signAddVote(tmproto.PrecommitType, nil, types.PartSetHeader{})
 		return
 	}
@@ -2079,10 +2065,9 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 			if (cs.LockedBlock != nil) &&
 				(cs.LockedRound < vote.Round) &&
 				(vote.Round <= cs.Round) &&
-				//	!cs.LockedBlock.HashesTo(blockID.Hash) && len(blockID.Hash) != 0 {
-				!cs.LockedBlock.HashesTo(blockID.Hash) {
+				!cs.LockedBlock.HashesTo(blockID.Hash) && len(blockID.Hash) != 0 {
 
-				cs.Logger.Debug("unlocking because of POL", "locked_round", cs.LockedRound, "pol_round", vote.Round)
+				cs.Logger.Debug("unlocking because of POL for non-nil block", "locked_round", cs.LockedRound, "pol_round", vote.Round)
 
 				cs.LockedRound = -1
 				cs.LockedBlock = nil
@@ -2122,8 +2107,6 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 				}
 			}
 		}
-
-		cs.Logger.Debug("moving to future round!")
 
 		// If +2/3 prevotes for *anything* for future round:
 		switch {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1408,7 +1408,7 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 	}
 
 	// +2/3 prevoted nil. Precommit nil.
-	if len(blockID.Hash) == 0 {
+	if blockID.IsNil() {
 		logger.Debug("precommit step; +2/3 prevoted for nil")
 		cs.signAddVote(tmproto.PrecommitType, nil, types.PartSetHeader{})
 		return
@@ -1577,7 +1577,7 @@ func (cs *State) tryFinalizeCommit(height int64) {
 	}
 
 	blockID, ok := cs.Votes.Precommits(cs.CommitRound).TwoThirdsMajority()
-	if !ok || len(blockID.Hash) == 0 {
+	if !ok || blockID.IsNil() {
 		logger.Error("failed attempt to finalize commit; there was no +2/3 majority or +2/3 was for nil")
 		return
 	}
@@ -1910,7 +1910,7 @@ func (cs *State) addProposalBlockPart(msg *BlockPartMessage, peerID types.NodeID
 		// Update Valid* if we can.
 		prevotes := cs.Votes.Prevotes(cs.Round)
 		blockID, hasTwoThirds := prevotes.TwoThirdsMajority()
-		if hasTwoThirds && !blockID.IsZero() && (cs.ValidRound < cs.Round) {
+		if hasTwoThirds && !blockID.IsNil() && (cs.ValidRound < cs.Round) {
 			if cs.ProposalBlock.HashesTo(blockID.Hash) {
 				cs.Logger.Debug(
 					"updating valid block to new proposal block",
@@ -2060,7 +2060,7 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 		cs.Logger.Debug("added vote to prevote", "vote", vote, "prevotes", prevotes.StringShort())
 
 		// Check to see if >2/3 of the voting power on the network voted for any non-nil block.
-		if blockID, ok := prevotes.TwoThirdsMajority(); ok && len(blockID.Hash) != 0 {
+		if blockID, ok := prevotes.TwoThirdsMajority(); ok && !blockID.IsNil() {
 			// Greater than 2/3 of the voting power on the network voted for some
 			// non-nil block
 
@@ -2120,7 +2120,7 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 
 		case cs.Round == vote.Round && cstypes.RoundStepPrevote <= cs.Step: // current round
 			blockID, ok := prevotes.TwoThirdsMajority()
-			if ok && (cs.isProposalComplete() || len(blockID.Hash) == 0) {
+			if ok && (cs.isProposalComplete() || blockID.IsNil()) {
 				cs.enterPrecommit(height, vote.Round)
 			} else if prevotes.HasTwoThirdsAny() {
 				cs.enterPrevoteWait(height, vote.Round)
@@ -2148,7 +2148,7 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 			cs.enterNewRound(height, vote.Round)
 			cs.enterPrecommit(height, vote.Round)
 
-			if len(blockID.Hash) != 0 {
+			if !blockID.IsNil() {
 				cs.enterCommit(height, vote.Round)
 				if cs.config.SkipTimeoutCommit && precommits.HasAll() {
 					cs.enterNewRound(cs.Height, 0)

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2059,8 +2059,12 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 
 		// Check to see if >2/3 of the voting power on the network voted for any non-nil block.
 		if blockID, ok := prevotes.TwoThirdsMajority(); ok && len(blockID.Hash) != 0 {
-			// There was a polka!
-			// If it matches our ProposalBlock, update the ValidBlock
+			// Greater than 2/3 of the voting power on the network voted for some
+			// non-nil block
+
+			// If we locked a different block in an earlier round, unlock it.
+			// We are going to relock a new block when we precommit, so this unlock
+			// is only temporary.
 			if (cs.LockedBlock != nil) &&
 				(cs.LockedRound < vote.Round) &&
 				(vote.Round <= cs.Round) &&

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2057,7 +2057,7 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 		prevotes := cs.Votes.Prevotes(vote.Round)
 		cs.Logger.Debug("added vote to prevote", "vote", vote, "prevotes", prevotes.StringShort())
 
-		// If +2/3 prevotes for a block for *any* round:
+		// Check to see if >2/3 of the voting power on the network voted for any non-nil block.
 		if blockID, ok := prevotes.TwoThirdsMajority(); ok {
 			// There was a polka!
 			// If it matches our ProposalBlock, update the ValidBlock

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1455,9 +1455,9 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 	// The +2/3 prevotes for this round is the POL for our unlock.
 	logger.Debug("precommit step; +2/3 prevotes for a block we do not have; voting nil", "block_id", blockID)
 
-	//	cs.LockedRound = -1
-	//	cs.LockedBlock = nil
-	//	cs.LockedBlockParts = nil
+	cs.LockedRound = -1
+	cs.LockedBlock = nil
+	cs.LockedBlockParts = nil
 
 	if !cs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
 		cs.ProposalBlock = nil

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1407,7 +1407,7 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 		panic(fmt.Sprintf("this POLRound should be %v but got %v", round, polRound))
 	}
 
-	// +2/3 prevoted nil.
+	// +2/3 prevoted nil. Precommit nil.
 	if len(blockID.Hash) == 0 {
 		logger.Debug("precommit step; +2/3 prevoted for nil")
 		cs.signAddVote(tmproto.PrecommitType, nil, types.PartSetHeader{})

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2061,7 +2061,6 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 		if blockID, ok := prevotes.TwoThirdsMajority(); ok {
 			// There was a polka!
 			// If it matches our ProposalBlock, update the ValidBlock
-			// If we're locked but this is a recent polka, lock on the new block.
 			if (cs.LockedBlock != nil) &&
 				(cs.LockedRound < vote.Round) &&
 				(vote.Round <= cs.Round) &&

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2058,13 +2058,13 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 		cs.Logger.Debug("added vote to prevote", "vote", vote, "prevotes", prevotes.StringShort())
 
 		// Check to see if >2/3 of the voting power on the network voted for any non-nil block.
-		if blockID, ok := prevotes.TwoThirdsMajority(); ok {
+		if blockID, ok := prevotes.TwoThirdsMajority(); ok && len(blockID.Hash) != 0 {
 			// There was a polka!
 			// If it matches our ProposalBlock, update the ValidBlock
 			if (cs.LockedBlock != nil) &&
 				(cs.LockedRound < vote.Round) &&
 				(vote.Round <= cs.Round) &&
-				!cs.LockedBlock.HashesTo(blockID.Hash) && len(blockID.Hash) != 0 {
+				!cs.LockedBlock.HashesTo(blockID.Hash) {
 
 				cs.Logger.Debug("unlocking because of POL for non-nil block", "locked_round", cs.LockedRound, "pol_round", vote.Round)
 
@@ -2078,8 +2078,7 @@ func (cs *State) addVote(vote *types.Vote, peerID types.NodeID) (added bool, err
 			}
 
 			// Update Valid* if we can.
-			// NOTE: our proposal block may be nil or not what received a polka..
-			if len(blockID.Hash) != 0 && (cs.ValidRound < vote.Round) && (vote.Round == cs.Round) {
+			if cs.ValidRound < vote.Round && vote.Round == cs.Round {
 				if cs.ProposalBlock.HashesTo(blockID.Hash) {
 					cs.Logger.Debug("updating valid block because of POL", "valid_round", cs.ValidRound, "pol_round", vote.Round)
 					cs.ValidRound = vote.Round

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1455,11 +1455,9 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 	// The +2/3 prevotes for this round is the POL for our unlock.
 	logger.Debug("precommit step; +2/3 prevotes for a block we do not have; voting nil", "block_id", blockID)
 
-	/*
-		cs.LockedRound = -1
-		cs.LockedBlock = nil
-		cs.LockedBlockParts = nil
-	*/
+	//	cs.LockedRound = -1
+	//	cs.LockedBlock = nil
+	//	cs.LockedBlockParts = nil
 
 	if !cs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
 		cs.ProposalBlock = nil

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1429,7 +1429,9 @@ func (cs *State) enterPrecommit(height int64, round int32) {
 		return
 	}
 
-	// If +2/3 prevoted for proposal block, stage and precommit it
+	// If greater than 2/3 of the voting power on the network prevoted for
+	// the proposed block, update our locked block to this block and issue a
+	// precommit vote for it.
 	if cs.ProposalBlock.HashesTo(blockID.Hash) {
 		logger.Debug("precommit step; +2/3 prevoted proposal block; locking", "hash", blockID.Hash)
 

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -648,7 +648,7 @@ func TestStateLockPOLRelock(t *testing.T) {
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, theBlockHash, theBlockParts, vs2, vs3, vs4)
 	// check that we lock on the first block
-	ensureLock(lockCh, height, round)
+	ensureLock(t, lockCh, height, round)
 
 	ensurePrecommit(t, voteCh, height, round) // our precommit
 	// the proposed block should now be locked and our precommit added
@@ -793,7 +793,7 @@ func TestStatePOLDoesNotUnlock(t *testing.T) {
 	t.Log("#### ONTO ROUND 1")
 	round++
 	incrementRound(vs2, vs3, vs4)
-	prop, propBlock := decideProposal(cs1, vs2, vs2.Height, vs2.Round)
+	prop, propBlock := decideProposal(t, cs1, vs2, vs2.Height, vs2.Round)
 	propBlockParts := propBlock.MakePartSet(types.BlockPartSizeBytes)
 	if err := cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, ""); err != nil {
 		t.Fatal(err)
@@ -829,7 +829,7 @@ func TestStatePOLDoesNotUnlock(t *testing.T) {
 	t.Log("#### ONTO ROUND 2")
 	round++
 	incrementRound(vs2, vs3, vs4)
-	prop, propBlock = decideProposal(cs1, vs3, vs3.Height, vs3.Round)
+	prop, propBlock = decideProposal(t, cs1, vs3, vs3.Height, vs3.Round)
 	propBlockParts = propBlock.MakePartSet(types.BlockPartSizeBytes)
 	if err := cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, ""); err != nil {
 		t.Fatal(err)
@@ -1238,7 +1238,7 @@ func TestProposeValidBlock(t *testing.T) {
 	// the others sign a polka
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlockHash, propBlock.MakePartSet(partSize).Header(), vs2, vs3, vs4)
 
-  ensurePrecommit(t, voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	// we should have precommitted the proposed block in this round.
 
 	validatePrecommit(t, cs1, round, round, vss[0], propBlockHash, propBlockHash)
@@ -1253,7 +1253,6 @@ func TestProposeValidBlock(t *testing.T) {
 	ensureNewRound(t, newRoundCh, height, round)
 	t.Log("### ONTO ROUND 1")
 
-
 	// timeout of propose
 	ensureNewTimeout(t, timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
 
@@ -1266,7 +1265,6 @@ func TestProposeValidBlock(t *testing.T) {
 	// we should have precommitted nil during this round because we received
 	// >2/3 precommits for nil from the other validators.
 	validatePrecommit(t, cs1, round, 0, vss[0], nil, propBlockHash)
-
 
 	incrementRound(vs2, vs3, vs4)
 	incrementRound(vs2, vs3, vs4)
@@ -1285,7 +1283,6 @@ func TestProposeValidBlock(t *testing.T) {
 	ensureNewRound(t, newRoundCh, height, round)
 
 	ensureNewProposal(t, proposalCh, height, round)
-
 
 	rs = cs1.GetRoundState()
 	assert.True(t, bytes.Equal(rs.ProposalBlock.Hash(), propBlockHash))

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -35,16 +35,16 @@ x * TestFullRound1 - 1 val, full successful round
 x * TestFullRoundNil - 1 val, full round of nil
 x * TestFullRound2 - 2 vals, both required for full round
 LockSuite
-x * TestStateLockNoPOL - 2 vals, 4 rounds. one val locked, precommits nil every round except first.
-x * TestStateLockPOLRelock - 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
-x_*_TestStateLockPOLDoesNotUnlock 4 vals, one precommits, other 3 polka nil at next round, so we precommit nil but maintain lock
-x * TestStateLockPOLSafety1 - 4 vals. We shouldn't change lock based on polka at earlier round
-x * TestStateLockPOLSafety2 - 4 vals. After unlocking, we shouldn't relock based on polka at earlier round
+x * TestStateLock_NoPOL - 2 vals, 4 rounds. one val locked, precommits nil every round except first.
+x * TestStateLock_POLRelock - 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
+x_*_TestStateLock_POLDoesNotUnlock 4 vals, one precommits, other 3 polka nil at next round, so we precommit nil but maintain lock
+x * TestStateLock_POLSafety1 - 4 vals. We shouldn't change lock based on polka at earlier round
+x * TestStateLock_POLSafety2 - 4 vals. After unlocking, we shouldn't relock based on polka at earlier round
   * TestNetworkLock - once +1/3 precommits, network should be locked
   * TestNetworkLockPOL - once +1/3 precommits, the block with more recent polka is committed
 SlashingSuite
-x * TestSlashingPrevotes - a validator prevoting twice in a round gets slashed
-x * TestSlashingPrecommits - a validator precomitting twice in a round gets slashed
+x * TestSlashing_Prevotes - a validator prevoting twice in a round gets slashed
+x * TestSlashing_Precommits - a validator precomitting twice in a round gets slashed
 CatchupSuite
   * TestCatchup - if we might be behind and we've seen any 2/3 prevotes, round skip to new round, precommit, or prevote
 HaltSuite
@@ -1750,7 +1750,7 @@ func TestResetTimeoutPrecommitUponNewHeight(t *testing.T) {
 // TODO: Slashing
 
 /*
-func TestStateSlashingPrevotes(t *testing.T) {
+func TestStateSlashing_Prevotes(t *testing.T) {
 	cs1, vss := randState(2)
 	vs2 := vss[1]
 
@@ -1785,7 +1785,7 @@ func TestStateSlashingPrevotes(t *testing.T) {
 	// XXX: Check for existence of Dupeout info
 }
 
-func TestStateSlashingPrecommits(t *testing.T) {
+func TestStateSlashing_Precommits(t *testing.T) {
 	cs1, vss := randState(2)
 	vs2 := vss[1]
 

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -40,7 +40,8 @@ x * TestStateLock_POLUpdateLock - 4 vals, one precommits,
 other 3 polka at next round, so we unlock and precomit the polka
 x * TestStateLock_POLRelock - 4 vals, polka in round 1 and polka in round 2.
 Ensure validator updates locked round.
-x_*_TestStateLock_POLDoesNotUnlock 4 vals, one precommits, other 3 polka nil at next round, so we precommit nil but maintain lock
+x_*_TestStateLock_POLDoesNotUnlock 4 vals, one precommits, other 3 polka nil at
+next round, so we precommit nil but maintain lock
 x * TestStateLock_MissingProposalWhenPOLSeenDoesNotUpdateLock - 4 vals, 1 misses proposal but sees POL.
 x * TestStateLock_MissingProposalWhenPOLSeenDoesNotUnlock - 4 vals, 1 misses proposal but sees POL.
 x * TestStateLock_POLSafety1 - 4 vals. We shouldn't change lock based on polka at earlier round
@@ -720,8 +721,6 @@ func TestStateLock_POLRelock(t *testing.T) {
 	cs1, vss := randState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
-
-	//partSize := types.BlockPartSizeBytes
 
 	timeoutWaitCh := subscribe(cs1.eventBus, types.EventQueryTimeoutWait)
 	proposalCh := subscribe(cs1.eventBus, types.EventQueryCompleteProposal)

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -692,6 +692,8 @@ func TestStateLockPOLRelock(t *testing.T) {
 	ensureNewProposal(proposalCh, height, round)
 
 	// go to prevote, node should prevote for locked block (not the new proposal) - this is relocking
+	// TODO: Ensure we prevote for the proposal if it is valid and from a round greater than
+	// the valid round: https://github.com/tendermint/tendermint/issues/6850.
 	ensurePrevote(voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], theBlockHash)
 
@@ -799,7 +801,10 @@ func TestStatePOLDoesNotUnlock(t *testing.T) {
 
 	ensureNewProposal(proposalCh, height, round)
 
-	// go to prevote, prevote for locked block (not proposal)
+	// prevote for the locked block. We do not currently prevote for the
+	// proposal.
+	// TODO: do not prevote the locked block if it does not match the proposal.
+	// (https://github.com/tendermint/tendermint/issues/6850)
 	ensurePrevote(voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], theBlockHash)
 	// add >2/3 prevotes for nil from all other validators

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -127,8 +127,8 @@ func TestStateProposerSelection2(t *testing.T) {
 				prop.Address))
 		}
 
-		rs := cs1.GetRoundState()
-		signAddVotes(config, cs1, tmproto.PrecommitType, nil, rs.ProposalBlockParts.Header(), vss[1:]...)
+		signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vss[1:]...)
+		time.Sleep(time.Second)
 		ensureNewRound(t, newRoundCh, height, i+round+1) // wait for the new round event each round
 		incrementRound(vss[1:]...)
 	}

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -1272,6 +1272,8 @@ func TestProposeValidBlock(t *testing.T) {
 	ensureNewRound(newRoundCh, height, round)
 	t.Log("### ONTO ROUND 3")
 
+	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+
 	round++ // moving to the next round
 
 	ensureNewRound(newRoundCh, height, round)

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -36,8 +36,10 @@ x * TestFullRoundNil - 1 val, full round of nil
 x * TestFullRound2 - 2 vals, both required for full round
 LockSuite
 x * TestStateLock_NoPOL - 2 vals, 4 rounds. one val locked, precommits nil every round except first.
-x * TestStateLock_POLUpdateLock - 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
-x * TestStateLock_POLRelock - 4 vals, polka in round 1 and polka in round 2. Ensure validator updates locked round.
+x * TestStateLock_POLUpdateLock - 4 vals, one precommits,
+other 3 polka at next round, so we unlock and precomit the polka
+x * TestStateLock_POLRelock - 4 vals, polka in round 1 and polka in round 2.
+Ensure validator updates locked round.
 x_*_TestStateLock_POLDoesNotUnlock 4 vals, one precommits, other 3 polka nil at next round, so we precommit nil but maintain lock
 x * TestStateLock_MissingProposalWhenPOLSeenDoesNotUpdateLock - 4 vals, 1 misses proposal but sees POL.
 x * TestStateLock_MissingProposalWhenPOLSeenDoesNotUnlock - 4 vals, 1 misses proposal but sees POL.

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -622,7 +622,6 @@ func TestStateLockPOLRelock(t *testing.T) {
 	require.NoError(t, err)
 	addr := pv1.Address()
 	voteCh := subscribeToVoter(cs1, addr)
-	unlockCh := subscribe(cs1.eventBus, types.EventQueryUnlock)
 	lockCh := subscribe(cs1.eventBus, types.EventQueryLock)
 	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
 	newBlockCh := subscribe(cs1.eventBus, types.EventQueryNewBlockHeader)
@@ -700,8 +699,6 @@ func TestStateLockPOLRelock(t *testing.T) {
 	// now lets add prevotes from everyone else for the new block
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlockHash, propBlockParts.Header(), vs2, vs3, vs4)
 
-	// check that we unlock on the old block
-	ensureNewUnlock(t, unlockCh, height, round)
 	// check that we lock on the new block
 	ensureLock(t, lockCh, height, round)
 
@@ -719,6 +716,9 @@ func TestStateLockPOLRelock(t *testing.T) {
 
 // TestStatePOLDoesNotUnlock tests that a validator maintains its locked block
 // despite receiving +2/3 nil prevotes and nil precommits from other validators.
+// Tendermint used to 'unlock' its locked block when greater than 2/3 prevotes
+// for a block nil were seen. This behavior has been removed and this test ensures
+// that it has been completely removed.
 func TestStatePOLDoesNotUnlock(t *testing.T) {
 	config := configSetup(t)
 	/*
@@ -1118,7 +1118,6 @@ func TestStateLockPOLSafety2(t *testing.T) {
 	proposalCh := subscribe(cs1.eventBus, types.EventQueryCompleteProposal)
 	timeoutWaitCh := subscribe(cs1.eventBus, types.EventQueryTimeoutWait)
 	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
-	unlockCh := subscribe(cs1.eventBus, types.EventQueryUnlock)
 	pv1, err := cs1.privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
 	addr := pv1.Address()
@@ -1194,7 +1193,6 @@ func TestStateLockPOLSafety2(t *testing.T) {
 	*/
 	ensureNewProposal(t, proposalCh, height, round)
 
-	ensureNoNewUnlock(t, unlockCh)
 	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], propBlockHash1)
 

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -707,6 +707,7 @@ func TestStateLockPOLRelock(t *testing.T) {
 }
 
 // 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
+/*
 func TestStateLockPOLUnlock(t *testing.T) {
 	config := configSetup(t)
 
@@ -727,10 +728,8 @@ func TestStateLockPOLUnlock(t *testing.T) {
 
 	// everything done from perspective of cs1
 
-	/*
-		Round1 (cs1, B) // B B B B // B nil B nil
-		eg. didn't see the 2/3 prevotes
-	*/
+//		Round1 (cs1, B) // B B B B // B nil B nil
+//		eg. didn't see the 2/3 prevotes
 
 	// start round and wait for propose and prevote
 	startTestRound(cs1, height, round)
@@ -768,10 +767,8 @@ func TestStateLockPOLUnlock(t *testing.T) {
 
 	ensureNewRound(newRoundCh, height, round)
 	t.Log("#### ONTO ROUND 1")
-	/*
-		Round2 (vs2, C) // B nil nil nil // nil nil nil _
-		cs1 unlocks!
-	*/
+//		Round2 (vs2, C) // B nil nil nil // nil nil nil _
+//		cs1 unlocks!
 	//XXX: this isnt guaranteed to get there before the timeoutPropose ...
 	if err := cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer"); err != nil {
 		t.Fatal(err)
@@ -796,6 +793,7 @@ func TestStateLockPOLUnlock(t *testing.T) {
 	signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vs2, vs3)
 	ensureNewRound(newRoundCh, height, round+1)
 }
+*/
 
 // 4 vals, one precommits, other 3 polka on nil at next round. We maintain the locked block but precommit nil
 func TestStatePOLDoesNotUnlock(t *testing.T) {

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -803,7 +803,6 @@ func TestStatePOLDoesNotUnlock(t *testing.T) {
 	// go to prevote, prevote for locked block (not proposal)
 	ensurePrevote(voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], theBlockHash)
-
 	// add >2/3 prevotes for nil from all other validators
 	signAddVotes(config, cs1, tmproto.PrevoteType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
@@ -1204,7 +1203,7 @@ func TestProposeValidBlock(t *testing.T) {
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlockHash, propBlock.MakePartSet(partSize).Header(), vs2, vs3, vs4)
 
 	ensurePrecommit(voteCh, height, round)
-	// we should have precommitted
+	// we should have precommitted the proposed block in this round.
 	validatePrecommit(t, cs1, round, round, vss[0], propBlockHash, propBlockHash)
 
 	signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
@@ -1226,7 +1225,8 @@ func TestProposeValidBlock(t *testing.T) {
 	signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
 	ensurePrecommit(voteCh, height, round)
-	// we should have precommitted
+	// we should have precommitted nil during this round because we received
+	// >2/3 precommits for nil from the other validators.
 	validatePrecommit(t, cs1, round, 0, vss[0], nil, propBlockHash)
 
 	incrementRound(vs2, vs3, vs4)

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -128,7 +128,6 @@ func TestStateProposerSelection2(t *testing.T) {
 		}
 
 		signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vss[1:]...)
-		time.Sleep(time.Second)
 		ensureNewRound(t, newRoundCh, height, i+round+1) // wait for the new round event each round
 		incrementRound(vss[1:]...)
 	}

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -35,11 +35,12 @@ x * TestFullRound1 - 1 val, full successful round
 x * TestFullRoundNil - 1 val, full round of nil
 x * TestFullRound2 - 2 vals, both required for full round
 LockSuite
-x * TestLockNoPOL - 2 vals, 4 rounds. one val locked, precommits nil every round except first.
-x * TestLockPOLRelock - 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
-x * TestLockPOLUnlock - 4 vals, one precommits, other 3 polka nil at next round, so we unlock and precomit nil
-x * TestLockPOLSafety1 - 4 vals. We shouldn't change lock based on polka at earlier round
-x * TestLockPOLSafety2 - 4 vals. After unlocking, we shouldn't relock based on polka at earlier round
+x * TestStateLockNoPOL - 2 vals, 4 rounds. one val locked, precommits nil every round except first.
+x * TestStateLockPOLRelock - 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
+x * TestStateLockPOLUnlock - 4 vals, one precommits, other 3 polka nil at next round, so we unlock and precomit nil
+x_*_TestStateLockPOLDoesNotUnlock 4 vals, one precommits, other 3 polka nil at next round, so we precommit nil but maintain lock
+x * TestStateLockPOLSafety1 - 4 vals. We shouldn't change lock based on polka at earlier round
+x * TestStateLockPOLSafety2 - 4 vals. After unlocking, we shouldn't relock based on polka at earlier round
   * TestNetworkLock - once +1/3 precommits, network should be locked
   * TestNetworkLockPOL - once +1/3 precommits, the block with more recent polka is committed
 SlashingSuite

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -416,7 +416,7 @@ func TestStateFullRound2(t *testing.T) {
 
 // two validators, 4 rounds.
 // two vals take turns proposing. val1 locks on first one, precommits nil on everything else
-func TestStateLockNoPOL(t *testing.T) {
+func TestStateLock_NoPOL(t *testing.T) {
 	config := configSetup(t)
 
 	cs1, vss := randState(config, 2)
@@ -602,12 +602,12 @@ func TestStateLockNoPOL(t *testing.T) {
 	ensurePrecommit(t, voteCh, height, round)
 }
 
-// TestStateLockPOLRelock tests that a validator maintains updates its locked
+// TestStateLock_POLRelock tests that a validator maintains updates its locked
 // block if the following conditions are met within a round:
 // 1. The validator received a valid proposal for the block
 // 2. The validator received prevotes representing greater than 2/3 of the voting
 // power on the network for the block.
-func TestStateLockPOLRelock(t *testing.T) {
+func TestStateLock_POLRelock(t *testing.T) {
 	config := configSetup(t)
 
 	cs1, vss := randState(config, 4)
@@ -706,12 +706,12 @@ func TestStateLockPOLRelock(t *testing.T) {
 	validatePrecommit(t, cs1, round, round, vss[0], propBlockR1Hash, propBlockR1Hash)
 }
 
-// TestStateLockPOLDoesNotUnlock tests that a validator maintains its locked block
+// TestStateLock_POLDoesNotUnlock tests that a validator maintains its locked block
 // despite receiving +2/3 nil prevotes and nil precommits from other validators.
 // Tendermint used to 'unlock' its locked block when greater than 2/3 prevotes
 // for a nil block were seen. This behavior has been removed and this test ensures
 // that it has been completely removed.
-func TestStatePOLDoesNotUnlock(t *testing.T) {
+func TestStateLock_POLDoesNotUnlock(t *testing.T) {
 	config := configSetup(t)
 	/*
 		All of the assertions in this test occur on the `cs1` validator.
@@ -843,11 +843,10 @@ func TestStatePOLDoesNotUnlock(t *testing.T) {
 
 }
 
-// 4 vals, v1 locks on proposed block in the first round but the other validators only prevote
-// In the second round, v1 misses the proposal but sees a majority prevote an unknown block so
-// v1 should unlock and precommit nil. In the third round another block is proposed, all vals
-// prevote and now v1 can lock onto the third block and precommit that
-func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
+// TestStateLock_MissingProposalWhenPOLSeenDoesNotUnlock tests that observing
+// a two thirds majority for a block does not cause a validator to relock on the
+// new block if a proposal was not seen for that block.
+func TestStateLock_MissingProposalWhenPOLSeenDoesNotRelock(t *testing.T) {
 	config := configSetup(t)
 
 	cs1, vss := randState(config, 4)
@@ -975,7 +974,7 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 // a polka at round 1 but we miss it
 // then a polka at round 2 that we lock on
 // then we see the polka from round 1 but shouldn't unlock
-func TestStateLockPOLSafety1(t *testing.T) {
+func TestStateLock_POLSafety1(t *testing.T) {
 	config := configSetup(t)
 
 	cs1, vss := randState(config, 4)
@@ -1098,7 +1097,7 @@ func TestStateLockPOLSafety1(t *testing.T) {
 
 // What we want:
 // dont see P0, lock on P1 at R1, dont unlock using P0 at R2
-func TestStateLockPOLSafety2(t *testing.T) {
+func TestStateLock_POLSafety2(t *testing.T) {
 	config := configSetup(t)
 
 	cs1, vss := randState(config, 4)

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -716,7 +716,7 @@ func TestStateLockPOLRelock(t *testing.T) {
 // TestStatePOLDoesNotUnlock tests that a validator maintains its locked block
 // despite receiving +2/3 nil prevotes and nil precommits from other validators.
 // Tendermint used to 'unlock' its locked block when greater than 2/3 prevotes
-// for a block nil were seen. This behavior has been removed and this test ensures
+// for a nil block were seen. This behavior has been removed and this test ensures
 // that it has been completely removed.
 func TestStatePOLDoesNotUnlock(t *testing.T) {
 	config := configSetup(t)

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -43,8 +43,8 @@ x * TestStateLock_POLSafety2 - 4 vals. After unlocking, we shouldn't relock base
   * TestNetworkLock - once +1/3 precommits, network should be locked
   * TestNetworkLockPOL - once +1/3 precommits, the block with more recent polka is committed
 SlashingSuite
-x * TestSlashing_Prevotes - a validator prevoting twice in a round gets slashed
-x * TestSlashing_Precommits - a validator precomitting twice in a round gets slashed
+x * TestStateSlashing_Prevotes - a validator prevoting twice in a round gets slashed
+x * TestStateSlashing_Precommits - a validator precomitting twice in a round gets slashed
 CatchupSuite
   * TestCatchup - if we might be behind and we've seen any 2/3 prevotes, round skip to new round, precommit, or prevote
 HaltSuite

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -798,7 +798,7 @@ func TestStateLockPOLUnlock(t *testing.T) {
 }
 
 // 4 vals, one precommits, other 3 polka on nil at next round. We maintain the locked block but precommit nil
-func TestStateNilPrevoteDoesNotUnlock(t *testing.T) {
+func TestStatePOLDoesNotUnlock(t *testing.T) {
 	config := configSetup(t)
 
 	cs1, vss := randState(config, 4)

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -36,8 +36,11 @@ x * TestFullRoundNil - 1 val, full round of nil
 x * TestFullRound2 - 2 vals, both required for full round
 LockSuite
 x * TestStateLock_NoPOL - 2 vals, 4 rounds. one val locked, precommits nil every round except first.
-x * TestStateLock_POLRelock - 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
+x * TestStateLock_POLUpdateLock - 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
+x * TestStateLock_POLRelock - 4 vals, polka in round 1 and polka in round 2. Ensure validator updates locked round.
 x_*_TestStateLock_POLDoesNotUnlock 4 vals, one precommits, other 3 polka nil at next round, so we precommit nil but maintain lock
+x * TestStateLock_MissingProposalWhenPOLSeenDoesNotUpdateLock - 4 vals, 1 misses proposal but sees POL.
+x * TestStateLock_MissingProposalWhenPOLSeenDoesNotUnlock - 4 vals, 1 misses proposal but sees POL.
 x * TestStateLock_POLSafety1 - 4 vals. We shouldn't change lock based on polka at earlier round
 x * TestStateLock_POLSafety2 - 4 vals. After unlocking, we shouldn't relock based on polka at earlier round
   * TestNetworkLock - once +1/3 precommits, network should be locked
@@ -602,12 +605,12 @@ func TestStateLock_NoPOL(t *testing.T) {
 	ensurePrecommit(t, voteCh, height, round)
 }
 
-// TestStateLock_POLRelock tests that a validator maintains updates its locked
+// TestStateLock_POLUpdateLock tests that a validator maintains updates its locked
 // block if the following conditions are met within a round:
 // 1. The validator received a valid proposal for the block
 // 2. The validator received prevotes representing greater than 2/3 of the voting
 // power on the network for the block.
-func TestStateLock_POLRelock(t *testing.T) {
+func TestStateLock_POLUpdateLock(t *testing.T) {
 	config := configSetup(t)
 
 	cs1, vss := randState(config, 4)
@@ -844,9 +847,9 @@ func TestStateLock_POLDoesNotUnlock(t *testing.T) {
 }
 
 // TestStateLock_MissingProposalWhenPOLSeenDoesNotUnlock tests that observing
-// a two thirds majority for a block does not cause a validator to relock on the
+// a two thirds majority for a block does not cause a validator to upate its lock on the
 // new block if a proposal was not seen for that block.
-func TestStateLock_MissingProposalWhenPOLSeenDoesNotRelock(t *testing.T) {
+func TestStateLock_MissingProposalWhenPOLSeenDoesNotUpdateLock(t *testing.T) {
 	config := configSetup(t)
 
 	cs1, vss := randState(config, 4)

--- a/internal/test/factory/block.go
+++ b/internal/test/factory/block.go
@@ -55,7 +55,7 @@ func MakeHeader(h *types.Header) (*types.Header, error) {
 	if h.Height == 0 {
 		h.Height = 1
 	}
-	if h.LastBlockID.IsZero() {
+	if h.LastBlockID.IsNil() {
 		h.LastBlockID = MakeBlockID()
 	}
 	if h.ChainID == "" {

--- a/types/block.go
+++ b/types/block.go
@@ -883,7 +883,7 @@ func (commit *Commit) ValidateBasic() error {
 	}
 
 	if commit.Height >= 1 {
-		if commit.BlockID.IsZero() {
+		if commit.BlockID.IsNil() {
 			return errors.New("commit cannot be for nil block")
 		}
 
@@ -1204,8 +1204,8 @@ func (blockID BlockID) ValidateBasic() error {
 	return nil
 }
 
-// IsZero returns true if this is the BlockID of a nil block.
-func (blockID BlockID) IsZero() bool {
+// IsNil returns true if this is the BlockID of a nil block.
+func (blockID BlockID) IsNil() bool {
 	return len(blockID.Hash) == 0 &&
 		blockID.PartSetHeader.IsZero()
 }

--- a/types/canonical.go
+++ b/types/canonical.go
@@ -21,7 +21,7 @@ func CanonicalizeBlockID(bid tmproto.BlockID) *tmproto.CanonicalBlockID {
 		panic(err)
 	}
 	var cbid *tmproto.CanonicalBlockID
-	if rbid == nil || rbid.IsZero() {
+	if rbid == nil || rbid.IsNil() {
 		cbid = nil
 	} else {
 		cbid = &tmproto.CanonicalBlockID{

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -221,10 +221,6 @@ func (b *EventBus) PublishEventPolka(data EventDataRoundState) error {
 	return b.Publish(EventPolkaValue, data)
 }
 
-func (b *EventBus) PublishEventUnlock(data EventDataRoundState) error {
-	return b.Publish(EventUnlockValue, data)
-}
-
 func (b *EventBus) PublishEventRelock(data EventDataRoundState) error {
 	return b.Publish(EventRelockValue, data)
 }
@@ -298,10 +294,6 @@ func (NopEventBus) PublishEventCompleteProposal(data EventDataRoundState) error 
 }
 
 func (NopEventBus) PublishEventPolka(data EventDataRoundState) error {
-	return nil
-}
-
-func (NopEventBus) PublishEventUnlock(data EventDataRoundState) error {
 	return nil
 }
 

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -362,8 +362,6 @@ func TestEventBusPublish(t *testing.T) {
 	require.NoError(t, err)
 	err = eventBus.PublishEventPolka(EventDataRoundState{})
 	require.NoError(t, err)
-	err = eventBus.PublishEventUnlock(EventDataRoundState{})
-	require.NoError(t, err)
 	err = eventBus.PublishEventRelock(EventDataRoundState{})
 	require.NoError(t, err)
 	err = eventBus.PublishEventLock(EventDataRoundState{})
@@ -475,7 +473,6 @@ var events = []string{
 	EventTimeoutProposeValue,
 	EventCompleteProposalValue,
 	EventPolkaValue,
-	EventUnlockValue,
 	EventLockValue,
 	EventRelockValue,
 	EventTimeoutWaitValue,
@@ -497,7 +494,6 @@ var queries = []tmpubsub.Query{
 	EventQueryTimeoutPropose,
 	EventQueryCompleteProposal,
 	EventQueryPolka,
-	EventQueryUnlock,
 	EventQueryLock,
 	EventQueryRelock,
 	EventQueryTimeoutWait,

--- a/types/events.go
+++ b/types/events.go
@@ -38,7 +38,6 @@ const (
 	EventStateSyncStatusValue = "StateSyncStatus"
 	EventTimeoutProposeValue  = "TimeoutPropose"
 	EventTimeoutWaitValue     = "TimeoutWait"
-	EventUnlockValue          = "Unlock"
 	EventValidBlockValue      = "ValidBlock"
 	EventVoteValue            = "Vote"
 )
@@ -223,7 +222,6 @@ var (
 	EventQueryTimeoutPropose      = QueryForEvent(EventTimeoutProposeValue)
 	EventQueryTimeoutWait         = QueryForEvent(EventTimeoutWaitValue)
 	EventQueryTx                  = QueryForEvent(EventTxValue)
-	EventQueryUnlock              = QueryForEvent(EventUnlockValue)
 	EventQueryValidatorSetUpdates = QueryForEvent(EventValidatorSetUpdatesValue)
 	EventQueryValidBlock          = QueryForEvent(EventValidBlockValue)
 	EventQueryVote                = QueryForEvent(EventVoteValue)

--- a/types/vote.go
+++ b/types/vote.go
@@ -68,7 +68,7 @@ func (vote *Vote) CommitSig() CommitSig {
 	switch {
 	case vote.BlockID.IsComplete():
 		blockIDFlag = BlockIDFlagCommit
-	case vote.BlockID.IsZero():
+	case vote.BlockID.IsNil():
 		blockIDFlag = BlockIDFlagNil
 	default:
 		panic(fmt.Sprintf("Invalid vote %v - expected BlockID to be either empty or complete", vote))
@@ -177,7 +177,7 @@ func (vote *Vote) ValidateBasic() error {
 
 	// BlockID.ValidateBasic would not err if we for instance have an empty hash but a
 	// non-empty PartsSetHeader:
-	if !vote.BlockID.IsZero() && !vote.BlockID.IsComplete() {
+	if !vote.BlockID.IsNil() && !vote.BlockID.IsComplete() {
 		return fmt.Errorf("blockID must be either empty or complete, got: %v", vote.BlockID)
 	}
 

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -27,7 +27,7 @@ func TestVoteSet_AddVote_Good(t *testing.T) {
 	assert.Nil(t, voteSet.GetByAddress(val0Addr))
 	assert.False(t, voteSet.BitArray().GetIndex(0))
 	blockID, ok := voteSet.TwoThirdsMajority()
-	assert.False(t, ok || !blockID.IsZero(), "there should be no 2/3 majority")
+	assert.False(t, ok || !blockID.IsNil(), "there should be no 2/3 majority")
 
 	vote := &Vote{
 		ValidatorAddress: val0Addr,
@@ -44,7 +44,7 @@ func TestVoteSet_AddVote_Good(t *testing.T) {
 	assert.NotNil(t, voteSet.GetByAddress(val0Addr))
 	assert.True(t, voteSet.BitArray().GetIndex(0))
 	blockID, ok = voteSet.TwoThirdsMajority()
-	assert.False(t, ok || !blockID.IsZero(), "there should be no 2/3 majority")
+	assert.False(t, ok || !blockID.IsNil(), "there should be no 2/3 majority")
 }
 
 func TestVoteSet_AddVote_Bad(t *testing.T) {
@@ -145,7 +145,7 @@ func TestVoteSet_2_3Majority(t *testing.T) {
 		require.NoError(t, err)
 	}
 	blockID, ok := voteSet.TwoThirdsMajority()
-	assert.False(t, ok || !blockID.IsZero(), "there should be no 2/3 majority")
+	assert.False(t, ok || !blockID.IsNil(), "there should be no 2/3 majority")
 
 	// 7th validator voted for some blockhash
 	{
@@ -156,7 +156,7 @@ func TestVoteSet_2_3Majority(t *testing.T) {
 		_, err = signAddVote(privValidators[6], withBlockHash(vote, tmrand.Bytes(32)), voteSet)
 		require.NoError(t, err)
 		blockID, ok = voteSet.TwoThirdsMajority()
-		assert.False(t, ok || !blockID.IsZero(), "there should be no 2/3 majority")
+		assert.False(t, ok || !blockID.IsNil(), "there should be no 2/3 majority")
 	}
 
 	// 8th validator voted for nil.
@@ -168,7 +168,7 @@ func TestVoteSet_2_3Majority(t *testing.T) {
 		_, err = signAddVote(privValidators[7], vote, voteSet)
 		require.NoError(t, err)
 		blockID, ok = voteSet.TwoThirdsMajority()
-		assert.True(t, ok || blockID.IsZero(), "there should be 2/3 majority for nil")
+		assert.True(t, ok || blockID.IsNil(), "there should be 2/3 majority for nil")
 	}
 }
 
@@ -200,7 +200,7 @@ func TestVoteSet_2_3MajorityRedux(t *testing.T) {
 		require.NoError(t, err)
 	}
 	blockID, ok := voteSet.TwoThirdsMajority()
-	assert.False(t, ok || !blockID.IsZero(),
+	assert.False(t, ok || !blockID.IsNil(),
 		"there should be no 2/3 majority")
 
 	// 67th validator voted for nil
@@ -212,7 +212,7 @@ func TestVoteSet_2_3MajorityRedux(t *testing.T) {
 		_, err = signAddVote(privValidators[66], withBlockHash(vote, nil), voteSet)
 		require.NoError(t, err)
 		blockID, ok = voteSet.TwoThirdsMajority()
-		assert.False(t, ok || !blockID.IsZero(),
+		assert.False(t, ok || !blockID.IsNil(),
 			"there should be no 2/3 majority: last vote added was nil")
 	}
 
@@ -226,7 +226,7 @@ func TestVoteSet_2_3MajorityRedux(t *testing.T) {
 		_, err = signAddVote(privValidators[67], withBlockPartSetHeader(vote, blockPartsHeader), voteSet)
 		require.NoError(t, err)
 		blockID, ok = voteSet.TwoThirdsMajority()
-		assert.False(t, ok || !blockID.IsZero(),
+		assert.False(t, ok || !blockID.IsNil(),
 			"there should be no 2/3 majority: last vote added had different PartSetHeader Hash")
 	}
 
@@ -240,7 +240,7 @@ func TestVoteSet_2_3MajorityRedux(t *testing.T) {
 		_, err = signAddVote(privValidators[68], withBlockPartSetHeader(vote, blockPartsHeader), voteSet)
 		require.NoError(t, err)
 		blockID, ok = voteSet.TwoThirdsMajority()
-		assert.False(t, ok || !blockID.IsZero(),
+		assert.False(t, ok || !blockID.IsNil(),
 			"there should be no 2/3 majority: last vote added had different PartSetHeader Total")
 	}
 
@@ -253,7 +253,7 @@ func TestVoteSet_2_3MajorityRedux(t *testing.T) {
 		_, err = signAddVote(privValidators[69], withBlockHash(vote, tmrand.Bytes(32)), voteSet)
 		require.NoError(t, err)
 		blockID, ok = voteSet.TwoThirdsMajority()
-		assert.False(t, ok || !blockID.IsZero(),
+		assert.False(t, ok || !blockID.IsNil(),
 			"there should be no 2/3 majority: last vote added had different BlockHash")
 	}
 


### PR DESCRIPTION
## What does this change do?

This change removes the logic for a validator to 'unlock' its locked block if it sees > 2/3 prevotes for nil in a round. This condition is not in the algorithm description in the Tendermint paper.

This logic was present in both `enterPrecommit` and `addVote`. The logic in `addVote` has been updated to only unlock on receipt of 2/3 prevotes for non-nil values and the logic in `enterPrecommit` has been completely removed. 

This change also updates the tests to add a new test for the unlock condition. As a cosmetic fixup, the test file was also updated to match the comments with the current names of the `Lock` suite of tests. Finally, the `Relock` test was updated to use the lock channels to ensure the unlock/lock logic remained correct despite this change. The test for the old behavior was removed. 

## Notes

* The logic for a validator to prevote its own locked block regardless of proposal is maintained during this change. It will be updated in a future pull request.

closes: #6849 