### PR TITLE
e2e: backport minor reliability improvements

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -15,7 +15,6 @@ var (
 	// separate testnet for each combination (Cartesian product) of options.
 	testnetCombinations = map[string][]interface{}{
 		"topology":      {"single", "quad", "large"},
-		"ipv6":          {false, true},
 		"initialHeight": {0, 1000},
 		"initialState": {
 			map[string]string{},
@@ -26,11 +25,12 @@ var (
 
 	// The following specify randomly chosen values for testnet nodes.
 	nodeDatabases = uniformChoice{"goleveldb", "cleveldb", "rocksdb", "boltdb", "badgerdb"}
+	ipv6          = uniformChoice{false, true}
 	// FIXME: grpc disabled due to https://github.com/tendermint/tendermint/issues/5439
 	nodeABCIProtocols    = uniformChoice{"unix", "tcp", "builtin"} // "grpc"
 	nodePrivvalProtocols = uniformChoice{"file", "unix", "tcp"}
 	// FIXME: v2 disabled due to flake
-	nodeFastSyncs         = uniformChoice{"", "v0"} // "v2"
+	nodeFastSyncs         = uniformChoice{"v0"} // "v2"
 	nodeStateSyncs        = uniformChoice{false, true}
 	nodePersistIntervals  = uniformChoice{0, 1, 5}
 	nodeSnapshotIntervals = uniformChoice{0, 3}
@@ -66,7 +66,7 @@ func Generate(r *rand.Rand) ([]e2e.Manifest, error) {
 // generateTestnet generates a single testnet with the given options.
 func generateTestnet(r *rand.Rand, opt map[string]interface{}) (e2e.Manifest, error) {
 	manifest := e2e.Manifest{
-		IPv6:             opt["ipv6"].(bool),
+		IPv6:             ipv6.Choose(r).(bool),
 		InitialHeight:    int64(opt["initialHeight"].(int)),
 		InitialState:     opt["initialState"].(map[string]string),
 		Validators:       &map[string]int64{},

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -17,9 +17,6 @@ import (
 // Tests that any initial state given in genesis has made it into the app.
 func TestApp_InitialState(t *testing.T) {
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Stateless() {
-			return
-		}
 		if len(node.Testnet.InitialState) == 0 {
 			return
 		}
@@ -39,12 +36,6 @@ func TestApp_InitialState(t *testing.T) {
 // block and the node sync status.
 func TestApp_Hash(t *testing.T) {
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		// disables tests for light clients
-		// see https://github.com/tendermint/tendermint/issues/6671
-		if node.Mode == e2e.ModeSeed || node.Mode == e2e.ModeLight {
-			return
-		}
-
 		client, err := node.Client()
 		require.NoError(t, err)
 		info, err := client.ABCIInfo(ctx)
@@ -66,12 +57,6 @@ func TestApp_Hash(t *testing.T) {
 // Tests that we can set a value and retrieve it.
 func TestApp_Tx(t *testing.T) {
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		// disables tests for light clients
-		// see https://github.com/tendermint/tendermint/issues/6671
-		if node.Mode == e2e.ModeSeed || node.Mode == e2e.ModeLight {
-			return
-		}
-
 		client, err := node.Client()
 		require.NoError(t, err)
 

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -50,6 +50,10 @@ func testNode(t *testing.T, testFunc func(*testing.T, e2e.Node)) {
 	}
 
 	for _, node := range nodes {
+		if node.Stateless() {
+			continue
+		}
+
 		node := *node
 		t.Run(node.Name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
This patch makes several small reliability and scope reduction improvements to the e2e tests in the 0.34 branch that we've been running in master for some months. 