### PR TITLE
Backport event subscription changes into v0.34.x

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,4 +22,6 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### IMPROVEMENTS
 
+- [types] #6955 Backport event subscription refactor to unflatten events and order attributes (@creachadair)
+
 ### BUG FIXES

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -54,7 +54,7 @@ func (cs *State) readReplayMessage(msg *TimedWALMessage, newStepSub types.Subscr
 				if m.Height != m2.Height || m.Round != m2.Round || m.Step != m2.Step {
 					return fmt.Errorf("roundState mismatch. Got %v; Expected %v", m2, m)
 				}
-			case <-newStepSub.Cancelled():
+			case <-newStepSub.Canceled():
 				return fmt.Errorf("failed to read off newStepSub.Out(). newStepSub was cancelled")
 			case <-ticker:
 				return fmt.Errorf("failed to read off newStepSub.Out()")

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -15,6 +15,7 @@ import (
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"
+	"github.com/tendermint/tendermint/libs/pubsub"
 	"github.com/tendermint/tendermint/proxy"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/store"
@@ -58,7 +59,10 @@ func (cs *State) ReplayFile(file string, console bool) error {
 		return fmt.Errorf("failed to subscribe %s to %v", subscriber, types.EventQueryNewRoundStep)
 	}
 	defer func() {
-		if err := cs.eventBus.Unsubscribe(ctx, subscriber, types.EventQueryNewRoundStep); err != nil {
+		if err := cs.eventBus.Unsubscribe(ctx, pubsub.UnsubscribeArgs{
+			Subscriber: subscriber,
+			Query:      types.EventQueryNewRoundStep,
+		}); err != nil {
 			cs.Logger.Error("Error unsubscribing to event bus", "err", err)
 		}
 	}()
@@ -225,7 +229,10 @@ func (pb *playback) replayConsoleLoop() int {
 				tmos.Exit(fmt.Sprintf("failed to subscribe %s to %v", subscriber, types.EventQueryNewRoundStep))
 			}
 			defer func() {
-				if err := pb.cs.eventBus.Unsubscribe(ctx, subscriber, types.EventQueryNewRoundStep); err != nil {
+				if err := pb.cs.eventBus.Unsubscribe(ctx, pubsub.UnsubscribeArgs{
+					Subscriber: subscriber,
+					Query:      types.EventQueryNewRoundStep,
+				}); err != nil {
 					pb.cs.Logger.Error("Error unsubscribing from eventBus", "err", err)
 				}
 			}()

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -97,7 +97,7 @@ func startNewStateAndWaitForBlock(t *testing.T, consensusReplayConfig *cfg.Confi
 	require.NoError(t, err)
 	select {
 	case <-newBlockSub.Out():
-	case <-newBlockSub.Cancelled():
+	case <-newBlockSub.Canceled():
 		t.Fatal("newBlockSub was cancelled")
 	case <-time.After(120 * time.Second):
 		t.Fatal("Timed out waiting for new block (see trace above)")

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.0
 	github.com/google/orderedcode v0.0.1
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/gtank/merlin v0.1.1
 	github.com/lib/pq v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/libs/events/events.go
+++ b/libs/events/events.go
@@ -4,8 +4,8 @@ package events
 import (
 	"fmt"
 
+	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/libs/service"
-	tmsync "github.com/tendermint/tendermint/libs/sync"
 )
 
 // ErrListenerWasRemoved is returned by AddEvent if the listener was removed.
@@ -32,7 +32,7 @@ type Eventable interface {
 //
 // FireEvent fires an event with the given name and data.
 type Fireable interface {
-	FireEvent(event string, data EventData)
+	FireEvent(eventValue string, data EventData)
 }
 
 // EventSwitch is the interface for synchronous pubsub, where listeners
@@ -46,7 +46,7 @@ type EventSwitch interface {
 	service.Service
 	Fireable
 
-	AddListenerForEvent(listenerID, event string, cb EventCallback) error
+	AddListenerForEvent(listenerID, eventValue string, cb EventCallback) error
 	RemoveListenerForEvent(event string, listenerID string)
 	RemoveListener(listenerID string)
 }
@@ -74,27 +74,29 @@ func (evsw *eventSwitch) OnStart() error {
 
 func (evsw *eventSwitch) OnStop() {}
 
-func (evsw *eventSwitch) AddListenerForEvent(listenerID, event string, cb EventCallback) error {
+func (evsw *eventSwitch) AddListenerForEvent(listenerID, eventValue string, cb EventCallback) error {
 	// Get/Create eventCell and listener.
 	evsw.mtx.Lock()
-	eventCell := evsw.eventCells[event]
+
+	eventCell := evsw.eventCells[eventValue]
 	if eventCell == nil {
 		eventCell = newEventCell()
-		evsw.eventCells[event] = eventCell
+		evsw.eventCells[eventValue] = eventCell
 	}
+
 	listener := evsw.listeners[listenerID]
 	if listener == nil {
 		listener = newEventListener(listenerID)
 		evsw.listeners[listenerID] = listener
 	}
+
 	evsw.mtx.Unlock()
 
-	// Add event and listener.
-	if err := listener.AddEvent(event); err != nil {
+	if err := listener.AddEvent(eventValue); err != nil {
 		return err
 	}
-	eventCell.AddListener(listenerID, cb)
 
+	eventCell.AddListener(listenerID, cb)
 	return nil
 }
 

--- a/libs/events/events.go
+++ b/libs/events/events.go
@@ -4,8 +4,8 @@ package events
 import (
 	"fmt"
 
-	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/libs/service"
+	tmsync "github.com/tendermint/tendermint/libs/sync"
 )
 
 // ErrListenerWasRemoved is returned by AddEvent if the listener was removed.

--- a/libs/pubsub/example_test.go
+++ b/libs/pubsub/example_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
-
 	"github.com/tendermint/tendermint/libs/pubsub"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 )
@@ -15,8 +15,9 @@ import (
 func TestExample(t *testing.T) {
 	s := pubsub.NewServer()
 	s.SetLogger(log.TestingLogger())
-	err := s.Start()
-	require.NoError(t, err)
+
+	require.NoError(t, s.Start())
+
 	t.Cleanup(func() {
 		if err := s.Stop(); err != nil {
 			t.Error(err)
@@ -24,9 +25,18 @@ func TestExample(t *testing.T) {
 	})
 
 	ctx := context.Background()
+
 	subscription, err := s.Subscribe(ctx, "example-client", query.MustParse("abci.account.name='John'"))
 	require.NoError(t, err)
-	err = s.PublishWithEvents(ctx, "Tombstone", map[string][]string{"abci.account.name": {"John"}})
+
+	events := []abci.Event{
+		{
+			Type:       "abci.account",
+			Attributes: []abci.EventAttribute{{Key: "name", Value: "John"}},
+		},
+	}
+	err = s.PublishWithEvents(ctx, "Tombstone", events)
 	require.NoError(t, err)
+
 	assertReceive(t, "Tombstone", subscription.Out())
 }

--- a/libs/pubsub/example_test.go
+++ b/libs/pubsub/example_test.go
@@ -32,7 +32,7 @@ func TestExample(t *testing.T) {
 	events := []abci.Event{
 		{
 			Type:       "abci.account",
-			Attributes: []abci.EventAttribute{{Key: "name", Value: "John"}},
+			Attributes: []abci.EventAttribute{{Key: []byte("name"), Value: []byte("John")}},
 		},
 	}
 	err = s.PublishWithEvents(ctx, "Tombstone", events)

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -27,7 +27,7 @@
 //         select {
 //         case msg <- subscription.Out():
 //             // handle msg.Data() and msg.Events()
-//         case <-subscription.Cancelled():
+//         case <-subscription.Canceled():
 //             return subscription.Err()
 //         }
 //     }
@@ -39,8 +39,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/tendermint/tendermint/abci/types"
+	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
+	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/libs/service"
-	tmsync "github.com/tendermint/tendermint/libs/sync"
 )
 
 type operation int
@@ -69,8 +71,26 @@ var (
 // allows event types to repeat themselves with the same set of keys and
 // different values.
 type Query interface {
-	Matches(events map[string][]string) (bool, error)
+	Matches(events []types.Event) (bool, error)
 	String() string
+}
+
+type UnsubscribeArgs struct {
+	ID         string
+	Subscriber string
+	Query      Query
+}
+
+func (args UnsubscribeArgs) Validate() error {
+	if args.Subscriber == "" {
+		return errors.New("must specify a subscriber")
+	}
+
+	if args.ID == "" && args.Query == nil {
+		return fmt.Errorf("subscription is not fully defined [subscriber=%q]", args.Subscriber)
+	}
+
+	return nil
 }
 
 type cmd struct {
@@ -83,7 +103,7 @@ type cmd struct {
 
 	// publish
 	msg    interface{}
-	events map[string][]string
+	events []types.Event
 }
 
 // Server allows clients to subscribe/unsubscribe for messages, publishing
@@ -96,8 +116,12 @@ type Server struct {
 
 	// check if we have subscription before
 	// subscribing or unsubscribing
-	mtx           tmsync.RWMutex
-	subscriptions map[string]map[string]struct{} // subscriber -> query (string) -> empty struct
+	mtx tmsync.RWMutex
+
+	// subscriber -> [query->id (string) OR id->query (string))],
+	//   track connections both by ID (new) and query (legacy) to
+	//   avoid breaking the interface.
+	subscriptions map[string]map[string]string
 }
 
 // Option sets a parameter for the server.
@@ -108,7 +132,7 @@ type Option func(*Server)
 // provided, the resulting server's queue is unbuffered.
 func NewServer(options ...Option) *Server {
 	s := &Server{
-		subscriptions: make(map[string]map[string]struct{}),
+		subscriptions: make(map[string]map[string]string),
 	}
 	s.BaseService = *service.NewBaseService(nil, "PubSub", s)
 
@@ -186,9 +210,10 @@ func (s *Server) subscribe(ctx context.Context, clientID string, query Query, ou
 	case s.cmds <- cmd{op: sub, clientID: clientID, query: query, subscription: subscription}:
 		s.mtx.Lock()
 		if _, ok = s.subscriptions[clientID]; !ok {
-			s.subscriptions[clientID] = make(map[string]struct{})
+			s.subscriptions[clientID] = make(map[string]string)
 		}
-		s.subscriptions[clientID][query.String()] = struct{}{}
+		s.subscriptions[clientID][query.String()] = subscription.id
+		s.subscriptions[clientID][subscription.id] = query.String()
 		s.mtx.Unlock()
 		return subscription, nil
 	case <-ctx.Done():
@@ -201,23 +226,45 @@ func (s *Server) subscribe(ctx context.Context, clientID string, query Query, ou
 // Unsubscribe removes the subscription on the given query. An error will be
 // returned to the caller if the context is canceled or if subscription does
 // not exist.
-func (s *Server) Unsubscribe(ctx context.Context, clientID string, query Query) error {
-	s.mtx.RLock()
-	clientSubscriptions, ok := s.subscriptions[clientID]
-	if ok {
-		_, ok = clientSubscriptions[query.String()]
+func (s *Server) Unsubscribe(ctx context.Context, args UnsubscribeArgs) error {
+	if err := args.Validate(); err != nil {
+		return err
 	}
+	var qs string
+	if args.Query != nil {
+		qs = args.Query.String()
+	}
+
+	s.mtx.RLock()
+	clientSubscriptions, ok := s.subscriptions[args.Subscriber]
+	if args.ID != "" {
+		qs, ok = clientSubscriptions[args.ID]
+
+		if ok && args.Query == nil {
+			var err error
+			args.Query, err = query.New(qs)
+			if err != nil {
+				return err
+			}
+		}
+	} else if qs != "" {
+		args.ID, ok = clientSubscriptions[qs]
+	}
+
 	s.mtx.RUnlock()
 	if !ok {
 		return ErrSubscriptionNotFound
 	}
 
 	select {
-	case s.cmds <- cmd{op: unsub, clientID: clientID, query: query}:
+	case s.cmds <- cmd{op: unsub, clientID: args.Subscriber, query: args.Query, subscription: &Subscription{id: args.ID}}:
 		s.mtx.Lock()
-		delete(clientSubscriptions, query.String())
+
+		delete(clientSubscriptions, args.ID)
+		delete(clientSubscriptions, qs)
+
 		if len(clientSubscriptions) == 0 {
-			delete(s.subscriptions, clientID)
+			delete(s.subscriptions, args.Subscriber)
 		}
 		s.mtx.Unlock()
 		return nil
@@ -262,19 +309,19 @@ func (s *Server) NumClients() int {
 func (s *Server) NumClientSubscriptions(clientID string) int {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
-	return len(s.subscriptions[clientID])
+	return len(s.subscriptions[clientID]) / 2
 }
 
 // Publish publishes the given message. An error will be returned to the caller
 // if the context is canceled.
 func (s *Server) Publish(ctx context.Context, msg interface{}) error {
-	return s.PublishWithEvents(ctx, msg, make(map[string][]string))
+	return s.PublishWithEvents(ctx, msg, []types.Event{})
 }
 
 // PublishWithEvents publishes the given message with the set of events. The set
 // is matched with clients queries. If there is a match, the message is sent to
 // the client.
-func (s *Server) PublishWithEvents(ctx context.Context, msg interface{}, events map[string][]string) error {
+func (s *Server) PublishWithEvents(ctx context.Context, msg interface{}, events []types.Event) error {
 	select {
 	case s.cmds <- cmd{op: pub, msg: msg, events: events}:
 		return nil
@@ -325,7 +372,7 @@ loop:
 		switch cmd.op {
 		case unsub:
 			if cmd.query != nil {
-				state.remove(cmd.clientID, cmd.query.String(), ErrUnsubscribed)
+				state.remove(cmd.clientID, cmd.query.String(), cmd.subscription.id, ErrUnsubscribed)
 			} else {
 				state.removeClient(cmd.clientID, ErrUnsubscribed)
 			}
@@ -349,8 +396,14 @@ func (state *state) add(clientID string, q Query, subscription *Subscription) {
 	if _, ok := state.subscriptions[qStr]; !ok {
 		state.subscriptions[qStr] = make(map[string]*Subscription)
 	}
+
+	if _, ok := state.subscriptions[subscription.id]; !ok {
+		state.subscriptions[subscription.id] = make(map[string]*Subscription)
+	}
+
 	// create subscription
 	state.subscriptions[qStr][clientID] = subscription
+	state.subscriptions[subscription.id][clientID] = subscription
 
 	// initialize query if needed
 	if _, ok := state.queries[qStr]; !ok {
@@ -360,7 +413,7 @@ func (state *state) add(clientID string, q Query, subscription *Subscription) {
 	state.queries[qStr].refCount++
 }
 
-func (state *state) remove(clientID string, qStr string, reason error) {
+func (state *state) remove(clientID string, qStr, id string, reason error) {
 	clientSubscriptions, ok := state.subscriptions[qStr]
 	if !ok {
 		return
@@ -376,37 +429,62 @@ func (state *state) remove(clientID string, qStr string, reason error) {
 	// remove client from query map.
 	// if query has no other clients subscribed, remove it.
 	delete(state.subscriptions[qStr], clientID)
+	delete(state.subscriptions[id], clientID)
 	if len(state.subscriptions[qStr]) == 0 {
 		delete(state.subscriptions, qStr)
 	}
 
 	// decrease ref counter in queries
-	state.queries[qStr].refCount--
-	// remove the query if nobody else is using it
-	if state.queries[qStr].refCount == 0 {
-		delete(state.queries, qStr)
+	if ref, ok := state.queries[qStr]; ok {
+		ref.refCount--
+		if ref.refCount == 0 {
+			// remove the query if nobody else is using it
+			delete(state.queries, qStr)
+		}
 	}
 }
 
 func (state *state) removeClient(clientID string, reason error) {
+	seen := map[string]struct{}{}
 	for qStr, clientSubscriptions := range state.subscriptions {
-		if _, ok := clientSubscriptions[clientID]; ok {
-			state.remove(clientID, qStr, reason)
+		if sub, ok := clientSubscriptions[clientID]; ok {
+			if _, ok = seen[sub.id]; ok {
+				// all subscriptions are double indexed by ID and query, only
+				// process them once.
+				continue
+			}
+			state.remove(clientID, qStr, sub.id, reason)
+			seen[sub.id] = struct{}{}
 		}
 	}
 }
 
 func (state *state) removeAll(reason error) {
 	for qStr, clientSubscriptions := range state.subscriptions {
+		sub, ok := clientSubscriptions[qStr]
+		if !ok || ok && sub.id == qStr {
+			// all subscriptions are double indexed by ID and query, only
+			// process them once.
+			continue
+		}
+
 		for clientID := range clientSubscriptions {
-			state.remove(clientID, qStr, reason)
+			state.remove(clientID, qStr, sub.id, reason)
 		}
 	}
 }
 
-func (state *state) send(msg interface{}, events map[string][]string) error {
+func (state *state) send(msg interface{}, events []types.Event) error {
 	for qStr, clientSubscriptions := range state.subscriptions {
-		q := state.queries[qStr].q
+		if sub, ok := clientSubscriptions[qStr]; ok && sub.id == qStr {
+			continue
+		}
+		var q Query
+		if qi, ok := state.queries[qStr]; ok {
+			q = qi.q
+		} else {
+			continue
+		}
 
 		match, err := q.Matches(events)
 		if err != nil {
@@ -417,13 +495,13 @@ func (state *state) send(msg interface{}, events map[string][]string) error {
 			for clientID, subscription := range clientSubscriptions {
 				if cap(subscription.out) == 0 {
 					// block on unbuffered channel
-					subscription.out <- NewMessage(msg, events)
+					subscription.out <- NewMessage(subscription.id, msg, events)
 				} else {
 					// don't block on buffered channels
 					select {
-					case subscription.out <- NewMessage(msg, events):
+					case subscription.out <- NewMessage(subscription.id, msg, events):
 					default:
-						state.remove(clientID, qStr, ErrOutOfCapacity)
+						state.remove(clientID, qStr, subscription.id, ErrOutOfCapacity)
 					}
 				}
 			}

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -40,9 +40,9 @@ import (
 	"fmt"
 
 	"github.com/tendermint/tendermint/abci/types"
-	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/libs/service"
+	tmsync "github.com/tendermint/tendermint/libs/sync"
 )
 
 type operation int

--- a/libs/pubsub/pubsub_test.go
+++ b/libs/pubsub/pubsub_test.go
@@ -24,9 +24,9 @@ const (
 type kvPair = [2]string
 
 func makeEventAttrs(kvPairs []kvPair) []abci.EventAttribute {
-	var attrs []abci.EventAttribute
-	for _, pair := range kvPairs {
-		attrs = append(attrs, abci.EventAttribute{Key: []byte(pair[0]), Value: []byte(pair[1])})
+	attrs := make([]abci.EventAttribute, len(kvPairs))
+	for i, pair := range kvPairs {
+		attrs[i] = abci.EventAttribute{Key: []byte(pair[0]), Value: []byte(pair[1])}
 	}
 	return attrs
 }

--- a/libs/pubsub/pubsub_test.go
+++ b/libs/pubsub/pubsub_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/tendermint/tendermint/libs/pubsub"
@@ -35,8 +36,8 @@ func TestSubscribe(t *testing.T) {
 	subscription, err := s.Subscribe(ctx, clientID, query.Empty{})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, s.NumClients())
-	assert.Equal(t, 1, s.NumClientSubscriptions(clientID))
+	require.Equal(t, 1, s.NumClients())
+	require.Equal(t, 1, s.NumClientSubscriptions(clientID))
 
 	err = s.Publish(ctx, "Ka-Zar")
 	require.NoError(t, err)
@@ -47,19 +48,19 @@ func TestSubscribe(t *testing.T) {
 		defer close(published)
 
 		err := s.Publish(ctx, "Quicksilver")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = s.Publish(ctx, "Asylum")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = s.Publish(ctx, "Ivan")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}()
 
 	select {
 	case <-published:
 		assertReceive(t, "Quicksilver", subscription.Out())
-		assertCancelled(t, subscription, pubsub.ErrOutOfCapacity)
+		assertCanceled(t, subscription, pubsub.ErrOutOfCapacity)
 	case <-time.After(3 * time.Second):
 		t.Fatal("Expected Publish(Asylum) not to block")
 	}
@@ -77,11 +78,11 @@ func TestSubscribeWithCapacity(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	assert.Panics(t, func() {
+	require.Panics(t, func() {
 		_, err = s.Subscribe(ctx, clientID, query.Empty{}, -1)
 		require.NoError(t, err)
 	})
-	assert.Panics(t, func() {
+	require.Panics(t, func() {
 		_, err = s.Subscribe(ctx, clientID, query.Empty{}, 0)
 		require.NoError(t, err)
 	})
@@ -112,10 +113,10 @@ func TestSubscribeUnbuffered(t *testing.T) {
 		defer close(published)
 
 		err := s.Publish(ctx, "Ultron")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = s.Publish(ctx, "Darkhawk")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}()
 
 	select {
@@ -146,14 +147,14 @@ func TestSlowClientIsRemovedWithErrOutOfCapacity(t *testing.T) {
 	err = s.Publish(ctx, "Viper")
 	require.NoError(t, err)
 
-	assertCancelled(t, subscription, pubsub.ErrOutOfCapacity)
+	assertCanceled(t, subscription, pubsub.ErrOutOfCapacity)
 }
 
 func TestDifferentClients(t *testing.T) {
 	s := pubsub.NewServer()
 	s.SetLogger(log.TestingLogger())
-	err := s.Start()
-	require.NoError(t, err)
+
+	require.NoError(t, s.Start())
 	t.Cleanup(func() {
 		if err := s.Stop(); err != nil {
 			t.Error(err)
@@ -161,10 +162,18 @@ func TestDifferentClients(t *testing.T) {
 	})
 
 	ctx := context.Background()
+
 	subscription1, err := s.Subscribe(ctx, "client-1", query.MustParse("tm.events.type='NewBlock'"))
 	require.NoError(t, err)
-	err = s.PublishWithEvents(ctx, "Iceman", map[string][]string{"tm.events.type": {"NewBlock"}})
-	require.NoError(t, err)
+
+	events := []abci.Event{
+		{
+			Type:       "tm.events",
+			Attributes: []abci.EventAttribute{{Key: "type", Value: "NewBlock"}},
+		},
+	}
+
+	require.NoError(t, s.PublishWithEvents(ctx, "Iceman", events))
 	assertReceive(t, "Iceman", subscription1.Out())
 
 	subscription2, err := s.Subscribe(
@@ -173,12 +182,19 @@ func TestDifferentClients(t *testing.T) {
 		query.MustParse("tm.events.type='NewBlock' AND abci.account.name='Igor'"),
 	)
 	require.NoError(t, err)
-	err = s.PublishWithEvents(
-		ctx,
-		"Ultimo",
-		map[string][]string{"tm.events.type": {"NewBlock"}, "abci.account.name": {"Igor"}},
-	)
-	require.NoError(t, err)
+
+	events = []abci.Event{
+		{
+			Type:       "tm.events",
+			Attributes: []abci.EventAttribute{{Key: "type", Value: "NewBlock"}},
+		},
+		{
+			Type:       "abci.account",
+			Attributes: []abci.EventAttribute{{Key: "name", Value: "Igor"}},
+		},
+	}
+
+	require.NoError(t, s.PublishWithEvents(ctx, "Ultimo", events))
 	assertReceive(t, "Ultimo", subscription1.Out())
 	assertReceive(t, "Ultimo", subscription2.Out())
 
@@ -188,16 +204,25 @@ func TestDifferentClients(t *testing.T) {
 		query.MustParse("tm.events.type='NewRoundStep' AND abci.account.name='Igor' AND abci.invoice.number = 10"),
 	)
 	require.NoError(t, err)
-	err = s.PublishWithEvents(ctx, "Valeria Richards", map[string][]string{"tm.events.type": {"NewRoundStep"}})
-	require.NoError(t, err)
-	assert.Zero(t, len(subscription3.Out()))
+
+	events = []abci.Event{
+		{
+			Type:       "tm.events",
+			Attributes: []abci.EventAttribute{{Key: "type", Value: "NewRoundStep"}},
+		},
+	}
+
+	require.NoError(t, s.PublishWithEvents(ctx, "Valeria Richards", events))
+	require.Zero(t, len(subscription3.Out()))
 }
 
 func TestSubscribeDuplicateKeys(t *testing.T) {
 	ctx := context.Background()
 	s := pubsub.NewServer()
 	s.SetLogger(log.TestingLogger())
+
 	require.NoError(t, s.Start())
+
 	t.Cleanup(func() {
 		if err := s.Stop(); err != nil {
 			t.Error(err)
@@ -230,15 +255,26 @@ func TestSubscribeDuplicateKeys(t *testing.T) {
 		sub, err := s.Subscribe(ctx, fmt.Sprintf("client-%d", i), query.MustParse(tc.query))
 		require.NoError(t, err)
 
-		err = s.PublishWithEvents(
-			ctx,
-			"Iceman",
-			map[string][]string{
-				"transfer.sender":  {"foo", "bar", "baz"},
-				"withdraw.rewards": {"1", "17", "22"},
+		events := []abci.Event{
+			{
+				Type: "transfer",
+				Attributes: []abci.EventAttribute{
+					{Key: "sender", Value: "foo"},
+					{Key: "sender", Value: "bar"},
+					{Key: "sender", Value: "baz"},
+				},
 			},
-		)
-		require.NoError(t, err)
+			{
+				Type: "withdraw",
+				Attributes: []abci.EventAttribute{
+					{Key: "rewards", Value: "1"},
+					{Key: "rewards", Value: "17"},
+					{Key: "rewards", Value: "22"},
+				},
+			},
+		}
+
+		require.NoError(t, s.PublishWithEvents(ctx, "Iceman", events))
 
 		if tc.expected != nil {
 			assertReceive(t, tc.expected, sub.Out())
@@ -264,16 +300,22 @@ func TestClientSubscribesTwice(t *testing.T) {
 
 	subscription1, err := s.Subscribe(ctx, clientID, q)
 	require.NoError(t, err)
-	err = s.PublishWithEvents(ctx, "Goblin Queen", map[string][]string{"tm.events.type": {"NewBlock"}})
-	require.NoError(t, err)
+
+	events := []abci.Event{
+		{
+			Type:       "tm.events",
+			Attributes: []abci.EventAttribute{{Key: "type", Value: "NewBlock"}},
+		},
+	}
+
+	require.NoError(t, s.PublishWithEvents(ctx, "Goblin Queen", events))
 	assertReceive(t, "Goblin Queen", subscription1.Out())
 
 	subscription2, err := s.Subscribe(ctx, clientID, q)
 	require.Error(t, err)
 	require.Nil(t, subscription2)
 
-	err = s.PublishWithEvents(ctx, "Spider-Man", map[string][]string{"tm.events.type": {"NewBlock"}})
-	require.NoError(t, err)
+	require.NoError(t, s.PublishWithEvents(ctx, "Spider-Man", events))
 	assertReceive(t, "Spider-Man", subscription1.Out())
 }
 
@@ -291,14 +333,16 @@ func TestUnsubscribe(t *testing.T) {
 	ctx := context.Background()
 	subscription, err := s.Subscribe(ctx, clientID, query.MustParse("tm.events.type='NewBlock'"))
 	require.NoError(t, err)
-	err = s.Unsubscribe(ctx, clientID, query.MustParse("tm.events.type='NewBlock'"))
+	err = s.Unsubscribe(ctx, pubsub.UnsubscribeArgs{
+		Subscriber: clientID,
+		Query:      query.MustParse("tm.events.type='NewBlock'")})
 	require.NoError(t, err)
 
 	err = s.Publish(ctx, "Nick Fury")
 	require.NoError(t, err)
-	assert.Zero(t, len(subscription.Out()), "Should not receive anything after Unsubscribe")
+	require.Zero(t, len(subscription.Out()), "Should not receive anything after Unsubscribe")
 
-	assertCancelled(t, subscription, pubsub.ErrUnsubscribed)
+	assertCanceled(t, subscription, pubsub.ErrUnsubscribed)
 }
 
 func TestClientUnsubscribesTwice(t *testing.T) {
@@ -315,13 +359,17 @@ func TestClientUnsubscribesTwice(t *testing.T) {
 	ctx := context.Background()
 	_, err = s.Subscribe(ctx, clientID, query.MustParse("tm.events.type='NewBlock'"))
 	require.NoError(t, err)
-	err = s.Unsubscribe(ctx, clientID, query.MustParse("tm.events.type='NewBlock'"))
+	err = s.Unsubscribe(ctx, pubsub.UnsubscribeArgs{
+		Subscriber: clientID,
+		Query:      query.MustParse("tm.events.type='NewBlock'")})
 	require.NoError(t, err)
 
-	err = s.Unsubscribe(ctx, clientID, query.MustParse("tm.events.type='NewBlock'"))
-	assert.Equal(t, pubsub.ErrSubscriptionNotFound, err)
+	err = s.Unsubscribe(ctx, pubsub.UnsubscribeArgs{
+		Subscriber: clientID,
+		Query:      query.MustParse("tm.events.type='NewBlock'")})
+	require.Equal(t, pubsub.ErrSubscriptionNotFound, err)
 	err = s.UnsubscribeAll(ctx, clientID)
-	assert.Equal(t, pubsub.ErrSubscriptionNotFound, err)
+	require.Equal(t, pubsub.ErrSubscriptionNotFound, err)
 }
 
 func TestResubscribe(t *testing.T) {
@@ -338,7 +386,7 @@ func TestResubscribe(t *testing.T) {
 	ctx := context.Background()
 	_, err = s.Subscribe(ctx, clientID, query.Empty{})
 	require.NoError(t, err)
-	err = s.Unsubscribe(ctx, clientID, query.Empty{})
+	err = s.Unsubscribe(ctx, pubsub.UnsubscribeArgs{Subscriber: clientID, Query: query.Empty{}})
 	require.NoError(t, err)
 	subscription, err := s.Subscribe(ctx, clientID, query.Empty{})
 	require.NoError(t, err)
@@ -370,18 +418,18 @@ func TestUnsubscribeAll(t *testing.T) {
 
 	err = s.Publish(ctx, "Nick Fury")
 	require.NoError(t, err)
-	assert.Zero(t, len(subscription1.Out()), "Should not receive anything after UnsubscribeAll")
-	assert.Zero(t, len(subscription2.Out()), "Should not receive anything after UnsubscribeAll")
+	require.Zero(t, len(subscription1.Out()), "Should not receive anything after UnsubscribeAll")
+	require.Zero(t, len(subscription2.Out()), "Should not receive anything after UnsubscribeAll")
 
-	assertCancelled(t, subscription1, pubsub.ErrUnsubscribed)
-	assertCancelled(t, subscription2, pubsub.ErrUnsubscribed)
+	assertCanceled(t, subscription1, pubsub.ErrUnsubscribed)
+	assertCanceled(t, subscription2, pubsub.ErrUnsubscribed)
 }
 
 func TestBufferCapacity(t *testing.T) {
 	s := pubsub.NewServer(pubsub.BufferCapacity(2))
 	s.SetLogger(log.TestingLogger())
 
-	assert.Equal(t, 2, s.BufferCapacity())
+	require.Equal(t, 2, s.BufferCapacity())
 
 	ctx := context.Background()
 	err := s.Publish(ctx, "Nighthawk")
@@ -391,9 +439,10 @@ func TestBufferCapacity(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer cancel()
+
 	err = s.Publish(ctx, "Ironclad")
 	if assert.Error(t, err) {
-		assert.Equal(t, context.DeadlineExceeded, err)
+		require.Equal(t, context.DeadlineExceeded, err)
 	}
 }
 
@@ -431,7 +480,7 @@ func benchmarkNClients(n int, b *testing.B) {
 				select {
 				case <-subscription.Out():
 					continue
-				case <-subscription.Cancelled():
+				case <-subscription.Canceled():
 					return
 				}
 			}
@@ -441,12 +490,18 @@ func benchmarkNClients(n int, b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err = s.PublishWithEvents(
-			ctx,
-			"Gamora",
-			map[string][]string{"abci.Account.Owner": {"Ivan"}, "abci.Invoices.Number": {string(rune(i))}},
-		)
-		require.NoError(b, err)
+		events := []abci.Event{
+			{
+				Type:       "abci.Account",
+				Attributes: []abci.EventAttribute{{Key: "Owner", Value: "Ivan"}},
+			},
+			{
+				Type:       "abci.Invoices",
+				Attributes: []abci.EventAttribute{{Key: "Number", Value: string(rune(i))}},
+			},
+		}
+
+		require.NoError(b, s.PublishWithEvents(ctx, "Gamora", events))
 	}
 }
 
@@ -472,7 +527,7 @@ func benchmarkNClientsOneQuery(n int, b *testing.B) {
 				select {
 				case <-subscription.Out():
 					continue
-				case <-subscription.Cancelled():
+				case <-subscription.Canceled():
 					return
 				}
 			}
@@ -481,10 +536,20 @@ func benchmarkNClientsOneQuery(n int, b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
-		err = s.PublishWithEvents(ctx, "Gamora", map[string][]string{"abci.Account.Owner": {"Ivan"},
-			"abci.Invoices.Number": {"1"}})
-		require.NoError(b, err)
+		events := []abci.Event{
+			{
+				Type:       "abci.Account",
+				Attributes: []abci.EventAttribute{{Key: "Owner", Value: "Ivan"}},
+			},
+			{
+				Type:       "abci.Invoices",
+				Attributes: []abci.EventAttribute{{Key: "Number", Value: "1"}},
+			},
+		}
+
+		require.NoError(b, s.PublishWithEvents(ctx, "Gamora", events))
 	}
 }
 
@@ -493,15 +558,15 @@ func benchmarkNClientsOneQuery(n int, b *testing.B) {
 func assertReceive(t *testing.T, expected interface{}, ch <-chan pubsub.Message, msgAndArgs ...interface{}) {
 	select {
 	case actual := <-ch:
-		assert.Equal(t, expected, actual.Data(), msgAndArgs...)
+		require.Equal(t, expected, actual.Data(), msgAndArgs...)
 	case <-time.After(1 * time.Second):
 		t.Errorf("expected to receive %v from the channel, got nothing after 1s", expected)
 		debug.PrintStack()
 	}
 }
 
-func assertCancelled(t *testing.T, subscription *pubsub.Subscription, err error) {
-	_, ok := <-subscription.Cancelled()
-	assert.False(t, ok)
-	assert.Equal(t, err, subscription.Err())
+func assertCanceled(t *testing.T, subscription *pubsub.Subscription, err error) {
+	_, ok := <-subscription.Canceled()
+	require.False(t, ok)
+	require.Equal(t, err, subscription.Err())
 }

--- a/libs/pubsub/pubsub_test.go
+++ b/libs/pubsub/pubsub_test.go
@@ -21,6 +21,16 @@ const (
 	clientID = "test-client"
 )
 
+type kvPair = [2]string
+
+func makeEventAttrs(kvPairs []kvPair) []abci.EventAttribute {
+	var attrs []abci.EventAttribute
+	for _, pair := range kvPairs {
+		attrs = append(attrs, abci.EventAttribute{Key: []byte(pair[0]), Value: []byte(pair[1])})
+	}
+	return attrs
+}
+
 func TestSubscribe(t *testing.T) {
 	s := pubsub.NewServer()
 	s.SetLogger(log.TestingLogger())
@@ -169,7 +179,7 @@ func TestDifferentClients(t *testing.T) {
 	events := []abci.Event{
 		{
 			Type:       "tm.events",
-			Attributes: []abci.EventAttribute{{Key: "type", Value: "NewBlock"}},
+			Attributes: makeEventAttrs([]kvPair{{"type", "NewBlock"}}),
 		},
 	}
 
@@ -186,11 +196,11 @@ func TestDifferentClients(t *testing.T) {
 	events = []abci.Event{
 		{
 			Type:       "tm.events",
-			Attributes: []abci.EventAttribute{{Key: "type", Value: "NewBlock"}},
+			Attributes: makeEventAttrs([]kvPair{{"type", "NewBlock"}}),
 		},
 		{
 			Type:       "abci.account",
-			Attributes: []abci.EventAttribute{{Key: "name", Value: "Igor"}},
+			Attributes: makeEventAttrs([]kvPair{{"name", "Igor"}}),
 		},
 	}
 
@@ -208,7 +218,7 @@ func TestDifferentClients(t *testing.T) {
 	events = []abci.Event{
 		{
 			Type:       "tm.events",
-			Attributes: []abci.EventAttribute{{Key: "type", Value: "NewRoundStep"}},
+			Attributes: makeEventAttrs([]kvPair{{"type", "NewRoundStep"}}),
 		},
 	}
 
@@ -258,19 +268,19 @@ func TestSubscribeDuplicateKeys(t *testing.T) {
 		events := []abci.Event{
 			{
 				Type: "transfer",
-				Attributes: []abci.EventAttribute{
-					{Key: "sender", Value: "foo"},
-					{Key: "sender", Value: "bar"},
-					{Key: "sender", Value: "baz"},
-				},
+				Attributes: makeEventAttrs([]kvPair{
+					{"sender", "foo"},
+					{"sender", "bar"},
+					{"sender", "baz"},
+				}),
 			},
 			{
 				Type: "withdraw",
-				Attributes: []abci.EventAttribute{
-					{Key: "rewards", Value: "1"},
-					{Key: "rewards", Value: "17"},
-					{Key: "rewards", Value: "22"},
-				},
+				Attributes: makeEventAttrs([]kvPair{
+					{"rewards", "1"},
+					{"rewards", "17"},
+					{"rewards", "22"},
+				}),
 			},
 		}
 
@@ -304,7 +314,7 @@ func TestClientSubscribesTwice(t *testing.T) {
 	events := []abci.Event{
 		{
 			Type:       "tm.events",
-			Attributes: []abci.EventAttribute{{Key: "type", Value: "NewBlock"}},
+			Attributes: makeEventAttrs([]kvPair{{"type", "NewBlock"}}),
 		},
 	}
 
@@ -493,11 +503,11 @@ func benchmarkNClients(n int, b *testing.B) {
 		events := []abci.Event{
 			{
 				Type:       "abci.Account",
-				Attributes: []abci.EventAttribute{{Key: "Owner", Value: "Ivan"}},
+				Attributes: makeEventAttrs([]kvPair{{"Owner", "Ivan"}}),
 			},
 			{
 				Type:       "abci.Invoices",
-				Attributes: []abci.EventAttribute{{Key: "Number", Value: string(rune(i))}},
+				Attributes: makeEventAttrs([]kvPair{{"Number", string(rune(i))}}),
 			},
 		}
 
@@ -541,11 +551,11 @@ func benchmarkNClientsOneQuery(n int, b *testing.B) {
 		events := []abci.Event{
 			{
 				Type:       "abci.Account",
-				Attributes: []abci.EventAttribute{{Key: "Owner", Value: "Ivan"}},
+				Attributes: makeEventAttrs([]kvPair{{"Owner", "Ivan"}}),
 			},
 			{
 				Type:       "abci.Invoices",
-				Attributes: []abci.EventAttribute{{Key: "Number", Value: "1"}},
+				Attributes: makeEventAttrs([]kvPair{{"Number", "1"}}),
 			},
 		}
 

--- a/libs/pubsub/query/empty.go
+++ b/libs/pubsub/query/empty.go
@@ -1,11 +1,15 @@
 package query
 
+import (
+	"github.com/tendermint/tendermint/abci/types"
+)
+
 // Empty query matches any set of events.
 type Empty struct {
 }
 
 // Matches always returns true.
-func (Empty) Matches(tags map[string][]string) (bool, error) {
+func (Empty) Matches(events []types.Event) (bool, error) {
 	return true, nil
 }
 

--- a/libs/pubsub/query/empty_test.go
+++ b/libs/pubsub/query/empty_test.go
@@ -3,8 +3,8 @@ package query_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 )
 
@@ -12,17 +12,44 @@ func TestEmptyQueryMatchesAnything(t *testing.T) {
 	q := query.Empty{}
 
 	testCases := []struct {
-		query map[string][]string
+		events []abci.Event
 	}{
-		{map[string][]string{}},
-		{map[string][]string{"Asher": {"Roth"}}},
-		{map[string][]string{"Route": {"66"}}},
-		{map[string][]string{"Route": {"66"}, "Billy": {"Blue"}}},
+		{
+			[]abci.Event{},
+		},
+		{
+			[]abci.Event{
+				{
+					Type:       "Asher",
+					Attributes: []abci.EventAttribute{{Key: "Roth"}},
+				},
+			},
+		},
+		{
+			[]abci.Event{
+				{
+					Type:       "Route",
+					Attributes: []abci.EventAttribute{{Key: "66"}},
+				},
+			},
+		},
+		{
+			[]abci.Event{
+				{
+					Type:       "Route",
+					Attributes: []abci.EventAttribute{{Key: "66"}},
+				},
+				{
+					Type:       "Billy",
+					Attributes: []abci.EventAttribute{{Key: "Blue"}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
-		match, err := q.Matches(tc.query)
-		assert.Nil(t, err)
-		assert.True(t, match)
+		match, err := q.Matches(tc.events)
+		require.Nil(t, err)
+		require.True(t, match)
 	}
 }

--- a/libs/pubsub/query/empty_test.go
+++ b/libs/pubsub/query/empty_test.go
@@ -21,7 +21,7 @@ func TestEmptyQueryMatchesAnything(t *testing.T) {
 			[]abci.Event{
 				{
 					Type:       "Asher",
-					Attributes: []abci.EventAttribute{{Key: "Roth"}},
+					Attributes: []abci.EventAttribute{{Key: []byte("Roth")}},
 				},
 			},
 		},
@@ -29,7 +29,7 @@ func TestEmptyQueryMatchesAnything(t *testing.T) {
 			[]abci.Event{
 				{
 					Type:       "Route",
-					Attributes: []abci.EventAttribute{{Key: "66"}},
+					Attributes: []abci.EventAttribute{{Key: []byte("66")}},
 				},
 			},
 		},
@@ -37,11 +37,11 @@ func TestEmptyQueryMatchesAnything(t *testing.T) {
 			[]abci.Event{
 				{
 					Type:       "Route",
-					Attributes: []abci.EventAttribute{{Key: "66"}},
+					Attributes: []abci.EventAttribute{{Key: []byte("66")}},
 				},
 				{
 					Type:       "Billy",
-					Attributes: []abci.EventAttribute{{Key: "Blue"}},
+					Attributes: []abci.EventAttribute{{Key: []byte("Blue")}},
 				},
 			},
 		},

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -518,8 +518,8 @@ func flattenEvents(events []types.Event) map[string][]string {
 				continue
 			}
 
-			compositeEvent := fmt.Sprintf("%s.%s", event.Type, attr.Key)
-			flattened[compositeEvent] = append(flattened[compositeEvent], attr.Value)
+			compositeEvent := fmt.Sprintf("%s.%s", event.Type, string(attr.Key))
+			flattened[compositeEvent] = append(flattened[compositeEvent], string(attr.Value))
 		}
 	}
 

--- a/libs/pubsub/query/query_test.go
+++ b/libs/pubsub/query/query_test.go
@@ -2,14 +2,37 @@ package query_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
+	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 )
+
+func expandEvents(flattenedEvents map[string][]string) []abci.Event {
+	events := make([]abci.Event, len(flattenedEvents))
+
+	for composite, values := range flattenedEvents {
+		tokens := strings.Split(composite, ".")
+
+		attrs := make([]abci.EventAttribute, len(values))
+		for i, v := range values {
+			attrs[i] = abci.EventAttribute{
+				Key:   tokens[len(tokens)-1],
+				Value: v,
+			}
+		}
+
+		events = append(events, abci.Event{
+			Type:       strings.Join(tokens[:len(tokens)-1], "."),
+			Attributes: attrs,
+		})
+	}
+
+	return events
+}
 
 func TestMatches(t *testing.T) {
 	var (
@@ -159,21 +182,23 @@ func TestMatches(t *testing.T) {
 		}
 		require.NotNil(t, q, "Query '%s' should not be nil", tc.s)
 
+		rawEvents := expandEvents(tc.events)
+
 		if tc.matches {
-			match, err := q.Matches(tc.events)
-			assert.Nil(t, err, "Query '%s' should not error on match %v", tc.s, tc.events)
-			assert.True(t, match, "Query '%s' should match %v", tc.s, tc.events)
+			match, err := q.Matches(rawEvents)
+			require.Nil(t, err, "Query '%s' should not error on match %v", tc.s, tc.events)
+			require.True(t, match, "Query '%s' should match %v", tc.s, tc.events)
 		} else {
-			match, err := q.Matches(tc.events)
-			assert.Equal(t, tc.matchErr, err != nil, "Unexpected error for query '%s' match %v", tc.s, tc.events)
-			assert.False(t, match, "Query '%s' should not match %v", tc.s, tc.events)
+			match, err := q.Matches(rawEvents)
+			require.Equal(t, tc.matchErr, err != nil, "Unexpected error for query '%s' match %v", tc.s, tc.events)
+			require.False(t, match, "Query '%s' should not match %v", tc.s, tc.events)
 		}
 	}
 }
 
 func TestMustParse(t *testing.T) {
-	assert.Panics(t, func() { query.MustParse("=") })
-	assert.NotPanics(t, func() { query.MustParse("tm.events.type='NewBlock'") })
+	require.Panics(t, func() { query.MustParse("=") })
+	require.NotPanics(t, func() { query.MustParse("tm.events.type='NewBlock'") })
 }
 
 func TestConditions(t *testing.T) {
@@ -217,6 +242,6 @@ func TestConditions(t *testing.T) {
 
 		c, err := q.Conditions()
 		require.NoError(t, err)
-		assert.Equal(t, tc.conditions, c)
+		require.Equal(t, tc.conditions, c)
 	}
 }

--- a/libs/pubsub/query/query_test.go
+++ b/libs/pubsub/query/query_test.go
@@ -20,8 +20,8 @@ func expandEvents(flattenedEvents map[string][]string) []abci.Event {
 		attrs := make([]abci.EventAttribute, len(values))
 		for i, v := range values {
 			attrs[i] = abci.EventAttribute{
-				Key:   tokens[len(tokens)-1],
-				Value: v,
+				Key:   []byte(tokens[len(tokens)-1]),
+				Value: []byte(v),
 			}
 		}
 

--- a/libs/pubsub/subscription.go
+++ b/libs/pubsub/subscription.go
@@ -2,8 +2,11 @@ package pubsub
 
 import (
 	"errors"
+	"fmt"
 
-	tmsync "github.com/tendermint/tendermint/libs/sync"
+	"github.com/google/uuid"
+	"github.com/tendermint/tendermint/abci/types"
+	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 )
 
 var (
@@ -21,18 +24,20 @@ var (
 // 2) channel which is closed if a client is too slow or choose to unsubscribe
 // 3) err indicating the reason for (2)
 type Subscription struct {
+	id  string
 	out chan Message
 
-	cancelled chan struct{}
-	mtx       tmsync.RWMutex
-	err       error
+	canceled chan struct{}
+	mtx      tmsync.RWMutex
+	err      error
 }
 
 // NewSubscription returns a new subscription with the given outCapacity.
 func NewSubscription(outCapacity int) *Subscription {
 	return &Subscription{
-		out:       make(chan Message, outCapacity),
-		cancelled: make(chan struct{}),
+		id:       uuid.NewString(),
+		out:      make(chan Message, outCapacity),
+		canceled: make(chan struct{}),
 	}
 }
 
@@ -43,13 +48,15 @@ func (s *Subscription) Out() <-chan Message {
 	return s.out
 }
 
-// Cancelled returns a channel that's closed when the subscription is
+func (s *Subscription) ID() string { return s.id }
+
+// Canceled returns a channel that's closed when the subscription is
 // terminated and supposed to be used in a select statement.
-func (s *Subscription) Cancelled() <-chan struct{} {
-	return s.cancelled
+func (s *Subscription) Canceled() <-chan struct{} {
+	return s.canceled
 }
 
-// Err returns nil if the channel returned by Cancelled is not yet closed.
+// Err returns nil if the channel returned by Canceled is not yet closed.
 // If the channel is closed, Err returns a non-nil error explaining why:
 //   - ErrUnsubscribed if the subscriber choose to unsubscribe,
 //   - ErrOutOfCapacity if the subscriber is not pulling messages fast enough
@@ -64,27 +71,42 @@ func (s *Subscription) Err() error {
 
 func (s *Subscription) cancel(err error) {
 	s.mtx.Lock()
-	s.err = err
-	s.mtx.Unlock()
-	close(s.cancelled)
+	defer s.mtx.Unlock()
+	defer func() {
+		perr := recover()
+		if err == nil && perr != nil {
+			err = fmt.Errorf("problem closing subscription: %v", perr)
+		}
+	}()
+
+	if s.err == nil && err != nil {
+		s.err = err
+	}
+
+	close(s.canceled)
 }
 
 // Message glues data and events together.
 type Message struct {
+	subID  string
 	data   interface{}
-	events map[string][]string
+	events []types.Event
 }
 
-func NewMessage(data interface{}, events map[string][]string) Message {
-	return Message{data, events}
+func NewMessage(subID string, data interface{}, events []types.Event) Message {
+	return Message{
+		subID:  subID,
+		data:   data,
+		events: events,
+	}
 }
+
+// SubscriptionID returns the unique identifier for the subscription
+// that produced this message.
+func (msg Message) SubscriptionID() string { return msg.subID }
 
 // Data returns an original data published.
-func (msg Message) Data() interface{} {
-	return msg.data
-}
+func (msg Message) Data() interface{} { return msg.data }
 
 // Events returns events, which matched the client's query.
-func (msg Message) Events() map[string][]string {
-	return msg.events
-}
+func (msg Message) Events() []types.Event { return msg.events }

--- a/libs/pubsub/subscription.go
+++ b/libs/pubsub/subscription.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/tendermint/tendermint/abci/types"
-	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
+	tmsync "github.com/tendermint/tendermint/libs/sync"
 )
 
 var (

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -49,7 +49,7 @@ func TestNodeStartStop(t *testing.T) {
 	require.NoError(t, err)
 	select {
 	case <-blocksSub.Out():
-	case <-blocksSub.Cancelled():
+	case <-blocksSub.Canceled():
 		t.Fatal("blocksSub was cancelled")
 	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for the node to produce a block")

--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -27,9 +27,7 @@ func MakeTxKV() ([]byte, []byte, []byte) {
 }
 
 func TestHeaderEvents(t *testing.T) {
-	n, conf := NodeSuite(t)
-
-	for i, c := range GetClients(t, n, conf) {
+	for i, c := range GetClients() {
 		i, c := i, c
 		t.Run(reflect.TypeOf(c).String(), func(t *testing.T) {
 			// start for this test it if it wasn't already running
@@ -44,7 +42,8 @@ func TestHeaderEvents(t *testing.T) {
 				})
 			}
 
-			evt, err := client.WaitForOneEvent(c, types.EventNewBlockHeader, waitForEventTimeout)
+			evtTyp := types.EventNewBlockHeader
+			evt, err := client.WaitForOneEvent(c, evtTyp, waitForEventTimeout)
 			require.Nil(t, err, "%d: %+v", i, err)
 			_, ok := evt.(types.EventDataNewBlockHeader)
 			require.True(t, ok, "%d: %#v", i, evt)
@@ -55,8 +54,7 @@ func TestHeaderEvents(t *testing.T) {
 
 // subscribe to new blocks and make sure height increments by 1
 func TestBlockEvents(t *testing.T) {
-	n, conf := NodeSuite(t)
-	for _, c := range GetClients(t, n, conf) {
+	for _, c := range GetClients() {
 		c := c
 		t.Run(reflect.TypeOf(c).String(), func(t *testing.T) {
 
@@ -104,8 +102,7 @@ func TestTxEventsSentWithBroadcastTxAsync(t *testing.T) { testTxEventsSent(t, "a
 func TestTxEventsSentWithBroadcastTxSync(t *testing.T)  { testTxEventsSent(t, "sync") }
 
 func testTxEventsSent(t *testing.T, broadcastMethod string) {
-	n, conf := NodeSuite(t)
-	for _, c := range GetClients(t, n, conf) {
+	for _, c := range GetClients() {
 		c := c
 		t.Run(reflect.TypeOf(c).String(), func(t *testing.T) {
 
@@ -166,24 +163,19 @@ func TestClientsResubscribe(t *testing.T) {
 }
 
 func TestHTTPReturnsErrorIfClientIsNotRunning(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	_, conf := NodeSuite(t)
-
-	c := getHTTPClient(t, conf)
+	c := getHTTPClient()
 
 	// on Subscribe
-	_, err := c.Subscribe(ctx, "TestHeaderEvents",
+	_, err := c.Subscribe(context.Background(), "TestHeaderEvents",
 		types.QueryForEvent(types.EventNewBlockHeader).String())
 	assert.Error(t, err)
 
 	// on Unsubscribe
-	err = c.Unsubscribe(ctx, "TestHeaderEvents",
+	err = c.Unsubscribe(context.Background(), "TestHeaderEvents",
 		types.QueryForEvent(types.EventNewBlockHeader).String())
 	assert.Error(t, err)
 
 	// on UnsubscribeAll
-	err = c.UnsubscribeAll(ctx, "TestHeaderEvents")
+	err = c.UnsubscribeAll(context.Background(), "TestHeaderEvents")
 	assert.Error(t, err)
 }

--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -44,7 +44,7 @@ func TestHeaderEvents(t *testing.T) {
 				})
 			}
 
-			evt, err := client.WaitForOneEvent(c, types.EventNewBlockHeaderValue, waitForEventTimeout)
+			evt, err := client.WaitForOneEvent(c, types.EventNewBlockHeader, waitForEventTimeout)
 			require.Nil(t, err, "%d: %+v", i, err)
 			_, ok := evt.(types.EventDataNewBlockHeader)
 			require.True(t, ok, "%d: %#v", i, evt)
@@ -74,7 +74,7 @@ func TestBlockEvents(t *testing.T) {
 
 			const subscriber = "TestBlockEvents"
 
-			eventCh, err := c.Subscribe(context.Background(), subscriber, types.QueryForEvent(types.EventNewBlockValue).String())
+			eventCh, err := c.Subscribe(context.Background(), subscriber, types.QueryForEvent(types.EventNewBlock).String())
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				if err := c.UnsubscribeAll(context.Background(), subscriber); err != nil {
@@ -145,7 +145,7 @@ func testTxEventsSent(t *testing.T, broadcastMethod string) {
 			}()
 
 			// and wait for confirmation
-			evt, err := client.WaitForOneEvent(c, types.EventTxValue, waitForEventTimeout)
+			evt, err := client.WaitForOneEvent(c, types.EventTx, waitForEventTimeout)
 			require.Nil(t, err)
 
 			// and make sure it has the proper info
@@ -175,12 +175,12 @@ func TestHTTPReturnsErrorIfClientIsNotRunning(t *testing.T) {
 
 	// on Subscribe
 	_, err := c.Subscribe(ctx, "TestHeaderEvents",
-		types.QueryForEvent(types.EventNewBlockHeaderValue).String())
+		types.QueryForEvent(types.EventNewBlockHeader).String())
 	assert.Error(t, err)
 
 	// on Unsubscribe
 	err = c.Unsubscribe(ctx, "TestHeaderEvents",
-		types.QueryForEvent(types.EventNewBlockHeaderValue).String())
+		types.QueryForEvent(types.EventNewBlockHeader).String())
 	assert.Error(t, err)
 
 	// on UnsubscribeAll

--- a/rpc/client/helpers.go
+++ b/rpc/client/helpers.go
@@ -57,17 +57,18 @@ func WaitForHeight(c StatusClient, h int64, waiter Waiter) error {
 // when the timeout duration has expired.
 //
 // This handles subscribing and unsubscribing under the hood
-func WaitForOneEvent(c EventsClient, evtTyp string, timeout time.Duration) (types.TMEventData, error) {
+func WaitForOneEvent(c EventsClient, eventValue string, timeout time.Duration) (types.TMEventData, error) {
 	const subscriber = "helpers"
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	// register for the next event of this type
-	eventCh, err := c.Subscribe(ctx, subscriber, types.QueryForEvent(evtTyp).String())
+	eventCh, err := c.Subscribe(ctx, subscriber, types.QueryForEvent(eventValue).String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to subscribe: %w", err)
 	}
-	// make sure to unregister after the test is over
+
+	// make sure to un-register after the test is over
 	defer func() {
 		if deferErr := c.UnsubscribeAll(ctx, subscriber); deferErr != nil {
 			panic(err)

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -254,7 +254,7 @@ func (c *Local) eventsRoutine(
 					c.Logger.Error("wanted to publish ResultEvent, but out channel is full", "result", result, "query", result.Query)
 				}
 			}
-		case <-sub.Cancelled():
+		case <-sub.Canceled():
 			if sub.Err() == tmpubsub.ErrUnsubscribed {
 				return
 			}

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -293,7 +293,10 @@ func (c *Local) Unsubscribe(ctx context.Context, subscriber, query string) error
 	if err != nil {
 		return fmt.Errorf("failed to parse query: %w", err)
 	}
-	return c.EventBus.Unsubscribe(ctx, subscriber, q)
+	return c.EventBus.Unsubscribe(ctx, tmpubsub.UnsubscribeArgs{
+		Subscriber: subscriber,
+		Query:      q,
+	})
 }
 
 func (c *Local) UnsubscribeAll(ctx context.Context, subscriber string) error {

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -92,7 +92,10 @@ func Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query: %w", err)
 	}
-	err = env.EventBus.Unsubscribe(context.Background(), addr, q)
+	err = env.EventBus.Unsubscribe(context.Background(), tmpubsub.UnsubscribeArgs{
+		Subscriber: addr,
+		Query:      q,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -58,7 +58,7 @@ func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, er
 					env.Logger.Info("Can't write response (slow client)",
 						"to", addr, "subscriptionID", subscriptionID, "err", err)
 				}
-			case <-sub.Cancelled():
+			case <-sub.Canceled():
 				if sub.Err() != tmpubsub.ErrUnsubscribed {
 					var reason string
 					if sub.Err() == nil {

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/pubsub"
 	mempl "github.com/tendermint/tendermint/mempool"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
@@ -72,7 +73,10 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadc
 		return nil, err
 	}
 	defer func() {
-		if err := env.EventBus.Unsubscribe(context.Background(), subscriber, q); err != nil {
+		if err := env.EventBus.Unsubscribe(context.Background(), pubsub.UnsubscribeArgs{
+			Subscriber: subscriber,
+			Query:      q,
+		}); err != nil {
 			env.Logger.Error("Error unsubscribing from eventBus", "err", err)
 		}
 	}()

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -106,7 +106,7 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadc
 			Hash:      tx.Hash(),
 			Height:    deliverTxRes.Height,
 		}, nil
-	case <-deliverTxSub.Cancelled():
+	case <-deliverTxSub.Canceled():
 		var reason string
 		if deliverTxSub.Err() == nil {
 			reason = "Tendermint exited"

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -7,8 +7,8 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
-	"github.com/tendermint/tendermint/internal/p2p"
 	"github.com/tendermint/tendermint/libs/bytes"
+	"github.com/tendermint/tendermint/p2p"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
 )

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -109,9 +109,9 @@ type ValidatorInfo struct {
 
 // Node Status
 type ResultStatus struct {
-	NodeInfo      types.NodeInfo `json:"node_info"`
-	SyncInfo      SyncInfo       `json:"sync_info"`
-	ValidatorInfo ValidatorInfo  `json:"validator_info"`
+	NodeInfo      p2p.DefaultNodeInfo `json:"node_info"`
+	SyncInfo      SyncInfo            `json:"sync_info"`
+	ValidatorInfo ValidatorInfo       `json:"validator_info"`
 }
 
 // Is TxIndexing enabled
@@ -142,7 +142,7 @@ type ResultDialPeers struct {
 
 // A peer
 type Peer struct {
-	NodeInfo         types.NodeInfo       `json:"node_info"`
+	NodeInfo         p2p.DefaultNodeInfo  `json:"node_info"`
 	IsOutbound       bool                 `json:"is_outbound"`
 	ConnectionStatus p2p.ConnectionStatus `json:"connection_status"`
 	RemoteIP         string               `json:"remote_ip"`
@@ -160,8 +160,8 @@ type ResultValidators struct {
 
 // ConsensusParams for given height
 type ResultConsensusParams struct {
-	BlockHeight     int64                 `json:"block_height"`
-	ConsensusParams types.ConsensusParams `json:"consensus_params"`
+	BlockHeight     int64                   `json:"block_height"`
+	ConsensusParams tmproto.ConsensusParams `json:"consensus_params"`
 }
 
 // Info about the consensus state.

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -2,7 +2,6 @@ package coretypes
 
 import (
 	"encoding/json"
-	"errors"
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -11,18 +10,6 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
-)
-
-// List of standardized errors used across RPC
-var (
-	ErrZeroOrNegativePerPage  = errors.New("zero or negative per_page")
-	ErrPageOutOfRange         = errors.New("page should be within range")
-	ErrZeroOrNegativeHeight   = errors.New("height must be greater than zero")
-	ErrHeightExceedsChainHead = errors.New("height must be less than or equal to the head of the node's blockchain")
-	ErrHeightNotAvailable     = errors.New("height is not available")
-	// ErrInvalidRequest is used as a wrapper to cover more specific cases where the user has
-	// made an invalid request
-	ErrInvalidRequest = errors.New("invalid request")
 )
 
 // List of blocks

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -407,7 +407,7 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 			assert.Equal(t, pubkey, event.ValidatorUpdates[0].PubKey)
 			assert.EqualValues(t, 10, event.ValidatorUpdates[0].VotingPower)
 		}
-	case <-updatesSub.Cancelled():
+	case <-updatesSub.Canceled():
 		t.Fatalf("updatesSub was cancelled (reason: %v)", updatesSub.Err())
 	case <-time.After(1 * time.Second):
 		t.Fatal("Did not receive EventValidatorSetUpdates within 1 sec.")

--- a/test/maverick/consensus/replay.go
+++ b/test/maverick/consensus/replay.go
@@ -55,7 +55,7 @@ func (cs *State) readReplayMessage(msg *tmcon.TimedWALMessage, newStepSub types.
 				if m.Height != m2.Height || m.Round != m2.Round || m.Step != m2.Step {
 					return fmt.Errorf("roundState mismatch. Got %v; Expected %v", m2, m)
 				}
-			case <-newStepSub.Cancelled():
+			case <-newStepSub.Canceled():
 				return fmt.Errorf("failed to read off newStepSub.Out(). newStepSub was cancelled")
 			case <-ticker:
 				return fmt.Errorf("failed to read off newStepSub.Out()")

--- a/test/maverick/consensus/replay_file.go
+++ b/test/maverick/consensus/replay_file.go
@@ -16,6 +16,7 @@ import (
 	tmcon "github.com/tendermint/tendermint/consensus"
 	"github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"
+	"github.com/tendermint/tendermint/libs/pubsub"
 	"github.com/tendermint/tendermint/proxy"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/store"
@@ -59,7 +60,10 @@ func (cs *State) ReplayFile(file string, console bool) error {
 		return fmt.Errorf("failed to subscribe %s to %v", subscriber, types.EventQueryNewRoundStep)
 	}
 	defer func() {
-		if err := cs.eventBus.Unsubscribe(ctx, subscriber, types.EventQueryNewRoundStep); err != nil {
+		if err := cs.eventBus.Unsubscribe(ctx, pubsub.UnsubscribeArgs{
+			Subscriber: subscriber,
+			Query:      types.EventQueryNewRoundStep,
+		}); err != nil {
 			cs.Logger.Error("Error unsubscribing to event bus", "err", err)
 		}
 	}()
@@ -226,7 +230,10 @@ func (pb *playback) replayConsoleLoop() int {
 				tmos.Exit(fmt.Sprintf("failed to subscribe %s to %v", subscriber, types.EventQueryNewRoundStep))
 			}
 			defer func() {
-				if err := pb.cs.eventBus.Unsubscribe(ctx, subscriber, types.EventQueryNewRoundStep); err != nil {
+				if err := pb.cs.eventBus.Unsubscribe(ctx, pubsub.UnsubscribeArgs{
+					Subscriber: subscriber,
+					Query:      types.EventQueryNewRoundStep,
+				}); err != nil {
 					pb.cs.Logger.Error("Error unsubscribing from eventBus", "err", err)
 				}
 			}()

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
@@ -14,7 +15,7 @@ const defaultCapacity = 0
 
 type EventBusSubscriber interface {
 	Subscribe(ctx context.Context, subscriber string, query tmpubsub.Query, outCapacity ...int) (Subscription, error)
-	Unsubscribe(ctx context.Context, subscriber string, query tmpubsub.Query) error
+	Unsubscribe(ctx context.Context, args tmpubsub.UnsubscribeArgs) error
 	UnsubscribeAll(ctx context.Context, subscriber string) error
 
 	NumClients() int
@@ -22,8 +23,9 @@ type EventBusSubscriber interface {
 }
 
 type Subscription interface {
+	ID() string
 	Out() <-chan tmpubsub.Message
-	Cancelled() <-chan struct{}
+	Canceled() <-chan struct{}
 	Err() error
 }
 
@@ -91,55 +93,39 @@ func (b *EventBus) SubscribeUnbuffered(
 	return b.pubsub.SubscribeUnbuffered(ctx, subscriber, query)
 }
 
-func (b *EventBus) Unsubscribe(ctx context.Context, subscriber string, query tmpubsub.Query) error {
-	return b.pubsub.Unsubscribe(ctx, subscriber, query)
+func (b *EventBus) Unsubscribe(ctx context.Context, args tmpubsub.UnsubscribeArgs) error {
+	return b.pubsub.Unsubscribe(ctx, args)
 }
 
 func (b *EventBus) UnsubscribeAll(ctx context.Context, subscriber string) error {
 	return b.pubsub.UnsubscribeAll(ctx, subscriber)
 }
 
-func (b *EventBus) Publish(eventType string, eventData TMEventData) error {
+func (b *EventBus) Publish(eventValue string, eventData TMEventData) error {
 	// no explicit deadline for publishing events
 	ctx := context.Background()
-	return b.pubsub.PublishWithEvents(ctx, eventData, map[string][]string{EventTypeKey: {eventType}})
-}
 
-// validateAndStringifyEvents takes a slice of event objects and creates a
-// map of stringified events where each key is composed of the event
-// type and each of the event's attributes keys in the form of
-// "{event.Type}.{attribute.Key}" and the value is each attribute's value.
-func (b *EventBus) validateAndStringifyEvents(events []types.Event, logger log.Logger) map[string][]string {
-	result := make(map[string][]string)
-	for _, event := range events {
-		if len(event.Type) == 0 {
-			logger.Debug("Got an event with an empty type (skipping)", "event", event)
-			continue
-		}
-
-		for _, attr := range event.Attributes {
-			if len(attr.Key) == 0 {
-				logger.Debug("Got an event attribute with an empty key(skipping)", "event", event)
-				continue
-			}
-
-			compositeTag := fmt.Sprintf("%s.%s", event.Type, string(attr.Key))
-			result[compositeTag] = append(result[compositeTag], string(attr.Value))
-		}
+	tokens := strings.Split(EventTypeKey, ".")
+	event := types.Event{
+		Type: tokens[0],
+		Attributes: []types.EventAttribute{
+			{
+				Key:   tokens[1],
+				Value: eventValue,
+			},
+		},
 	}
 
-	return result
+	return b.pubsub.PublishWithEvents(ctx, eventData, []types.Event{event})
 }
 
 func (b *EventBus) PublishEventNewBlock(data EventDataNewBlock) error {
 	// no explicit deadline for publishing events
 	ctx := context.Background()
+	events := append(data.ResultBeginBlock.Events, data.ResultEndBlock.Events...)
 
-	resultEvents := append(data.ResultBeginBlock.Events, data.ResultEndBlock.Events...)
-	events := b.validateAndStringifyEvents(resultEvents, b.Logger.With("block", data.Block.StringShort()))
-
-	// add predefined new block event
-	events[EventTypeKey] = append(events[EventTypeKey], EventNewBlock)
+	// add Tendermint-reserved new block event
+	events = append(events, EventNewBlock)
 
 	return b.pubsub.PublishWithEvents(ctx, data, events)
 }
@@ -147,27 +133,24 @@ func (b *EventBus) PublishEventNewBlock(data EventDataNewBlock) error {
 func (b *EventBus) PublishEventNewBlockHeader(data EventDataNewBlockHeader) error {
 	// no explicit deadline for publishing events
 	ctx := context.Background()
+	events := append(data.ResultBeginBlock.Events, data.ResultEndBlock.Events...)
 
-	resultTags := append(data.ResultBeginBlock.Events, data.ResultEndBlock.Events...)
-	// TODO: Create StringShort method for Header and use it in logger.
-	events := b.validateAndStringifyEvents(resultTags, b.Logger.With("header", data.Header))
-
-	// add predefined new block header event
-	events[EventTypeKey] = append(events[EventTypeKey], EventNewBlockHeader)
+	// add Tendermint-reserved new block header event
+	events = append(events, EventNewBlockHeader)
 
 	return b.pubsub.PublishWithEvents(ctx, data, events)
 }
 
 func (b *EventBus) PublishEventNewEvidence(evidence EventDataNewEvidence) error {
-	return b.Publish(EventNewEvidence, evidence)
+	return b.Publish(EventNewEvidenceValue, evidence)
 }
 
 func (b *EventBus) PublishEventVote(data EventDataVote) error {
-	return b.Publish(EventVote, data)
+	return b.Publish(EventVoteValue, data)
 }
 
 func (b *EventBus) PublishEventValidBlock(data EventDataRoundState) error {
-	return b.Publish(EventValidBlock, data)
+	return b.Publish(EventValidBlockValue, data)
 }
 
 // PublishEventTx publishes tx event with events from Result. Note it will add
@@ -176,55 +159,74 @@ func (b *EventBus) PublishEventValidBlock(data EventDataRoundState) error {
 func (b *EventBus) PublishEventTx(data EventDataTx) error {
 	// no explicit deadline for publishing events
 	ctx := context.Background()
+	events := data.Result.Events
 
-	events := b.validateAndStringifyEvents(data.Result.Events, b.Logger.With("tx", data.Tx))
+	// add Tendermint-reserved events
+	events = append(events, EventTx)
 
-	// add predefined compositeKeys
-	events[EventTypeKey] = append(events[EventTypeKey], EventTx)
-	events[TxHashKey] = append(events[TxHashKey], fmt.Sprintf("%X", Tx(data.Tx).Hash()))
-	events[TxHeightKey] = append(events[TxHeightKey], fmt.Sprintf("%d", data.Height))
+	tokens := strings.Split(TxHashKey, ".")
+	events = append(events, types.Event{
+		Type: tokens[0],
+		Attributes: []types.EventAttribute{
+			{
+				Key:   tokens[1],
+				Value: fmt.Sprintf("%X", Tx(data.Tx).Hash()),
+			},
+		},
+	})
+
+	tokens = strings.Split(TxHeightKey, ".")
+	events = append(events, types.Event{
+		Type: tokens[0],
+		Attributes: []types.EventAttribute{
+			{
+				Key:   tokens[1],
+				Value: fmt.Sprintf("%d", data.Height),
+			},
+		},
+	})
 
 	return b.pubsub.PublishWithEvents(ctx, data, events)
 }
 
 func (b *EventBus) PublishEventNewRoundStep(data EventDataRoundState) error {
-	return b.Publish(EventNewRoundStep, data)
+	return b.Publish(EventNewRoundStepValue, data)
 }
 
 func (b *EventBus) PublishEventTimeoutPropose(data EventDataRoundState) error {
-	return b.Publish(EventTimeoutPropose, data)
+	return b.Publish(EventTimeoutProposeValue, data)
 }
 
 func (b *EventBus) PublishEventTimeoutWait(data EventDataRoundState) error {
-	return b.Publish(EventTimeoutWait, data)
+	return b.Publish(EventTimeoutWaitValue, data)
 }
 
 func (b *EventBus) PublishEventNewRound(data EventDataNewRound) error {
-	return b.Publish(EventNewRound, data)
+	return b.Publish(EventNewRoundValue, data)
 }
 
 func (b *EventBus) PublishEventCompleteProposal(data EventDataCompleteProposal) error {
-	return b.Publish(EventCompleteProposal, data)
+	return b.Publish(EventCompleteProposalValue, data)
 }
 
 func (b *EventBus) PublishEventPolka(data EventDataRoundState) error {
-	return b.Publish(EventPolka, data)
+	return b.Publish(EventPolkaValue, data)
 }
 
 func (b *EventBus) PublishEventUnlock(data EventDataRoundState) error {
-	return b.Publish(EventUnlock, data)
+	return b.Publish(EventUnlockValue, data)
 }
 
 func (b *EventBus) PublishEventRelock(data EventDataRoundState) error {
-	return b.Publish(EventRelock, data)
+	return b.Publish(EventRelockValue, data)
 }
 
 func (b *EventBus) PublishEventLock(data EventDataRoundState) error {
-	return b.Publish(EventLock, data)
+	return b.Publish(EventLockValue, data)
 }
 
 func (b *EventBus) PublishEventValidatorSetUpdates(data EventDataValidatorSetUpdates) error {
-	return b.Publish(EventValidatorSetUpdates, data)
+	return b.Publish(EventValidatorSetUpdatesValue, data)
 }
 
 //-----------------------------------------------------------------------------
@@ -239,7 +241,7 @@ func (NopEventBus) Subscribe(
 	return nil
 }
 
-func (NopEventBus) Unsubscribe(ctx context.Context, subscriber string, query tmpubsub.Query) error {
+func (NopEventBus) Unsubscribe(ctx context.Context, args tmpubsub.UnsubscribeArgs) error {
 	return nil
 }
 

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -142,15 +142,15 @@ func (b *EventBus) PublishEventNewBlockHeader(data EventDataNewBlockHeader) erro
 }
 
 func (b *EventBus) PublishEventNewEvidence(evidence EventDataNewEvidence) error {
-	return b.Publish(EventNewEvidenceValue, evidence)
+	return b.Publish(EventNewEvidence, evidence)
 }
 
 func (b *EventBus) PublishEventVote(data EventDataVote) error {
-	return b.Publish(EventVoteValue, data)
+	return b.Publish(EventVote, data)
 }
 
 func (b *EventBus) PublishEventValidBlock(data EventDataRoundState) error {
-	return b.Publish(EventValidBlockValue, data)
+	return b.Publish(EventValidBlock, data)
 }
 
 // PublishEventTx publishes tx event with events from Result. Note it will add
@@ -190,43 +190,43 @@ func (b *EventBus) PublishEventTx(data EventDataTx) error {
 }
 
 func (b *EventBus) PublishEventNewRoundStep(data EventDataRoundState) error {
-	return b.Publish(EventNewRoundStepValue, data)
+	return b.Publish(EventNewRoundStep, data)
 }
 
 func (b *EventBus) PublishEventTimeoutPropose(data EventDataRoundState) error {
-	return b.Publish(EventTimeoutProposeValue, data)
+	return b.Publish(EventTimeoutPropose, data)
 }
 
 func (b *EventBus) PublishEventTimeoutWait(data EventDataRoundState) error {
-	return b.Publish(EventTimeoutWaitValue, data)
+	return b.Publish(EventTimeoutWait, data)
 }
 
 func (b *EventBus) PublishEventNewRound(data EventDataNewRound) error {
-	return b.Publish(EventNewRoundValue, data)
+	return b.Publish(EventNewRound, data)
 }
 
 func (b *EventBus) PublishEventCompleteProposal(data EventDataCompleteProposal) error {
-	return b.Publish(EventCompleteProposalValue, data)
+	return b.Publish(EventCompleteProposal, data)
 }
 
 func (b *EventBus) PublishEventPolka(data EventDataRoundState) error {
-	return b.Publish(EventPolkaValue, data)
+	return b.Publish(EventPolka, data)
 }
 
 func (b *EventBus) PublishEventUnlock(data EventDataRoundState) error {
-	return b.Publish(EventUnlockValue, data)
+	return b.Publish(EventUnlock, data)
 }
 
 func (b *EventBus) PublishEventRelock(data EventDataRoundState) error {
-	return b.Publish(EventRelockValue, data)
+	return b.Publish(EventRelock, data)
 }
 
 func (b *EventBus) PublishEventLock(data EventDataRoundState) error {
-	return b.Publish(EventLockValue, data)
+	return b.Publish(EventLock, data)
 }
 
 func (b *EventBus) PublishEventValidatorSetUpdates(data EventDataValidatorSetUpdates) error {
-	return b.Publish(EventValidatorSetUpdatesValue, data)
+	return b.Publish(EventValidatorSetUpdates, data)
 }
 
 //-----------------------------------------------------------------------------

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -125,7 +125,7 @@ func (b *EventBus) PublishEventNewBlock(data EventDataNewBlock) error {
 	events := append(data.ResultBeginBlock.Events, data.ResultEndBlock.Events...)
 
 	// add Tendermint-reserved new block event
-	events = append(events, EventNewBlock)
+	events = append(events, _EventNewBlock)
 
 	return b.pubsub.PublishWithEvents(ctx, data, events)
 }
@@ -136,7 +136,7 @@ func (b *EventBus) PublishEventNewBlockHeader(data EventDataNewBlockHeader) erro
 	events := append(data.ResultBeginBlock.Events, data.ResultEndBlock.Events...)
 
 	// add Tendermint-reserved new block header event
-	events = append(events, EventNewBlockHeader)
+	events = append(events, _EventNewBlockHeader)
 
 	return b.pubsub.PublishWithEvents(ctx, data, events)
 }
@@ -162,7 +162,7 @@ func (b *EventBus) PublishEventTx(data EventDataTx) error {
 	events := data.Result.Events
 
 	// add Tendermint-reserved events
-	events = append(events, EventTx)
+	events = append(events, _EventTx)
 
 	tokens := strings.Split(TxHashKey, ".")
 	events = append(events, types.Event{

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -105,13 +105,13 @@ func (b *EventBus) Publish(eventValue string, eventData TMEventData) error {
 	// no explicit deadline for publishing events
 	ctx := context.Background()
 
-	tokens := strings.Split(EventTypeKey, ".")
+	tokens := strings.SplitN(EventTypeKey, ".", 2)
 	event := types.Event{
 		Type: tokens[0],
 		Attributes: []types.EventAttribute{
 			{
-				Key:   tokens[1],
-				Value: eventValue,
+				Key:   []byte(tokens[1]),
+				Value: []byte(eventValue),
 			},
 		},
 	}
@@ -164,24 +164,24 @@ func (b *EventBus) PublishEventTx(data EventDataTx) error {
 	// add Tendermint-reserved events
 	events = append(events, _EventTx)
 
-	tokens := strings.Split(TxHashKey, ".")
+	tokens := strings.SplitN(TxHashKey, ".", 2)
 	events = append(events, types.Event{
 		Type: tokens[0],
 		Attributes: []types.EventAttribute{
 			{
-				Key:   tokens[1],
-				Value: fmt.Sprintf("%X", Tx(data.Tx).Hash()),
+				Key:   []byte(tokens[1]),
+				Value: []byte(fmt.Sprintf("%X", Tx(data.Tx).Hash())),
 			},
 		},
 	})
 
-	tokens = strings.Split(TxHeightKey, ".")
+	tokens = strings.SplitN(TxHeightKey, ".", 2)
 	events = append(events, types.Event{
 		Type: tokens[0],
 		Attributes: []types.EventAttribute{
 			{
-				Key:   tokens[1],
-				Value: fmt.Sprintf("%d", data.Height),
+				Key:   []byte(tokens[1]),
+				Value: []byte(fmt.Sprintf("%d", data.Height)),
 			},
 		},
 	})

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	mrand "math/rand"
 	"testing"
 	"time"
 
@@ -13,7 +13,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
-	tmrand "github.com/tendermint/tendermint/libs/rand"
 )
 
 func TestEventBusPublishEventTx(t *testing.T) {
@@ -30,7 +29,7 @@ func TestEventBusPublishEventTx(t *testing.T) {
 	result := abci.ResponseDeliverTx{
 		Data: []byte("bar"),
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key: []byte("baz"), Value: []byte("1")}}},
+			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "baz", Value: "1"}}},
 		},
 	}
 
@@ -76,14 +75,15 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 	})
 
 	block := MakeBlock(0, []Tx{}, nil, []Evidence{})
+	blockID := BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(BlockPartSizeBytes).Header()}
 	resultBeginBlock := abci.ResponseBeginBlock{
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key: []byte("baz"), Value: []byte("1")}}},
+			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "baz", Value: "1"}}},
 		},
 	}
 	resultEndBlock := abci.ResponseEndBlock{
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key: []byte("foz"), Value: []byte("2")}}},
+			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "foz", Value: "2"}}},
 		},
 	}
 
@@ -97,6 +97,7 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 		msg := <-blocksSub.Out()
 		edt := msg.Data().(EventDataNewBlock)
 		assert.Equal(t, block, edt.Block)
+		assert.Equal(t, blockID, edt.BlockID)
 		assert.Equal(t, resultBeginBlock, edt.ResultBeginBlock)
 		assert.Equal(t, resultEndBlock, edt.ResultEndBlock)
 		close(done)
@@ -104,6 +105,7 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 
 	err = eventBus.PublishEventNewBlock(EventDataNewBlock{
 		Block:            block,
+		BlockID:          blockID,
 		ResultBeginBlock: resultBeginBlock,
 		ResultEndBlock:   resultEndBlock,
 	})
@@ -133,25 +135,25 @@ func TestEventBusPublishEventTxDuplicateKeys(t *testing.T) {
 			{
 				Type: "transfer",
 				Attributes: []abci.EventAttribute{
-					{Key: []byte("sender"), Value: []byte("foo")},
-					{Key: []byte("recipient"), Value: []byte("bar")},
-					{Key: []byte("amount"), Value: []byte("5")},
+					{Key: "sender", Value: "foo"},
+					{Key: "recipient", Value: "bar"},
+					{Key: "amount", Value: "5"},
 				},
 			},
 			{
 				Type: "transfer",
 				Attributes: []abci.EventAttribute{
-					{Key: []byte("sender"), Value: []byte("baz")},
-					{Key: []byte("recipient"), Value: []byte("cat")},
-					{Key: []byte("amount"), Value: []byte("13")},
+					{Key: "sender", Value: "baz"},
+					{Key: "recipient", Value: "cat"},
+					{Key: "amount", Value: "13"},
 				},
 			},
 			{
 				Type: "withdraw.rewards",
 				Attributes: []abci.EventAttribute{
-					{Key: []byte("address"), Value: []byte("bar")},
-					{Key: []byte("source"), Value: []byte("iceman")},
-					{Key: []byte("amount"), Value: []byte("33")},
+					{Key: "address", Value: "bar"},
+					{Key: "source", Value: "iceman"},
+					{Key: "amount", Value: "33"},
 				},
 			},
 		},
@@ -237,12 +239,12 @@ func TestEventBusPublishEventNewBlockHeader(t *testing.T) {
 	block := MakeBlock(0, []Tx{}, nil, []Evidence{})
 	resultBeginBlock := abci.ResponseBeginBlock{
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key: []byte("baz"), Value: []byte("1")}}},
+			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "baz", Value: "1"}}},
 		},
 	}
 	resultEndBlock := abci.ResponseEndBlock{
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key: []byte("foz"), Value: []byte("2")}}},
+			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "foz", Value: "2"}}},
 		},
 	}
 
@@ -340,7 +342,7 @@ func TestEventBusPublish(t *testing.T) {
 		}
 	}()
 
-	err = eventBus.Publish(EventNewBlockHeader, EventDataNewBlockHeader{})
+	err = eventBus.Publish(EventNewBlockHeaderValue, EventDataNewBlockHeader{})
 	require.NoError(t, err)
 	err = eventBus.PublishEventNewBlock(EventDataNewBlock{})
 	require.NoError(t, err)
@@ -410,7 +412,7 @@ func BenchmarkEventBus(b *testing.B) {
 
 func benchmarkEventBus(numClients int, randQueries bool, randEvents bool, b *testing.B) {
 	// for random* functions
-	rand.Seed(time.Now().Unix())
+	mrand.Seed(time.Now().Unix())
 
 	eventBus := NewEventBusWithBufferCapacity(0) // set buffer capacity to 0 so we are not testing cache
 	err := eventBus.Start()
@@ -438,23 +440,23 @@ func benchmarkEventBus(numClients int, randQueries bool, randEvents bool, b *tes
 			for {
 				select {
 				case <-sub.Out():
-				case <-sub.Cancelled():
+				case <-sub.Canceled():
 					return
 				}
 			}
 		}()
 	}
 
-	eventType := EventNewBlock
+	eventValue := EventNewBlockValue
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if randEvents {
-			eventType = randEvent()
+			eventValue = randEventValue()
 		}
 
-		err := eventBus.Publish(eventType, EventDataString("Gamora"))
+		err := eventBus.Publish(eventValue, EventDataString("Gamora"))
 		if err != nil {
 			b.Error(err)
 		}
@@ -462,21 +464,22 @@ func benchmarkEventBus(numClients int, randQueries bool, randEvents bool, b *tes
 }
 
 var events = []string{
-	EventNewBlock,
-	EventNewBlockHeader,
-	EventNewRound,
-	EventNewRoundStep,
-	EventTimeoutPropose,
-	EventCompleteProposal,
-	EventPolka,
-	EventUnlock,
-	EventLock,
-	EventRelock,
-	EventTimeoutWait,
-	EventVote}
+	EventNewBlockValue,
+	EventNewBlockHeaderValue,
+	EventNewRoundValue,
+	EventNewRoundStepValue,
+	EventTimeoutProposeValue,
+	EventCompleteProposalValue,
+	EventPolkaValue,
+	EventUnlockValue,
+	EventLockValue,
+	EventRelockValue,
+	EventTimeoutWaitValue,
+	EventVoteValue,
+}
 
-func randEvent() string {
-	return events[tmrand.Intn(len(events))]
+func randEventValue() string {
+	return events[mrand.Intn(len(events))]
 }
 
 var queries = []tmpubsub.Query{
@@ -494,5 +497,5 @@ var queries = []tmpubsub.Query{
 	EventQueryVote}
 
 func randQuery() tmpubsub.Query {
-	return queries[tmrand.Intn(len(queries))]
+	return queries[mrand.Intn(len(queries))]
 }

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -342,7 +342,7 @@ func TestEventBusPublish(t *testing.T) {
 		}
 	}()
 
-	err = eventBus.Publish(EventNewBlockHeaderValue, EventDataNewBlockHeader{})
+	err = eventBus.Publish(EventNewBlockHeader, EventDataNewBlockHeader{})
 	require.NoError(t, err)
 	err = eventBus.PublishEventNewBlock(EventDataNewBlock{})
 	require.NoError(t, err)
@@ -447,7 +447,7 @@ func benchmarkEventBus(numClients int, randQueries bool, randEvents bool, b *tes
 		}()
 	}
 
-	eventValue := EventNewBlockValue
+	eventValue := EventNewBlock
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -464,18 +464,18 @@ func benchmarkEventBus(numClients int, randQueries bool, randEvents bool, b *tes
 }
 
 var events = []string{
-	EventNewBlockValue,
-	EventNewBlockHeaderValue,
-	EventNewRoundValue,
-	EventNewRoundStepValue,
-	EventTimeoutProposeValue,
-	EventCompleteProposalValue,
-	EventPolkaValue,
-	EventUnlockValue,
-	EventLockValue,
-	EventRelockValue,
-	EventTimeoutWaitValue,
-	EventVoteValue,
+	EventNewBlock,
+	EventNewBlockHeader,
+	EventNewRound,
+	EventNewRoundStep,
+	EventTimeoutPropose,
+	EventCompleteProposal,
+	EventPolka,
+	EventUnlock,
+	EventLock,
+	EventRelock,
+	EventTimeoutWait,
+	EventVote,
 }
 
 func randEventValue() string {

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -18,9 +18,9 @@ import (
 type kvPair = [2]string
 
 func makeEventAttrs(kvPairs []kvPair) []abci.EventAttribute {
-	var attrs []abci.EventAttribute
-	for _, pair := range kvPairs {
-		attrs = append(attrs, abci.EventAttribute{Key: []byte(pair[0]), Value: []byte(pair[1])})
+	attrs := make([]abci.EventAttribute, len(kvPairs))
+	for i, pair := range kvPairs {
+		attrs[i] = abci.EventAttribute{Key: []byte(pair[0]), Value: []byte(pair[1])}
 	}
 	return attrs
 }

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -85,7 +85,6 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 	})
 
 	block := MakeBlock(0, []Tx{}, nil, []Evidence{})
-	blockID := BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(BlockPartSizeBytes).Header()}
 	resultBeginBlock := abci.ResponseBeginBlock{
 		Events: []abci.Event{
 			{Type: "testType", Attributes: makeEventAttrs([]kvPair{{"baz", "1"}})},
@@ -107,7 +106,6 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 		msg := <-blocksSub.Out()
 		edt := msg.Data().(EventDataNewBlock)
 		assert.Equal(t, block, edt.Block)
-		assert.Equal(t, blockID, edt.BlockID)
 		assert.Equal(t, resultBeginBlock, edt.ResultBeginBlock)
 		assert.Equal(t, resultEndBlock, edt.ResultEndBlock)
 		close(done)
@@ -115,7 +113,6 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 
 	err = eventBus.PublishEventNewBlock(EventDataNewBlock{
 		Block:            block,
-		BlockID:          blockID,
 		ResultBeginBlock: resultBeginBlock,
 		ResultEndBlock:   resultEndBlock,
 	})

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -15,6 +15,16 @@ import (
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
 )
 
+type kvPair = [2]string
+
+func makeEventAttrs(kvPairs []kvPair) []abci.EventAttribute {
+	var attrs []abci.EventAttribute
+	for _, pair := range kvPairs {
+		attrs = append(attrs, abci.EventAttribute{Key: []byte(pair[0]), Value: []byte(pair[1])})
+	}
+	return attrs
+}
+
 func TestEventBusPublishEventTx(t *testing.T) {
 	eventBus := NewEventBus()
 	err := eventBus.Start()
@@ -29,7 +39,7 @@ func TestEventBusPublishEventTx(t *testing.T) {
 	result := abci.ResponseDeliverTx{
 		Data: []byte("bar"),
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "baz", Value: "1"}}},
+			{Type: "testType", Attributes: makeEventAttrs([]kvPair{{"baz", "1"}})},
 		},
 	}
 
@@ -78,12 +88,12 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 	blockID := BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(BlockPartSizeBytes).Header()}
 	resultBeginBlock := abci.ResponseBeginBlock{
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "baz", Value: "1"}}},
+			{Type: "testType", Attributes: makeEventAttrs([]kvPair{{"baz", "1"}})},
 		},
 	}
 	resultEndBlock := abci.ResponseEndBlock{
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "foz", Value: "2"}}},
+			{Type: "testType", Attributes: makeEventAttrs([]kvPair{{"foz", "2"}})},
 		},
 	}
 
@@ -134,27 +144,27 @@ func TestEventBusPublishEventTxDuplicateKeys(t *testing.T) {
 		Events: []abci.Event{
 			{
 				Type: "transfer",
-				Attributes: []abci.EventAttribute{
-					{Key: "sender", Value: "foo"},
-					{Key: "recipient", Value: "bar"},
-					{Key: "amount", Value: "5"},
-				},
+				Attributes: makeEventAttrs([]kvPair{
+					{"sender", "foo"},
+					{"recipient", "bar"},
+					{"amount", "5"},
+				}),
 			},
 			{
 				Type: "transfer",
-				Attributes: []abci.EventAttribute{
-					{Key: "sender", Value: "baz"},
-					{Key: "recipient", Value: "cat"},
-					{Key: "amount", Value: "13"},
-				},
+				Attributes: makeEventAttrs([]kvPair{
+					{"sender", "baz"},
+					{"recipient", "cat"},
+					{"amount", "13"},
+				}),
 			},
 			{
 				Type: "withdraw.rewards",
-				Attributes: []abci.EventAttribute{
-					{Key: "address", Value: "bar"},
-					{Key: "source", Value: "iceman"},
-					{Key: "amount", Value: "33"},
-				},
+				Attributes: makeEventAttrs([]kvPair{
+					{"address", "bar"},
+					{"source", "iceman"},
+					{"amount", "33"},
+				}),
 			},
 		},
 	}
@@ -239,12 +249,12 @@ func TestEventBusPublishEventNewBlockHeader(t *testing.T) {
 	block := MakeBlock(0, []Tx{}, nil, []Evidence{})
 	resultBeginBlock := abci.ResponseBeginBlock{
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "baz", Value: "1"}}},
+			{Type: "testType", Attributes: makeEventAttrs([]kvPair{{"baz", "1"}})},
 		},
 	}
 	resultEndBlock := abci.ResponseEndBlock{
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key: "foz", Value: "2"}}},
+			{Type: "testType", Attributes: makeEventAttrs([]kvPair{{"foz", "2"}})},
 		},
 	}
 

--- a/types/events.go
+++ b/types/events.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmjson "github.com/tendermint/tendermint/libs/json"
@@ -16,26 +17,69 @@ const (
 	// after a block has been committed.
 	// These are also used by the tx indexer for async indexing.
 	// All of this data can be fetched through the rpc.
-	EventNewBlock            = "NewBlock"
-	EventNewBlockHeader      = "NewBlockHeader"
-	EventNewEvidence         = "NewEvidence"
-	EventTx                  = "Tx"
-	EventValidatorSetUpdates = "ValidatorSetUpdates"
+	EventNewBlockValue            = "NewBlock"
+	EventNewBlockHeaderValue      = "NewBlockHeader"
+	EventNewEvidenceValue         = "NewEvidence"
+	EventTxValue                  = "Tx"
+	EventValidatorSetUpdatesValue = "ValidatorSetUpdates"
 
 	// Internal consensus events.
 	// These are used for testing the consensus state machine.
 	// They can also be used to build real-time consensus visualizers.
-	EventCompleteProposal = "CompleteProposal"
-	EventLock             = "Lock"
-	EventNewRound         = "NewRound"
-	EventNewRoundStep     = "NewRoundStep"
-	EventPolka            = "Polka"
-	EventRelock           = "Relock"
-	EventTimeoutPropose   = "TimeoutPropose"
-	EventTimeoutWait      = "TimeoutWait"
-	EventUnlock           = "Unlock"
-	EventValidBlock       = "ValidBlock"
-	EventVote             = "Vote"
+	EventCompleteProposalValue = "CompleteProposal"
+	EventLockValue             = "Lock"
+	EventNewRoundValue         = "NewRound"
+	EventNewRoundStepValue     = "NewRoundStep"
+	EventPolkaValue            = "Polka"
+	EventRelockValue           = "Relock"
+	EventTimeoutProposeValue   = "TimeoutPropose"
+	EventTimeoutWaitValue      = "TimeoutWait"
+	EventUnlockValue           = "Unlock"
+	EventValidBlockValue       = "ValidBlock"
+	EventVoteValue             = "Vote"
+)
+
+// Pre-populated ABCI Tendermint-reserved events
+var (
+	EventNewBlock = abci.Event{
+		Type: strings.Split(EventTypeKey, ".")[0],
+		Attributes: []abci.EventAttribute{
+			{
+				Key:   strings.Split(EventTypeKey, ".")[1],
+				Value: EventNewBlockValue,
+			},
+		},
+	}
+
+	EventNewBlockHeader = abci.Event{
+		Type: strings.Split(EventTypeKey, ".")[0],
+		Attributes: []abci.EventAttribute{
+			{
+				Key:   strings.Split(EventTypeKey, ".")[1],
+				Value: EventNewBlockHeaderValue,
+			},
+		},
+	}
+
+	EventNewEvidence = abci.Event{
+		Type: strings.Split(EventTypeKey, ".")[0],
+		Attributes: []abci.EventAttribute{
+			{
+				Key:   strings.Split(EventTypeKey, ".")[1],
+				Value: EventNewEvidenceValue,
+			},
+		},
+	}
+
+	EventTx = abci.Event{
+		Type: strings.Split(EventTypeKey, ".")[0],
+		Attributes: []abci.EventAttribute{
+			{
+				Key:   strings.Split(EventTypeKey, ".")[1],
+				Value: EventTxValue,
+			},
+		},
+	}
 )
 
 // ENCODING / DECODING
@@ -62,7 +106,8 @@ func init() {
 // but some (an input to a call tx or a receive) are more exotic
 
 type EventDataNewBlock struct {
-	Block *Block `json:"block"`
+	Block   *Block  `json:"block"`
+	BlockID BlockID `json:"block_id"`
 
 	ResultBeginBlock abci.ResponseBeginBlock `json:"result_begin_block"`
 	ResultEndBlock   abci.ResponseEndBlock   `json:"result_end_block"`
@@ -140,33 +185,36 @@ const (
 	// BlockHeightKey is a reserved key used for indexing BeginBlock and Endblock
 	// events.
 	BlockHeightKey = "block.height"
+
+	EventTypeBeginBlock = "begin_block"
+	EventTypeEndBlock   = "end_block"
 )
 
 var (
-	EventQueryCompleteProposal    = QueryForEvent(EventCompleteProposal)
-	EventQueryLock                = QueryForEvent(EventLock)
-	EventQueryNewBlock            = QueryForEvent(EventNewBlock)
-	EventQueryNewBlockHeader      = QueryForEvent(EventNewBlockHeader)
-	EventQueryNewEvidence         = QueryForEvent(EventNewEvidence)
-	EventQueryNewRound            = QueryForEvent(EventNewRound)
-	EventQueryNewRoundStep        = QueryForEvent(EventNewRoundStep)
-	EventQueryPolka               = QueryForEvent(EventPolka)
-	EventQueryRelock              = QueryForEvent(EventRelock)
-	EventQueryTimeoutPropose      = QueryForEvent(EventTimeoutPropose)
-	EventQueryTimeoutWait         = QueryForEvent(EventTimeoutWait)
-	EventQueryTx                  = QueryForEvent(EventTx)
-	EventQueryUnlock              = QueryForEvent(EventUnlock)
-	EventQueryValidatorSetUpdates = QueryForEvent(EventValidatorSetUpdates)
-	EventQueryValidBlock          = QueryForEvent(EventValidBlock)
-	EventQueryVote                = QueryForEvent(EventVote)
+	EventQueryCompleteProposal    = QueryForEvent(EventCompleteProposalValue)
+	EventQueryLock                = QueryForEvent(EventLockValue)
+	EventQueryNewBlock            = QueryForEvent(EventNewBlockValue)
+	EventQueryNewBlockHeader      = QueryForEvent(EventNewBlockHeaderValue)
+	EventQueryNewEvidence         = QueryForEvent(EventNewEvidenceValue)
+	EventQueryNewRound            = QueryForEvent(EventNewRoundValue)
+	EventQueryNewRoundStep        = QueryForEvent(EventNewRoundStepValue)
+	EventQueryPolka               = QueryForEvent(EventPolkaValue)
+	EventQueryRelock              = QueryForEvent(EventRelockValue)
+	EventQueryTimeoutPropose      = QueryForEvent(EventTimeoutProposeValue)
+	EventQueryTimeoutWait         = QueryForEvent(EventTimeoutWaitValue)
+	EventQueryTx                  = QueryForEvent(EventTxValue)
+	EventQueryUnlock              = QueryForEvent(EventUnlockValue)
+	EventQueryValidatorSetUpdates = QueryForEvent(EventValidatorSetUpdatesValue)
+	EventQueryValidBlock          = QueryForEvent(EventValidBlockValue)
+	EventQueryVote                = QueryForEvent(EventVoteValue)
 )
 
 func EventQueryTxFor(tx Tx) tmpubsub.Query {
-	return tmquery.MustParse(fmt.Sprintf("%s='%s' AND %s='%X'", EventTypeKey, EventTx, TxHashKey, tx.Hash()))
+	return tmquery.MustParse(fmt.Sprintf("%s='%s' AND %s='%X'", EventTypeKey, EventTxValue, TxHashKey, tx.Hash()))
 }
 
-func QueryForEvent(eventType string) tmpubsub.Query {
-	return tmquery.MustParse(fmt.Sprintf("%s='%s'", EventTypeKey, eventType))
+func QueryForEvent(eventValue string) tmpubsub.Query {
+	return tmquery.MustParse(fmt.Sprintf("%s='%s'", EventTypeKey, eventValue))
 }
 
 // BlockEventPublisher publishes all block related events

--- a/types/events.go
+++ b/types/events.go
@@ -41,7 +41,7 @@ const (
 
 // Pre-populated ABCI Tendermint-reserved events
 var (
-	EventNewBlock = abci.Event{
+	_EventNewBlock = abci.Event{
 		Type: strings.Split(EventTypeKey, ".")[0],
 		Attributes: []abci.EventAttribute{
 			{
@@ -51,7 +51,7 @@ var (
 		},
 	}
 
-	EventNewBlockHeader = abci.Event{
+	_EventNewBlockHeader = abci.Event{
 		Type: strings.Split(EventTypeKey, ".")[0],
 		Attributes: []abci.EventAttribute{
 			{
@@ -61,7 +61,7 @@ var (
 		},
 	}
 
-	EventNewEvidence = abci.Event{
+	_EventNewEvidence = abci.Event{
 		Type: strings.Split(EventTypeKey, ".")[0],
 		Attributes: []abci.EventAttribute{
 			{
@@ -71,7 +71,7 @@ var (
 		},
 	}
 
-	EventTx = abci.Event{
+	_EventTx = abci.Event{
 		Type: strings.Split(EventTypeKey, ".")[0],
 		Attributes: []abci.EventAttribute{
 			{

--- a/types/events.go
+++ b/types/events.go
@@ -95,8 +95,7 @@ func init() {
 // but some (an input to a call tx or a receive) are more exotic
 
 type EventDataNewBlock struct {
-	Block   *Block  `json:"block"`
-	BlockID BlockID `json:"block_id"`
+	Block *Block `json:"block"`
 
 	ResultBeginBlock abci.ResponseBeginBlock `json:"result_begin_block"`
 	ResultEndBlock   abci.ResponseEndBlock   `json:"result_end_block"`

--- a/types/events.go
+++ b/types/events.go
@@ -17,26 +17,26 @@ const (
 	// after a block has been committed.
 	// These are also used by the tx indexer for async indexing.
 	// All of this data can be fetched through the rpc.
-	EventNewBlockValue            = "NewBlock"
-	EventNewBlockHeaderValue      = "NewBlockHeader"
-	EventNewEvidenceValue         = "NewEvidence"
-	EventTxValue                  = "Tx"
-	EventValidatorSetUpdatesValue = "ValidatorSetUpdates"
+	EventNewBlock            = "NewBlock"
+	EventNewBlockHeader      = "NewBlockHeader"
+	EventNewEvidence         = "NewEvidence"
+	EventTx                  = "Tx"
+	EventValidatorSetUpdates = "ValidatorSetUpdates"
 
 	// Internal consensus events.
 	// These are used for testing the consensus state machine.
 	// They can also be used to build real-time consensus visualizers.
-	EventCompleteProposalValue = "CompleteProposal"
-	EventLockValue             = "Lock"
-	EventNewRoundValue         = "NewRound"
-	EventNewRoundStepValue     = "NewRoundStep"
-	EventPolkaValue            = "Polka"
-	EventRelockValue           = "Relock"
-	EventTimeoutProposeValue   = "TimeoutPropose"
-	EventTimeoutWaitValue      = "TimeoutWait"
-	EventUnlockValue           = "Unlock"
-	EventValidBlockValue       = "ValidBlock"
-	EventVoteValue             = "Vote"
+	EventCompleteProposal = "CompleteProposal"
+	EventLock             = "Lock"
+	EventNewRound         = "NewRound"
+	EventNewRoundStep     = "NewRoundStep"
+	EventPolka            = "Polka"
+	EventRelock           = "Relock"
+	EventTimeoutPropose   = "TimeoutPropose"
+	EventTimeoutWait      = "TimeoutWait"
+	EventUnlock           = "Unlock"
+	EventValidBlock       = "ValidBlock"
+	EventVote             = "Vote"
 )
 
 // Pre-populated ABCI Tendermint-reserved events
@@ -46,7 +46,7 @@ var (
 		Attributes: []abci.EventAttribute{
 			{
 				Key:   strings.Split(EventTypeKey, ".")[1],
-				Value: EventNewBlockValue,
+				Value: EventNewBlock,
 			},
 		},
 	}
@@ -56,7 +56,7 @@ var (
 		Attributes: []abci.EventAttribute{
 			{
 				Key:   strings.Split(EventTypeKey, ".")[1],
-				Value: EventNewBlockHeaderValue,
+				Value: EventNewBlockHeader,
 			},
 		},
 	}
@@ -66,7 +66,7 @@ var (
 		Attributes: []abci.EventAttribute{
 			{
 				Key:   strings.Split(EventTypeKey, ".")[1],
-				Value: EventNewEvidenceValue,
+				Value: EventNewEvidence,
 			},
 		},
 	}
@@ -76,7 +76,7 @@ var (
 		Attributes: []abci.EventAttribute{
 			{
 				Key:   strings.Split(EventTypeKey, ".")[1],
-				Value: EventTxValue,
+				Value: EventTx,
 			},
 		},
 	}
@@ -191,26 +191,26 @@ const (
 )
 
 var (
-	EventQueryCompleteProposal    = QueryForEvent(EventCompleteProposalValue)
-	EventQueryLock                = QueryForEvent(EventLockValue)
-	EventQueryNewBlock            = QueryForEvent(EventNewBlockValue)
-	EventQueryNewBlockHeader      = QueryForEvent(EventNewBlockHeaderValue)
-	EventQueryNewEvidence         = QueryForEvent(EventNewEvidenceValue)
-	EventQueryNewRound            = QueryForEvent(EventNewRoundValue)
-	EventQueryNewRoundStep        = QueryForEvent(EventNewRoundStepValue)
-	EventQueryPolka               = QueryForEvent(EventPolkaValue)
-	EventQueryRelock              = QueryForEvent(EventRelockValue)
-	EventQueryTimeoutPropose      = QueryForEvent(EventTimeoutProposeValue)
-	EventQueryTimeoutWait         = QueryForEvent(EventTimeoutWaitValue)
-	EventQueryTx                  = QueryForEvent(EventTxValue)
-	EventQueryUnlock              = QueryForEvent(EventUnlockValue)
-	EventQueryValidatorSetUpdates = QueryForEvent(EventValidatorSetUpdatesValue)
-	EventQueryValidBlock          = QueryForEvent(EventValidBlockValue)
-	EventQueryVote                = QueryForEvent(EventVoteValue)
+	EventQueryCompleteProposal    = QueryForEvent(EventCompleteProposal)
+	EventQueryLock                = QueryForEvent(EventLock)
+	EventQueryNewBlock            = QueryForEvent(EventNewBlock)
+	EventQueryNewBlockHeader      = QueryForEvent(EventNewBlockHeader)
+	EventQueryNewEvidence         = QueryForEvent(EventNewEvidence)
+	EventQueryNewRound            = QueryForEvent(EventNewRound)
+	EventQueryNewRoundStep        = QueryForEvent(EventNewRoundStep)
+	EventQueryPolka               = QueryForEvent(EventPolka)
+	EventQueryRelock              = QueryForEvent(EventRelock)
+	EventQueryTimeoutPropose      = QueryForEvent(EventTimeoutPropose)
+	EventQueryTimeoutWait         = QueryForEvent(EventTimeoutWait)
+	EventQueryTx                  = QueryForEvent(EventTx)
+	EventQueryUnlock              = QueryForEvent(EventUnlock)
+	EventQueryValidatorSetUpdates = QueryForEvent(EventValidatorSetUpdates)
+	EventQueryValidBlock          = QueryForEvent(EventValidBlock)
+	EventQueryVote                = QueryForEvent(EventVote)
 )
 
 func EventQueryTxFor(tx Tx) tmpubsub.Query {
-	return tmquery.MustParse(fmt.Sprintf("%s='%s' AND %s='%X'", EventTypeKey, EventTxValue, TxHashKey, tx.Hash()))
+	return tmquery.MustParse(fmt.Sprintf("%s='%s' AND %s='%X'", EventTypeKey, EventTx, TxHashKey, tx.Hash()))
 }
 
 func QueryForEvent(eventValue string) tmpubsub.Query {

--- a/types/events.go
+++ b/types/events.go
@@ -60,16 +60,6 @@ var (
 		},
 	}
 
-	_EventNewEvidence = abci.Event{
-		Type: eventReservedType,
-		Attributes: []abci.EventAttribute{
-			{
-				Key:   []byte(eventReservedKey),
-				Value: []byte(EventNewEvidence),
-			},
-		},
-	}
-
 	_EventTx = abci.Event{
 		Type: eventReservedType,
 		Attributes: []abci.EventAttribute{

--- a/types/events.go
+++ b/types/events.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"fmt"
-	"strings"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmjson "github.com/tendermint/tendermint/libs/json"
@@ -42,41 +41,41 @@ const (
 // Pre-populated ABCI Tendermint-reserved events
 var (
 	_EventNewBlock = abci.Event{
-		Type: strings.Split(EventTypeKey, ".")[0],
+		Type: eventReservedType,
 		Attributes: []abci.EventAttribute{
 			{
-				Key:   strings.Split(EventTypeKey, ".")[1],
-				Value: EventNewBlock,
+				Key:   []byte(eventReservedKey),
+				Value: []byte(EventNewBlock),
 			},
 		},
 	}
 
 	_EventNewBlockHeader = abci.Event{
-		Type: strings.Split(EventTypeKey, ".")[0],
+		Type: eventReservedType,
 		Attributes: []abci.EventAttribute{
 			{
-				Key:   strings.Split(EventTypeKey, ".")[1],
-				Value: EventNewBlockHeader,
+				Key:   []byte(eventReservedKey),
+				Value: []byte(EventNewBlockHeader),
 			},
 		},
 	}
 
 	_EventNewEvidence = abci.Event{
-		Type: strings.Split(EventTypeKey, ".")[0],
+		Type: eventReservedType,
 		Attributes: []abci.EventAttribute{
 			{
-				Key:   strings.Split(EventTypeKey, ".")[1],
-				Value: EventNewEvidence,
+				Key:   []byte(eventReservedKey),
+				Value: []byte(EventNewEvidence),
 			},
 		},
 	}
 
 	_EventTx = abci.Event{
-		Type: strings.Split(EventTypeKey, ".")[0],
+		Type: eventReservedType,
 		Attributes: []abci.EventAttribute{
 			{
-				Key:   strings.Split(EventTypeKey, ".")[1],
-				Value: EventTx,
+				Key:   []byte(eventReservedKey),
+				Value: []byte(EventTx),
 			},
 		},
 	}
@@ -173,8 +172,12 @@ type EventDataValidatorSetUpdates struct {
 // PUBSUB
 
 const (
+	eventReservedType = "tm"
+	eventReservedKey  = "event"
+
 	// EventTypeKey is a reserved composite key for event name.
-	EventTypeKey = "tm.event"
+	EventTypeKey = eventReservedType + "." + eventReservedKey
+
 	// TxHashKey is a reserved key, used to specify transaction's hash.
 	// see EventBus#PublishEventTx
 	TxHashKey = "tx.hash"

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -18,10 +18,10 @@ func TestQueryTxFor(t *testing.T) {
 func TestQueryForEvent(t *testing.T) {
 	assert.Equal(t,
 		"tm.event='NewBlock'",
-		QueryForEvent(EventNewBlock).String(),
+		QueryForEvent(EventNewBlockValue).String(),
 	)
 	assert.Equal(t,
 		"tm.event='NewEvidence'",
-		QueryForEvent(EventNewEvidence).String(),
+		QueryForEvent(EventNewEvidenceValue).String(),
 	)
 }

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -18,10 +18,10 @@ func TestQueryTxFor(t *testing.T) {
 func TestQueryForEvent(t *testing.T) {
 	assert.Equal(t,
 		"tm.event='NewBlock'",
-		QueryForEvent(EventNewBlockValue).String(),
+		QueryForEvent(EventNewBlock).String(),
 	)
 	assert.Equal(t,
 		"tm.event='NewEvidence'",
-		QueryForEvent(EventNewEvidenceValue).String(),
+		QueryForEvent(EventNewEvidence).String(),
 	)
 }


### PR DESCRIPTION
This change backports the event subscription changes from #6634, addressing part of #6828.

As implemented, this is not a perfectly clean backport: I regressed most of the breaking API changes in the core types packages, RPC plumbing, and tests, but left some breaking Go API changes in the `pubsub` package, not hidden behind a feature flag. 

A feature flag may still be practical—but even if we add one, it will make a breaking change in the API, just one that will probably pass on "conventional" usage of the package. I think it is reasonable in this case to keep the break:  

- There is no direct use of this package in the Cosmos SDK or the Cosmos Relayer, and
- A large sample of all matching results from a GitHub search suggests that most (and possibly all) other references from Go code are from clones or forks of the Tendermint core, not dependencies. 

(This analysis does not include code inaccessible from GitHub, however, so if there are other important consumers I should investigate, please leave comments below).

As written, this change builds and passes all our existing tests. Before merging, though, I would like feedback from either the Cosmos SDK folks and/or other user(s) intending to take use this change via a potential v0.34 update. Specifically, I'd like for someone to patch this PR into a real workload and check whether or not it builds successfully and does what you wanted.

TODO:
- [ ] Feedback from a real use candidate.
- [x] Update the changelog.
- [x] Clean up lint warnings from export surface changes.
