### PR TITLE
consensus: remove panics from test helper functions

### DIFF
--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -52,7 +52,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 			defer os.RemoveAll(thisConfig.RootDir)
 
-			ensureDir(path.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
+			ensureDir(t, path.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
 			app := appFunc()
 			vals := types.TM2PB.ValidatorUpdates(state.Validators)
 			app.InitChain(abci.RequestInitChain{Validators: vals})

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -228,6 +228,7 @@ func decideProposal(
 	height int64,
 	round int32,
 ) (proposal *types.Proposal, block *types.Block) {
+	t.Helper()
 	cs1.mtx.Lock()
 	block, blockParts := cs1.createProposalBlock()
 	validRound := cs1.ValidRound
@@ -269,6 +270,7 @@ func signAddVotes(
 }
 
 func validatePrevote(t *testing.T, cs *State, round int32, privVal *validatorStub, blockHash []byte) {
+	t.Helper()
 	prevotes := cs.Votes.Prevotes(round)
 	pubKey, err := privVal.GetPubKey(context.Background())
 	require.NoError(t, err)
@@ -289,6 +291,7 @@ func validatePrevote(t *testing.T, cs *State, round int32, privVal *validatorStu
 }
 
 func validateLastPrecommit(t *testing.T, cs *State, privVal *validatorStub, blockHash []byte) {
+	t.Helper()
 	votes := cs.LastCommit
 	pv, err := privVal.GetPubKey(context.Background())
 	require.NoError(t, err)
@@ -311,6 +314,7 @@ func validatePrecommit(
 	votedBlockHash,
 	lockedBlockHash []byte,
 ) {
+	t.Helper()
 	precommits := cs.Votes.Precommits(thisRound)
 	pv, err := privVal.GetPubKey(context.Background())
 	require.NoError(t, err)
@@ -359,6 +363,7 @@ func validatePrevoteAndPrecommit(
 	votedBlockHash,
 	lockedBlockHash []byte,
 ) {
+	t.Helper()
 	// verify the prevote
 	validatePrevote(t, cs, thisRound, privVal, votedBlockHash)
 	// verify precommit
@@ -741,6 +746,7 @@ func randConsensusState(
 	appFunc func() abci.Application,
 	configOpts ...func(*cfg.Config),
 ) ([]*State, cleanupFunc) {
+	t.Helper()
 
 	genDoc, privVals := factory.RandGenesisDoc(config, nValidators, false, 30)
 	css := make([]*State, nValidators)

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -646,12 +646,6 @@ func ensureNewUnlock(t *testing.T, unlockCh <-chan tmpubsub.Message, height int6
 		"Timeout expired while waiting for NewUnlock event")
 }
 
-func ensureLock(t *testing.T, lockCh <-chan tmpubsub.Message, height int64, round int32) {
-	t.Helper()
-	ensureNewEvent(t, lockCh, height, round, ensureTimeout,
-		"Timeout expired while waiting for LockValue event")
-}
-
 func ensureProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID) {
 	t.Helper()
 	select {

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -69,9 +69,10 @@ func configSetup(t *testing.T) *cfg.Config {
 	return config
 }
 
-func ensureDir(dir string, mode os.FileMode) {
+func ensureDir(t *testing.T, dir string, mode os.FileMode) {
+	t.Helper()
 	if err := tmos.EnsureDir(dir, mode); err != nil {
-		panic(err)
+		t.Fatalf("error opening directory: %s", err)
 	}
 }
 
@@ -221,6 +222,7 @@ func startTestRound(cs *State, height int64, round int32) {
 
 // Create proposal block from cs1 but sign it with vs.
 func decideProposal(
+	t *testing.T,
 	cs1 *State,
 	vs *validatorStub,
 	height int64,
@@ -232,7 +234,7 @@ func decideProposal(
 	chainID := cs1.state.ChainID
 	cs1.mtx.Unlock()
 	if block == nil {
-		panic("Failed to createProposalBlock. Did you forget to add commit for previous block?")
+		t.Fatal("Failed to createProposalBlock. Did you forget to add commit for previous block?")
 	}
 
 	// Make proposal
@@ -240,7 +242,7 @@ func decideProposal(
 	proposal = types.NewProposal(height, round, polRound, propBlockID)
 	p := proposal.ToProto()
 	if err := vs.SignProposal(context.Background(), chainID, p); err != nil {
-		panic(err)
+		t.Fatalf("error signing proposal: %s", err)
 	}
 
 	proposal.Signature = p.Signature
@@ -273,15 +275,15 @@ func validatePrevote(t *testing.T, cs *State, round int32, privVal *validatorStu
 	address := pubKey.Address()
 	var vote *types.Vote
 	if vote = prevotes.GetByAddress(address); vote == nil {
-		panic("Failed to find prevote from validator")
+		t.Fatalf("Failed to find prevote from validator")
 	}
 	if blockHash == nil {
 		if vote.BlockID.Hash != nil {
-			panic(fmt.Sprintf("Expected prevote to be for nil, got %X", vote.BlockID.Hash))
+			t.Fatalf("Expected prevote to be for nil, got %X", vote.BlockID.Hash)
 		}
 	} else {
 		if !bytes.Equal(vote.BlockID.Hash, blockHash) {
-			panic(fmt.Sprintf("Expected prevote to be for %X, got %X", blockHash, vote.BlockID.Hash))
+			t.Fatalf("Expected prevote to be for %X, got %X", blockHash, vote.BlockID.Hash)
 		}
 	}
 }
@@ -293,10 +295,10 @@ func validateLastPrecommit(t *testing.T, cs *State, privVal *validatorStub, bloc
 	address := pv.Address()
 	var vote *types.Vote
 	if vote = votes.GetByAddress(address); vote == nil {
-		panic("Failed to find precommit from validator")
+		t.Fatalf("Failed to find precommit from validator")
 	}
 	if !bytes.Equal(vote.BlockID.Hash, blockHash) {
-		panic(fmt.Sprintf("Expected precommit to be for %X, got %X", blockHash, vote.BlockID.Hash))
+		t.Fatalf("Expected precommit to be for %X, got %X", blockHash, vote.BlockID.Hash)
 	}
 }
 
@@ -315,35 +317,35 @@ func validatePrecommit(
 	address := pv.Address()
 	var vote *types.Vote
 	if vote = precommits.GetByAddress(address); vote == nil {
-		panic("Failed to find precommit from validator")
+		t.Fatalf("Failed to find precommit from validator")
 	}
 
 	if votedBlockHash == nil {
 		if vote.BlockID.Hash != nil {
-			panic("Expected precommit to be for nil")
+			t.Fatalf("Expected precommit to be for nil")
 		}
 	} else {
 		if !bytes.Equal(vote.BlockID.Hash, votedBlockHash) {
-			panic("Expected precommit to be for proposal block")
+			t.Fatalf("Expected precommit to be for proposal block")
 		}
 	}
 
 	if lockedBlockHash == nil {
 		if cs.LockedRound != lockRound || cs.LockedBlock != nil {
-			panic(fmt.Sprintf(
+			t.Fatalf(
 				"Expected to be locked on nil at round %d. Got locked at round %d with block %v",
 				lockRound,
 				cs.LockedRound,
-				cs.LockedBlock))
+				cs.LockedBlock)
 		}
 	} else {
 		if cs.LockedRound != lockRound || !bytes.Equal(cs.LockedBlock.Hash(), lockedBlockHash) {
-			panic(fmt.Sprintf(
+			t.Fatalf(
 				"Expected block to be locked on round %d, got %d. Got locked block %X, expected %X",
 				lockRound,
 				cs.LockedRound,
 				cs.LockedBlock.Hash(),
-				lockedBlockHash))
+				lockedBlockHash)
 		}
 	}
 }
@@ -444,13 +446,14 @@ func newStateWithConfigAndBlockStore(
 	return cs
 }
 
-func loadPrivValidator(config *cfg.Config) *privval.FilePV {
+func loadPrivValidator(t *testing.T, config *cfg.Config) *privval.FilePV {
+	t.Helper()
 	privValidatorKeyFile := config.PrivValidator.KeyFile()
-	ensureDir(filepath.Dir(privValidatorKeyFile), 0700)
+	ensureDir(t, filepath.Dir(privValidatorKeyFile), 0700)
 	privValidatorStateFile := config.PrivValidator.StateFile()
 	privValidator, err := privval.LoadOrGenFilePV(privValidatorKeyFile, privValidatorStateFile)
 	if err != nil {
-		panic(err)
+		t.Fatalf("error generating validator file: %s", err)
 	}
 	privValidator.Reset()
 	return privValidator
@@ -475,220 +478,247 @@ func randState(config *cfg.Config, nValidators int) (*State, []*validatorStub) {
 
 //-------------------------------------------------------------------------------
 
-func ensureNoNewEvent(ch <-chan tmpubsub.Message, timeout time.Duration,
+func ensureNoNewEvent(t *testing.T, ch <-chan tmpubsub.Message, timeout time.Duration,
 	errorMessage string) {
+	t.Helper()
 	select {
 	case <-time.After(timeout):
 		break
 	case <-ch:
-		panic(errorMessage)
+		t.Fatalf("unexpected event: %s", errorMessage)
 	}
 }
 
-func ensureNoNewEventOnChannel(ch <-chan tmpubsub.Message) {
+func ensureNoNewEventOnChannel(t *testing.T, ch <-chan tmpubsub.Message) {
+	t.Helper()
 	ensureNoNewEvent(
+		t,
 		ch,
 		ensureTimeout,
 		"We should be stuck waiting, not receiving new event on the channel")
 }
 
-func ensureNoNewRoundStep(stepCh <-chan tmpubsub.Message) {
+func ensureNoNewRoundStep(t *testing.T, stepCh <-chan tmpubsub.Message) {
+	t.Helper()
 	ensureNoNewEvent(
+		t,
 		stepCh,
 		ensureTimeout,
 		"We should be stuck waiting, not receiving NewRoundStep event")
 }
 
-func ensureNoNewUnlock(unlockCh <-chan tmpubsub.Message) {
+func ensureNoNewUnlock(t *testing.T, unlockCh <-chan tmpubsub.Message) {
+	t.Helper()
 	ensureNoNewEvent(
+		t,
 		unlockCh,
 		ensureTimeout,
 		"We should be stuck waiting, not receiving Unlock event")
 }
 
-func ensureNoNewTimeout(stepCh <-chan tmpubsub.Message, timeout int64) {
+func ensureNoNewTimeout(t *testing.T, stepCh <-chan tmpubsub.Message, timeout int64) {
+	t.Helper()
 	timeoutDuration := time.Duration(timeout*10) * time.Nanosecond
 	ensureNoNewEvent(
+		t,
 		stepCh,
 		timeoutDuration,
 		"We should be stuck waiting, not receiving NewTimeout event")
 }
 
-func ensureNewEvent(ch <-chan tmpubsub.Message, height int64, round int32, timeout time.Duration, errorMessage string) {
+func ensureNewEvent(t *testing.T, ch <-chan tmpubsub.Message, height int64, round int32, timeout time.Duration, errorMessage string) {
+	t.Helper()
 	select {
 	case <-time.After(timeout):
-		panic(errorMessage)
+		t.Fatalf("timed out waiting for new event: %s", errorMessage)
 	case msg := <-ch:
 		roundStateEvent, ok := msg.Data().(types.EventDataRoundState)
 		if !ok {
-			panic(fmt.Sprintf("expected a EventDataRoundState, got %T. Wrong subscription channel?",
-				msg.Data()))
+			t.Fatalf("expected a EventDataRoundState, got %T. Wrong subscription channel?", msg.Data())
 		}
 		if roundStateEvent.Height != height {
-			panic(fmt.Sprintf("expected height %v, got %v", height, roundStateEvent.Height))
+			t.Fatalf("expected height %v, got %v", height, roundStateEvent.Height)
 		}
 		if roundStateEvent.Round != round {
-			panic(fmt.Sprintf("expected round %v, got %v", round, roundStateEvent.Round))
+			t.Fatalf("expected round %v, got %v", round, roundStateEvent.Round)
 		}
 		// TODO: We could check also for a step at this point!
 	}
 }
 
-func ensureNewRound(roundCh <-chan tmpubsub.Message, height int64, round int32) {
+func ensureNewRound(t *testing.T, roundCh <-chan tmpubsub.Message, height int64, round int32) {
+	t.Helper()
 	select {
 	case <-time.After(ensureTimeout):
-		panic("Timeout expired while waiting for NewRound event")
+		t.Fatal("Timeout expired while waiting for NewRound event")
 	case msg := <-roundCh:
 		newRoundEvent, ok := msg.Data().(types.EventDataNewRound)
 		if !ok {
-			panic(fmt.Sprintf("expected a EventDataNewRound, got %T. Wrong subscription channel?",
-				msg.Data()))
+			t.Fatalf("expected a EventDataNewRound, got %T. Wrong subscription channel?", msg.Data())
 		}
 		if newRoundEvent.Height != height {
-			panic(fmt.Sprintf("expected height %v, got %v", height, newRoundEvent.Height))
+			t.Fatalf("expected height %v, got %v", height, newRoundEvent.Height)
 		}
 		if newRoundEvent.Round != round {
-			panic(fmt.Sprintf("expected round %v, got %v", round, newRoundEvent.Round))
+			t.Fatalf("expected round %v, got %v", round, newRoundEvent.Round)
 		}
 	}
 }
 
-func ensureNewTimeout(timeoutCh <-chan tmpubsub.Message, height int64, round int32, timeout int64) {
+func ensureNewTimeout(t *testing.T, timeoutCh <-chan tmpubsub.Message, height int64, round int32, timeout int64) {
+	t.Helper()
 	timeoutDuration := time.Duration(timeout*10) * time.Nanosecond
-	ensureNewEvent(timeoutCh, height, round, timeoutDuration,
+	ensureNewEvent(t, timeoutCh, height, round, timeoutDuration,
 		"Timeout expired while waiting for NewTimeout event")
 }
 
-func ensureNewProposal(proposalCh <-chan tmpubsub.Message, height int64, round int32) {
+func ensureNewProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32) {
+	t.Helper()
 	select {
 	case <-time.After(ensureTimeout):
-		panic("Timeout expired while waiting for NewProposal event")
+		t.Fatalf("Timeout expired while waiting for NewProposal event")
 	case msg := <-proposalCh:
 		proposalEvent, ok := msg.Data().(types.EventDataCompleteProposal)
 		if !ok {
-			panic(fmt.Sprintf("expected a EventDataCompleteProposal, got %T. Wrong subscription channel?",
-				msg.Data()))
+			t.Fatalf("expected a EventDataCompleteProposal, got %T. Wrong subscription channel?",
+				msg.Data())
 		}
 		if proposalEvent.Height != height {
-			panic(fmt.Sprintf("expected height %v, got %v", height, proposalEvent.Height))
+			t.Fatalf("expected height %v, got %v", height, proposalEvent.Height)
 		}
 		if proposalEvent.Round != round {
-			panic(fmt.Sprintf("expected round %v, got %v", round, proposalEvent.Round))
+			t.Fatalf("expected round %v, got %v", round, proposalEvent.Round)
 		}
 	}
 }
 
-func ensureNewValidBlock(validBlockCh <-chan tmpubsub.Message, height int64, round int32) {
-	ensureNewEvent(validBlockCh, height, round, ensureTimeout,
+func ensureNewValidBlock(t *testing.T, validBlockCh <-chan tmpubsub.Message, height int64, round int32) {
+	t.Helper()
+	ensureNewEvent(t, validBlockCh, height, round, ensureTimeout,
 		"Timeout expired while waiting for NewValidBlock event")
 }
 
-func ensureNewBlock(blockCh <-chan tmpubsub.Message, height int64) {
+func ensureNewBlock(t *testing.T, blockCh <-chan tmpubsub.Message, height int64) {
+	t.Helper()
 	select {
 	case <-time.After(ensureTimeout):
-		panic("Timeout expired while waiting for NewBlock event")
+		t.Fatalf("Timeout expired while waiting for NewBlock event")
 	case msg := <-blockCh:
 		blockEvent, ok := msg.Data().(types.EventDataNewBlock)
 		if !ok {
-			panic(fmt.Sprintf("expected a EventDataNewBlock, got %T. Wrong subscription channel?",
-				msg.Data()))
+			t.Fatalf("expected a EventDataNewBlock, got %T. Wrong subscription channel?",
+				msg.Data())
 		}
 		if blockEvent.Block.Height != height {
-			panic(fmt.Sprintf("expected height %v, got %v", height, blockEvent.Block.Height))
+			t.Fatalf("expected height %v, got %v", height, blockEvent.Block.Height)
 		}
 	}
 }
 
-func ensureNewBlockHeader(blockCh <-chan tmpubsub.Message, height int64, blockHash tmbytes.HexBytes) {
+func ensureNewBlockHeader(t *testing.T, blockCh <-chan tmpubsub.Message, height int64, blockHash tmbytes.HexBytes) {
+	t.Helper()
 	select {
 	case <-time.After(ensureTimeout):
-		panic("Timeout expired while waiting for NewBlockHeader event")
+		t.Fatalf("Timeout expired while waiting for NewBlockHeader event")
 	case msg := <-blockCh:
 		blockHeaderEvent, ok := msg.Data().(types.EventDataNewBlockHeader)
 		if !ok {
-			panic(fmt.Sprintf("expected a EventDataNewBlockHeader, got %T. Wrong subscription channel?",
-				msg.Data()))
+			t.Fatalf("expected a EventDataNewBlockHeader, got %T. Wrong subscription channel?",
+				msg.Data())
 		}
 		if blockHeaderEvent.Header.Height != height {
-			panic(fmt.Sprintf("expected height %v, got %v", height, blockHeaderEvent.Header.Height))
+			t.Fatalf("expected height %v, got %v", height, blockHeaderEvent.Header.Height)
 		}
 		if !bytes.Equal(blockHeaderEvent.Header.Hash(), blockHash) {
-			panic(fmt.Sprintf("expected header %X, got %X", blockHash, blockHeaderEvent.Header.Hash()))
+			t.Fatalf("expected header %X, got %X", blockHash, blockHeaderEvent.Header.Hash())
 		}
 	}
 }
 
-func ensureNewUnlock(unlockCh <-chan tmpubsub.Message, height int64, round int32) {
-	ensureNewEvent(unlockCh, height, round, ensureTimeout,
+func ensureNewUnlock(t *testing.T, unlockCh <-chan tmpubsub.Message, height int64, round int32) {
+	t.Helper()
+	ensureNewEvent(t, unlockCh, height, round, ensureTimeout,
 		"Timeout expired while waiting for NewUnlock event")
 }
 
-func ensureProposal(proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID) {
+func ensureLock(t *testing.T, lockCh <-chan tmpubsub.Message, height int64, round int32) {
+	t.Helper()
+	ensureNewEvent(t, lockCh, height, round, ensureTimeout,
+		"Timeout expired while waiting for LockValue event")
+}
+
+func ensureProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID) {
+	t.Helper()
 	select {
 	case <-time.After(ensureTimeout):
-		panic("Timeout expired while waiting for NewProposal event")
+		t.Fatalf("Timeout expired while waiting for NewProposal event")
 	case msg := <-proposalCh:
 		proposalEvent, ok := msg.Data().(types.EventDataCompleteProposal)
 		if !ok {
-			panic(fmt.Sprintf("expected a EventDataCompleteProposal, got %T. Wrong subscription channel?",
-				msg.Data()))
+			t.Fatalf("expected a EventDataCompleteProposal, got %T. Wrong subscription channel?",
+				msg.Data())
 		}
 		if proposalEvent.Height != height {
-			panic(fmt.Sprintf("expected height %v, got %v", height, proposalEvent.Height))
+			t.Fatalf("expected height %v, got %v", height, proposalEvent.Height)
 		}
 		if proposalEvent.Round != round {
-			panic(fmt.Sprintf("expected round %v, got %v", round, proposalEvent.Round))
+			t.Fatalf("expected round %v, got %v", round, proposalEvent.Round)
 		}
 		if !proposalEvent.BlockID.Equals(propID) {
-			panic(fmt.Sprintf("Proposed block does not match expected block (%v != %v)", proposalEvent.BlockID, propID))
+			t.Fatalf("Proposed block does not match expected block (%v != %v)", proposalEvent.BlockID, propID)
 		}
 	}
 }
 
-func ensurePrecommit(voteCh <-chan tmpubsub.Message, height int64, round int32) {
-	ensureVote(voteCh, height, round, tmproto.PrecommitType)
+func ensurePrecommit(t *testing.T, voteCh <-chan tmpubsub.Message, height int64, round int32) {
+	t.Helper()
+	ensureVote(t, voteCh, height, round, tmproto.PrecommitType)
 }
 
-func ensurePrevote(voteCh <-chan tmpubsub.Message, height int64, round int32) {
-	ensureVote(voteCh, height, round, tmproto.PrevoteType)
+func ensurePrevote(t *testing.T, voteCh <-chan tmpubsub.Message, height int64, round int32) {
+	t.Helper()
+	ensureVote(t, voteCh, height, round, tmproto.PrevoteType)
 }
 
-func ensureVote(voteCh <-chan tmpubsub.Message, height int64, round int32,
+func ensureVote(t *testing.T, voteCh <-chan tmpubsub.Message, height int64, round int32,
 	voteType tmproto.SignedMsgType) {
+	t.Helper()
 	select {
 	case <-time.After(ensureTimeout):
-		panic("Timeout expired while waiting for NewVote event")
+		t.Fatalf("Timeout expired while waiting for NewVote event")
 	case msg := <-voteCh:
 		voteEvent, ok := msg.Data().(types.EventDataVote)
 		if !ok {
-			panic(fmt.Sprintf("expected a EventDataVote, got %T. Wrong subscription channel?",
-				msg.Data()))
+			t.Fatalf("expected a EventDataVote, got %T. Wrong subscription channel?",
+				msg.Data())
 		}
 		vote := voteEvent.Vote
 		if vote.Height != height {
-			panic(fmt.Sprintf("expected height %v, got %v", height, vote.Height))
+			t.Fatalf("expected height %v, got %v", height, vote.Height)
 		}
 		if vote.Round != round {
-			panic(fmt.Sprintf("expected round %v, got %v", round, vote.Round))
+			t.Fatalf("expected round %v, got %v", round, vote.Round)
 		}
 		if vote.Type != voteType {
-			panic(fmt.Sprintf("expected type %v, got %v", voteType, vote.Type))
+			t.Fatalf("expected type %v, got %v", voteType, vote.Type)
 		}
 	}
 }
 
-func ensurePrecommitTimeout(ch <-chan tmpubsub.Message) {
+func ensurePrecommitTimeout(t *testing.T, ch <-chan tmpubsub.Message) {
+	t.Helper()
 	select {
 	case <-time.After(ensureTimeout):
-		panic("Timeout expired while waiting for the Precommit to Timeout")
+		t.Fatalf("Timeout expired while waiting for the Precommit to Timeout")
 	case <-ch:
 	}
 }
 
-func ensureNewEventOnChannel(ch <-chan tmpubsub.Message) {
+func ensureNewEventOnChannel(t *testing.T, ch <-chan tmpubsub.Message) {
+	t.Helper()
 	select {
 	case <-time.After(ensureTimeout):
-		panic("Timeout expired while waiting for new activity on the channel")
+		t.Fatalf("Timeout expired while waiting for new activity on the channel")
 	case <-ch:
 	}
 }
@@ -731,7 +761,7 @@ func randConsensusState(
 			opt(thisConfig)
 		}
 
-		ensureDir(filepath.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
+		ensureDir(t, filepath.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
 
 		app := appFunc()
 
@@ -759,6 +789,7 @@ func randConsensusState(
 
 // nPeers = nValidators + nNotValidator
 func randConsensusNetWithPeers(
+	t *testing.T,
 	config *cfg.Config,
 	nValidators,
 	nPeers int,
@@ -768,6 +799,7 @@ func randConsensusNetWithPeers(
 ) ([]*State, *types.GenesisDoc, *cfg.Config, cleanupFunc) {
 	genDoc, privVals := factory.RandGenesisDoc(config, nValidators, false, testMinPower)
 	css := make([]*State, nPeers)
+	t.Helper()
 	logger := consensusLogger()
 
 	var peer0Config *cfg.Config
@@ -776,7 +808,7 @@ func randConsensusNetWithPeers(
 		state, _ := sm.MakeGenesisState(genDoc)
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		configRootDirs = append(configRootDirs, thisConfig.RootDir)
-		ensureDir(filepath.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
+		ensureDir(t, filepath.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
 		if i == 0 {
 			peer0Config = thisConfig
 		}
@@ -786,16 +818,16 @@ func randConsensusNetWithPeers(
 		} else {
 			tempKeyFile, err := ioutil.TempFile("", "priv_validator_key_")
 			if err != nil {
-				panic(err)
+				t.Fatalf("error creating temp file for validator key: %s", err)
 			}
 			tempStateFile, err := ioutil.TempFile("", "priv_validator_state_")
 			if err != nil {
-				panic(err)
+				t.Fatalf("error loading validator state: %s", err)
 			}
 
 			privVal, err = privval.GenFilePV(tempKeyFile.Name(), tempStateFile.Name(), "")
 			if err != nil {
-				panic(err)
+				t.Fatalf("error generating validator key: %s", err)
 			}
 		}
 

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -531,7 +531,7 @@ func ensureNoNewTimeout(t *testing.T, stepCh <-chan tmpubsub.Message, timeout in
 		"We should be stuck waiting, not receiving NewTimeout event")
 }
 
-func ensureNewEvent(t *testing.T, ch <-chan tmpubsub.Message, height int64, round int32, timeout time.Duration, errorMessage string) {
+func ensureNewEvent(t *testing.T, ch <-chan tmpubsub.Message, height int64, round int32, timeout time.Duration, errorMessage string) { //nolint: lll
 	t.Helper()
 	select {
 	case <-time.After(timeout):

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -40,12 +40,12 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
 	startTestRound(cs, height, round)
 
-	ensureNewEventOnChannel(newBlockCh) // first block gets committed
-	ensureNoNewEventOnChannel(newBlockCh)
+	ensureNewEventOnChannel(t, newBlockCh) // first block gets committed
+	ensureNoNewEventOnChannel(t, newBlockCh)
 	deliverTxsRange(cs, 0, 1)
-	ensureNewEventOnChannel(newBlockCh) // commit txs
-	ensureNewEventOnChannel(newBlockCh) // commit updated app hash
-	ensureNoNewEventOnChannel(newBlockCh)
+	ensureNewEventOnChannel(t, newBlockCh) // commit txs
+	ensureNewEventOnChannel(t, newBlockCh) // commit updated app hash
+	ensureNoNewEventOnChannel(t, newBlockCh)
 }
 
 func TestMempoolProgressAfterCreateEmptyBlocksInterval(t *testing.T) {
@@ -63,9 +63,9 @@ func TestMempoolProgressAfterCreateEmptyBlocksInterval(t *testing.T) {
 	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
 	startTestRound(cs, cs.Height, cs.Round)
 
-	ensureNewEventOnChannel(newBlockCh)   // first block gets committed
-	ensureNoNewEventOnChannel(newBlockCh) // then we dont make a block ...
-	ensureNewEventOnChannel(newBlockCh)   // until the CreateEmptyBlocksInterval has passed
+	ensureNewEventOnChannel(t, newBlockCh)   // first block gets committed
+	ensureNoNewEventOnChannel(t, newBlockCh) // then we dont make a block ...
+	ensureNewEventOnChannel(t, newBlockCh)   // until the CreateEmptyBlocksInterval has passed
 }
 
 func TestMempoolProgressInHigherRound(t *testing.T) {
@@ -93,19 +93,19 @@ func TestMempoolProgressInHigherRound(t *testing.T) {
 	}
 	startTestRound(cs, height, round)
 
-	ensureNewRound(newRoundCh, height, round) // first round at first height
-	ensureNewEventOnChannel(newBlockCh)       // first block gets committed
+	ensureNewRound(t, newRoundCh, height, round) // first round at first height
+	ensureNewEventOnChannel(t, newBlockCh)       // first block gets committed
 
 	height++ // moving to the next height
 	round = 0
 
-	ensureNewRound(newRoundCh, height, round) // first round at next height
-	deliverTxsRange(cs, 0, 1)                 // we deliver txs, but dont set a proposal so we get the next round
-	ensureNewTimeout(timeoutCh, height, round, cs.config.TimeoutPropose.Nanoseconds())
+	ensureNewRound(t, newRoundCh, height, round) // first round at next height
+	deliverTxsRange(cs, 0, 1)                    // we deliver txs, but dont set a proposal so we get the next round
+	ensureNewTimeout(t, timeoutCh, height, round, cs.config.TimeoutPropose.Nanoseconds())
 
-	round++                                   // moving to the next round
-	ensureNewRound(newRoundCh, height, round) // wait for the next round
-	ensureNewEventOnChannel(newBlockCh)       // now we can commit the block
+	round++                                      // moving to the next round
+	ensureNewRound(t, newRoundCh, height, round) // wait for the next round
+	ensureNewEventOnChannel(t, newBlockCh)       // now we can commit the block
 }
 
 func deliverTxsRange(cs *State, start, end int) {

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -336,7 +336,7 @@ func TestReactorWithEvidence(t *testing.T) {
 
 		defer os.RemoveAll(thisConfig.RootDir)
 
-		ensureDir(path.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
+		ensureDir(t, path.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
 		app := appFunc()
 		vals := types.TM2PB.ValidatorUpdates(state.Validators)
 		app.InitChain(abci.RequestInitChain{Validators: vals})
@@ -627,6 +627,7 @@ func TestReactorValidatorSetChanges(t *testing.T) {
 	nPeers := 7
 	nVals := 4
 	states, _, _, cleanup := randConsensusNetWithPeers(
+		t,
 		config,
 		nVals,
 		nPeers,

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -67,7 +67,7 @@ func TestStateProposerSelection0(t *testing.T) {
 	startTestRound(cs1, height, round)
 
 	// Wait for new round so proposer is set.
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	// Commit a block and ensure proposer for the next height is correct.
 	prop := cs1.GetRoundState().Validators.GetProposer()
@@ -79,13 +79,13 @@ func TestStateProposerSelection0(t *testing.T) {
 	}
 
 	// Wait for complete proposal.
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 
 	rs := cs1.GetRoundState()
 	signAddVotes(config, cs1, tmproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), vss[1:]...)
 
 	// Wait for new round so next validator is set.
-	ensureNewRound(newRoundCh, height+1, 0)
+	ensureNewRound(t, newRoundCh, height+1, 0)
 
 	prop = cs1.GetRoundState().Validators.GetProposer()
 	pv1, err := vss[1].GetPubKey(context.Background())
@@ -111,7 +111,7 @@ func TestStateProposerSelection2(t *testing.T) {
 	var round int32 = 2
 	startTestRound(cs1, height, round)
 
-	ensureNewRound(newRoundCh, height, round) // wait for the new round
+	ensureNewRound(t, newRoundCh, height, round) // wait for the new round
 
 	// everyone just votes nil. we get a new proposer each round
 	for i := int32(0); int(i) < len(vss); i++ {
@@ -129,7 +129,7 @@ func TestStateProposerSelection2(t *testing.T) {
 
 		rs := cs1.GetRoundState()
 		signAddVotes(config, cs1, tmproto.PrecommitType, nil, rs.ProposalBlockParts.Header(), vss[1:]...)
-		ensureNewRound(newRoundCh, height, i+round+1) // wait for the new round event each round
+		ensureNewRound(t, newRoundCh, height, i+round+1) // wait for the new round event each round
 		incrementRound(vss[1:]...)
 	}
 
@@ -149,7 +149,7 @@ func TestStateEnterProposeNoPrivValidator(t *testing.T) {
 	startTestRound(cs, height, round)
 
 	// if we're not a validator, EnterPropose should timeout
-	ensureNewTimeout(timeoutCh, height, round, cs.config.TimeoutPropose.Nanoseconds())
+	ensureNewTimeout(t, timeoutCh, height, round, cs.config.TimeoutPropose.Nanoseconds())
 
 	if cs.GetRoundState().Proposal != nil {
 		t.Error("Expected to make no proposal, since no privValidator")
@@ -171,7 +171,7 @@ func TestStateEnterProposeYesPrivValidator(t *testing.T) {
 	cs.enterNewRound(height, round)
 	cs.startRoutines(3)
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 
 	// Check that Proposal, ProposalBlock, ProposalBlockParts are set.
 	rs := cs.GetRoundState()
@@ -186,7 +186,7 @@ func TestStateEnterProposeYesPrivValidator(t *testing.T) {
 	}
 
 	// if we're a validator, enterPropose should not timeout
-	ensureNoNewTimeout(timeoutCh, cs.config.TimeoutPropose.Nanoseconds())
+	ensureNoNewTimeout(t, timeoutCh, cs.config.TimeoutPropose.Nanoseconds())
 }
 
 func TestStateBadProposal(t *testing.T) {
@@ -233,18 +233,18 @@ func TestStateBadProposal(t *testing.T) {
 	startTestRound(cs1, height, round)
 
 	// wait for proposal
-	ensureProposal(proposalCh, height, round, blockID)
+	ensureProposal(t, proposalCh, height, round, blockID)
 
 	// wait for prevote
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], nil)
 
 	// add bad prevote from vs2 and wait for it
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlock.Hash(), propBlock.MakePartSet(partSize).Header(), vs2)
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 
 	// wait for precommit
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	validatePrecommit(t, cs1, round, -1, vss[0], nil, nil)
 	signAddVotes(config, cs1, tmproto.PrecommitType, propBlock.Hash(), propBlock.MakePartSet(partSize).Header(), vs2)
 }
@@ -296,15 +296,15 @@ func TestStateOversizedBlock(t *testing.T) {
 
 	// c1 should log an error with the block part message as it exceeds the consensus params. The
 	// block is not added to cs.ProposalBlock so the node timeouts.
-	ensureNewTimeout(timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
 
 	// and then should send nil prevote and precommit regardless of whether other validators prevote and
 	// precommit on it
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], nil)
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlock.Hash(), propBlock.MakePartSet(partSize).Header(), vs2)
-	ensurePrevote(voteCh, height, round)
-	ensurePrecommit(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	validatePrecommit(t, cs1, round, -1, vss[0], nil, nil)
 	signAddVotes(config, cs1, tmproto.PrecommitType, propBlock.Hash(), propBlock.MakePartSet(partSize).Header(), vs2)
 }
@@ -338,18 +338,18 @@ func TestStateFullRound1(t *testing.T) {
 	// Maybe it would be better to call explicitly startRoutines(4)
 	startTestRound(cs, height, round)
 
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensureNewProposal(propCh, height, round)
+	ensureNewProposal(t, propCh, height, round)
 	propBlockHash := cs.GetRoundState().ProposalBlock.Hash()
 
-	ensurePrevote(voteCh, height, round) // wait for prevote
+	ensurePrevote(t, voteCh, height, round) // wait for prevote
 	validatePrevote(t, cs, round, vss[0], propBlockHash)
 
-	ensurePrecommit(voteCh, height, round) // wait for precommit
+	ensurePrecommit(t, voteCh, height, round) // wait for precommit
 
 	// we're going to roll right into new height
-	ensureNewRound(newRoundCh, height+1, 0)
+	ensureNewRound(t, newRoundCh, height+1, 0)
 
 	validateLastPrecommit(t, cs, vss[0], propBlockHash)
 }
@@ -366,8 +366,8 @@ func TestStateFullRoundNil(t *testing.T) {
 	cs.enterPrevote(height, round)
 	cs.startRoutines(4)
 
-	ensurePrevote(voteCh, height, round)   // prevote
-	ensurePrecommit(voteCh, height, round) // precommit
+	ensurePrevote(t, voteCh, height, round)   // prevote
+	ensurePrecommit(t, voteCh, height, round) // precommit
 
 	// should prevote and precommit nil
 	validatePrevoteAndPrecommit(t, cs, round, -1, vss[0], nil, nil)
@@ -388,7 +388,7 @@ func TestStateFullRound2(t *testing.T) {
 	// start round and wait for propose and prevote
 	startTestRound(cs1, height, round)
 
-	ensurePrevote(voteCh, height, round) // prevote
+	ensurePrevote(t, voteCh, height, round) // prevote
 
 	// we should be stuck in limbo waiting for more prevotes
 	rs := cs1.GetRoundState()
@@ -396,9 +396,9 @@ func TestStateFullRound2(t *testing.T) {
 
 	// prevote arrives from vs2:
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlockHash, propPartSetHeader, vs2)
-	ensurePrevote(voteCh, height, round) // prevote
+	ensurePrevote(t, voteCh, height, round) // prevote
 
-	ensurePrecommit(voteCh, height, round) // precommit
+	ensurePrecommit(t, voteCh, height, round) // precommit
 	// the proposed block should now be locked and our precommit added
 	validatePrecommit(t, cs1, 0, 0, vss[0], propBlockHash, propBlockHash)
 
@@ -406,10 +406,10 @@ func TestStateFullRound2(t *testing.T) {
 
 	// precommit arrives from vs2:
 	signAddVotes(config, cs1, tmproto.PrecommitType, propBlockHash, propPartSetHeader, vs2)
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 
 	// wait to finish commit, propose in next height
-	ensureNewBlock(newBlockCh, height)
+	ensureNewBlock(t, newBlockCh, height)
 }
 
 //------------------------------------------------------------------------------------------
@@ -440,21 +440,21 @@ func TestStateLockNoPOL(t *testing.T) {
 	cs1.enterNewRound(height, round)
 	cs1.startRoutines(0)
 
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	roundState := cs1.GetRoundState()
 	theBlockHash := roundState.ProposalBlock.Hash()
 	thePartSetHeader := roundState.ProposalBlockParts.Header()
 
-	ensurePrevote(voteCh, height, round) // prevote
+	ensurePrevote(t, voteCh, height, round) // prevote
 
 	// we should now be stuck in limbo forever, waiting for more prevotes
 	// prevote arrives from vs2:
 	signAddVotes(config, cs1, tmproto.PrevoteType, theBlockHash, thePartSetHeader, vs2)
-	ensurePrevote(voteCh, height, round) // prevote
+	ensurePrevote(t, voteCh, height, round) // prevote
 
-	ensurePrecommit(voteCh, height, round) // precommit
+	ensurePrecommit(t, voteCh, height, round) // precommit
 	// the proposed block should now be locked and our precommit added
 	validatePrecommit(t, cs1, round, round, vss[0], theBlockHash, theBlockHash)
 
@@ -464,16 +464,16 @@ func TestStateLockNoPOL(t *testing.T) {
 	copy(hash, theBlockHash)
 	hash[0] = (hash[0] + 1) % 255
 	signAddVotes(config, cs1, tmproto.PrecommitType, hash, thePartSetHeader, vs2)
-	ensurePrecommit(voteCh, height, round) // precommit
+	ensurePrecommit(t, voteCh, height, round) // precommit
 
 	// (note we're entering precommit for a second time this round)
 	// but with invalid args. then we enterPrecommitWait, and the timeout to new round
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	///
 
 	round++ // moving to the next round
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 	t.Log("#### ONTO ROUND 1")
 	/*
 		Round2 (cs1, B) // B B2
@@ -482,7 +482,7 @@ func TestStateLockNoPOL(t *testing.T) {
 	incrementRound(vs2)
 
 	// now we're on a new round and not the proposer, so wait for timeout
-	ensureNewTimeout(timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
 
 	rs := cs1.GetRoundState()
 
@@ -491,33 +491,33 @@ func TestStateLockNoPOL(t *testing.T) {
 	}
 
 	// wait to finish prevote
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	// we should have prevoted our locked block
 	validatePrevote(t, cs1, round, vss[0], rs.LockedBlock.Hash())
 
 	// add a conflicting prevote from the other validator
 	signAddVotes(config, cs1, tmproto.PrevoteType, hash, rs.LockedBlock.MakePartSet(partSize).Header(), vs2)
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 
 	// now we're going to enter prevote again, but with invalid args
 	// and then prevote wait, which should timeout. then wait for precommit
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Prevote(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Prevote(round).Nanoseconds())
 
-	ensurePrecommit(voteCh, height, round) // precommit
+	ensurePrecommit(t, voteCh, height, round) // precommit
 	// the proposed block should still be locked and our precommit added
 	// we should precommit nil and be locked on the proposal
 	validatePrecommit(t, cs1, round, 0, vss[0], nil, theBlockHash)
 
 	// add conflicting precommit from vs2
 	signAddVotes(config, cs1, tmproto.PrecommitType, hash, rs.LockedBlock.MakePartSet(partSize).Header(), vs2)
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 
 	// (note we're entering precommit for a second time this round, but with invalid args
 	// then we enterPrecommitWait and timeout into NewRound
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	round++ // entering new round
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 	t.Log("#### ONTO ROUND 2")
 	/*
 		Round3 (vs2, _) // B, B2
@@ -525,7 +525,7 @@ func TestStateLockNoPOL(t *testing.T) {
 
 	incrementRound(vs2)
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs = cs1.GetRoundState()
 
 	// now we're on a new round and are the proposer
@@ -536,14 +536,14 @@ func TestStateLockNoPOL(t *testing.T) {
 			rs.LockedBlock))
 	}
 
-	ensurePrevote(voteCh, height, round) // prevote
+	ensurePrevote(t, voteCh, height, round) // prevote
 	validatePrevote(t, cs1, round, vss[0], rs.LockedBlock.Hash())
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, hash, rs.ProposalBlock.MakePartSet(partSize).Header(), vs2)
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Prevote(round).Nanoseconds())
-	ensurePrecommit(voteCh, height, round) // precommit
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Prevote(round).Nanoseconds())
+	ensurePrecommit(t, voteCh, height, round) // precommit
 
 	validatePrecommit(t, cs1, round, 0, vss[0], nil, theBlockHash) // precommit nil but be locked on proposal
 
@@ -554,13 +554,13 @@ func TestStateLockNoPOL(t *testing.T) {
 		hash,
 		rs.ProposalBlock.MakePartSet(partSize).Header(),
 		vs2) // NOTE: conflicting precommits at same height
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	cs2, _ := randState(config, 2) // needed so generated block is different than locked block
 	// before we time out into new round, set next proposal block
-	prop, propBlock := decideProposal(cs2, vs2, vs2.Height, vs2.Round+1)
+	prop, propBlock := decideProposal(t, cs2, vs2, vs2.Height, vs2.Round+1)
 	if prop == nil || propBlock == nil {
 		t.Fatal("Failed to create proposal block with vs2")
 	}
@@ -568,7 +568,7 @@ func TestStateLockNoPOL(t *testing.T) {
 	incrementRound(vs2)
 
 	round++ // entering new round
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 	t.Log("#### ONTO ROUND 3")
 	/*
 		Round4 (vs2, C) // B C // B C
@@ -580,17 +580,17 @@ func TestStateLockNoPOL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ensureNewProposal(proposalCh, height, round)
-	ensurePrevote(voteCh, height, round) // prevote
+	ensureNewProposal(t, proposalCh, height, round)
+	ensurePrevote(t, voteCh, height, round) // prevote
 	// prevote for locked block (not proposal)
 	validatePrevote(t, cs1, 3, vss[0], cs1.LockedBlock.Hash())
 
 	// prevote for proposed block
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlock.Hash(), propBlock.MakePartSet(partSize).Header(), vs2)
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Prevote(round).Nanoseconds())
-	ensurePrecommit(voteCh, height, round)
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Prevote(round).Nanoseconds())
+	ensurePrecommit(t, voteCh, height, round)
 	validatePrecommit(t, cs1, round, 0, vss[0], nil, theBlockHash) // precommit nil but locked on proposal
 
 	signAddVotes(
@@ -600,7 +600,7 @@ func TestStateLockNoPOL(t *testing.T) {
 		propBlock.Hash(),
 		propBlock.MakePartSet(partSize).Header(),
 		vs2) // NOTE: conflicting precommits at same height
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 }
 
 // 4 vals in two rounds,
@@ -636,17 +636,17 @@ func TestStateLockPOLRelock(t *testing.T) {
 	// start round and wait for propose and prevote
 	startTestRound(cs1, height, round)
 
-	ensureNewRound(newRoundCh, height, round)
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs := cs1.GetRoundState()
 	theBlockHash := rs.ProposalBlock.Hash()
 	theBlockParts := rs.ProposalBlockParts.Header()
 
-	ensurePrevote(voteCh, height, round) // prevote
+	ensurePrevote(t, voteCh, height, round) // prevote
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, theBlockHash, theBlockParts, vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round) // our precommit
+	ensurePrecommit(t, voteCh, height, round) // our precommit
 	// the proposed block should now be locked and our precommit added
 	validatePrecommit(t, cs1, round, round, vss[0], theBlockHash, theBlockHash)
 
@@ -655,7 +655,7 @@ func TestStateLockPOLRelock(t *testing.T) {
 
 	// before we timeout to the new round set the new proposal
 	cs2 := newState(cs1.state, vs2, kvstore.NewApplication())
-	prop, propBlock := decideProposal(cs2, vs2, vs2.Height, vs2.Round+1)
+	prop, propBlock := decideProposal(t, cs2, vs2, vs2.Height, vs2.Round+1)
 	if prop == nil || propBlock == nil {
 		t.Fatal("Failed to create proposal block with vs2")
 	}
@@ -666,7 +666,7 @@ func TestStateLockPOLRelock(t *testing.T) {
 	incrementRound(vs2, vs3, vs4)
 
 	// timeout to new round
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	round++ // moving to the next round
 	//XXX: this isnt guaranteed to get there before the timeoutPropose ...
@@ -674,7 +674,7 @@ func TestStateLockPOLRelock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 	t.Log("### ONTO ROUND 1")
 
 	/*
@@ -685,24 +685,26 @@ func TestStateLockPOLRelock(t *testing.T) {
 
 	// now we're on a new round and not the proposer
 	// but we should receive the proposal
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 
 	// go to prevote, node should prevote for locked block (not the new proposal) - this is relocking
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], theBlockHash)
 
 	// now lets add prevotes from everyone else for the new block
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlockHash, propBlockParts.Header(), vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round)
+	ensureLock(t, lockCh, height, round)
+
+	ensurePrecommit(t, voteCh, height, round)
 	// we should have unlocked and locked on the new block, sending a precommit for this new block
 	validatePrecommit(t, cs1, round, round, vss[0], propBlockHash, propBlockHash)
 
 	// more prevote creating a majority on the new block and this is then committed
 	signAddVotes(config, cs1, tmproto.PrecommitType, propBlockHash, propBlockParts.Header(), vs2, vs3)
-	ensureNewBlockHeader(newBlockCh, height, propBlockHash)
+	ensureNewBlockHeader(t, newBlockCh, height, propBlockHash)
 
-	ensureNewRound(newRoundCh, height+1, 0)
+	ensureNewRound(t, newRoundCh, height+1, 0)
 }
 
 // 4 vals, one precommits, other 3 polka at next round, so we unlock and precomit the polka
@@ -733,20 +735,21 @@ func TestStateLockPOLUnlock(t *testing.T) {
 
 	// start round and wait for propose and prevote
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs := cs1.GetRoundState()
 	theBlockHash := rs.ProposalBlock.Hash()
 	theBlockParts := rs.ProposalBlockParts.Header()
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], theBlockHash)
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, theBlockHash, theBlockParts, vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round)
-	// the proposed block should now be locked and our precommit added
+
+	ensurePrecommit(t, voteCh, height, round)
+	// the proposed block should now be locked and our should be for this locked block.
 	validatePrecommit(t, cs1, round, round, vss[0], theBlockHash, theBlockHash)
 
 	// add precommits from the rest
@@ -776,24 +779,24 @@ func TestStateLockPOLUnlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 
 	// go to prevote, prevote for locked block (not proposal)
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], lockedBlockHash)
 	// now lets add prevotes from everyone else for nil (a polka!)
 	signAddVotes(config, cs1, tmproto.PrevoteType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
 	// the polka makes us unlock and precommit nil
-	ensureNewUnlock(unlockCh, height, round)
-	ensurePrecommit(voteCh, height, round)
+	ensureNewUnlock(t, unlockCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 
 	// we should have unlocked and committed nil
 	// NOTE: since we don't relock on nil, the lock round is -1
 	validatePrecommit(t, cs1, round, -1, vss[0], nil, nil)
 
 	signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vs2, vs3)
-	ensureNewRound(newRoundCh, height, round+1)
+	ensureNewRound(t, newRoundCh, height, round+1)
 }
 
 // 4 vals, v1 locks on proposed block in the first round but the other validators only prevote
@@ -825,17 +828,17 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 	// start round and wait for propose and prevote
 	startTestRound(cs1, height, round)
 
-	ensureNewRound(newRoundCh, height, round)
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs := cs1.GetRoundState()
 	firstBlockHash := rs.ProposalBlock.Hash()
 	firstBlockParts := rs.ProposalBlockParts.Header()
 
-	ensurePrevote(voteCh, height, round) // prevote
+	ensurePrevote(t, voteCh, height, round) // prevote
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, firstBlockHash, firstBlockParts, vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round) // our precommit
+	ensurePrecommit(t, voteCh, height, round) // our precommit
 	// the proposed block should now be locked and our precommit added
 	validatePrecommit(t, cs1, round, round, vss[0], firstBlockHash, firstBlockHash)
 
@@ -844,7 +847,7 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 
 	// before we timeout to the new round set the new proposal
 	cs2 := newState(cs1.state, vs2, kvstore.NewApplication())
-	prop, propBlock := decideProposal(cs2, vs2, vs2.Height, vs2.Round+1)
+	prop, propBlock := decideProposal(t, cs2, vs2, vs2.Height, vs2.Round+1)
 	if prop == nil || propBlock == nil {
 		t.Fatal("Failed to create proposal block with vs2")
 	}
@@ -855,11 +858,11 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 	incrementRound(vs2, vs3, vs4)
 
 	// timeout to new round
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	round++ // moving to the next round
 
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 	t.Log("### ONTO ROUND 1")
 
 	/*
@@ -869,13 +872,13 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 	// now we're on a new round but v1 misses the proposal
 
 	// go to prevote, node should prevote for locked block (not the new proposal) - this is relocking
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], firstBlockHash)
 
 	// now lets add prevotes from everyone else for the new block
 	signAddVotes(config, cs1, tmproto.PrevoteType, secondBlockHash, secondBlockParts.Header(), vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	// we should have unlocked and locked on the new block, sending a precommit for this new block
 	validatePrecommit(t, cs1, round, -1, vss[0], nil, nil)
 
@@ -888,7 +891,7 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 
 	// before we timeout to the new round set the new proposal
 	cs3 := newState(cs1.state, vs3, kvstore.NewApplication())
-	prop, propBlock = decideProposal(cs3, vs3, vs3.Height, vs3.Round+1)
+	prop, propBlock = decideProposal(t, cs3, vs3, vs3.Height, vs3.Round+1)
 	if prop == nil || propBlock == nil {
 		t.Fatal("Failed to create proposal block with vs2")
 	}
@@ -899,10 +902,10 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 	incrementRound(vs2, vs3, vs4)
 
 	// timeout to new round
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	round++ // moving to the next round
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 	t.Log("### ONTO ROUND 2")
 
 	/*
@@ -913,13 +916,13 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	// we are no longer locked to the first block so we should be able to prevote
 	validatePrevote(t, cs1, round, vss[0], thirdPropBlockHash)
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, thirdPropBlockHash, thirdPropBlockParts.Header(), vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	// we have a majority, now vs1 can change lock to the third block
 	validatePrecommit(t, cs1, round, round, vss[0], thirdPropBlockHash, thirdPropBlockHash)
 }
@@ -948,13 +951,13 @@ func TestStateLockPOLSafety1(t *testing.T) {
 
 	// start round and wait for propose and prevote
 	startTestRound(cs1, cs1.Height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs := cs1.GetRoundState()
 	propBlock := rs.ProposalBlock
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], propBlock.Hash())
 
 	// the others sign a polka but we don't see it
@@ -968,19 +971,19 @@ func TestStateLockPOLSafety1(t *testing.T) {
 	signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
 	// cs1 precommit nil
-	ensurePrecommit(voteCh, height, round)
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensurePrecommit(t, voteCh, height, round)
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	t.Log("### ONTO ROUND 1")
 
-	prop, propBlock := decideProposal(cs1, vs2, vs2.Height, vs2.Round+1)
+	prop, propBlock := decideProposal(t, cs1, vs2, vs2.Height, vs2.Round+1)
 	propBlockHash := propBlock.Hash()
 	propBlockParts := propBlock.MakePartSet(partSize)
 
 	incrementRound(vs2, vs3, vs4)
 
 	round++ // moving to the next round
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	//XXX: this isnt guaranteed to get there before the timeoutPropose ...
 	if err := cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer"); err != nil {
@@ -991,7 +994,7 @@ func TestStateLockPOLSafety1(t *testing.T) {
 	// a polka happened but we didn't see it!
 	*/
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 
 	rs = cs1.GetRoundState()
 
@@ -1001,24 +1004,24 @@ func TestStateLockPOLSafety1(t *testing.T) {
 	t.Logf("new prop hash %v", fmt.Sprintf("%X", propBlockHash))
 
 	// go to prevote, prevote for proposal block
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], propBlockHash)
 
 	// now we see the others prevote for it, so we should lock on it
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlockHash, propBlockParts.Header(), vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	// we should have precommitted
 	validatePrecommit(t, cs1, round, round, vss[0], propBlockHash, propBlockHash)
 
 	signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	incrementRound(vs2, vs3, vs4)
 	round++ // moving to the next round
 
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	t.Log("### ONTO ROUND 2")
 	/*Round3
@@ -1026,10 +1029,10 @@ func TestStateLockPOLSafety1(t *testing.T) {
 	*/
 
 	// timeout of propose
-	ensureNewTimeout(timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
 
 	// finish prevote
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	// we should prevote what we're locked on
 	validatePrevote(t, cs1, round, vss[0], propBlockHash)
 
@@ -1041,7 +1044,7 @@ func TestStateLockPOLSafety1(t *testing.T) {
 
 	t.Log("Done adding prevotes!")
 
-	ensureNoNewRoundStep(newStepCh)
+	ensureNoNewRoundStep(t, newStepCh)
 }
 
 // 4 vals.
@@ -1071,7 +1074,7 @@ func TestStateLockPOLSafety2(t *testing.T) {
 
 	// the block for R0: gets polkad but we miss it
 	// (even though we signed it, shhh)
-	_, propBlock0 := decideProposal(cs1, vss[0], height, round)
+	_, propBlock0 := decideProposal(t, cs1, vss[0], height, round)
 	propBlockHash0 := propBlock0.Hash()
 	propBlockParts0 := propBlock0.MakePartSet(partSize)
 	propBlockID0 := types.BlockID{Hash: propBlockHash0, PartSetHeader: propBlockParts0.Header()}
@@ -1080,7 +1083,7 @@ func TestStateLockPOLSafety2(t *testing.T) {
 	prevotes := signVotes(config, tmproto.PrevoteType, propBlockHash0, propBlockParts0.Header(), vs2, vs3, vs4)
 
 	// the block for round 1
-	prop1, propBlock1 := decideProposal(cs1, vs2, vs2.Height, vs2.Round+1)
+	prop1, propBlock1 := decideProposal(t, cs1, vs2, vs2.Height, vs2.Round+1)
 	propBlockHash1 := propBlock1.Hash()
 	propBlockParts1 := propBlock1.MakePartSet(partSize)
 
@@ -1090,19 +1093,19 @@ func TestStateLockPOLSafety2(t *testing.T) {
 	t.Log("### ONTO Round 1")
 	// jump in at round 1
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	if err := cs1.SetProposalAndBlock(prop1, propBlock1, propBlockParts1, "some peer"); err != nil {
 		t.Fatal(err)
 	}
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], propBlockHash1)
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlockHash1, propBlockParts1.Header(), vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	// the proposed block should now be locked and our precommit added
 	validatePrecommit(t, cs1, round, round, vss[0], propBlockHash1, propBlockHash1)
 
@@ -1113,7 +1116,7 @@ func TestStateLockPOLSafety2(t *testing.T) {
 	incrementRound(vs2, vs3, vs4)
 
 	// timeout of precommit wait to new round
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	round++ // moving to the next round
 	// in round 2 we see the polkad block from round 0
@@ -1132,15 +1135,15 @@ func TestStateLockPOLSafety2(t *testing.T) {
 	// Add the pol votes
 	addVotes(cs1, prevotes...)
 
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 	t.Log("### ONTO Round 2")
 	/*Round2
 	// now we see the polka from round 1, but we shouldnt unlock
 	*/
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 
-	ensureNoNewUnlock(unlockCh)
-	ensurePrevote(voteCh, height, round)
+	ensureNoNewUnlock(t, unlockCh)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], propBlockHash1)
 
 }
@@ -1171,45 +1174,45 @@ func TestProposeValidBlock(t *testing.T) {
 
 	// start round and wait for propose and prevote
 	startTestRound(cs1, cs1.Height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs := cs1.GetRoundState()
 	propBlock := rs.ProposalBlock
 	propBlockHash := propBlock.Hash()
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], propBlockHash)
 
 	// the others sign a polka
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlockHash, propBlock.MakePartSet(partSize).Header(), vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	// we should have precommitted
 	validatePrecommit(t, cs1, round, round, vss[0], propBlockHash, propBlockHash)
 
 	signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	incrementRound(vs2, vs3, vs4)
 	round++ // moving to the next round
 
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	t.Log("### ONTO ROUND 2")
 
 	// timeout of propose
-	ensureNewTimeout(timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], propBlockHash)
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
-	ensureNewUnlock(unlockCh, height, round)
+	ensureNewUnlock(t, unlockCh, height, round)
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	// we should have precommitted
 	validatePrecommit(t, cs1, round, -1, vss[0], nil, nil)
 
@@ -1220,18 +1223,18 @@ func TestProposeValidBlock(t *testing.T) {
 
 	round += 2 // moving to the next round
 
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 	t.Log("### ONTO ROUND 3")
 
 	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	round++ // moving to the next round
 
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	t.Log("### ONTO ROUND 4")
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 
 	rs = cs1.GetRoundState()
 	assert.True(t, bytes.Equal(rs.ProposalBlock.Hash(), propBlockHash))
@@ -1262,15 +1265,15 @@ func TestSetValidBlockOnDelayedPrevote(t *testing.T) {
 
 	// start round and wait for propose and prevote
 	startTestRound(cs1, cs1.Height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs := cs1.GetRoundState()
 	propBlock := rs.ProposalBlock
 	propBlockHash := propBlock.Hash()
 	propBlockParts := propBlock.MakePartSet(partSize)
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], propBlockHash)
 
 	// vs2 send prevote for propBlock
@@ -1279,9 +1282,9 @@ func TestSetValidBlockOnDelayedPrevote(t *testing.T) {
 	// vs3 send prevote nil
 	signAddVotes(config, cs1, tmproto.PrevoteType, nil, types.PartSetHeader{}, vs3)
 
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Prevote(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Prevote(round).Nanoseconds())
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	// we should have precommitted
 	validatePrecommit(t, cs1, round, -1, vss[0], nil, nil)
 
@@ -1294,7 +1297,7 @@ func TestSetValidBlockOnDelayedPrevote(t *testing.T) {
 	// vs2 send (delayed) prevote for propBlock
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlockHash, propBlockParts.Header(), vs4)
 
-	ensureNewValidBlock(validBlockCh, height, round)
+	ensureNewValidBlock(t, validBlockCh, height, round)
 
 	rs = cs1.GetRoundState()
 
@@ -1329,31 +1332,31 @@ func TestSetValidBlockOnDelayedProposal(t *testing.T) {
 	incrementRound(vs2, vs3, vs4)
 
 	startTestRound(cs1, cs1.Height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensureNewTimeout(timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], nil)
 
-	prop, propBlock := decideProposal(cs1, vs2, vs2.Height, vs2.Round+1)
+	prop, propBlock := decideProposal(t, cs1, vs2, vs2.Height, vs2.Round+1)
 	propBlockHash := propBlock.Hash()
 	propBlockParts := propBlock.MakePartSet(partSize)
 
 	// vs2, vs3 and vs4 send prevote for propBlock
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlockHash, propBlockParts.Header(), vs2, vs3, vs4)
-	ensureNewValidBlock(validBlockCh, height, round)
+	ensureNewValidBlock(t, validBlockCh, height, round)
 
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Prevote(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Prevote(round).Nanoseconds())
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	validatePrecommit(t, cs1, round, -1, vss[0], nil, nil)
 
 	if err := cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer"); err != nil {
 		t.Fatal(err)
 	}
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs := cs1.GetRoundState()
 
 	assert.True(t, bytes.Equal(rs.ValidBlock.Hash(), propBlockHash))
@@ -1376,12 +1379,12 @@ func TestWaitingTimeoutOnNilPolka(t *testing.T) {
 
 	// start round
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
-	ensureNewRound(newRoundCh, height, round+1)
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewRound(t, newRoundCh, height, round+1)
 }
 
 // 4 vals, 3 Prevotes for nil from the higher round.
@@ -1403,22 +1406,22 @@ func TestWaitingTimeoutProposeOnNewRound(t *testing.T) {
 
 	// start round
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 
 	incrementRound(vss[1:]...)
 	signAddVotes(config, cs1, tmproto.PrevoteType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
 	round++ // moving to the next round
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	rs := cs1.GetRoundState()
 	assert.True(t, rs.Step == cstypes.RoundStepPropose) // P0 does not prevote before timeoutPropose expires
 
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Propose(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Propose(round).Nanoseconds())
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], nil)
 }
 
@@ -1441,23 +1444,23 @@ func TestRoundSkipOnNilPolkaFromHigherRound(t *testing.T) {
 
 	// start round
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 
 	incrementRound(vss[1:]...)
 	signAddVotes(config, cs1, tmproto.PrecommitType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
 	round++ // moving to the next round
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	validatePrecommit(t, cs1, round, -1, vss[0], nil, nil)
 
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	round++ // moving to the next round
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 }
 
 // 4 vals, 3 Prevotes for nil in the current round.
@@ -1479,14 +1482,14 @@ func TestWaitTimeoutProposeOnNilPolkaForTheCurrentRound(t *testing.T) {
 
 	// start round in which PO is not proposer
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	incrementRound(vss[1:]...)
 	signAddVotes(config, cs1, tmproto.PrevoteType, nil, types.PartSetHeader{}, vs2, vs3, vs4)
 
-	ensureNewTimeout(timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutProposeCh, height, round, cs1.config.Propose(round).Nanoseconds())
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], nil)
 }
 
@@ -1506,17 +1509,17 @@ func TestEmitNewValidBlockEventOnCommitWithoutBlock(t *testing.T) {
 	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
 	validBlockCh := subscribe(cs1.eventBus, types.EventQueryValidBlock)
 
-	_, propBlock := decideProposal(cs1, vs2, vs2.Height, vs2.Round)
+	_, propBlock := decideProposal(t, cs1, vs2, vs2.Height, vs2.Round)
 	propBlockHash := propBlock.Hash()
 	propBlockParts := propBlock.MakePartSet(partSize)
 
 	// start round in which PO is not proposer
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	// vs2, vs3 and vs4 send precommit for propBlock
 	signAddVotes(config, cs1, tmproto.PrecommitType, propBlockHash, propBlockParts.Header(), vs2, vs3, vs4)
-	ensureNewValidBlock(validBlockCh, height, round)
+	ensureNewValidBlock(t, validBlockCh, height, round)
 
 	rs := cs1.GetRoundState()
 	assert.True(t, rs.Step == cstypes.RoundStepCommit)
@@ -1541,18 +1544,18 @@ func TestCommitFromPreviousRound(t *testing.T) {
 	validBlockCh := subscribe(cs1.eventBus, types.EventQueryValidBlock)
 	proposalCh := subscribe(cs1.eventBus, types.EventQueryCompleteProposal)
 
-	prop, propBlock := decideProposal(cs1, vs2, vs2.Height, vs2.Round)
+	prop, propBlock := decideProposal(t, cs1, vs2, vs2.Height, vs2.Round)
 	propBlockHash := propBlock.Hash()
 	propBlockParts := propBlock.MakePartSet(partSize)
 
 	// start round in which PO is not proposer
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
 	// vs2, vs3 and vs4 send precommit for propBlock for the previous round
 	signAddVotes(config, cs1, tmproto.PrecommitType, propBlockHash, propBlockParts.Header(), vs2, vs3, vs4)
 
-	ensureNewValidBlock(validBlockCh, height, round)
+	ensureNewValidBlock(t, validBlockCh, height, round)
 
 	rs := cs1.GetRoundState()
 	assert.True(t, rs.Step == cstypes.RoundStepCommit)
@@ -1564,8 +1567,8 @@ func TestCommitFromPreviousRound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ensureNewProposal(proposalCh, height, round)
-	ensureNewRound(newRoundCh, height+1, 0)
+	ensureNewProposal(t, proposalCh, height, round)
+	ensureNewRound(t, newRoundCh, height+1, 0)
 }
 
 type fakeTxNotifier struct {
@@ -1606,19 +1609,19 @@ func TestStartNextHeightCorrectlyAfterTimeout(t *testing.T) {
 
 	// start round and wait for propose and prevote
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs := cs1.GetRoundState()
 	theBlockHash := rs.ProposalBlock.Hash()
 	theBlockParts := rs.ProposalBlockParts.Header()
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], theBlockHash)
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, theBlockHash, theBlockParts, vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	// the proposed block should now be locked and our precommit added
 	validatePrecommit(t, cs1, round, round, vss[0], theBlockHash, theBlockHash)
 
@@ -1627,18 +1630,18 @@ func TestStartNextHeightCorrectlyAfterTimeout(t *testing.T) {
 	signAddVotes(config, cs1, tmproto.PrecommitType, theBlockHash, theBlockParts, vs3)
 
 	// wait till timeout occurs
-	ensurePrecommitTimeout(precommitTimeoutCh)
+	ensurePrecommitTimeout(t, precommitTimeoutCh)
 
-	ensureNewRound(newRoundCh, height, round+1)
+	ensureNewRound(t, newRoundCh, height, round+1)
 
 	// majority is now reached
 	signAddVotes(config, cs1, tmproto.PrecommitType, theBlockHash, theBlockParts, vs4)
 
-	ensureNewBlockHeader(newBlockHeader, height, theBlockHash)
+	ensureNewBlockHeader(t, newBlockHeader, height, theBlockHash)
 
 	cs1.txNotifier.(*fakeTxNotifier).Notify()
 
-	ensureNewTimeout(timeoutProposeCh, height+1, round, cs1.config.Propose(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutProposeCh, height+1, round, cs1.config.Propose(round).Nanoseconds())
 	rs = cs1.GetRoundState()
 	assert.False(
 		t,
@@ -1668,19 +1671,19 @@ func TestResetTimeoutPrecommitUponNewHeight(t *testing.T) {
 
 	// start round and wait for propose and prevote
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs := cs1.GetRoundState()
 	theBlockHash := rs.ProposalBlock.Hash()
 	theBlockParts := rs.ProposalBlockParts.Header()
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], theBlockHash)
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, theBlockHash, theBlockParts, vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	validatePrecommit(t, cs1, round, round, vss[0], theBlockHash, theBlockHash)
 
 	// add precommits
@@ -1688,15 +1691,15 @@ func TestResetTimeoutPrecommitUponNewHeight(t *testing.T) {
 	signAddVotes(config, cs1, tmproto.PrecommitType, theBlockHash, theBlockParts, vs3)
 	signAddVotes(config, cs1, tmproto.PrecommitType, theBlockHash, theBlockParts, vs4)
 
-	ensureNewBlockHeader(newBlockHeader, height, theBlockHash)
+	ensureNewBlockHeader(t, newBlockHeader, height, theBlockHash)
 
-	prop, propBlock := decideProposal(cs1, vs2, height+1, 0)
+	prop, propBlock := decideProposal(t, cs1, vs2, height+1, 0)
 	propBlockParts := propBlock.MakePartSet(partSize)
 
 	if err := cs1.SetProposalAndBlock(prop, propBlock, propBlockParts, "some peer"); err != nil {
 		t.Fatal(err)
 	}
-	ensureNewProposal(proposalCh, height+1, 0)
+	ensureNewProposal(t, proposalCh, height+1, 0)
 
 	rs = cs1.GetRoundState()
 	assert.False(
@@ -1809,18 +1812,18 @@ func TestStateHalt1(t *testing.T) {
 
 	// start round and wait for propose and prevote
 	startTestRound(cs1, height, round)
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
+	ensureNewProposal(t, proposalCh, height, round)
 	rs := cs1.GetRoundState()
 	propBlock := rs.ProposalBlock
 	propBlockParts := propBlock.MakePartSet(partSize)
 
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 
 	signAddVotes(config, cs1, tmproto.PrevoteType, propBlock.Hash(), propBlockParts.Header(), vs2, vs3, vs4)
 
-	ensurePrecommit(voteCh, height, round)
+	ensurePrecommit(t, voteCh, height, round)
 	// the proposed block should now be locked and our precommit added
 	validatePrecommit(t, cs1, round, round, vss[0], propBlock.Hash(), propBlock.Hash())
 
@@ -1833,11 +1836,11 @@ func TestStateHalt1(t *testing.T) {
 	incrementRound(vs2, vs3, vs4)
 
 	// timeout to new round
-	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
+	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
 	round++ // moving to the next round
 
-	ensureNewRound(newRoundCh, height, round)
+	ensureNewRound(t, newRoundCh, height, round)
 	rs = cs1.GetRoundState()
 
 	t.Log("### ONTO ROUND 1")
@@ -1847,16 +1850,16 @@ func TestStateHalt1(t *testing.T) {
 	*/
 
 	// go to prevote, prevote for locked block
-	ensurePrevote(voteCh, height, round)
+	ensurePrevote(t, voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], rs.LockedBlock.Hash())
 
 	// now we receive the precommit from the previous round
 	addVotes(cs1, precommit4)
 
 	// receiving that precommit should take us straight to commit
-	ensureNewBlock(newBlockCh, height)
+	ensureNewBlock(t, newBlockCh, height)
 
-	ensureNewRound(newRoundCh, height+1, 0)
+	ensureNewRound(t, newRoundCh, height+1, 0)
 }
 
 func TestStateOutputsBlockPartsStats(t *testing.T) {


### PR DESCRIPTION
This change removes many of the panics in the `internal/consensus/*_test.go` methods. Instead, it plumbs through a `*testing.T` and makes use of `t.Fatalf` in the place of `panic`.

 Using panic makes the test output more difficult to parse. Using `t.Fatal` and marking the `ensure*` and `validate*` functions as helpers using `t.Helper()` allows the testing to play a bit more nicely with tooling as well by indicating which line _in the test_ the failure originated from.