### PR TITLE
cleanup: Reduce and normalize import path aliasing.

### DIFF
--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/libs/log"
-	pc "github.com/tendermint/tendermint/proto/tendermint/crypto"
+	cryptoproto "github.com/tendermint/tendermint/proto/tendermint/crypto"
 )
 
 const (
@@ -30,7 +30,7 @@ type PersistentKVStoreApplication struct {
 	// validator set
 	ValUpdates []types.ValidatorUpdate
 
-	valAddrToPubKeyMap map[string]pc.PublicKey
+	valAddrToPubKeyMap map[string]cryptoproto.PublicKey
 
 	logger log.Logger
 }
@@ -46,7 +46,7 @@ func NewPersistentKVStoreApplication(dbDir string) *PersistentKVStoreApplication
 
 	return &PersistentKVStoreApplication{
 		app:                &Application{state: state},
-		valAddrToPubKeyMap: make(map[string]pc.PublicKey),
+		valAddrToPubKeyMap: make(map[string]cryptoproto.PublicKey),
 		logger:             log.NewNopLogger(),
 	}
 }
@@ -194,7 +194,7 @@ func (app *PersistentKVStoreApplication) Validators() (validators []types.Valida
 	return
 }
 
-func MakeValSetChangeTx(pubkey pc.PublicKey, power int64) []byte {
+func MakeValSetChangeTx(pubkey cryptoproto.PublicKey, power int64) []byte {
 	pk, err := encoding.PubKeyFromProto(pubkey)
 	if err != nil {
 		panic(err)

--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/tendermint/tendermint/abci/example/code"
 	"github.com/tendermint/tendermint/abci/types"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/libs/log"
 	pc "github.com/tendermint/tendermint/proto/tendermint/crypto"
 )
@@ -195,7 +195,7 @@ func (app *PersistentKVStoreApplication) Validators() (validators []types.Valida
 }
 
 func MakeValSetChangeTx(pubkey pc.PublicKey, power int64) []byte {
-	pk, err := cryptoenc.PubKeyFromProto(pubkey)
+	pk, err := encoding.PubKeyFromProto(pubkey)
 	if err != nil {
 		panic(err)
 	}
@@ -243,7 +243,7 @@ func (app *PersistentKVStoreApplication) execValidatorTx(tx []byte) types.Respon
 
 // add, update, or remove a validator
 func (app *PersistentKVStoreApplication) updateValidator(v types.ValidatorUpdate) types.ResponseDeliverTx {
-	pubkey, err := cryptoenc.PubKeyFromProto(v.PubKey)
+	pubkey, err := encoding.PubKeyFromProto(v.PubKey)
 	if err != nil {
 		panic(fmt.Errorf("can't decode public key: %w", err))
 	}

--- a/abci/types/pubkey.go
+++ b/abci/types/pubkey.go
@@ -4,7 +4,7 @@ import (
 	fmt "fmt"
 
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 	"github.com/tendermint/tendermint/crypto/sr25519"
 )
@@ -12,7 +12,7 @@ import (
 func Ed25519ValidatorUpdate(pk []byte, power int64) ValidatorUpdate {
 	pke := ed25519.PubKey(pk)
 
-	pkp, err := cryptoenc.PubKeyToProto(pke)
+	pkp, err := encoding.PubKeyToProto(pke)
 	if err != nil {
 		panic(err)
 	}
@@ -29,7 +29,7 @@ func UpdateValidator(pk []byte, power int64, keyType string) ValidatorUpdate {
 		return Ed25519ValidatorUpdate(pk, power)
 	case secp256k1.KeyType:
 		pke := secp256k1.PubKey(pk)
-		pkp, err := cryptoenc.PubKeyToProto(pke)
+		pkp, err := encoding.PubKeyToProto(pke)
 		if err != nil {
 			panic(err)
 		}
@@ -39,7 +39,7 @@ func UpdateValidator(pk []byte, power int64, keyType string) ValidatorUpdate {
 		}
 	case sr25519.KeyType:
 		pke := sr25519.PubKey(pk)
-		pkp, err := cryptoenc.PubKeyToProto(pke)
+		pkp, err := encoding.PubKeyToProto(pke)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/tendermint/commands/debug/dump.go
+++ b/cmd/tendermint/commands/debug/dump.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
@@ -65,9 +65,9 @@ func dumpCmdHandler(_ *cobra.Command, args []string) error {
 	}
 
 	home := viper.GetString(cli.HomeFlag)
-	conf := cfg.DefaultConfig()
+	conf := config.DefaultConfig()
 	conf = conf.SetRoot(home)
-	cfg.EnsureRoot(conf.RootDir)
+	config.EnsureRoot(conf.RootDir)
 
 	dumpDebugData(outDir, conf, rpc)
 
@@ -79,7 +79,7 @@ func dumpCmdHandler(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func dumpDebugData(outDir string, conf *cfg.Config, rpc *rpchttp.HTTP) {
+func dumpDebugData(outDir string, conf *config.Config, rpc *rpchttp.HTTP) {
 	start := time.Now().UTC()
 
 	tmpDir, err := ioutil.TempDir(outDir, "tendermint_debug_tmp")

--- a/cmd/tendermint/commands/debug/kill.go
+++ b/cmd/tendermint/commands/debug/kill.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
@@ -50,9 +50,9 @@ func killCmdHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	home := viper.GetString(cli.HomeFlag)
-	conf := cfg.DefaultConfig()
+	conf := config.DefaultConfig()
 	conf = conf.SetRoot(home)
-	cfg.EnsureRoot(conf.RootDir)
+	config.EnsureRoot(conf.RootDir)
 
 	// Create a temporary directory which will contain all the state dumps and
 	// relevant files and directories that will be compressed into a file.

--- a/cmd/tendermint/commands/debug/util.go
+++ b/cmd/tendermint/commands/debug/util.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"path/filepath"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
@@ -48,7 +48,7 @@ func dumpConsensusState(rpc *rpchttp.HTTP, dir, filename string) error {
 
 // copyWAL copies the Tendermint node's WAL file. It returns an error if the
 // WAL file cannot be read or copied.
-func copyWAL(conf *cfg.Config, dir string) error {
+func copyWAL(conf *config.Config, dir string) error {
 	walPath := conf.Consensus.WalFile()
 	walFile := filepath.Base(walPath)
 

--- a/cmd/tendermint/commands/light.go
+++ b/cmd/tendermint/commands/light.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/libs/log"

--- a/cmd/tendermint/commands/reindex_event.go
+++ b/cmd/tendermint/commands/reindex_event.go
@@ -221,7 +221,8 @@ func checkValidHeight(bs state.BlockStore) error {
 	}
 
 	if startHeight < base {
-		return fmt.Errorf("%s (requested start height: %d, base height: %d)", coretypes.ErrHeightNotAvailable, startHeight, base)
+		return fmt.Errorf("%s (requested start height: %d, base height: %d)",
+			coretypes.ErrHeightNotAvailable, startHeight, base)
 	}
 
 	height := bs.Height()

--- a/cmd/tendermint/commands/reindex_event.go
+++ b/cmd/tendermint/commands/reindex_event.go
@@ -15,7 +15,7 @@ import (
 	"github.com/tendermint/tendermint/internal/state/indexer"
 	"github.com/tendermint/tendermint/internal/state/indexer/sink/kv"
 	"github.com/tendermint/tendermint/internal/state/indexer/sink/psql"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
 )
@@ -221,14 +221,14 @@ func checkValidHeight(bs state.BlockStore) error {
 	}
 
 	if startHeight < base {
-		return fmt.Errorf("%s (requested start height: %d, base height: %d)", ctypes.ErrHeightNotAvailable, startHeight, base)
+		return fmt.Errorf("%s (requested start height: %d, base height: %d)", coretypes.ErrHeightNotAvailable, startHeight, base)
 	}
 
 	height := bs.Height()
 
 	if startHeight > height {
 		return fmt.Errorf(
-			"%s (requested start height: %d, store height: %d)", ctypes.ErrHeightNotAvailable, startHeight, height)
+			"%s (requested start height: %d, store height: %d)", coretypes.ErrHeightNotAvailable, startHeight, height)
 	}
 
 	if endHeight == 0 || endHeight > height {
@@ -238,13 +238,13 @@ func checkValidHeight(bs state.BlockStore) error {
 
 	if endHeight < base {
 		return fmt.Errorf(
-			"%s (requested end height: %d, base height: %d)", ctypes.ErrHeightNotAvailable, endHeight, base)
+			"%s (requested end height: %d, base height: %d)", coretypes.ErrHeightNotAvailable, endHeight, base)
 	}
 
 	if endHeight < startHeight {
 		return fmt.Errorf(
 			"%s (requested the end height: %d is less than the start height: %d)",
-			ctypes.ErrInvalidRequest, startHeight, endHeight)
+			coretypes.ErrInvalidRequest, startHeight, endHeight)
 	}
 
 	return nil

--- a/cmd/tendermint/commands/reindex_event.go
+++ b/cmd/tendermint/commands/reindex_event.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	tmdb "github.com/tendermint/tm-db"
+	dbm "github.com/tendermint/tm-db"
 
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmcfg "github.com/tendermint/tendermint/config"
@@ -129,17 +129,17 @@ func loadEventSinks(cfg *tmcfg.Config) ([]indexer.EventSink, error) {
 }
 
 func loadStateAndBlockStore(cfg *tmcfg.Config) (*store.BlockStore, state.Store, error) {
-	dbType := tmdb.BackendType(cfg.DBBackend)
+	dbType := dbm.BackendType(cfg.DBBackend)
 
 	// Get BlockStore
-	blockStoreDB, err := tmdb.NewDB("blockstore", dbType, cfg.DBDir())
+	blockStoreDB, err := dbm.NewDB("blockstore", dbType, cfg.DBDir())
 	if err != nil {
 		return nil, nil, err
 	}
 	blockStore := store.NewBlockStore(blockStoreDB)
 
 	// Get StateStore
-	stateDB, err := tmdb.NewDB("state", dbType, cfg.DBDir())
+	stateDB, err := dbm.NewDB("state", dbType, cfg.DBDir())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tendermint/tendermint/cmd/tendermint/commands/debug"
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
-	nm "github.com/tendermint/tendermint/node"
+	"github.com/tendermint/tendermint/node"
 )
 
 func main() {
@@ -42,7 +42,7 @@ func main() {
 	//	* Provide their own DB implementation
 	// can copy this file and use something other than the
 	// node.NewDefault function
-	nodeFunc := nm.NewDefault
+	nodeFunc := node.NewDefault
 
 	// Create & start node
 	rootCmd.AddCommand(cmd.NewRunNodeCmd(nodeFunc))

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -6,7 +6,7 @@ import (
 
 	cmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	"github.com/tendermint/tendermint/cmd/tendermint/commands/debug"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
 	nm "github.com/tendermint/tendermint/node"
 )
@@ -47,7 +47,7 @@ func main() {
 	// Create & start node
 	rootCmd.AddCommand(cmd.NewRunNodeCmd(nodeFunc))
 
-	cmd := cli.PrepareBaseCmd(rootCmd, "TM", os.ExpandEnv(filepath.Join("$HOME", cfg.DefaultTendermintDir)))
+	cmd := cli.PrepareBaseCmd(rootCmd, "TM", os.ExpandEnv(filepath.Join("$HOME", config.DefaultTendermintDir)))
 	if err := cmd.Execute(); err != nil {
 		panic(err)
 	}

--- a/config/db.go
+++ b/config/db.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	dbm "github.com/tendermint/tm-db"
+
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/libs/service"
-	db "github.com/tendermint/tm-db"
 )
 
 // ServiceProvider takes a config and a logger and returns a ready to go Node.
@@ -16,11 +17,11 @@ type DBContext struct {
 }
 
 // DBProvider takes a DBContext and returns an instantiated DB.
-type DBProvider func(*DBContext) (db.DB, error)
+type DBProvider func(*DBContext) (dbm.DB, error)
 
 // DefaultDBProvider returns a database using the DBBackend and DBDir
 // specified in the Config.
-func DefaultDBProvider(ctx *DBContext) (db.DB, error) {
-	dbType := db.BackendType(ctx.Config.DBBackend)
-	return db.NewDB(ctx.ID, dbType, ctx.Config.DBDir())
+func DefaultDBProvider(ctx *DBContext) (dbm.DB, error) {
+	dbType := dbm.BackendType(ctx.Config.DBBackend)
+	return dbm.NewDB(ctx.ID, dbType, ctx.Config.DBDir())
 }

--- a/crypto/encoding/codec.go
+++ b/crypto/encoding/codec.go
@@ -8,34 +8,34 @@ import (
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 	"github.com/tendermint/tendermint/crypto/sr25519"
 	"github.com/tendermint/tendermint/libs/json"
-	pc "github.com/tendermint/tendermint/proto/tendermint/crypto"
+	cryptoproto "github.com/tendermint/tendermint/proto/tendermint/crypto"
 )
 
 func init() {
-	json.RegisterType((*pc.PublicKey)(nil), "tendermint.crypto.PublicKey")
-	json.RegisterType((*pc.PublicKey_Ed25519)(nil), "tendermint.crypto.PublicKey_Ed25519")
-	json.RegisterType((*pc.PublicKey_Secp256K1)(nil), "tendermint.crypto.PublicKey_Secp256K1")
+	json.RegisterType((*cryptoproto.PublicKey)(nil), "tendermint.crypto.PublicKey")
+	json.RegisterType((*cryptoproto.PublicKey_Ed25519)(nil), "tendermint.crypto.PublicKey_Ed25519")
+	json.RegisterType((*cryptoproto.PublicKey_Secp256K1)(nil), "tendermint.crypto.PublicKey_Secp256K1")
 }
 
 // PubKeyToProto takes crypto.PubKey and transforms it to a protobuf Pubkey
-func PubKeyToProto(k crypto.PubKey) (pc.PublicKey, error) {
-	var kp pc.PublicKey
+func PubKeyToProto(k crypto.PubKey) (cryptoproto.PublicKey, error) {
+	var kp cryptoproto.PublicKey
 	switch k := k.(type) {
 	case ed25519.PubKey:
-		kp = pc.PublicKey{
-			Sum: &pc.PublicKey_Ed25519{
+		kp = cryptoproto.PublicKey{
+			Sum: &cryptoproto.PublicKey_Ed25519{
 				Ed25519: k,
 			},
 		}
 	case secp256k1.PubKey:
-		kp = pc.PublicKey{
-			Sum: &pc.PublicKey_Secp256K1{
+		kp = cryptoproto.PublicKey{
+			Sum: &cryptoproto.PublicKey_Secp256K1{
 				Secp256K1: k,
 			},
 		}
 	case sr25519.PubKey:
-		kp = pc.PublicKey{
-			Sum: &pc.PublicKey_Sr25519{
+		kp = cryptoproto.PublicKey{
+			Sum: &cryptoproto.PublicKey_Sr25519{
 				Sr25519: k,
 			},
 		}
@@ -46,9 +46,9 @@ func PubKeyToProto(k crypto.PubKey) (pc.PublicKey, error) {
 }
 
 // PubKeyFromProto takes a protobuf Pubkey and transforms it to a crypto.Pubkey
-func PubKeyFromProto(k pc.PublicKey) (crypto.PubKey, error) {
+func PubKeyFromProto(k cryptoproto.PublicKey) (crypto.PubKey, error) {
 	switch k := k.Sum.(type) {
-	case *pc.PublicKey_Ed25519:
+	case *cryptoproto.PublicKey_Ed25519:
 		if len(k.Ed25519) != ed25519.PubKeySize {
 			return nil, fmt.Errorf("invalid size for PubKeyEd25519. Got %d, expected %d",
 				len(k.Ed25519), ed25519.PubKeySize)
@@ -56,7 +56,7 @@ func PubKeyFromProto(k pc.PublicKey) (crypto.PubKey, error) {
 		pk := make(ed25519.PubKey, ed25519.PubKeySize)
 		copy(pk, k.Ed25519)
 		return pk, nil
-	case *pc.PublicKey_Secp256K1:
+	case *cryptoproto.PublicKey_Secp256K1:
 		if len(k.Secp256K1) != secp256k1.PubKeySize {
 			return nil, fmt.Errorf("invalid size for PubKeySecp256k1. Got %d, expected %d",
 				len(k.Secp256K1), secp256k1.PubKeySize)
@@ -64,7 +64,7 @@ func PubKeyFromProto(k pc.PublicKey) (crypto.PubKey, error) {
 		pk := make(secp256k1.PubKey, secp256k1.PubKeySize)
 		copy(pk, k.Secp256K1)
 		return pk, nil
-	case *pc.PublicKey_Sr25519:
+	case *cryptoproto.PublicKey_Sr25519:
 		if len(k.Sr25519) != sr25519.PubKeySize {
 			return nil, fmt.Errorf("invalid size for PubKeySr25519. Got %d, expected %d",
 				len(k.Sr25519), sr25519.PubKeySize)

--- a/crypto/secp256k1/secp256k1_test.go
+++ b/crypto/secp256k1/secp256k1_test.go
@@ -5,14 +5,13 @@ import (
 	"math/big"
 	"testing"
 
+	underlyingSecp256k1 "github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
-
-	underlyingSecp256k1 "github.com/btcsuite/btcd/btcec"
 )
 
 type keyData struct {

--- a/crypto/xchacha20poly1305/xchachapoly_test.go
+++ b/crypto/xchacha20poly1305/xchachapoly_test.go
@@ -2,8 +2,8 @@ package xchacha20poly1305
 
 import (
 	"bytes"
-	cr "crypto/rand"
-	mr "math/rand"
+	crand "crypto/rand"
+	mrand "math/rand"
 	"testing"
 )
 
@@ -19,23 +19,23 @@ func TestRandom(t *testing.T) {
 		var nonce [24]byte
 		var key [32]byte
 
-		al := mr.Intn(128)
-		pl := mr.Intn(16384)
+		al := mrand.Intn(128)
+		pl := mrand.Intn(16384)
 		ad := make([]byte, al)
 		plaintext := make([]byte, pl)
-		_, err := cr.Read(key[:])
+		_, err := crand.Read(key[:])
 		if err != nil {
 			t.Errorf("error on read: %w", err)
 		}
-		_, err = cr.Read(nonce[:])
+		_, err = crand.Read(nonce[:])
 		if err != nil {
 			t.Errorf("error on read: %w", err)
 		}
-		_, err = cr.Read(ad)
+		_, err = crand.Read(ad)
 		if err != nil {
 			t.Errorf("error on read: %w", err)
 		}
-		_, err = cr.Read(plaintext)
+		_, err = crand.Read(plaintext)
 		if err != nil {
 			t.Errorf("error on read: %w", err)
 		}
@@ -59,7 +59,7 @@ func TestRandom(t *testing.T) {
 		}
 
 		if len(ad) > 0 {
-			alterAdIdx := mr.Intn(len(ad))
+			alterAdIdx := mrand.Intn(len(ad))
 			ad[alterAdIdx] ^= 0x80
 			if _, err := aead.Open(nil, nonce[:], ct, ad); err == nil {
 				t.Errorf("random #%d: Open was successful after altering additional data", i)
@@ -67,14 +67,14 @@ func TestRandom(t *testing.T) {
 			ad[alterAdIdx] ^= 0x80
 		}
 
-		alterNonceIdx := mr.Intn(aead.NonceSize())
+		alterNonceIdx := mrand.Intn(aead.NonceSize())
 		nonce[alterNonceIdx] ^= 0x80
 		if _, err := aead.Open(nil, nonce[:], ct, ad); err == nil {
 			t.Errorf("random #%d: Open was successful after altering nonce", i)
 		}
 		nonce[alterNonceIdx] ^= 0x80
 
-		alterCtIdx := mr.Intn(len(ct))
+		alterCtIdx := mrand.Intn(len(ct))
 		ct[alterCtIdx] ^= 0x80
 		if _, err := aead.Open(nil, nonce[:], ct, ad); err == nil {
 			t.Errorf("random #%d: Open was successful after altering ciphertext", i)

--- a/internal/blocksync/v0/reactor.go
+++ b/internal/blocksync/v0/reactor.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	bc "github.com/tendermint/tendermint/internal/blocksync"
+	"github.com/tendermint/tendermint/internal/blocksync"
 	"github.com/tendermint/tendermint/internal/consensus"
 	"github.com/tendermint/tendermint/internal/p2p"
 	sm "github.com/tendermint/tendermint/internal/state"
@@ -36,7 +36,7 @@ var (
 				Priority:            5,
 				SendQueueCapacity:   1000,
 				RecvBufferCapacity:  1024,
-				RecvMessageCapacity: bc.MaxMsgSize,
+				RecvMessageCapacity: blocksync.MaxMsgSize,
 				MaxSendBytes:        100,
 			},
 		},

--- a/internal/blocksync/v0/reactor.go
+++ b/internal/blocksync/v0/reactor.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	bc "github.com/tendermint/tendermint/internal/blocksync"
-	cons "github.com/tendermint/tendermint/internal/consensus"
+	"github.com/tendermint/tendermint/internal/consensus"
 	"github.com/tendermint/tendermint/internal/p2p"
 	sm "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/libs/log"
@@ -107,7 +107,7 @@ type Reactor struct {
 	// stopping the p2p Channel(s).
 	poolWG sync.WaitGroup
 
-	metrics *cons.Metrics
+	metrics *consensus.Metrics
 
 	syncStartTime time.Time
 }
@@ -122,7 +122,7 @@ func NewReactor(
 	blockSyncCh *p2p.Channel,
 	peerUpdates *p2p.PeerUpdates,
 	blockSync bool,
-	metrics *cons.Metrics,
+	metrics *consensus.Metrics,
 ) (*Reactor, error) {
 	if state.LastBlockHeight != store.Height() {
 		return nil, fmt.Errorf("state (%v) and store (%v) height mismatch", state.LastBlockHeight, store.Height())

--- a/internal/blocksync/v0/reactor.go
+++ b/internal/blocksync/v0/reactor.go
@@ -12,7 +12,7 @@ import (
 	sm "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/libs/service"
-	tmSync "github.com/tendermint/tendermint/libs/sync"
+	tmsync "github.com/tendermint/tendermint/libs/sync"
 	bcproto "github.com/tendermint/tendermint/proto/tendermint/blocksync"
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
@@ -85,7 +85,7 @@ type Reactor struct {
 	store       *store.BlockStore
 	pool        *BlockPool
 	consReactor consensusReactor
-	blockSync   *tmSync.AtomicBool
+	blockSync   *tmsync.AtomicBool
 
 	blockSyncCh *p2p.Channel
 	// blockSyncOutBridgeCh defines a channel that acts as a bridge between sending Envelope
@@ -142,7 +142,7 @@ func NewReactor(
 		store:                store,
 		pool:                 NewBlockPool(startHeight, requestsCh, errorsCh),
 		consReactor:          consReactor,
-		blockSync:            tmSync.NewBool(blockSync),
+		blockSync:            tmsync.NewBool(blockSync),
 		requestsCh:           requestsCh,
 		errorsCh:             errorsCh,
 		blockSyncCh:          blockSyncCh,

--- a/internal/blocksync/v0/reactor_test.go
+++ b/internal/blocksync/v0/reactor_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -22,7 +23,6 @@ import (
 	bcproto "github.com/tendermint/tendermint/proto/tendermint/blocksync"
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 )
 
 type reactorTestSuite struct {

--- a/internal/blocksync/v0/reactor_test.go
+++ b/internal/blocksync/v0/reactor_test.go
@@ -10,7 +10,7 @@ import (
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
-	cons "github.com/tendermint/tendermint/internal/consensus"
+	"github.com/tendermint/tendermint/internal/consensus"
 	"github.com/tendermint/tendermint/internal/mempool/mock"
 	"github.com/tendermint/tendermint/internal/p2p"
 	"github.com/tendermint/tendermint/internal/p2p/p2ptest"
@@ -165,7 +165,7 @@ func (rts *reactorTestSuite) addNode(t *testing.T,
 		rts.blockSyncChannels[nodeID],
 		rts.peerUpdates[nodeID],
 		rts.blockSync,
-		cons.NopMetrics())
+		consensus.NopMetrics())
 	require.NoError(t, err)
 
 	require.NoError(t, rts.reactors[nodeID].Start())

--- a/internal/blocksync/v0/reactor_test.go
+++ b/internal/blocksync/v0/reactor_test.go
@@ -9,7 +9,7 @@ import (
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/consensus"
 	"github.com/tendermint/tendermint/internal/mempool/mock"
 	"github.com/tendermint/tendermint/internal/p2p"
@@ -182,10 +182,10 @@ func (rts *reactorTestSuite) start(t *testing.T) {
 }
 
 func TestReactor_AbruptDisconnect(t *testing.T) {
-	config := cfg.ResetTestRoot("block_sync_reactor_test")
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("block_sync_reactor_test")
+	defer os.RemoveAll(cfg.RootDir)
 
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	genDoc, privVals := factory.RandGenesisDoc(cfg, 1, false, 30)
 	maxBlockHeight := int64(64)
 
 	rts := setup(t, genDoc, privVals[0], []int64{maxBlockHeight, 0}, 0)
@@ -217,10 +217,10 @@ func TestReactor_AbruptDisconnect(t *testing.T) {
 }
 
 func TestReactor_SyncTime(t *testing.T) {
-	config := cfg.ResetTestRoot("block_sync_reactor_test")
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("block_sync_reactor_test")
+	defer os.RemoveAll(cfg.RootDir)
 
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	genDoc, privVals := factory.RandGenesisDoc(cfg, 1, false, 30)
 	maxBlockHeight := int64(101)
 
 	rts := setup(t, genDoc, privVals[0], []int64{maxBlockHeight, 0}, 0)
@@ -240,10 +240,10 @@ func TestReactor_SyncTime(t *testing.T) {
 }
 
 func TestReactor_NoBlockResponse(t *testing.T) {
-	config := cfg.ResetTestRoot("block_sync_reactor_test")
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("block_sync_reactor_test")
+	defer os.RemoveAll(cfg.RootDir)
 
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	genDoc, privVals := factory.RandGenesisDoc(cfg, 1, false, 30)
 	maxBlockHeight := int64(65)
 
 	rts := setup(t, genDoc, privVals[0], []int64{maxBlockHeight, 0}, 0)
@@ -287,11 +287,11 @@ func TestReactor_BadBlockStopsPeer(t *testing.T) {
 	// See: https://github.com/tendermint/tendermint/issues/6005
 	t.SkipNow()
 
-	config := cfg.ResetTestRoot("block_sync_reactor_test")
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("block_sync_reactor_test")
+	defer os.RemoveAll(cfg.RootDir)
 
 	maxBlockHeight := int64(48)
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	genDoc, privVals := factory.RandGenesisDoc(cfg, 1, false, 30)
 
 	rts := setup(t, genDoc, privVals[0], []int64{maxBlockHeight, 0, 0, 0, 0}, 1000)
 
@@ -325,7 +325,7 @@ func TestReactor_BadBlockStopsPeer(t *testing.T) {
 	//
 	// XXX: This causes a potential race condition.
 	// See: https://github.com/tendermint/tendermint/issues/6005
-	otherGenDoc, otherPrivVals := factory.RandGenesisDoc(config, 1, false, 30)
+	otherGenDoc, otherPrivVals := factory.RandGenesisDoc(cfg, 1, false, 30)
 	newNode := rts.network.MakeNode(t, p2ptest.NodeOptions{
 		MaxPeers:     uint16(len(rts.nodes) + 1),
 		MaxConnected: uint16(len(rts.nodes) + 1),

--- a/internal/blocksync/v2/processor.go
+++ b/internal/blocksync/v2/processor.go
@@ -3,7 +3,7 @@ package v2
 import (
 	"fmt"
 
-	tmState "github.com/tendermint/tendermint/internal/state"
+	tmstate "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -36,7 +36,7 @@ func (e pcBlockProcessed) String() string {
 type pcFinished struct {
 	priorityNormal
 	blocksSynced int
-	tmState      tmState.State
+	tmState      tmstate.State
 }
 
 func (p pcFinished) Error() string {
@@ -148,11 +148,11 @@ func (state *pcState) handle(event Event) (Event, error) {
 		return noOp, nil
 
 	case rProcessBlock:
-		tmState := state.context.tmState()
+		tmstate := state.context.tmState()
 		firstItem, secondItem, err := state.nextTwo()
 		if err != nil {
 			if state.draining {
-				return pcFinished{tmState: tmState, blocksSynced: state.blocksSynced}, nil
+				return pcFinished{tmState: tmstate, blocksSynced: state.blocksSynced}, nil
 			}
 			return noOp, nil
 		}
@@ -164,7 +164,7 @@ func (state *pcState) handle(event Event) (Event, error) {
 		)
 
 		// verify if +second+ last commit "confirms" +first+ block
-		err = state.context.verifyCommit(tmState.ChainID, firstID, first.Height, second.LastCommit)
+		err = state.context.verifyCommit(tmstate.ChainID, firstID, first.Height, second.LastCommit)
 		if err != nil {
 			state.purgePeer(firstItem.peerID)
 			if firstItem.peerID != secondItem.peerID {

--- a/internal/blocksync/v2/processor_context.go
+++ b/internal/blocksync/v2/processor_context.go
@@ -3,7 +3,7 @@ package v2
 import (
 	"fmt"
 
-	cons "github.com/tendermint/tendermint/internal/consensus"
+	"github.com/tendermint/tendermint/internal/consensus"
 	"github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/types"
 )
@@ -21,10 +21,10 @@ type pContext struct {
 	store   blockStore
 	applier blockApplier
 	state   state.State
-	metrics *cons.Metrics
+	metrics *consensus.Metrics
 }
 
-func newProcessorContext(st blockStore, ex blockApplier, s state.State, m *cons.Metrics) *pContext {
+func newProcessorContext(st blockStore, ex blockApplier, s state.State, m *consensus.Metrics) *pContext {
 	return &pContext{
 		store:   st,
 		applier: ex,

--- a/internal/blocksync/v2/processor_test.go
+++ b/internal/blocksync/v2/processor_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	tmState "github.com/tendermint/tendermint/internal/state"
+	tmstate "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -33,7 +33,7 @@ func makePcBlock(height int64) *types.Block {
 // makeState takes test parameters and creates a specific processor state.
 func makeState(p *params) *pcState {
 	var (
-		tmState = tmState.State{LastBlockHeight: p.height}
+		tmState = tmstate.State{LastBlockHeight: p.height}
 		context = newMockProcessorContext(tmState, p.verBL, p.appBL)
 	)
 	state := newPcState(context)
@@ -207,7 +207,7 @@ func TestRProcessBlockSuccess(t *testing.T) {
 				{ // finish when H+1 or/and H+2 are missing
 					event:         rProcessBlock{},
 					wantState:     &params{height: 1, items: []pcBlock{{"P2", 2}, {"P1", 4}}, blocksSynced: 1, draining: true},
-					wantNextEvent: pcFinished{tmState: tmState.State{LastBlockHeight: 1}, blocksSynced: 1},
+					wantNextEvent: pcFinished{tmState: tmstate.State{LastBlockHeight: 1}, blocksSynced: 1},
 				},
 			},
 		},
@@ -271,7 +271,7 @@ func TestScFinishedEv(t *testing.T) {
 				{
 					currentState: &params{height: 100, items: []pcBlock{}, blocksSynced: 100}, event: scFinishedEv{},
 					wantState:     &params{height: 100, items: []pcBlock{}, blocksSynced: 100},
-					wantNextEvent: pcFinished{tmState: tmState.State{LastBlockHeight: 100}, blocksSynced: 100},
+					wantNextEvent: pcFinished{tmState: tmstate.State{LastBlockHeight: 100}, blocksSynced: 100},
 				},
 			},
 		},
@@ -282,7 +282,7 @@ func TestScFinishedEv(t *testing.T) {
 					currentState: &params{height: 100, items: []pcBlock{
 						{"P1", 101}}, blocksSynced: 100}, event: scFinishedEv{},
 					wantState:     &params{height: 100, items: []pcBlock{{"P1", 101}}, blocksSynced: 100},
-					wantNextEvent: pcFinished{tmState: tmState.State{LastBlockHeight: 100}, blocksSynced: 100},
+					wantNextEvent: pcFinished{tmState: tmstate.State{LastBlockHeight: 100}, blocksSynced: 100},
 				},
 			},
 		},

--- a/internal/blocksync/v2/reactor.go
+++ b/internal/blocksync/v2/reactor.go
@@ -7,7 +7,7 @@ import (
 
 	proto "github.com/gogo/protobuf/proto"
 
-	bc "github.com/tendermint/tendermint/internal/blocksync"
+	"github.com/tendermint/tendermint/internal/blocksync"
 	"github.com/tendermint/tendermint/internal/blocksync/v2/internal/behavior"
 	"github.com/tendermint/tendermint/internal/consensus"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
@@ -605,7 +605,7 @@ func (r *BlockchainReactor) GetChannels() []*p2p.ChannelDescriptor {
 			Priority:            5,
 			SendQueueCapacity:   2000,
 			RecvBufferCapacity:  1024,
-			RecvMessageCapacity: bc.MaxMsgSize,
+			RecvMessageCapacity: blocksync.MaxMsgSize,
 		},
 	}
 }

--- a/internal/blocksync/v2/reactor.go
+++ b/internal/blocksync/v2/reactor.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/tendermint/tendermint/internal/blocksync"
 	"github.com/tendermint/tendermint/internal/blocksync/v2/internal/behavior"

--- a/internal/blocksync/v2/reactor.go
+++ b/internal/blocksync/v2/reactor.go
@@ -9,7 +9,7 @@ import (
 
 	bc "github.com/tendermint/tendermint/internal/blocksync"
 	"github.com/tendermint/tendermint/internal/blocksync/v2/internal/behavior"
-	cons "github.com/tendermint/tendermint/internal/consensus"
+	"github.com/tendermint/tendermint/internal/consensus"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/internal/p2p"
 	"github.com/tendermint/tendermint/internal/state"
@@ -61,7 +61,7 @@ type blockApplier interface {
 
 // XXX: unify naming in this package around tmState
 func newReactor(state state.State, store blockStore, reporter behavior.Reporter,
-	blockApplier blockApplier, blockSync bool, metrics *cons.Metrics) *BlockchainReactor {
+	blockApplier blockApplier, blockSync bool, metrics *consensus.Metrics) *BlockchainReactor {
 	initHeight := state.LastBlockHeight + 1
 	if initHeight == 1 {
 		initHeight = state.InitialHeight
@@ -91,7 +91,7 @@ func NewBlockchainReactor(
 	blockApplier blockApplier,
 	store blockStore,
 	blockSync bool,
-	metrics *cons.Metrics) *BlockchainReactor {
+	metrics *consensus.Metrics) *BlockchainReactor {
 	reporter := behavior.NewMockReporter()
 	return newReactor(state, store, reporter, blockApplier, blockSync, metrics)
 }

--- a/internal/blocksync/v2/reactor_test.go
+++ b/internal/blocksync/v2/reactor_test.go
@@ -17,7 +17,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/blocksync/v2/internal/behavior"
-	cons "github.com/tendermint/tendermint/internal/consensus"
+	"github.com/tendermint/tendermint/internal/consensus"
 	"github.com/tendermint/tendermint/internal/mempool/mock"
 	"github.com/tendermint/tendermint/internal/p2p"
 	"github.com/tendermint/tendermint/internal/p2p/conn"
@@ -177,7 +177,7 @@ func newTestReactor(t *testing.T, p testReactorParams) *BlockchainReactor {
 		require.NoError(t, err)
 	}
 
-	r := newReactor(state, store, reporter, appl, true, cons.NopMetrics())
+	r := newReactor(state, store, reporter, appl, true, consensus.NopMetrics())
 	logger := log.TestingLogger()
 	r.SetLogger(logger.With("module", "blockchain"))
 

--- a/internal/blocksync/v2/reactor_test.go
+++ b/internal/blocksync/v2/reactor_test.go
@@ -15,7 +15,7 @@ import (
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/blocksync/v2/internal/behavior"
 	"github.com/tendermint/tendermint/internal/consensus"
 	"github.com/tendermint/tendermint/internal/mempool/mock"
@@ -365,9 +365,9 @@ func TestReactorHelperMode(t *testing.T) {
 		channelID = byte(0x40)
 	)
 
-	config := cfg.ResetTestRoot("blockchain_reactor_v2_test")
-	defer os.RemoveAll(config.RootDir)
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	cfg := config.ResetTestRoot("blockchain_reactor_v2_test")
+	defer os.RemoveAll(cfg.RootDir)
+	genDoc, privVals := factory.RandGenesisDoc(cfg, 1, false, 30)
 
 	params := testReactorParams{
 		logger:      log.TestingLogger(),
@@ -455,9 +455,9 @@ func TestReactorHelperMode(t *testing.T) {
 }
 
 func TestReactorSetSwitchNil(t *testing.T) {
-	config := cfg.ResetTestRoot("blockchain_reactor_v2_test")
-	defer os.RemoveAll(config.RootDir)
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	cfg := config.ResetTestRoot("blockchain_reactor_v2_test")
+	defer os.RemoveAll(cfg.RootDir)
+	genDoc, privVals := factory.RandGenesisDoc(cfg, 1, false, 30)
 
 	reactor := newTestReactor(t, testReactorParams{
 		logger:   log.TestingLogger(),

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
+
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/internal/evidence"
@@ -23,7 +25,6 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 )
 
 // Byzantine node sends two different prevotes (nil and blockID) to the same

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -7,15 +7,13 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"path"
-
 	dbm "github.com/tendermint/tm-db"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -15,15 +15,15 @@ import (
 
 	"github.com/tendermint/tendermint/abci/example/code"
 	abci "github.com/tendermint/tendermint/abci/types"
-	mempl "github.com/tendermint/tendermint/internal/mempool"
+	"github.com/tendermint/tendermint/internal/mempool"
 	sm "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
 )
 
 // for testing
-func assertMempool(txn txNotifier) mempl.Mempool {
-	return txn.(mempl.Mempool)
+func assertMempool(txn txNotifier) mempool.Mempool {
+	return txn.(mempool.Mempool)
 }
 
 func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
@@ -113,7 +113,7 @@ func deliverTxsRange(cs *State, start, end int) {
 	for i := start; i < end; i++ {
 		txBytes := make([]byte, 8)
 		binary.BigEndian.PutUint64(txBytes, uint64(i))
-		err := assertMempool(cs.txNotifier).CheckTx(context.Background(), txBytes, nil, mempl.TxInfo{})
+		err := assertMempool(cs.txNotifier).CheckTx(context.Background(), txBytes, nil, mempool.TxInfo{})
 		if err != nil {
 			panic(fmt.Sprintf("Error after CheckTx: %v", err))
 		}
@@ -179,7 +179,7 @@ func TestMempoolRmBadTx(t *testing.T) {
 				return
 			}
 			checkTxRespCh <- struct{}{}
-		}, mempl.TxInfo{})
+		}, mempool.TxInfo{})
 		if err != nil {
 			t.Errorf("error after CheckTx: %v", err)
 			return

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/abci/example/code"

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -16,7 +16,7 @@ import (
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	abci "github.com/tendermint/tendermint/abci/types"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto/encoding"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/internal/mempool"
@@ -273,11 +273,11 @@ func ensureBlockSyncStatus(t *testing.T, msg tmpubsub.Message, complete bool, he
 }
 
 func TestReactorBasic(t *testing.T) {
-	config := configSetup(t)
+	cfg := configSetup(t)
 
 	n := 4
 	states, cleanup := randConsensusState(t,
-		config, n, "consensus_reactor_test",
+		cfg, n, "consensus_reactor_test",
 		newMockTickerFunc(true), newKVStore)
 	t.Cleanup(cleanup)
 
@@ -316,14 +316,14 @@ func TestReactorBasic(t *testing.T) {
 }
 
 func TestReactorWithEvidence(t *testing.T) {
-	config := configSetup(t)
+	cfg := configSetup(t)
 
 	n := 4
 	testName := "consensus_reactor_test"
 	tickerFunc := newMockTickerFunc(true)
 	appFunc := newKVStore
 
-	genDoc, privVals := factory.RandGenesisDoc(config, n, false, 30)
+	genDoc, privVals := factory.RandGenesisDoc(cfg, n, false, 30)
 	states := make([]*State, n)
 	logger := consensusLogger()
 
@@ -360,7 +360,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		// everyone includes evidence of another double signing
 		vIdx := (i + 1) % n
 
-		ev := types.NewMockDuplicateVoteEvidenceWithValidator(1, defaultTestTime, privVals[vIdx], config.ChainID())
+		ev := types.NewMockDuplicateVoteEvidenceWithValidator(1, defaultTestTime, privVals[vIdx], cfg.ChainID())
 		evpool := &statemocks.EvidencePool{}
 		evpool.On("CheckEvidence", mock.AnythingOfType("types.EvidenceList")).Return(nil)
 		evpool.On("PendingEvidence", mock.AnythingOfType("int64")).Return([]types.Evidence{
@@ -412,17 +412,17 @@ func TestReactorWithEvidence(t *testing.T) {
 }
 
 func TestReactorCreatesBlockWhenEmptyBlocksFalse(t *testing.T) {
-	config := configSetup(t)
+	cfg := configSetup(t)
 
 	n := 4
 	states, cleanup := randConsensusState(
 		t,
-		config,
+		cfg,
 		n,
 		"consensus_reactor_test",
 		newMockTickerFunc(true),
 		newKVStore,
-		func(c *cfg.Config) {
+		func(c *config.Config) {
 			c.Consensus.CreateEmptyBlocks = false
 		},
 	)
@@ -462,11 +462,11 @@ func TestReactorCreatesBlockWhenEmptyBlocksFalse(t *testing.T) {
 }
 
 func TestReactorRecordsVotesAndBlockParts(t *testing.T) {
-	config := configSetup(t)
+	cfg := configSetup(t)
 
 	n := 4
 	states, cleanup := randConsensusState(t,
-		config, n, "consensus_reactor_test",
+		cfg, n, "consensus_reactor_test",
 		newMockTickerFunc(true), newKVStore)
 	t.Cleanup(cleanup)
 
@@ -521,12 +521,12 @@ func TestReactorRecordsVotesAndBlockParts(t *testing.T) {
 }
 
 func TestReactorVotingPowerChange(t *testing.T) {
-	config := configSetup(t)
+	cfg := configSetup(t)
 
 	n := 4
 	states, cleanup := randConsensusState(
 		t,
-		config,
+		cfg,
 		n,
 		"consensus_voting_power_changes_test",
 		newMockTickerFunc(true),
@@ -622,12 +622,12 @@ func TestReactorVotingPowerChange(t *testing.T) {
 }
 
 func TestReactorValidatorSetChanges(t *testing.T) {
-	config := configSetup(t)
+	cfg := configSetup(t)
 
 	nPeers := 7
 	nVals := 4
 	states, _, _, cleanup := randConsensusNetWithPeers(
-		config,
+		cfg,
 		nVals,
 		nPeers,
 		"consensus_val_set_changes_test",

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
@@ -31,7 +32,6 @@ import (
 	tmcons "github.com/tendermint/tendermint/proto/tendermint/consensus"
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 )
 
 var (

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/internal/mempool"
 	mempoolv0 "github.com/tendermint/tendermint/internal/mempool/v0"
@@ -573,7 +573,7 @@ func TestReactorVotingPowerChange(t *testing.T) {
 	val1PubKey, err := states[0].privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
 
-	val1PubKeyABCI, err := cryptoenc.PubKeyToProto(val1PubKey)
+	val1PubKeyABCI, err := encoding.PubKeyToProto(val1PubKey)
 	require.NoError(t, err)
 
 	updateValidatorTx := kvstore.MakeValSetChangeTx(val1PubKeyABCI, 25)
@@ -668,7 +668,7 @@ func TestReactorValidatorSetChanges(t *testing.T) {
 	newValidatorPubKey1, err := states[nVals].privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
 
-	valPubKey1ABCI, err := cryptoenc.PubKeyToProto(newValidatorPubKey1)
+	valPubKey1ABCI, err := encoding.PubKeyToProto(newValidatorPubKey1)
 	require.NoError(t, err)
 
 	newValidatorTx1 := kvstore.MakeValSetChangeTx(valPubKey1ABCI, testMinPower)
@@ -701,7 +701,7 @@ func TestReactorValidatorSetChanges(t *testing.T) {
 	updateValidatorPubKey1, err := states[nVals].privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
 
-	updatePubKey1ABCI, err := cryptoenc.PubKeyToProto(updateValidatorPubKey1)
+	updatePubKey1ABCI, err := encoding.PubKeyToProto(updateValidatorPubKey1)
 	require.NoError(t, err)
 
 	updateValidatorTx1 := kvstore.MakeValSetChangeTx(updatePubKey1ABCI, 25)
@@ -721,7 +721,7 @@ func TestReactorValidatorSetChanges(t *testing.T) {
 	newValidatorPubKey2, err := states[nVals+1].privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
 
-	newVal2ABCI, err := cryptoenc.PubKeyToProto(newValidatorPubKey2)
+	newVal2ABCI, err := encoding.PubKeyToProto(newValidatorPubKey2)
 	require.NoError(t, err)
 
 	newValidatorTx2 := kvstore.MakeValSetChangeTx(newVal2ABCI, testMinPower)
@@ -729,7 +729,7 @@ func TestReactorValidatorSetChanges(t *testing.T) {
 	newValidatorPubKey3, err := states[nVals+2].privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
 
-	newVal3ABCI, err := cryptoenc.PubKeyToProto(newValidatorPubKey3)
+	newVal3ABCI, err := encoding.PubKeyToProto(newValidatorPubKey3)
 	require.NoError(t, err)
 
 	newValidatorTx3 := kvstore.MakeValSetChangeTx(newVal3ABCI, testMinPower)

--- a/internal/consensus/replay_file.go
+++ b/internal/consensus/replay_file.go
@@ -12,7 +12,7 @@ import (
 
 	dbm "github.com/tendermint/tm-db"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/proxy"
 	sm "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/libs/log"
@@ -31,8 +31,8 @@ const (
 // replay messages interactively or all at once
 
 // replay the wal file
-func RunReplayFile(config cfg.BaseConfig, csConfig *cfg.ConsensusConfig, console bool) {
-	consensusState := newConsensusStateForReplay(config, csConfig)
+func RunReplayFile(cfg config.BaseConfig, csConfig *config.ConsensusConfig, console bool) {
+	consensusState := newConsensusStateForReplay(cfg, csConfig)
 
 	if err := consensusState.ReplayFile(csConfig.WalFile(), console); err != nil {
 		tmos.Exit(fmt.Sprintf("Error during consensus replay: %v", err))
@@ -286,22 +286,22 @@ func (pb *playback) replayConsoleLoop() int {
 //--------------------------------------------------------------------------------
 
 // convenience for replay mode
-func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusConfig) *State {
-	dbType := dbm.BackendType(config.DBBackend)
+func newConsensusStateForReplay(cfg config.BaseConfig, csConfig *config.ConsensusConfig) *State {
+	dbType := dbm.BackendType(cfg.DBBackend)
 	// Get BlockStore
-	blockStoreDB, err := dbm.NewDB("blockstore", dbType, config.DBDir())
+	blockStoreDB, err := dbm.NewDB("blockstore", dbType, cfg.DBDir())
 	if err != nil {
 		tmos.Exit(err.Error())
 	}
 	blockStore := store.NewBlockStore(blockStoreDB)
 
 	// Get State
-	stateDB, err := dbm.NewDB("state", dbType, config.DBDir())
+	stateDB, err := dbm.NewDB("state", dbType, cfg.DBDir())
 	if err != nil {
 		tmos.Exit(err.Error())
 	}
 	stateStore := sm.NewStore(stateDB)
-	gdoc, err := sm.MakeGenesisDocFromFile(config.GenesisFile())
+	gdoc, err := sm.MakeGenesisDocFromFile(cfg.GenesisFile())
 	if err != nil {
 		tmos.Exit(err.Error())
 	}
@@ -311,7 +311,7 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 	}
 
 	// Create proxyAppConn connection (consensus, mempool, query)
-	clientCreator, _ := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
+	clientCreator, _ := proxy.DefaultClientCreator(cfg.ProxyApp, cfg.ABCI, cfg.DBDir())
 	proxyApp := proxy.NewAppConns(clientCreator)
 	err = proxyApp.Start()
 	if err != nil {

--- a/internal/consensus/replay_stubs.go
+++ b/internal/consensus/replay_stubs.go
@@ -6,7 +6,7 @@ import (
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/internal/libs/clist"
-	mempl "github.com/tendermint/tendermint/internal/mempool"
+	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/internal/proxy"
 	tmstate "github.com/tendermint/tendermint/proto/tendermint/state"
 	"github.com/tendermint/tendermint/types"
@@ -16,12 +16,12 @@ import (
 
 type emptyMempool struct{}
 
-var _ mempl.Mempool = emptyMempool{}
+var _ mempool.Mempool = emptyMempool{}
 
 func (emptyMempool) Lock()     {}
 func (emptyMempool) Unlock()   {}
 func (emptyMempool) Size() int { return 0 }
-func (emptyMempool) CheckTx(_ context.Context, _ types.Tx, _ func(*abci.Response), _ mempl.TxInfo) error {
+func (emptyMempool) CheckTx(_ context.Context, _ types.Tx, _ func(*abci.Response), _ mempool.TxInfo) error {
 	return nil
 }
 func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64) types.Txs { return types.Txs{} }
@@ -30,8 +30,8 @@ func (emptyMempool) Update(
 	_ int64,
 	_ types.Txs,
 	_ []*abci.ResponseDeliverTx,
-	_ mempl.PreCheckFunc,
-	_ mempl.PostCheckFunc,
+	_ mempool.PreCheckFunc,
+	_ mempool.PostCheckFunc,
 ) error {
 	return nil
 }

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -25,7 +25,7 @@ import (
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
-	mempl "github.com/tendermint/tendermint/internal/mempool"
+	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/internal/proxy"
 	sm "github.com/tendermint/tendermint/internal/state"
 	sf "github.com/tendermint/tendermint/internal/state/test/factory"
@@ -103,7 +103,7 @@ func sendTxs(ctx context.Context, cs *State) {
 			return
 		default:
 			tx := []byte{byte(i)}
-			if err := assertMempool(cs.txNotifier).CheckTx(context.Background(), tx, nil, mempl.TxInfo{}); err != nil {
+			if err := assertMempool(cs.txNotifier).CheckTx(context.Background(), tx, nil, mempool.TxInfo{}); err != nil {
 				panic(err)
 			}
 			i++
@@ -291,7 +291,7 @@ type simulatorTestSuite struct {
 	Commits      []*types.Commit
 	CleanupFunc  cleanupFunc
 
-	Mempool mempl.Mempool
+	Mempool mempool.Mempool
 	Evpool  sm.EvidencePool
 }
 
@@ -364,7 +364,7 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	valPubKey1ABCI, err := cryptoenc.PubKeyToProto(newValidatorPubKey1)
 	require.NoError(t, err)
 	newValidatorTx1 := kvstore.MakeValSetChangeTx(valPubKey1ABCI, testMinPower)
-	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), newValidatorTx1, nil, mempl.TxInfo{})
+	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), newValidatorTx1, nil, mempool.TxInfo{})
 	assert.Nil(t, err)
 	propBlock, _ := css[0].createProposalBlock() // changeProposer(t, cs1, vs2)
 	propBlockParts := propBlock.MakePartSet(partSize)
@@ -396,7 +396,7 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	updatePubKey1ABCI, err := cryptoenc.PubKeyToProto(updateValidatorPubKey1)
 	require.NoError(t, err)
 	updateValidatorTx1 := kvstore.MakeValSetChangeTx(updatePubKey1ABCI, 25)
-	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), updateValidatorTx1, nil, mempl.TxInfo{})
+	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), updateValidatorTx1, nil, mempool.TxInfo{})
 	assert.Nil(t, err)
 	propBlock, _ = css[0].createProposalBlock() // changeProposer(t, cs1, vs2)
 	propBlockParts = propBlock.MakePartSet(partSize)
@@ -428,14 +428,14 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	newVal2ABCI, err := cryptoenc.PubKeyToProto(newValidatorPubKey2)
 	require.NoError(t, err)
 	newValidatorTx2 := kvstore.MakeValSetChangeTx(newVal2ABCI, testMinPower)
-	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), newValidatorTx2, nil, mempl.TxInfo{})
+	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), newValidatorTx2, nil, mempool.TxInfo{})
 	assert.Nil(t, err)
 	newValidatorPubKey3, err := css[nVals+2].privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
 	newVal3ABCI, err := cryptoenc.PubKeyToProto(newValidatorPubKey3)
 	require.NoError(t, err)
 	newValidatorTx3 := kvstore.MakeValSetChangeTx(newVal3ABCI, testMinPower)
-	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), newValidatorTx3, nil, mempl.TxInfo{})
+	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), newValidatorTx3, nil, mempool.TxInfo{})
 	assert.Nil(t, err)
 	propBlock, _ = css[0].createProposalBlock() // changeProposer(t, cs1, vs2)
 	propBlockParts = propBlock.MakePartSet(partSize)
@@ -475,7 +475,7 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	ensureNewProposal(proposalCh, height, round)
 
 	removeValidatorTx2 := kvstore.MakeValSetChangeTx(newVal2ABCI, 0)
-	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), removeValidatorTx2, nil, mempl.TxInfo{})
+	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), removeValidatorTx2, nil, mempool.TxInfo{})
 	assert.Nil(t, err)
 
 	rs = css[0].GetRoundState()
@@ -514,7 +514,7 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	height++
 	incrementHeight(vss...)
 	removeValidatorTx3 := kvstore.MakeValSetChangeTx(newVal3ABCI, 0)
-	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), removeValidatorTx3, nil, mempl.TxInfo{})
+	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), removeValidatorTx3, nil, mempool.TxInfo{})
 	assert.Nil(t, err)
 	propBlock, _ = css[0].createProposalBlock() // changeProposer(t, cs1, vs2)
 	propBlockParts = propBlock.MakePartSet(partSize)
@@ -811,7 +811,7 @@ func testHandshakeReplay(t *testing.T, sim *simulatorTestSuite, nBlocks int, mod
 }
 
 func applyBlock(stateStore sm.Store,
-	mempool mempl.Mempool,
+	mempool mempool.Mempool,
 	evpool sm.EvidencePool,
 	st sm.State,
 	blk *types.Block,
@@ -831,7 +831,7 @@ func applyBlock(stateStore sm.Store,
 func buildAppStateFromChain(
 	proxyApp proxy.AppConns,
 	stateStore sm.Store,
-	mempool mempl.Mempool,
+	mempool mempool.Mempool,
 	evpool sm.EvidencePool,
 	state sm.State,
 	chain []*types.Block,
@@ -879,7 +879,7 @@ func buildAppStateFromChain(
 
 func buildTMStateFromChain(
 	config *cfg.Config,
-	mempool mempl.Mempool,
+	mempool mempool.Mempool,
 	evpool sm.EvidencePool,
 	stateStore sm.Store,
 	state sm.State,

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -24,7 +24,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/internal/proxy"
 	sm "github.com/tendermint/tendermint/internal/state"
@@ -361,7 +361,7 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	incrementHeight(vss...)
 	newValidatorPubKey1, err := css[nVals].privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
-	valPubKey1ABCI, err := cryptoenc.PubKeyToProto(newValidatorPubKey1)
+	valPubKey1ABCI, err := encoding.PubKeyToProto(newValidatorPubKey1)
 	require.NoError(t, err)
 	newValidatorTx1 := kvstore.MakeValSetChangeTx(valPubKey1ABCI, testMinPower)
 	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), newValidatorTx1, nil, mempool.TxInfo{})
@@ -393,7 +393,7 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	incrementHeight(vss...)
 	updateValidatorPubKey1, err := css[nVals].privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
-	updatePubKey1ABCI, err := cryptoenc.PubKeyToProto(updateValidatorPubKey1)
+	updatePubKey1ABCI, err := encoding.PubKeyToProto(updateValidatorPubKey1)
 	require.NoError(t, err)
 	updateValidatorTx1 := kvstore.MakeValSetChangeTx(updatePubKey1ABCI, 25)
 	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), updateValidatorTx1, nil, mempool.TxInfo{})
@@ -425,14 +425,14 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	incrementHeight(vss...)
 	newValidatorPubKey2, err := css[nVals+1].privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
-	newVal2ABCI, err := cryptoenc.PubKeyToProto(newValidatorPubKey2)
+	newVal2ABCI, err := encoding.PubKeyToProto(newValidatorPubKey2)
 	require.NoError(t, err)
 	newValidatorTx2 := kvstore.MakeValSetChangeTx(newVal2ABCI, testMinPower)
 	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), newValidatorTx2, nil, mempool.TxInfo{})
 	assert.Nil(t, err)
 	newValidatorPubKey3, err := css[nVals+2].privValidator.GetPubKey(context.Background())
 	require.NoError(t, err)
-	newVal3ABCI, err := cryptoenc.PubKeyToProto(newValidatorPubKey3)
+	newVal3ABCI, err := encoding.PubKeyToProto(newValidatorPubKey3)
 	require.NoError(t, err)
 	newValidatorTx3 := kvstore.MakeValSetChangeTx(newVal3ABCI, testMinPower)
 	err = assertMempool(css[0].txNotifier).CheckTx(context.Background(), newValidatorTx3, nil, mempool.TxInfo{})

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -22,7 +22,7 @@ import (
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	abci "github.com/tendermint/tendermint/abci/types"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/internal/mempool"
@@ -54,7 +54,7 @@ import (
 // and which ones we need the wal for - then we'd also be able to only flush the
 // wal writer when we need to, instead of with every message.
 
-func startNewStateAndWaitForBlock(t *testing.T, consensusReplayConfig *cfg.Config,
+func startNewStateAndWaitForBlock(t *testing.T, consensusReplayConfig *config.Config,
 	lastBlockHeight int64, blockDB dbm.DB, stateStore sm.Store) {
 	logger := log.TestingLogger()
 	state, err := sm.MakeGenesisStateFromFile(consensusReplayConfig.GenesisFile())
@@ -137,7 +137,7 @@ func TestWALCrash(t *testing.T) {
 	}
 }
 
-func crashWALandCheckLiveness(t *testing.T, consensusReplayConfig *cfg.Config,
+func crashWALandCheckLiveness(t *testing.T, consensusReplayConfig *config.Config,
 	initFn func(dbm.DB, *State, context.Context), heightToStop int64) {
 	walPanicked := make(chan error)
 	crashingWal := &crashingWAL{panicCh: walPanicked, heightToStop: heightToStop}
@@ -286,7 +286,7 @@ func (w *crashingWAL) Wait()        { w.next.Wait() }
 //------------------------------------------------------------------------------------------
 type simulatorTestSuite struct {
 	GenesisState sm.State
-	Config       *cfg.Config
+	Config       *config.Config
 	Chain        []*types.Block
 	Commits      []*types.Commit
 	CleanupFunc  cleanupFunc
@@ -311,7 +311,7 @@ var modes = []uint{0, 1, 2, 3}
 // This is actually not a test, it's for storing validator change tx data for testHandshakeReplay
 func setupSimulator(t *testing.T) *simulatorTestSuite {
 	t.Helper()
-	config := configSetup(t)
+	cfg := configSetup(t)
 
 	sim := &simulatorTestSuite{
 		Mempool: emptyMempool{},
@@ -321,14 +321,14 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	nPeers := 7
 	nVals := 4
 
-	css, genDoc, config, cleanup := randConsensusNetWithPeers(
-		config,
+	css, genDoc, cfg, cleanup := randConsensusNetWithPeers(
+		cfg,
 		nVals,
 		nPeers,
 		"replay_test",
 		newMockTickerFunc(true),
 		newPersistentKVStoreWithPath)
-	sim.Config = config
+	sim.Config = cfg
 	sim.GenesisState, _ = sm.MakeGenesisState(genDoc)
 	sim.CleanupFunc = cleanup
 
@@ -372,7 +372,7 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 
 	proposal := types.NewProposal(vss[1].Height, round, -1, blockID)
 	p := proposal.ToProto()
-	if err := vss[1].SignProposal(context.Background(), config.ChainID(), p); err != nil {
+	if err := vss[1].SignProposal(context.Background(), cfg.ChainID(), p); err != nil {
 		t.Fatal("failed to sign bad proposal", err)
 	}
 	proposal.Signature = p.Signature
@@ -404,7 +404,7 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 
 	proposal = types.NewProposal(vss[2].Height, round, -1, blockID)
 	p = proposal.ToProto()
-	if err := vss[2].SignProposal(context.Background(), config.ChainID(), p); err != nil {
+	if err := vss[2].SignProposal(context.Background(), cfg.ChainID(), p); err != nil {
 		t.Fatal("failed to sign bad proposal", err)
 	}
 	proposal.Signature = p.Signature
@@ -463,7 +463,7 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 
 	proposal = types.NewProposal(vss[3].Height, round, -1, blockID)
 	p = proposal.ToProto()
-	if err := vss[3].SignProposal(context.Background(), config.ChainID(), p); err != nil {
+	if err := vss[3].SignProposal(context.Background(), cfg.ChainID(), p); err != nil {
 		t.Fatal("failed to sign bad proposal", err)
 	}
 	proposal.Signature = p.Signature
@@ -526,7 +526,7 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	selfIndex = valIndexFn(0)
 	proposal = types.NewProposal(vss[1].Height, round, -1, blockID)
 	p = proposal.ToProto()
-	if err := vss[1].SignProposal(context.Background(), config.ChainID(), p); err != nil {
+	if err := vss[1].SignProposal(context.Background(), cfg.ChainID(), p); err != nil {
 		t.Fatal("failed to sign bad proposal", err)
 	}
 	proposal.Signature = p.Signature
@@ -611,8 +611,8 @@ func TestHandshakeReplayNone(t *testing.T) {
 // Test mockProxyApp should not panic when app return ABCIResponses with some empty ResponseDeliverTx
 func TestMockProxyApp(t *testing.T) {
 	sim := setupSimulator(t) // setup config and simulator
-	config := sim.Config
-	assert.NotNil(t, config)
+	cfg := sim.Config
+	assert.NotNil(t, cfg)
 
 	logger := log.TestingLogger()
 	var validTxs, invalidTxs = 0, 0
@@ -687,7 +687,7 @@ func testHandshakeReplay(t *testing.T, sim *simulatorTestSuite, nBlocks int, mod
 	var stateDB dbm.DB
 	var genesisState sm.State
 
-	config := sim.Config
+	cfg := sim.Config
 
 	if testValidatorsChange {
 		testConfig := ResetConfig(fmt.Sprintf("%s_%v_m", t.Name(), mode))
@@ -695,19 +695,19 @@ func testHandshakeReplay(t *testing.T, sim *simulatorTestSuite, nBlocks int, mod
 		stateDB = dbm.NewMemDB()
 
 		genesisState = sim.GenesisState
-		config = sim.Config
+		cfg = sim.Config
 		chain = append([]*types.Block{}, sim.Chain...) // copy chain
 		commits = sim.Commits
-		store = newMockBlockStore(config, genesisState.ConsensusParams)
+		store = newMockBlockStore(cfg, genesisState.ConsensusParams)
 	} else { // test single node
 		testConfig := ResetConfig(fmt.Sprintf("%s_%v_s", t.Name(), mode))
 		defer func() { _ = os.RemoveAll(testConfig.RootDir) }()
 		walBody, err := WALWithNBlocks(t, numBlocks)
 		require.NoError(t, err)
 		walFile := tempWALWithData(walBody)
-		config.Consensus.SetWalFile(walFile)
+		cfg.Consensus.SetWalFile(walFile)
 
-		privVal, err := privval.LoadFilePV(config.PrivValidator.KeyFile(), config.PrivValidator.StateFile())
+		privVal, err := privval.LoadFilePV(cfg.PrivValidator.KeyFile(), cfg.PrivValidator.StateFile())
 		require.NoError(t, err)
 
 		wal, err := NewWAL(walFile)
@@ -724,7 +724,7 @@ func testHandshakeReplay(t *testing.T, sim *simulatorTestSuite, nBlocks int, mod
 		require.NoError(t, err)
 		pubKey, err := privVal.GetPubKey(context.Background())
 		require.NoError(t, err)
-		stateDB, genesisState, store = stateAndStore(config, pubKey, kvstore.ProtocolVersion)
+		stateDB, genesisState, store = stateAndStore(cfg, pubKey, kvstore.ProtocolVersion)
 
 	}
 	stateStore := sm.NewStore(stateDB)
@@ -733,12 +733,12 @@ func testHandshakeReplay(t *testing.T, sim *simulatorTestSuite, nBlocks int, mod
 
 	state := genesisState.Copy()
 	// run the chain through state.ApplyBlock to build up the tendermint state
-	state = buildTMStateFromChain(config, sim.Mempool, sim.Evpool, stateStore, state, chain, nBlocks, mode, store)
+	state = buildTMStateFromChain(cfg, sim.Mempool, sim.Evpool, stateStore, state, chain, nBlocks, mode, store)
 	latestAppHash := state.AppHash
 
 	// make a new client creator
 	kvstoreApp := kvstore.NewPersistentKVStoreApplication(
-		filepath.Join(config.DBDir(), fmt.Sprintf("replay_test_%d_%d_a_r%d", nBlocks, mode, rand.Int())))
+		filepath.Join(cfg.DBDir(), fmt.Sprintf("replay_test_%d_%d_a_r%d", nBlocks, mode, rand.Int())))
 	t.Cleanup(func() { require.NoError(t, kvstoreApp.Close()) })
 
 	clientCreator2 := abciclient.NewLocalCreator(kvstoreApp)
@@ -763,7 +763,7 @@ func testHandshakeReplay(t *testing.T, sim *simulatorTestSuite, nBlocks int, mod
 	}
 
 	// now start the app using the handshake - it should sync
-	genDoc, _ := sm.MakeGenesisDocFromFile(config.GenesisFile())
+	genDoc, _ := sm.MakeGenesisDocFromFile(cfg.GenesisFile())
 	handshaker := NewHandshaker(stateStore, state, store, genDoc)
 	proxyApp := proxy.NewAppConns(clientCreator2)
 	if err := proxyApp.Start(); err != nil {
@@ -878,7 +878,7 @@ func buildAppStateFromChain(
 }
 
 func buildTMStateFromChain(
-	config *cfg.Config,
+	cfg *config.Config,
 	mempool mempool.Mempool,
 	evpool sm.EvidencePool,
 	stateStore sm.Store,
@@ -889,7 +889,7 @@ func buildTMStateFromChain(
 	blockStore *mockBlockStore) sm.State {
 	// run the whole chain against this client to build up the tendermint state
 	kvstoreApp := kvstore.NewPersistentKVStoreApplication(
-		filepath.Join(config.DBDir(), fmt.Sprintf("replay_test_%d_%d_t", nBlocks, mode)))
+		filepath.Join(cfg.DBDir(), fmt.Sprintf("replay_test_%d_%d_t", nBlocks, mode)))
 	defer kvstoreApp.Close()
 	clientCreator := abciclient.NewLocalCreator(kvstoreApp)
 
@@ -938,16 +938,16 @@ func TestHandshakePanicsIfAppReturnsWrongAppHash(t *testing.T) {
 	//		- 0x01
 	//		- 0x02
 	//		- 0x03
-	config := ResetConfig("handshake_test_")
-	t.Cleanup(func() { os.RemoveAll(config.RootDir) })
-	privVal, err := privval.LoadFilePV(config.PrivValidator.KeyFile(), config.PrivValidator.StateFile())
+	cfg := ResetConfig("handshake_test_")
+	t.Cleanup(func() { os.RemoveAll(cfg.RootDir) })
+	privVal, err := privval.LoadFilePV(cfg.PrivValidator.KeyFile(), cfg.PrivValidator.StateFile())
 	require.NoError(t, err)
 	const appVersion = 0x0
 	pubKey, err := privVal.GetPubKey(context.Background())
 	require.NoError(t, err)
-	stateDB, state, store := stateAndStore(config, pubKey, appVersion)
+	stateDB, state, store := stateAndStore(cfg, pubKey, appVersion)
 	stateStore := sm.NewStore(stateDB)
-	genDoc, _ := sm.MakeGenesisDocFromFile(config.GenesisFile())
+	genDoc, _ := sm.MakeGenesisDocFromFile(cfg.GenesisFile())
 	state.LastValidators = state.Validators.Copy()
 	// mode = 0 for committing all the blocks
 	blocks := sf.MakeBlocks(3, &state, privVal)
@@ -1153,14 +1153,14 @@ func readPieceFromWAL(msg *TimedWALMessage) interface{} {
 
 // fresh state and mock store
 func stateAndStore(
-	config *cfg.Config,
+	cfg *config.Config,
 	pubKey crypto.PubKey,
 	appVersion uint64) (dbm.DB, sm.State, *mockBlockStore) {
 	stateDB := dbm.NewMemDB()
 	stateStore := sm.NewStore(stateDB)
-	state, _ := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	state, _ := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
 	state.Version.Consensus.App = appVersion
-	store := newMockBlockStore(config, state.ConsensusParams)
+	store := newMockBlockStore(cfg, state.ConsensusParams)
 	if err := stateStore.Save(state); err != nil {
 		panic(err)
 	}
@@ -1171,7 +1171,7 @@ func stateAndStore(
 // mock block store
 
 type mockBlockStore struct {
-	config  *cfg.Config
+	cfg     *config.Config
 	params  types.ConsensusParams
 	chain   []*types.Block
 	commits []*types.Commit
@@ -1179,8 +1179,8 @@ type mockBlockStore struct {
 }
 
 // TODO: NewBlockStore(db.NewMemDB) ...
-func newMockBlockStore(config *cfg.Config, params types.ConsensusParams) *mockBlockStore {
-	return &mockBlockStore{config, params, nil, nil, 0}
+func newMockBlockStore(cfg *config.Config, params types.ConsensusParams) *mockBlockStore {
+	return &mockBlockStore{cfg, params, nil, nil, 0}
 }
 
 func (bs *mockBlockStore) Height() int64                       { return int64(len(bs.chain)) }
@@ -1228,20 +1228,20 @@ func TestHandshakeUpdatesValidators(t *testing.T) {
 	app := &initChainApp{vals: types.TM2PB.ValidatorUpdates(vals)}
 	clientCreator := abciclient.NewLocalCreator(app)
 
-	config := ResetConfig("handshake_test_")
-	t.Cleanup(func() { _ = os.RemoveAll(config.RootDir) })
+	cfg := ResetConfig("handshake_test_")
+	t.Cleanup(func() { _ = os.RemoveAll(cfg.RootDir) })
 
-	privVal, err := privval.LoadFilePV(config.PrivValidator.KeyFile(), config.PrivValidator.StateFile())
+	privVal, err := privval.LoadFilePV(cfg.PrivValidator.KeyFile(), cfg.PrivValidator.StateFile())
 	require.NoError(t, err)
 	pubKey, err := privVal.GetPubKey(context.Background())
 	require.NoError(t, err)
-	stateDB, state, store := stateAndStore(config, pubKey, 0x0)
+	stateDB, state, store := stateAndStore(cfg, pubKey, 0x0)
 	stateStore := sm.NewStore(stateDB)
 
 	oldValAddr := state.Validators.Validators[0].Address
 
 	// now start the app using the handshake - it should sync
-	genDoc, _ := sm.MakeGenesisDocFromFile(config.GenesisFile())
+	genDoc, _ := sm.MakeGenesisDocFromFile(cfg.GenesisFile())
 	handshaker := NewHandshaker(stateStore, state, store, genDoc)
 	proxyApp := proxy.NewAppConns(clientCreator)
 	if err := proxyApp.Start(); err != nil {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	cstypes "github.com/tendermint/tendermint/internal/consensus/types"
 	"github.com/tendermint/tendermint/internal/libs/fail"
@@ -80,7 +80,7 @@ type State struct {
 	service.BaseService
 
 	// config details
-	config            *cfg.ConsensusConfig
+	config            *config.ConsensusConfig
 	privValidator     types.PrivValidator // for signing votes
 	privValidatorType types.PrivValidatorType
 
@@ -152,7 +152,7 @@ type StateOption func(*State)
 
 // NewState returns a new State.
 func NewState(
-	config *cfg.ConsensusConfig,
+	cfg *config.ConsensusConfig,
 	state sm.State,
 	blockExec *sm.BlockExecutor,
 	blockStore sm.BlockStore,
@@ -161,7 +161,7 @@ func NewState(
 	options ...StateOption,
 ) *State {
 	cs := &State{
-		config:           config,
+		config:           cfg,
 		blockExec:        blockExec,
 		blockStore:       blockStore,
 		txNotifier:       txNotifier,

--- a/internal/consensus/types/height_vote_set_test.go
+++ b/internal/consensus/types/height_vote_set_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	"github.com/tendermint/tendermint/internal/test/factory"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
@@ -15,19 +15,19 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-var config *cfg.Config // NOTE: must be reset for each _test.go file
+var cfg *config.Config // NOTE: must be reset for each _test.go file
 
 func TestMain(m *testing.M) {
-	config = cfg.ResetTestRoot("consensus_height_vote_set_test")
+	cfg = config.ResetTestRoot("consensus_height_vote_set_test")
 	code := m.Run()
-	os.RemoveAll(config.RootDir)
+	os.RemoveAll(cfg.RootDir)
 	os.Exit(code)
 }
 
 func TestPeerCatchupRounds(t *testing.T) {
 	valSet, privVals := factory.RandValidatorSet(10, 1)
 
-	hvs := NewHeightVoteSet(config.ChainID(), 1, valSet)
+	hvs := NewHeightVoteSet(cfg.ChainID(), 1, valSet)
 
 	vote999_0 := makeVoteHR(t, 1, 0, 999, privVals)
 	added, err := hvs.AddVote(vote999_0, "peer1")
@@ -75,7 +75,7 @@ func makeVoteHR(t *testing.T, height int64, valIndex, round int32, privVals []ty
 		Type:             tmproto.PrecommitType,
 		BlockID:          types.BlockID{Hash: randBytes, PartSetHeader: types.PartSetHeader{}},
 	}
-	chainID := config.ChainID()
+	chainID := cfg.ChainID()
 
 	v := vote.ToProto()
 	err = privVal.SignVote(context.Background(), chainID, v)

--- a/internal/consensus/wal_generator.go
+++ b/internal/consensus/wal_generator.go
@@ -15,7 +15,7 @@ import (
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/proxy"
 	sm "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/libs/log"
@@ -30,9 +30,9 @@ import (
 // (byteBufferWAL) and waits until numBlocks are created.
 // If the node fails to produce given numBlocks, it returns an error.
 func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
-	config := getConfig(t)
+	cfg := getConfig(t)
 
-	app := kvstore.NewPersistentKVStoreApplication(filepath.Join(config.DBDir(), "wal_generator"))
+	app := kvstore.NewPersistentKVStoreApplication(filepath.Join(cfg.DBDir(), "wal_generator"))
 	t.Cleanup(func() { require.NoError(t, app.Close()) })
 
 	logger := log.TestingLogger().With("wal_generator", "wal_generator")
@@ -41,13 +41,13 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	// COPY PASTE FROM node.go WITH A FEW MODIFICATIONS
 	// NOTE: we can't import node package because of circular dependency.
 	// NOTE: we don't do handshake so need to set state.Version.Consensus.App directly.
-	privValidatorKeyFile := config.PrivValidator.KeyFile()
-	privValidatorStateFile := config.PrivValidator.StateFile()
+	privValidatorKeyFile := cfg.PrivValidator.KeyFile()
+	privValidatorStateFile := cfg.PrivValidator.StateFile()
 	privValidator, err := privval.LoadOrGenFilePV(privValidatorKeyFile, privValidatorStateFile)
 	if err != nil {
 		return err
 	}
-	genDoc, err := types.GenesisDocFromFile(config.GenesisFile())
+	genDoc, err := types.GenesisDocFromFile(cfg.GenesisFile())
 	if err != nil {
 		return fmt.Errorf("failed to read genesis file: %w", err)
 	}
@@ -89,7 +89,7 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	mempool := emptyMempool{}
 	evpool := sm.EmptyEvidencePool{}
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, blockStore)
-	consensusState := NewState(config.Consensus, state.Copy(), blockExec, blockStore, mempool, evpool)
+	consensusState := NewState(cfg.Consensus, state.Copy(), blockExec, blockStore, mempool, evpool)
 	consensusState.SetLogger(logger)
 	consensusState.SetEventBus(eventBus)
 	if privValidator != nil && privValidator != (*privval.FilePV)(nil) {
@@ -153,8 +153,8 @@ func makeAddrs() (string, string, string) {
 }
 
 // getConfig returns a config for test cases
-func getConfig(t *testing.T) *cfg.Config {
-	c := cfg.ResetTestRoot(t.Name())
+func getConfig(t *testing.T) *config.Config {
+	c := config.ResetTestRoot(t.Name())
 
 	// and we use random ports to run in parallel
 	tm, rpc, grpc := makeAddrs()

--- a/internal/consensus/wal_generator.go
+++ b/internal/consensus/wal_generator.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	db "github.com/tendermint/tm-db"
+	dbm "github.com/tendermint/tm-db"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
@@ -51,7 +51,7 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to read genesis file: %w", err)
 	}
-	blockStoreDB := db.NewMemDB()
+	blockStoreDB := dbm.NewMemDB()
 	stateDB := blockStoreDB
 	stateStore := sm.NewStore(stateDB)
 	state, err := sm.MakeGenesisState(genDoc)

--- a/internal/evidence/verify_test.go
+++ b/internal/evidence/verify_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/crypto"

--- a/internal/mempool/mock/mempool.go
+++ b/internal/mempool/mock/mempool.go
@@ -5,19 +5,19 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/internal/libs/clist"
-	mempl "github.com/tendermint/tendermint/internal/mempool"
+	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/types"
 )
 
 // Mempool is an empty implementation of a Mempool, useful for testing.
 type Mempool struct{}
 
-var _ mempl.Mempool = Mempool{}
+var _ mempool.Mempool = Mempool{}
 
 func (Mempool) Lock()     {}
 func (Mempool) Unlock()   {}
 func (Mempool) Size() int { return 0 }
-func (Mempool) CheckTx(_ context.Context, _ types.Tx, _ func(*abci.Response), _ mempl.TxInfo) error {
+func (Mempool) CheckTx(_ context.Context, _ types.Tx, _ func(*abci.Response), _ mempool.TxInfo) error {
 	return nil
 }
 func (Mempool) ReapMaxBytesMaxGas(_, _ int64) types.Txs { return types.Txs{} }
@@ -26,8 +26,8 @@ func (Mempool) Update(
 	_ int64,
 	_ types.Txs,
 	_ []*abci.ResponseDeliverTx,
-	_ mempl.PreCheckFunc,
-	_ mempl.PostCheckFunc,
+	_ mempool.PreCheckFunc,
+	_ mempool.PostCheckFunc,
 ) error {
 	return nil
 }

--- a/internal/mempool/v0/clist_mempool.go
+++ b/internal/mempool/v0/clist_mempool.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 
 	abci "github.com/tendermint/tendermint/abci/types"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/libs/clist"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/internal/mempool"
@@ -32,7 +32,7 @@ type CListMempool struct {
 	notifiedTxsAvailable bool
 	txsAvailable         chan struct{} // fires once for each height, when the mempool is not empty
 
-	config *cfg.MempoolConfig
+	config *config.MempoolConfig
 
 	// Exclusive mutex for Update method to prevent concurrent execution of
 	// CheckTx or ReapMaxBytesMaxGas(ReapMaxTxs) methods.
@@ -69,14 +69,14 @@ type CListMempoolOption func(*CListMempool)
 // NewCListMempool returns a new mempool with the given configuration and
 // connection to an application.
 func NewCListMempool(
-	config *cfg.MempoolConfig,
+	cfg *config.MempoolConfig,
 	proxyAppConn proxy.AppConnMempool,
 	height int64,
 	options ...CListMempoolOption,
 ) *CListMempool {
 
 	mp := &CListMempool{
-		config:        config,
+		config:        cfg,
 		proxyAppConn:  proxyAppConn,
 		txs:           clist.New(),
 		height:        height,
@@ -86,8 +86,8 @@ func NewCListMempool(
 		metrics:       mempool.NopMetrics(),
 	}
 
-	if config.CacheSize > 0 {
-		mp.cache = mempool.NewLRUTxCache(config.CacheSize)
+	if cfg.CacheSize > 0 {
+		mp.cache = mempool.NewLRUTxCache(cfg.CacheSize)
 	} else {
 		mp.cache = mempool.NopTxCache{}
 	}

--- a/internal/mempool/v0/clist_mempool_test.go
+++ b/internal/mempool/v0/clist_mempool_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	abciserver "github.com/tendermint/tendermint/abci/server"
 	abci "github.com/tendermint/tendermint/abci/types"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/libs/log"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
@@ -32,10 +32,10 @@ import (
 type cleanupFunc func()
 
 func newMempoolWithApp(cc abciclient.Creator) (*CListMempool, cleanupFunc) {
-	return newMempoolWithAppAndConfig(cc, cfg.ResetTestRoot("mempool_test"))
+	return newMempoolWithAppAndConfig(cc, config.ResetTestRoot("mempool_test"))
 }
 
-func newMempoolWithAppAndConfig(cc abciclient.Creator, config *cfg.Config) (*CListMempool, cleanupFunc) {
+func newMempoolWithAppAndConfig(cc abciclient.Creator, cfg *config.Config) (*CListMempool, cleanupFunc) {
 	appConnMem, _ := cc()
 	appConnMem.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "mempool"))
 	err := appConnMem.Start()
@@ -43,10 +43,10 @@ func newMempoolWithAppAndConfig(cc abciclient.Creator, config *cfg.Config) (*CLi
 		panic(err)
 	}
 
-	mp := NewCListMempool(config.Mempool, appConnMem, 0)
+	mp := NewCListMempool(cfg.Mempool, appConnMem, 0)
 	mp.SetLogger(log.TestingLogger())
 
-	return mp, func() { os.RemoveAll(config.RootDir) }
+	return mp, func() { os.RemoveAll(cfg.RootDir) }
 }
 
 func ensureNoFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
@@ -217,7 +217,7 @@ func TestMempoolUpdate(t *testing.T) {
 func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := abciclient.NewLocalCreator(app)
-	wcfg := cfg.DefaultConfig()
+	wcfg := config.DefaultConfig()
 	wcfg.Mempool.KeepInvalidTxsInCache = true
 	mp, cleanup := newMempoolWithAppAndConfig(cc, wcfg)
 	defer cleanup()
@@ -465,9 +465,9 @@ func TestMempool_CheckTxChecksTxSize(t *testing.T) {
 func TestMempoolTxsBytes(t *testing.T) {
 	app := kvstore.NewApplication()
 	cc := abciclient.NewLocalCreator(app)
-	config := cfg.ResetTestRoot("mempool_test")
-	config.Mempool.MaxTxsBytes = 10
-	mp, cleanup := newMempoolWithAppAndConfig(cc, config)
+	cfg := config.ResetTestRoot("mempool_test")
+	cfg.Mempool.MaxTxsBytes = 10
+	mp, cleanup := newMempoolWithAppAndConfig(cc, cfg)
 	defer cleanup()
 
 	// 1. zero by default
@@ -564,8 +564,8 @@ func TestMempoolRemoteAppConcurrency(t *testing.T) {
 			t.Error(err)
 		}
 	})
-	config := cfg.ResetTestRoot("mempool_test")
-	mp, cleanup := newMempoolWithAppAndConfig(cc, config)
+	cfg := config.ResetTestRoot("mempool_test")
+	mp, cleanup := newMempoolWithAppAndConfig(cc, cfg)
 	defer cleanup()
 
 	// generate small number of txs
@@ -577,7 +577,7 @@ func TestMempoolRemoteAppConcurrency(t *testing.T) {
 	}
 
 	// simulate a group of peers sending them over and over
-	N := config.Mempool.Size
+	N := cfg.Mempool.Size
 	maxPeers := 5
 	for i := 0; i < N; i++ {
 		peerID := mrand.Intn(maxPeers)

--- a/internal/mempool/v0/reactor.go
+++ b/internal/mempool/v0/reactor.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/libs/clist"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/internal/mempool"
@@ -37,7 +37,7 @@ type PeerManager interface {
 type Reactor struct {
 	service.BaseService
 
-	config  *cfg.MempoolConfig
+	cfg     *config.MempoolConfig
 	mempool *CListMempool
 	ids     *mempool.MempoolIDs
 
@@ -61,7 +61,7 @@ type Reactor struct {
 // NewReactor returns a reference to a new reactor.
 func NewReactor(
 	logger log.Logger,
-	config *cfg.MempoolConfig,
+	cfg *config.MempoolConfig,
 	peerMgr PeerManager,
 	mp *CListMempool,
 	mempoolCh *p2p.Channel,
@@ -69,7 +69,7 @@ func NewReactor(
 ) *Reactor {
 
 	r := &Reactor{
-		config:       config,
+		cfg:          cfg,
 		peerMgr:      peerMgr,
 		mempool:      mp,
 		ids:          mempool.NewMempoolIDs(),
@@ -90,8 +90,8 @@ func NewReactor(
 //
 // TODO: Remove once p2p refactor is complete.
 // ref: https://github.com/tendermint/tendermint/issues/5670
-func GetChannelShims(config *cfg.MempoolConfig) map[p2p.ChannelID]*p2p.ChannelDescriptorShim {
-	largestTx := make([]byte, config.MaxTxBytes)
+func GetChannelShims(cfg *config.MempoolConfig) map[p2p.ChannelID]*p2p.ChannelDescriptorShim {
+	largestTx := make([]byte, cfg.MaxTxBytes)
 	batchMsg := protomem.Message{
 		Sum: &protomem.Message_Txs{
 			Txs: &protomem.Txs{Txs: [][]byte{largestTx}},
@@ -117,7 +117,7 @@ func GetChannelShims(config *cfg.MempoolConfig) map[p2p.ChannelID]*p2p.ChannelDe
 // messages on that p2p channel accordingly. The caller must be sure to execute
 // OnStop to ensure the outbound p2p Channels are closed.
 func (r *Reactor) OnStart() error {
-	if !r.config.Broadcast {
+	if !r.cfg.Broadcast {
 		r.Logger.Info("tx broadcasting is disabled")
 	}
 
@@ -254,7 +254,7 @@ func (r *Reactor) processPeerUpdate(peerUpdate p2p.PeerUpdate) {
 			return
 		}
 
-		if r.config.Broadcast {
+		if r.cfg.Broadcast {
 			// Check if we've already started a goroutine for this peer, if not we create
 			// a new done channel so we can explicitly close the goroutine if the peer
 			// is later removed, we increment the waitgroup so the reactor can stop

--- a/internal/mempool/v1/reactor.go
+++ b/internal/mempool/v1/reactor.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/libs/clist"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/internal/mempool"
@@ -37,7 +37,7 @@ type PeerManager interface {
 type Reactor struct {
 	service.BaseService
 
-	config  *cfg.MempoolConfig
+	cfg     *config.MempoolConfig
 	mempool *TxMempool
 	ids     *mempool.MempoolIDs
 
@@ -65,7 +65,7 @@ type Reactor struct {
 // NewReactor returns a reference to a new reactor.
 func NewReactor(
 	logger log.Logger,
-	config *cfg.MempoolConfig,
+	cfg *config.MempoolConfig,
 	peerMgr PeerManager,
 	txmp *TxMempool,
 	mempoolCh *p2p.Channel,
@@ -73,7 +73,7 @@ func NewReactor(
 ) *Reactor {
 
 	r := &Reactor{
-		config:       config,
+		cfg:          cfg,
 		peerMgr:      peerMgr,
 		mempool:      txmp,
 		ids:          mempool.NewMempoolIDs(),
@@ -97,8 +97,8 @@ func defaultObservePanic(r interface{}) {}
 //
 // TODO: Remove once p2p refactor is complete.
 // ref: https://github.com/tendermint/tendermint/issues/5670
-func GetChannelShims(config *cfg.MempoolConfig) map[p2p.ChannelID]*p2p.ChannelDescriptorShim {
-	largestTx := make([]byte, config.MaxTxBytes)
+func GetChannelShims(cfg *config.MempoolConfig) map[p2p.ChannelID]*p2p.ChannelDescriptorShim {
+	largestTx := make([]byte, cfg.MaxTxBytes)
 	batchMsg := protomem.Message{
 		Sum: &protomem.Message_Txs{
 			Txs: &protomem.Txs{Txs: [][]byte{largestTx}},
@@ -124,7 +124,7 @@ func GetChannelShims(config *cfg.MempoolConfig) map[p2p.ChannelID]*p2p.ChannelDe
 // messages on that p2p channel accordingly. The caller must be sure to execute
 // OnStop to ensure the outbound p2p Channels are closed.
 func (r *Reactor) OnStart() error {
-	if !r.config.Broadcast {
+	if !r.cfg.Broadcast {
 		r.Logger.Info("tx broadcasting is disabled")
 	}
 
@@ -262,7 +262,7 @@ func (r *Reactor) processPeerUpdate(peerUpdate p2p.PeerUpdate) {
 			return
 		}
 
-		if r.config.Broadcast {
+		if r.cfg.Broadcast {
 			// Check if we've already started a goroutine for this peer, if not we create
 			// a new done channel so we can explicitly close the goroutine if the peer
 			// is later removed, we increment the waitgroup so the reactor can stop

--- a/internal/p2p/conn/evil_secret_connection_test.go
+++ b/internal/p2p/conn/evil_secret_connection_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/internal/libs/protoio"
 	tmp2p "github.com/tendermint/tendermint/proto/tendermint/p2p"
 )
@@ -113,7 +113,7 @@ func (c *evilConn) Read(data []byte) (n int, err error) {
 	case 1:
 		signature := c.signChallenge()
 		if !c.badAuthSignature {
-			pkpb, err := cryptoenc.PubKeyToProto(c.privKey.PubKey())
+			pkpb, err := encoding.PubKeyToProto(c.privKey.PubKey())
 			if err != nil {
 				panic(err)
 			}

--- a/internal/p2p/conn/secret_connection.go
+++ b/internal/p2p/conn/secret_connection.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/internal/libs/protoio"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/libs/async"
@@ -406,7 +406,7 @@ func shareAuthSignature(sc io.ReadWriter, pubKey crypto.PubKey, signature []byte
 	// Send our info and receive theirs in tandem.
 	var trs, _ = async.Parallel(
 		func(_ int) (val interface{}, abort bool, err error) {
-			pbpk, err := cryptoenc.PubKeyToProto(pubKey)
+			pbpk, err := encoding.PubKeyToProto(pubKey)
 			if err != nil {
 				return nil, true, err
 			}
@@ -423,7 +423,7 @@ func shareAuthSignature(sc io.ReadWriter, pubKey crypto.PubKey, signature []byte
 				return nil, true, err // abort
 			}
 
-			pk, err := cryptoenc.PubKeyFromProto(pba.PubKey)
+			pk, err := encoding.PubKeyFromProto(pba.PubKey)
 			if err != nil {
 				return nil, true, err // abort
 			}

--- a/internal/p2p/peermanager_scoring_test.go
+++ b/internal/p2p/peermanager_scoring_test.go
@@ -6,9 +6,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
+
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 )
 
 func TestPeerScoring(t *testing.T) {

--- a/internal/rpc/core/abci.go
+++ b/internal/rpc/core/abci.go
@@ -4,7 +4,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/internal/proxy"
 	"github.com/tendermint/tendermint/libs/bytes"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
@@ -16,7 +16,7 @@ func (env *Environment) ABCIQuery(
 	data bytes.HexBytes,
 	height int64,
 	prove bool,
-) (*ctypes.ResultABCIQuery, error) {
+) (*coretypes.ResultABCIQuery, error) {
 	resQuery, err := env.ProxyAppQuery.QuerySync(ctx.Context(), abci.RequestQuery{
 		Path:   path,
 		Data:   data,
@@ -27,16 +27,16 @@ func (env *Environment) ABCIQuery(
 		return nil, err
 	}
 
-	return &ctypes.ResultABCIQuery{Response: *resQuery}, nil
+	return &coretypes.ResultABCIQuery{Response: *resQuery}, nil
 }
 
 // ABCIInfo gets some info about the application.
 // More: https://docs.tendermint.com/master/rpc/#/ABCI/abci_info
-func (env *Environment) ABCIInfo(ctx *rpctypes.Context) (*ctypes.ResultABCIInfo, error) {
+func (env *Environment) ABCIInfo(ctx *rpctypes.Context) (*coretypes.ResultABCIInfo, error) {
 	resInfo, err := env.ProxyAppQuery.InfoSync(ctx.Context(), proxy.RequestInfo)
 	if err != nil {
 		return nil, err
 	}
 
-	return &ctypes.ResultABCIInfo{Response: *resInfo}, nil
+	return &coretypes.ResultABCIInfo{Response: *resInfo}, nil
 }

--- a/internal/rpc/core/blocks.go
+++ b/internal/rpc/core/blocks.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tendermint/tendermint/libs/bytes"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -25,7 +25,7 @@ import (
 // More: https://docs.tendermint.com/master/rpc/#/Info/blockchain
 func (env *Environment) BlockchainInfo(
 	ctx *rpctypes.Context,
-	minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error) {
+	minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
 
 	const limit int64 = 20
 
@@ -49,7 +49,7 @@ func (env *Environment) BlockchainInfo(
 		}
 	}
 
-	return &ctypes.ResultBlockchainInfo{
+	return &coretypes.ResultBlockchainInfo{
 		LastHeight: env.BlockStore.Height(),
 		BlockMetas: blockMetas}, nil
 }
@@ -60,7 +60,7 @@ func (env *Environment) BlockchainInfo(
 func filterMinMax(base, height, min, max, limit int64) (int64, int64, error) {
 	// filter negatives
 	if min < 0 || max < 0 {
-		return min, max, ctypes.ErrZeroOrNegativeHeight
+		return min, max, coretypes.ErrZeroOrNegativeHeight
 	}
 
 	// adjust for default values
@@ -83,7 +83,7 @@ func filterMinMax(base, height, min, max, limit int64) (int64, int64, error) {
 
 	if min > max {
 		return min, max, fmt.Errorf("%w: min height %d can't be greater than max height %d",
-			ctypes.ErrInvalidRequest, min, max)
+			coretypes.ErrInvalidRequest, min, max)
 	}
 	return min, max, nil
 }
@@ -91,7 +91,7 @@ func filterMinMax(base, height, min, max, limit int64) (int64, int64, error) {
 // Block gets block at a given height.
 // If no height is provided, it will fetch the latest block.
 // More: https://docs.tendermint.com/master/rpc/#/Info/block
-func (env *Environment) Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error) {
+func (env *Environment) Block(ctx *rpctypes.Context, heightPtr *int64) (*coretypes.ResultBlock, error) {
 	height, err := env.getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
 		return nil, err
@@ -99,33 +99,33 @@ func (env *Environment) Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.
 
 	blockMeta := env.BlockStore.LoadBlockMeta(height)
 	if blockMeta == nil {
-		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: nil}, nil
+		return &coretypes.ResultBlock{BlockID: types.BlockID{}, Block: nil}, nil
 	}
 
 	block := env.BlockStore.LoadBlock(height)
-	return &ctypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block}, nil
+	return &coretypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block}, nil
 }
 
 // BlockByHash gets block by hash.
 // More: https://docs.tendermint.com/master/rpc/#/Info/block_by_hash
-func (env *Environment) BlockByHash(ctx *rpctypes.Context, hash bytes.HexBytes) (*ctypes.ResultBlock, error) {
+func (env *Environment) BlockByHash(ctx *rpctypes.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error) {
 	// N.B. The hash parameter is HexBytes so that the reflective parameter
 	// decoding logic in the HTTP service will correctly translate from JSON.
 	// See https://github.com/tendermint/tendermint/issues/6802 for context.
 
 	block := env.BlockStore.LoadBlockByHash(hash)
 	if block == nil {
-		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: nil}, nil
+		return &coretypes.ResultBlock{BlockID: types.BlockID{}, Block: nil}, nil
 	}
 	// If block is not nil, then blockMeta can't be nil.
 	blockMeta := env.BlockStore.LoadBlockMeta(block.Height)
-	return &ctypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block}, nil
+	return &coretypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block}, nil
 }
 
 // Commit gets block commit at a given height.
 // If no height is provided, it will fetch the commit for the latest block.
 // More: https://docs.tendermint.com/master/rpc/#/Info/commit
-func (env *Environment) Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, error) {
+func (env *Environment) Commit(ctx *rpctypes.Context, heightPtr *int64) (*coretypes.ResultCommit, error) {
 	height, err := env.getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
 		return nil, err
@@ -144,7 +144,7 @@ func (env *Environment) Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes
 		// NOTE: we can't yet ensure atomicity of operations in asserting
 		// whether this is the latest height and retrieving the seen commit
 		if commit != nil && commit.Height == height {
-			return ctypes.NewResultCommit(&header, commit, false), nil
+			return coretypes.NewResultCommit(&header, commit, false), nil
 		}
 	}
 
@@ -153,7 +153,7 @@ func (env *Environment) Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes
 	if commit == nil {
 		return nil, nil
 	}
-	return ctypes.NewResultCommit(&header, commit, true), nil
+	return coretypes.NewResultCommit(&header, commit, true), nil
 }
 
 // BlockResults gets ABCIResults at a given height.
@@ -163,7 +163,7 @@ func (env *Environment) Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes
 // Thus response.results.deliver_tx[5] is the results of executing
 // getBlock(h).Txs[5]
 // More: https://docs.tendermint.com/master/rpc/#/Info/block_results
-func (env *Environment) BlockResults(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlockResults, error) {
+func (env *Environment) BlockResults(ctx *rpctypes.Context, heightPtr *int64) (*coretypes.ResultBlockResults, error) {
 	height, err := env.getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
 		return nil, err
@@ -179,7 +179,7 @@ func (env *Environment) BlockResults(ctx *rpctypes.Context, heightPtr *int64) (*
 		totalGasUsed += tx.GetGasUsed()
 	}
 
-	return &ctypes.ResultBlockResults{
+	return &coretypes.ResultBlockResults{
 		Height:                height,
 		TxsResults:            results.DeliverTxs,
 		TotalGasUsed:          totalGasUsed,
@@ -197,7 +197,7 @@ func (env *Environment) BlockSearch(
 	query string,
 	pagePtr, perPagePtr *int,
 	orderBy string,
-) (*ctypes.ResultBlockSearch, error) {
+) (*coretypes.ResultBlockSearch, error) {
 
 	if !indexer.KVSinkEnabled(env.EventSinks) {
 		return nil, fmt.Errorf("block searching is disabled due to no kvEventSink")
@@ -229,7 +229,7 @@ func (env *Environment) BlockSearch(
 		sort.Slice(results, func(i, j int) bool { return results[i] < results[j] })
 
 	default:
-		return nil, fmt.Errorf("expected order_by to be either `asc` or `desc` or empty: %w", ctypes.ErrInvalidRequest)
+		return nil, fmt.Errorf("expected order_by to be either `asc` or `desc` or empty: %w", coretypes.ErrInvalidRequest)
 	}
 
 	// paginate results
@@ -244,13 +244,13 @@ func (env *Environment) BlockSearch(
 	skipCount := validateSkipCount(page, perPage)
 	pageSize := tmmath.MinInt(perPage, totalCount-skipCount)
 
-	apiResults := make([]*ctypes.ResultBlock, 0, pageSize)
+	apiResults := make([]*coretypes.ResultBlock, 0, pageSize)
 	for i := skipCount; i < skipCount+pageSize; i++ {
 		block := env.BlockStore.LoadBlock(results[i])
 		if block != nil {
 			blockMeta := env.BlockStore.LoadBlockMeta(block.Height)
 			if blockMeta != nil {
-				apiResults = append(apiResults, &ctypes.ResultBlock{
+				apiResults = append(apiResults, &coretypes.ResultBlock{
 					Block:   block,
 					BlockID: blockMeta.BlockID,
 				})
@@ -258,5 +258,5 @@ func (env *Environment) BlockSearch(
 		}
 	}
 
-	return &ctypes.ResultBlockSearch{Blocks: apiResults, TotalCount: totalCount}, nil
+	return &coretypes.ResultBlockSearch{Blocks: apiResults, TotalCount: totalCount}, nil
 }

--- a/internal/rpc/core/blocks_test.go
+++ b/internal/rpc/core/blocks_test.go
@@ -12,7 +12,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	sm "github.com/tendermint/tendermint/internal/state"
 	tmstate "github.com/tendermint/tendermint/proto/tendermint/state"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -89,12 +89,12 @@ func TestBlockResults(t *testing.T) {
 	testCases := []struct {
 		height  int64
 		wantErr bool
-		wantRes *ctypes.ResultBlockResults
+		wantRes *coretypes.ResultBlockResults
 	}{
 		{-1, true, nil},
 		{0, true, nil},
 		{101, true, nil},
-		{100, false, &ctypes.ResultBlockResults{
+		{100, false, &coretypes.ResultBlockResults{
 			Height:                100,
 			TxsResults:            results.DeliverTxs,
 			TotalGasUsed:          15,

--- a/internal/rpc/core/consensus.go
+++ b/internal/rpc/core/consensus.go
@@ -3,7 +3,7 @@ package core
 import (
 	"errors"
 
-	cm "github.com/tendermint/tendermint/internal/consensus"
+	"github.com/tendermint/tendermint/internal/consensus"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
@@ -63,7 +63,7 @@ func (env *Environment) DumpConsensusState(ctx *rpctypes.Context) (*coretypes.Re
 		peers := env.P2PPeers.Peers().List()
 		peerStates = make([]coretypes.PeerStateInfo, 0, len(peers))
 		for _, peer := range peers {
-			peerState, ok := peer.Get(types.PeerStateKey).(*cm.PeerState)
+			peerState, ok := peer.Get(types.PeerStateKey).(*consensus.PeerState)
 			if !ok { // peer does not have a state yet
 				continue
 			}

--- a/internal/rpc/core/consensus.go
+++ b/internal/rpc/core/consensus.go
@@ -5,7 +5,7 @@ import (
 
 	cm "github.com/tendermint/tendermint/internal/consensus"
 	tmmath "github.com/tendermint/tendermint/libs/math"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -20,7 +20,7 @@ import (
 func (env *Environment) Validators(
 	ctx *rpctypes.Context,
 	heightPtr *int64,
-	pagePtr, perPagePtr *int) (*ctypes.ResultValidators, error) {
+	pagePtr, perPagePtr *int) (*coretypes.ResultValidators, error) {
 
 	// The latest validator that we know is the NextValidator of the last block.
 	height, err := env.getHeight(env.latestUncommittedHeight(), heightPtr)
@@ -44,7 +44,7 @@ func (env *Environment) Validators(
 
 	v := validators.Validators[skipCount : skipCount+tmmath.MinInt(perPage, totalCount-skipCount)]
 
-	return &ctypes.ResultValidators{
+	return &coretypes.ResultValidators{
 		BlockHeight: height,
 		Validators:  v,
 		Count:       len(v),
@@ -54,14 +54,14 @@ func (env *Environment) Validators(
 // DumpConsensusState dumps consensus state.
 // UNSTABLE
 // More: https://docs.tendermint.com/master/rpc/#/Info/dump_consensus_state
-func (env *Environment) DumpConsensusState(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState, error) {
+func (env *Environment) DumpConsensusState(ctx *rpctypes.Context) (*coretypes.ResultDumpConsensusState, error) {
 	// Get Peer consensus states.
 
-	var peerStates []ctypes.PeerStateInfo
+	var peerStates []coretypes.PeerStateInfo
 	switch {
 	case env.P2PPeers != nil:
 		peers := env.P2PPeers.Peers().List()
-		peerStates = make([]ctypes.PeerStateInfo, 0, len(peers))
+		peerStates = make([]coretypes.PeerStateInfo, 0, len(peers))
 		for _, peer := range peers {
 			peerState, ok := peer.Get(types.PeerStateKey).(*cm.PeerState)
 			if !ok { // peer does not have a state yet
@@ -71,7 +71,7 @@ func (env *Environment) DumpConsensusState(ctx *rpctypes.Context) (*ctypes.Resul
 			if err != nil {
 				return nil, err
 			}
-			peerStates = append(peerStates, ctypes.PeerStateInfo{
+			peerStates = append(peerStates, coretypes.PeerStateInfo{
 				// Peer basic info.
 				NodeAddress: peer.SocketAddr().String(),
 				// Peer consensus state.
@@ -80,7 +80,7 @@ func (env *Environment) DumpConsensusState(ctx *rpctypes.Context) (*ctypes.Resul
 		}
 	case env.PeerManager != nil:
 		peers := env.PeerManager.Peers()
-		peerStates = make([]ctypes.PeerStateInfo, 0, len(peers))
+		peerStates = make([]coretypes.PeerStateInfo, 0, len(peers))
 		for _, pid := range peers {
 			peerState, ok := env.ConsensusReactor.GetPeerState(pid)
 			if !ok {
@@ -94,7 +94,7 @@ func (env *Environment) DumpConsensusState(ctx *rpctypes.Context) (*ctypes.Resul
 
 			addr := env.PeerManager.Addresses(pid)
 			if len(addr) >= 1 {
-				peerStates = append(peerStates, ctypes.PeerStateInfo{
+				peerStates = append(peerStates, coretypes.PeerStateInfo{
 					// Peer basic info.
 					NodeAddress: addr[0].String(),
 					// Peer consensus state.
@@ -111,7 +111,7 @@ func (env *Environment) DumpConsensusState(ctx *rpctypes.Context) (*ctypes.Resul
 	if err != nil {
 		return nil, err
 	}
-	return &ctypes.ResultDumpConsensusState{
+	return &coretypes.ResultDumpConsensusState{
 		RoundState: roundState,
 		Peers:      peerStates}, nil
 }
@@ -119,10 +119,10 @@ func (env *Environment) DumpConsensusState(ctx *rpctypes.Context) (*ctypes.Resul
 // ConsensusState returns a concise summary of the consensus state.
 // UNSTABLE
 // More: https://docs.tendermint.com/master/rpc/#/Info/consensus_state
-func (env *Environment) GetConsensusState(ctx *rpctypes.Context) (*ctypes.ResultConsensusState, error) {
+func (env *Environment) GetConsensusState(ctx *rpctypes.Context) (*coretypes.ResultConsensusState, error) {
 	// Get self round state.
 	bz, err := env.ConsensusState.GetRoundStateSimpleJSON()
-	return &ctypes.ResultConsensusState{RoundState: bz}, err
+	return &coretypes.ResultConsensusState{RoundState: bz}, err
 }
 
 // ConsensusParams gets the consensus parameters at the given block height.
@@ -130,7 +130,7 @@ func (env *Environment) GetConsensusState(ctx *rpctypes.Context) (*ctypes.Result
 // More: https://docs.tendermint.com/master/rpc/#/Info/consensus_params
 func (env *Environment) ConsensusParams(
 	ctx *rpctypes.Context,
-	heightPtr *int64) (*ctypes.ResultConsensusParams, error) {
+	heightPtr *int64) (*coretypes.ResultConsensusParams, error) {
 
 	// The latest consensus params that we know is the consensus params after the
 	// last block.
@@ -144,7 +144,7 @@ func (env *Environment) ConsensusParams(
 		return nil, err
 	}
 
-	return &ctypes.ResultConsensusParams{
+	return &coretypes.ResultConsensusParams{
 		BlockHeight:     height,
 		ConsensusParams: consensusParams}, nil
 }

--- a/internal/rpc/core/dev.go
+++ b/internal/rpc/core/dev.go
@@ -1,12 +1,12 @@
 package core
 
 import (
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // UnsafeFlushMempool removes all transactions from the mempool.
-func (env *Environment) UnsafeFlushMempool(ctx *rpctypes.Context) (*ctypes.ResultUnsafeFlushMempool, error) {
+func (env *Environment) UnsafeFlushMempool(ctx *rpctypes.Context) (*coretypes.ResultUnsafeFlushMempool, error) {
 	env.Mempool.Flush()
-	return &ctypes.ResultUnsafeFlushMempool{}, nil
+	return &coretypes.ResultUnsafeFlushMempool{}, nil
 }

--- a/internal/rpc/core/env.go
+++ b/internal/rpc/core/env.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/internal/consensus"
 	"github.com/tendermint/tendermint/internal/mempool"
@@ -102,7 +102,7 @@ type Environment struct {
 
 	Logger log.Logger
 
-	Config cfg.RPCConfig
+	Config config.RPCConfig
 
 	// cache of chunked genesis data.
 	genChunks []string

--- a/internal/rpc/core/env.go
+++ b/internal/rpc/core/env.go
@@ -16,7 +16,7 @@ import (
 	"github.com/tendermint/tendermint/internal/statesync"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -113,7 +113,7 @@ type Environment struct {
 func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
 	// this can only happen if we haven't first run validatePerPage
 	if perPage < 1 {
-		panic(fmt.Errorf("%w (%d)", ctypes.ErrZeroOrNegativePerPage, perPage))
+		panic(fmt.Errorf("%w (%d)", coretypes.ErrZeroOrNegativePerPage, perPage))
 	}
 
 	if pagePtr == nil { // no page parameter
@@ -126,7 +126,7 @@ func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
 	}
 	page := *pagePtr
 	if page <= 0 || page > pages {
-		return 1, fmt.Errorf("%w expected range: [1, %d], given %d", ctypes.ErrPageOutOfRange, pages, page)
+		return 1, fmt.Errorf("%w expected range: [1, %d], given %d", coretypes.ErrPageOutOfRange, pages, page)
 	}
 
 	return page, nil
@@ -191,15 +191,15 @@ func (env *Environment) getHeight(latestHeight int64, heightPtr *int64) (int64, 
 	if heightPtr != nil {
 		height := *heightPtr
 		if height <= 0 {
-			return 0, fmt.Errorf("%w (requested height: %d)", ctypes.ErrZeroOrNegativeHeight, height)
+			return 0, fmt.Errorf("%w (requested height: %d)", coretypes.ErrZeroOrNegativeHeight, height)
 		}
 		if height > latestHeight {
 			return 0, fmt.Errorf("%w (requested height: %d, blockchain height: %d)",
-				ctypes.ErrHeightExceedsChainHead, height, latestHeight)
+				coretypes.ErrHeightExceedsChainHead, height, latestHeight)
 		}
 		base := env.BlockStore.Base()
 		if height < base {
-			return 0, fmt.Errorf("%w (requested height: %d, base height: %d)", ctypes.ErrHeightNotAvailable, height, base)
+			return 0, fmt.Errorf("%w (requested height: %d, base height: %d)", coretypes.ErrHeightNotAvailable, height, base)
 		}
 		return height, nil
 	}

--- a/internal/rpc/core/env.go
+++ b/internal/rpc/core/env.go
@@ -8,7 +8,7 @@ import (
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/internal/consensus"
-	mempl "github.com/tendermint/tendermint/internal/mempool"
+	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/internal/p2p"
 	"github.com/tendermint/tendermint/internal/proxy"
 	sm "github.com/tendermint/tendermint/internal/state"
@@ -96,7 +96,7 @@ type Environment struct {
 	GenDoc            *types.GenesisDoc // cache the genesis structure
 	EventSinks        []indexer.EventSink
 	EventBus          *types.EventBus // thread safe
-	Mempool           mempl.Mempool
+	Mempool           mempool.Mempool
 	BlockSyncReactor  consensus.BlockSyncReactor
 	StateSyncMetricer statesync.Metricer
 

--- a/internal/rpc/core/events.go
+++ b/internal/rpc/core/events.go
@@ -7,7 +7,7 @@ import (
 
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
@@ -18,7 +18,7 @@ const (
 
 // Subscribe for events via WebSocket.
 // More: https://docs.tendermint.com/master/rpc/#/Websocket/subscribe
-func (env *Environment) Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, error) {
+func (env *Environment) Subscribe(ctx *rpctypes.Context, query string) (*coretypes.ResultSubscribe, error) {
 	addr := ctx.RemoteAddr()
 
 	if env.EventBus.NumClients() >= env.Config.MaxSubscriptionClients {
@@ -49,7 +49,7 @@ func (env *Environment) Subscribe(ctx *rpctypes.Context, query string) (*ctypes.
 			select {
 			case msg := <-sub.Out():
 				var (
-					resultEvent = &ctypes.ResultEvent{Query: query, Data: msg.Data(), Events: msg.Events()}
+					resultEvent = &coretypes.ResultEvent{Query: query, Data: msg.Data(), Events: msg.Events()}
 					resp        = rpctypes.NewRPCSuccessResponse(subscriptionID, resultEvent)
 				)
 				writeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -80,12 +80,12 @@ func (env *Environment) Subscribe(ctx *rpctypes.Context, query string) (*ctypes.
 		}
 	}()
 
-	return &ctypes.ResultSubscribe{}, nil
+	return &coretypes.ResultSubscribe{}, nil
 }
 
 // Unsubscribe from events via WebSocket.
 // More: https://docs.tendermint.com/master/rpc/#/Websocket/unsubscribe
-func (env *Environment) Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe, error) {
+func (env *Environment) Unsubscribe(ctx *rpctypes.Context, query string) (*coretypes.ResultUnsubscribe, error) {
 	args := tmpubsub.UnsubscribeArgs{Subscriber: ctx.RemoteAddr()}
 	env.Logger.Info("Unsubscribe from query", "remote", args.Subscriber, "subscription", query)
 
@@ -100,17 +100,17 @@ func (env *Environment) Unsubscribe(ctx *rpctypes.Context, query string) (*ctype
 	if err != nil {
 		return nil, err
 	}
-	return &ctypes.ResultUnsubscribe{}, nil
+	return &coretypes.ResultUnsubscribe{}, nil
 }
 
 // UnsubscribeAll from all events via WebSocket.
 // More: https://docs.tendermint.com/master/rpc/#/Websocket/unsubscribe_all
-func (env *Environment) UnsubscribeAll(ctx *rpctypes.Context) (*ctypes.ResultUnsubscribe, error) {
+func (env *Environment) UnsubscribeAll(ctx *rpctypes.Context) (*coretypes.ResultUnsubscribe, error) {
 	addr := ctx.RemoteAddr()
 	env.Logger.Info("Unsubscribe from all", "remote", addr)
 	err := env.EventBus.UnsubscribeAll(ctx.Context(), addr)
 	if err != nil {
 		return nil, err
 	}
-	return &ctypes.ResultUnsubscribe{}, nil
+	return &coretypes.ResultUnsubscribe{}, nil
 }

--- a/internal/rpc/core/evidence.go
+++ b/internal/rpc/core/evidence.go
@@ -3,7 +3,7 @@ package core
 import (
 	"fmt"
 
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -12,10 +12,10 @@ import (
 // More: https://docs.tendermint.com/master/rpc/#/Evidence/broadcast_evidence
 func (env *Environment) BroadcastEvidence(
 	ctx *rpctypes.Context,
-	ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
+	ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
 
 	if ev == nil {
-		return nil, fmt.Errorf("%w: no evidence was provided", ctypes.ErrInvalidRequest)
+		return nil, fmt.Errorf("%w: no evidence was provided", coretypes.ErrInvalidRequest)
 	}
 
 	if err := ev.ValidateBasic(); err != nil {
@@ -25,5 +25,5 @@ func (env *Environment) BroadcastEvidence(
 	if err := env.EvidencePool.AddEvidence(ev); err != nil {
 		return nil, fmt.Errorf("failed to add evidence: %w", err)
 	}
-	return &ctypes.ResultBroadcastEvidence{Hash: ev.Hash()}, nil
+	return &coretypes.ResultBroadcastEvidence{Hash: ev.Hash()}, nil
 }

--- a/internal/rpc/core/health.go
+++ b/internal/rpc/core/health.go
@@ -1,13 +1,13 @@
 package core
 
 import (
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // Health gets node health. Returns empty result (200 OK) on success, no
 // response - in case of an error.
 // More: https://docs.tendermint.com/master/rpc/#/Info/health
-func (env *Environment) Health(ctx *rpctypes.Context) (*ctypes.ResultHealth, error) {
-	return &ctypes.ResultHealth{}, nil
+func (env *Environment) Health(ctx *rpctypes.Context) (*coretypes.ResultHealth, error) {
+	return &coretypes.ResultHealth{}, nil
 }

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
-	mempl "github.com/tendermint/tendermint/internal/mempool"
+	"github.com/tendermint/tendermint/internal/mempool"
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
@@ -21,7 +21,7 @@ import (
 // CheckTx nor DeliverTx results.
 // More: https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_async
 func (env *Environment) BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
-	err := env.Mempool.CheckTx(ctx.Context(), tx, nil, mempl.TxInfo{})
+	err := env.Mempool.CheckTx(ctx.Context(), tx, nil, mempool.TxInfo{})
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func (env *Environment) BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*co
 		ctx.Context(),
 		tx,
 		func(res *abci.Response) { resCh <- res },
-		mempl.TxInfo{},
+		mempool.TxInfo{},
 	)
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*
 		ctx.Context(),
 		tx,
 		func(res *abci.Response) { checkTxResCh <- res },
-		mempl.TxInfo{},
+		mempool.TxInfo{},
 	)
 	if err != nil {
 		env.Logger.Error("Error on broadcastTxCommit", "err", err)

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -59,7 +59,7 @@ func (env *Environment) BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*co
 
 // BroadcastTxCommit returns with the responses from CheckTx and DeliverTx.
 // More: https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_commit
-func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
+func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) { //nolint:lll
 	subscriber := ctx.RemoteAddr()
 
 	if env.EventBus.NumClients() >= env.Config.MaxSubscriptionClients {

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -9,7 +9,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	mempl "github.com/tendermint/tendermint/internal/mempool"
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -20,19 +20,19 @@ import (
 // BroadcastTxAsync returns right away, with no response. Does not wait for
 // CheckTx nor DeliverTx results.
 // More: https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_async
-func (env *Environment) BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (env *Environment) BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	err := env.Mempool.CheckTx(ctx.Context(), tx, nil, mempl.TxInfo{})
 	if err != nil {
 		return nil, err
 	}
 
-	return &ctypes.ResultBroadcastTx{Hash: tx.Hash()}, nil
+	return &coretypes.ResultBroadcastTx{Hash: tx.Hash()}, nil
 }
 
 // BroadcastTxSync returns with the response from CheckTx. Does not wait for
 // DeliverTx result.
 // More: https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_sync
-func (env *Environment) BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (env *Environment) BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	resCh := make(chan *abci.Response, 1)
 	err := env.Mempool.CheckTx(
 		ctx.Context(),
@@ -47,7 +47,7 @@ func (env *Environment) BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ct
 	res := <-resCh
 	r := res.GetCheckTx()
 
-	return &ctypes.ResultBroadcastTx{
+	return &coretypes.ResultBroadcastTx{
 		Code:         r.Code,
 		Data:         r.Data,
 		Log:          r.Log,
@@ -59,7 +59,7 @@ func (env *Environment) BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ct
 
 // BroadcastTxCommit returns with the responses from CheckTx and DeliverTx.
 // More: https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_commit
-func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
 	subscriber := ctx.RemoteAddr()
 
 	if env.EventBus.NumClients() >= env.Config.MaxSubscriptionClients {
@@ -102,7 +102,7 @@ func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*
 	checkTxRes := checkTxResMsg.GetCheckTx()
 
 	if checkTxRes.Code != abci.CodeTypeOK {
-		return &ctypes.ResultBroadcastTxCommit{
+		return &coretypes.ResultBroadcastTxCommit{
 			CheckTx:   *checkTxRes,
 			DeliverTx: abci.ResponseDeliverTx{},
 			Hash:      tx.Hash(),
@@ -113,7 +113,7 @@ func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*
 	select {
 	case msg := <-deliverTxSub.Out(): // The tx was included in a block.
 		deliverTxRes := msg.Data().(types.EventDataTx)
-		return &ctypes.ResultBroadcastTxCommit{
+		return &coretypes.ResultBroadcastTxCommit{
 			CheckTx:   *checkTxRes,
 			DeliverTx: deliverTxRes.Result,
 			Hash:      tx.Hash(),
@@ -128,7 +128,7 @@ func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*
 		}
 		err = fmt.Errorf("deliverTxSub was canceled (reason: %s)", reason)
 		env.Logger.Error("Error on broadcastTxCommit", "err", err)
-		return &ctypes.ResultBroadcastTxCommit{
+		return &coretypes.ResultBroadcastTxCommit{
 			CheckTx:   *checkTxRes,
 			DeliverTx: abci.ResponseDeliverTx{},
 			Hash:      tx.Hash(),
@@ -136,7 +136,7 @@ func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*
 	case <-time.After(env.Config.TimeoutBroadcastTxCommit):
 		err = errors.New("timed out waiting for tx to be included in a block")
 		env.Logger.Error("Error on broadcastTxCommit", "err", err)
-		return &ctypes.ResultBroadcastTxCommit{
+		return &coretypes.ResultBroadcastTxCommit{
 			CheckTx:   *checkTxRes,
 			DeliverTx: abci.ResponseDeliverTx{},
 			Hash:      tx.Hash(),
@@ -147,12 +147,12 @@ func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*
 // UnconfirmedTxs gets unconfirmed transactions (maximum ?limit entries)
 // including their number.
 // More: https://docs.tendermint.com/master/rpc/#/Info/unconfirmed_txs
-func (env *Environment) UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*ctypes.ResultUnconfirmedTxs, error) {
+func (env *Environment) UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*coretypes.ResultUnconfirmedTxs, error) {
 	// reuse per_page validator
 	limit := env.validatePerPage(limitPtr)
 
 	txs := env.Mempool.ReapMaxTxs(limit)
-	return &ctypes.ResultUnconfirmedTxs{
+	return &coretypes.ResultUnconfirmedTxs{
 		Count:      len(txs),
 		Total:      env.Mempool.Size(),
 		TotalBytes: env.Mempool.SizeBytes(),
@@ -161,8 +161,8 @@ func (env *Environment) UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*c
 
 // NumUnconfirmedTxs gets number of unconfirmed transactions.
 // More: https://docs.tendermint.com/master/rpc/#/Info/num_unconfirmed_txs
-func (env *Environment) NumUnconfirmedTxs(ctx *rpctypes.Context) (*ctypes.ResultUnconfirmedTxs, error) {
-	return &ctypes.ResultUnconfirmedTxs{
+func (env *Environment) NumUnconfirmedTxs(ctx *rpctypes.Context) (*coretypes.ResultUnconfirmedTxs, error) {
+	return &coretypes.ResultUnconfirmedTxs{
 		Count:      env.Mempool.Size(),
 		Total:      env.Mempool.Size(),
 		TotalBytes: env.Mempool.SizeBytes()}, nil
@@ -171,10 +171,10 @@ func (env *Environment) NumUnconfirmedTxs(ctx *rpctypes.Context) (*ctypes.Result
 // CheckTx checks the transaction without executing it. The transaction won't
 // be added to the mempool either.
 // More: https://docs.tendermint.com/master/rpc/#/Tx/check_tx
-func (env *Environment) CheckTx(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
+func (env *Environment) CheckTx(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultCheckTx, error) {
 	res, err := env.ProxyAppMempool.CheckTxSync(ctx.Context(), abci.RequestCheckTx{Tx: tx})
 	if err != nil {
 		return nil, err
 	}
-	return &ctypes.ResultCheckTx{ResponseCheckTx: *res}, nil
+	return &coretypes.ResultCheckTx{ResponseCheckTx: *res}, nil
 }

--- a/internal/rpc/core/net.go
+++ b/internal/rpc/core/net.go
@@ -6,21 +6,21 @@ import (
 	"strings"
 
 	"github.com/tendermint/tendermint/internal/p2p"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // NetInfo returns network info.
 // More: https://docs.tendermint.com/master/rpc/#/Info/net_info
-func (env *Environment) NetInfo(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error) {
-	var peers []ctypes.Peer
+func (env *Environment) NetInfo(ctx *rpctypes.Context) (*coretypes.ResultNetInfo, error) {
+	var peers []coretypes.Peer
 
 	switch {
 	case env.P2PPeers != nil:
 		peersList := env.P2PPeers.Peers().List()
-		peers = make([]ctypes.Peer, 0, len(peersList))
+		peers = make([]coretypes.Peer, 0, len(peersList))
 		for _, peer := range peersList {
-			peers = append(peers, ctypes.Peer{
+			peers = append(peers, coretypes.Peer{
 				ID:  peer.ID(),
 				URL: peer.SocketAddr().String(),
 			})
@@ -33,7 +33,7 @@ func (env *Environment) NetInfo(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, e
 				continue
 			}
 
-			peers = append(peers, ctypes.Peer{
+			peers = append(peers, coretypes.Peer{
 				ID:  peer,
 				URL: addrs[0].String(),
 			})
@@ -42,7 +42,7 @@ func (env *Environment) NetInfo(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, e
 		return nil, errors.New("peer management system does not support NetInfo responses")
 	}
 
-	return &ctypes.ResultNetInfo{
+	return &coretypes.ResultNetInfo{
 		Listening: env.P2PTransport.IsListening(),
 		Listeners: env.P2PTransport.Listeners(),
 		NPeers:    len(peers),
@@ -51,19 +51,19 @@ func (env *Environment) NetInfo(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, e
 }
 
 // UnsafeDialSeeds dials the given seeds (comma-separated id@IP:PORT).
-func (env *Environment) UnsafeDialSeeds(ctx *rpctypes.Context, seeds []string) (*ctypes.ResultDialSeeds, error) {
+func (env *Environment) UnsafeDialSeeds(ctx *rpctypes.Context, seeds []string) (*coretypes.ResultDialSeeds, error) {
 	if env.P2PPeers == nil {
 		return nil, errors.New("peer management system does not support this operation")
 	}
 
 	if len(seeds) == 0 {
-		return &ctypes.ResultDialSeeds{}, fmt.Errorf("%w: no seeds provided", ctypes.ErrInvalidRequest)
+		return &coretypes.ResultDialSeeds{}, fmt.Errorf("%w: no seeds provided", coretypes.ErrInvalidRequest)
 	}
 	env.Logger.Info("DialSeeds", "seeds", seeds)
 	if err := env.P2PPeers.DialPeersAsync(seeds); err != nil {
-		return &ctypes.ResultDialSeeds{}, err
+		return &coretypes.ResultDialSeeds{}, err
 	}
-	return &ctypes.ResultDialSeeds{Log: "Dialing seeds in progress. See /net_info for details"}, nil
+	return &coretypes.ResultDialSeeds{Log: "Dialing seeds in progress. See /net_info for details"}, nil
 }
 
 // UnsafeDialPeers dials the given peers (comma-separated id@IP:PORT),
@@ -71,19 +71,19 @@ func (env *Environment) UnsafeDialSeeds(ctx *rpctypes.Context, seeds []string) (
 func (env *Environment) UnsafeDialPeers(
 	ctx *rpctypes.Context,
 	peers []string,
-	persistent, unconditional, private bool) (*ctypes.ResultDialPeers, error) {
+	persistent, unconditional, private bool) (*coretypes.ResultDialPeers, error) {
 
 	if env.P2PPeers == nil {
 		return nil, errors.New("peer management system does not support this operation")
 	}
 
 	if len(peers) == 0 {
-		return &ctypes.ResultDialPeers{}, fmt.Errorf("%w: no peers provided", ctypes.ErrInvalidRequest)
+		return &coretypes.ResultDialPeers{}, fmt.Errorf("%w: no peers provided", coretypes.ErrInvalidRequest)
 	}
 
 	ids, err := getIDs(peers)
 	if err != nil {
-		return &ctypes.ResultDialPeers{}, err
+		return &coretypes.ResultDialPeers{}, err
 	}
 
 	env.Logger.Info("DialPeers", "peers", peers, "persistent",
@@ -91,40 +91,40 @@ func (env *Environment) UnsafeDialPeers(
 
 	if persistent {
 		if err := env.P2PPeers.AddPersistentPeers(peers); err != nil {
-			return &ctypes.ResultDialPeers{}, err
+			return &coretypes.ResultDialPeers{}, err
 		}
 	}
 
 	if private {
 		if err := env.P2PPeers.AddPrivatePeerIDs(ids); err != nil {
-			return &ctypes.ResultDialPeers{}, err
+			return &coretypes.ResultDialPeers{}, err
 		}
 	}
 
 	if unconditional {
 		if err := env.P2PPeers.AddUnconditionalPeerIDs(ids); err != nil {
-			return &ctypes.ResultDialPeers{}, err
+			return &coretypes.ResultDialPeers{}, err
 		}
 	}
 
 	if err := env.P2PPeers.DialPeersAsync(peers); err != nil {
-		return &ctypes.ResultDialPeers{}, err
+		return &coretypes.ResultDialPeers{}, err
 	}
 
-	return &ctypes.ResultDialPeers{Log: "Dialing peers in progress. See /net_info for details"}, nil
+	return &coretypes.ResultDialPeers{Log: "Dialing peers in progress. See /net_info for details"}, nil
 }
 
 // Genesis returns genesis file.
 // More: https://docs.tendermint.com/master/rpc/#/Info/genesis
-func (env *Environment) Genesis(ctx *rpctypes.Context) (*ctypes.ResultGenesis, error) {
+func (env *Environment) Genesis(ctx *rpctypes.Context) (*coretypes.ResultGenesis, error) {
 	if len(env.genChunks) > 1 {
 		return nil, errors.New("genesis response is large, please use the genesis_chunked API instead")
 	}
 
-	return &ctypes.ResultGenesis{Genesis: env.GenDoc}, nil
+	return &coretypes.ResultGenesis{Genesis: env.GenDoc}, nil
 }
 
-func (env *Environment) GenesisChunked(ctx *rpctypes.Context, chunk uint) (*ctypes.ResultGenesisChunk, error) {
+func (env *Environment) GenesisChunked(ctx *rpctypes.Context, chunk uint) (*coretypes.ResultGenesisChunk, error) {
 	if env.genChunks == nil {
 		return nil, fmt.Errorf("service configuration error, genesis chunks are not initialized")
 	}
@@ -139,7 +139,7 @@ func (env *Environment) GenesisChunked(ctx *rpctypes.Context, chunk uint) (*ctyp
 		return nil, fmt.Errorf("there are %d chunks, %d is invalid", len(env.genChunks)-1, id)
 	}
 
-	return &ctypes.ResultGenesisChunk{
+	return &coretypes.ResultGenesisChunk{
 		TotalChunks: len(env.genChunks),
 		ChunkNumber: id,
 		Data:        env.genChunks[id],

--- a/internal/rpc/core/net_test.go
+++ b/internal/rpc/core/net_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/p2p"
 	"github.com/tendermint/tendermint/libs/log"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 func TestUnsafeDialSeeds(t *testing.T) {
-	sw := p2p.MakeSwitch(cfg.DefaultP2PConfig(), 1, "testing", "123.123.123",
+	sw := p2p.MakeSwitch(config.DefaultP2PConfig(), 1, "testing", "123.123.123",
 		func(n int, sw *p2p.Switch) *p2p.Switch { return sw }, log.TestingLogger())
 	err := sw.Start()
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestUnsafeDialSeeds(t *testing.T) {
 }
 
 func TestUnsafeDialPeers(t *testing.T) {
-	sw := p2p.MakeSwitch(cfg.DefaultP2PConfig(), 1, "testing", "123.123.123",
+	sw := p2p.MakeSwitch(config.DefaultP2PConfig(), 1, "testing", "123.123.123",
 		func(n int, sw *p2p.Switch) *p2p.Switch { return sw }, log.TestingLogger())
 	sw.SetAddrBook(&p2p.AddrBookMock{
 		Addrs:        make(map[string]struct{}),

--- a/internal/rpc/core/status.go
+++ b/internal/rpc/core/status.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -13,7 +13,7 @@ import (
 // Status returns Tendermint status including node info, pubkey, latest block
 // hash, app hash, block height, current max peer block height, and time.
 // More: https://docs.tendermint.com/master/rpc/#/Info/status
-func (env *Environment) Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
+func (env *Environment) Status(ctx *rpctypes.Context) (*coretypes.ResultStatus, error) {
 	var (
 		earliestBlockHeight   int64
 		earliestBlockHash     tmbytes.HexBytes
@@ -50,17 +50,17 @@ func (env *Environment) Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, err
 	if val := env.validatorAtHeight(env.latestUncommittedHeight()); val != nil {
 		votingPower = val.VotingPower
 	}
-	validatorInfo := ctypes.ValidatorInfo{}
+	validatorInfo := coretypes.ValidatorInfo{}
 	if env.PubKey != nil {
-		validatorInfo = ctypes.ValidatorInfo{
+		validatorInfo = coretypes.ValidatorInfo{
 			Address:     env.PubKey.Address(),
 			PubKey:      env.PubKey,
 			VotingPower: votingPower,
 		}
 	}
-	result := &ctypes.ResultStatus{
+	result := &coretypes.ResultStatus{
 		NodeInfo: env.P2PTransport.NodeInfo(),
-		SyncInfo: ctypes.SyncInfo{
+		SyncInfo: coretypes.SyncInfo{
 			LatestBlockHash:     latestBlockHash,
 			LatestAppHash:       latestAppHash,
 			LatestBlockHeight:   latestHeight,

--- a/internal/rpc/core/tx.go
+++ b/internal/rpc/core/tx.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tendermint/tendermint/libs/bytes"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -18,7 +18,7 @@ import (
 // transaction is in the mempool, invalidated, or was not sent in the first
 // place.
 // More: https://docs.tendermint.com/master/rpc/#/Info/tx
-func (env *Environment) Tx(ctx *rpctypes.Context, hash bytes.HexBytes, prove bool) (*ctypes.ResultTx, error) {
+func (env *Environment) Tx(ctx *rpctypes.Context, hash bytes.HexBytes, prove bool) (*coretypes.ResultTx, error) {
 	// if index is disabled, return error
 
 	// N.B. The hash parameter is HexBytes so that the reflective parameter
@@ -45,7 +45,7 @@ func (env *Environment) Tx(ctx *rpctypes.Context, hash bytes.HexBytes, prove boo
 				proof = block.Data.Txs.Proof(int(index)) // XXX: overflow on 32-bit machines
 			}
 
-			return &ctypes.ResultTx{
+			return &coretypes.ResultTx{
 				Hash:     hash,
 				Height:   height,
 				Index:    index,
@@ -68,7 +68,7 @@ func (env *Environment) TxSearch(
 	prove bool,
 	pagePtr, perPagePtr *int,
 	orderBy string,
-) (*ctypes.ResultTxSearch, error) {
+) (*coretypes.ResultTxSearch, error) {
 
 	if !indexer.KVSinkEnabled(env.EventSinks) {
 		return nil, fmt.Errorf("transaction searching is disabled due to no kvEventSink")
@@ -103,7 +103,7 @@ func (env *Environment) TxSearch(
 					return results[i].Height < results[j].Height
 				})
 			default:
-				return nil, fmt.Errorf("expected order_by to be either `asc` or `desc` or empty: %w", ctypes.ErrInvalidRequest)
+				return nil, fmt.Errorf("expected order_by to be either `asc` or `desc` or empty: %w", coretypes.ErrInvalidRequest)
 			}
 
 			// paginate results
@@ -118,7 +118,7 @@ func (env *Environment) TxSearch(
 			skipCount := validateSkipCount(page, perPage)
 			pageSize := tmmath.MinInt(perPage, totalCount-skipCount)
 
-			apiResults := make([]*ctypes.ResultTx, 0, pageSize)
+			apiResults := make([]*coretypes.ResultTx, 0, pageSize)
 			for i := skipCount; i < skipCount+pageSize; i++ {
 				r := results[i]
 
@@ -128,7 +128,7 @@ func (env *Environment) TxSearch(
 					proof = block.Data.Txs.Proof(int(r.Index)) // XXX: overflow on 32-bit machines
 				}
 
-				apiResults = append(apiResults, &ctypes.ResultTx{
+				apiResults = append(apiResults, &coretypes.ResultTx{
 					Hash:     types.Tx(r.Tx).Hash(),
 					Height:   r.Height,
 					Index:    r.Index,
@@ -138,7 +138,7 @@ func (env *Environment) TxSearch(
 				})
 			}
 
-			return &ctypes.ResultTxSearch{Txs: apiResults, TotalCount: totalCount}, nil
+			return &coretypes.ResultTxSearch{Txs: apiResults, TotalCount: totalCount}, nil
 		}
 	}
 

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/internal/libs/fail"
 	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/internal/proxy"
@@ -424,7 +424,7 @@ func validateValidatorUpdates(abciUpdates []abci.ValidatorUpdate,
 		}
 
 		// Check if validator's pubkey matches an ABCI type in the consensus params
-		pk, err := cryptoenc.PubKeyFromProto(valUpdate.PubKey)
+		pk, err := encoding.PubKeyFromProto(valUpdate.PubKey)
 		if err != nil {
 			return err
 		}

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -9,7 +9,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/internal/libs/fail"
-	mempl "github.com/tendermint/tendermint/internal/mempool"
+	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/internal/proxy"
 	"github.com/tendermint/tendermint/libs/log"
 	tmstate "github.com/tendermint/tendermint/proto/tendermint/state"
@@ -37,7 +37,7 @@ type BlockExecutor struct {
 
 	// manage the mempool lock during commit
 	// and update both with block results after commit.
-	mempool mempl.Mempool
+	mempool mempool.Mempool
 	evpool  EvidencePool
 
 	logger  log.Logger
@@ -61,7 +61,7 @@ func NewBlockExecutor(
 	stateStore Store,
 	logger log.Logger,
 	proxyApp proxy.AppConnConsensus,
-	mempool mempl.Mempool,
+	pool mempool.Mempool,
 	evpool EvidencePool,
 	blockStore BlockStore,
 	options ...BlockExecutorOption,
@@ -70,7 +70,7 @@ func NewBlockExecutor(
 		store:      stateStore,
 		proxyApp:   proxyApp,
 		eventBus:   types.NopEventBus{},
-		mempool:    mempool,
+		mempool:    pool,
 		evpool:     evpool,
 		logger:     logger,
 		metrics:    NopMetrics(),

--- a/internal/state/execution_test.go
+++ b/internal/state/execution_test.go
@@ -13,7 +13,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	mmock "github.com/tendermint/tendermint/internal/mempool/mock"
 	"github.com/tendermint/tendermint/internal/proxy"
@@ -218,9 +218,9 @@ func TestBeginBlockByzantineValidators(t *testing.T) {
 func TestValidateValidatorUpdates(t *testing.T) {
 	pubkey1 := ed25519.GenPrivKey().PubKey()
 	pubkey2 := ed25519.GenPrivKey().PubKey()
-	pk1, err := cryptoenc.PubKeyToProto(pubkey1)
+	pk1, err := encoding.PubKeyToProto(pubkey1)
 	assert.NoError(t, err)
-	pk2, err := cryptoenc.PubKeyToProto(pubkey2)
+	pk2, err := encoding.PubKeyToProto(pubkey2)
 	assert.NoError(t, err)
 
 	defaultValidatorParams := types.ValidatorParams{PubKeyTypes: []string{types.ABCIPubKeyTypeEd25519}}
@@ -278,9 +278,9 @@ func TestUpdateValidators(t *testing.T) {
 	pubkey2 := ed25519.GenPrivKey().PubKey()
 	val2 := types.NewValidator(pubkey2, 20)
 
-	pk, err := cryptoenc.PubKeyToProto(pubkey1)
+	pk, err := encoding.PubKeyToProto(pubkey1)
 	require.NoError(t, err)
-	pk2, err := cryptoenc.PubKeyToProto(pubkey2)
+	pk2, err := encoding.PubKeyToProto(pubkey2)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -385,7 +385,7 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 
 	pubkey := ed25519.GenPrivKey().PubKey()
-	pk, err := cryptoenc.PubKeyToProto(pubkey)
+	pk, err := encoding.PubKeyToProto(pubkey)
 	require.NoError(t, err)
 	app.ValidatorUpdates = []abci.ValidatorUpdate{
 		{PubKey: pk, Power: 10},
@@ -442,7 +442,7 @@ func TestEndBlockValidatorUpdatesResultingInEmptySet(t *testing.T) {
 	block := sf.MakeBlock(state, 1, new(types.Commit))
 	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 
-	vp, err := cryptoenc.PubKeyToProto(state.Validators.Validators[0].PubKey)
+	vp, err := encoding.PubKeyToProto(state.Validators.Validators[0].PubKey)
 	require.NoError(t, err)
 	// Remove the only validator
 	app.ValidatorUpdates = []abci.ValidatorUpdate{

--- a/internal/state/execution_test.go
+++ b/internal/state/execution_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -25,7 +26,6 @@ import (
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
 	"github.com/tendermint/tendermint/version"
-	dbm "github.com/tendermint/tm-db"
 )
 
 var (

--- a/internal/state/helpers_test.go
+++ b/internal/state/helpers_test.go
@@ -11,7 +11,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/internal/proxy"
 	sm "github.com/tendermint/tendermint/internal/state"
 	sf "github.com/tendermint/tendermint/internal/state/test/factory"
@@ -148,11 +148,11 @@ func makeHeaderPartsResponsesValPubKeyChange(
 	// If the pubkey is new, remove the old and add the new.
 	_, val := state.NextValidators.GetByIndex(0)
 	if !bytes.Equal(pubkey.Bytes(), val.PubKey.Bytes()) {
-		vPbPk, err := cryptoenc.PubKeyToProto(val.PubKey)
+		vPbPk, err := encoding.PubKeyToProto(val.PubKey)
 		if err != nil {
 			panic(err)
 		}
-		pbPk, err := cryptoenc.PubKeyToProto(pubkey)
+		pbPk, err := encoding.PubKeyToProto(pubkey)
 		if err != nil {
 			panic(err)
 		}
@@ -181,7 +181,7 @@ func makeHeaderPartsResponsesValPowerChange(
 	// If the pubkey is new, remove the old and add the new.
 	_, val := state.NextValidators.GetByIndex(0)
 	if val.VotingPower != power {
-		vPbPk, err := cryptoenc.PubKeyToProto(val.PubKey)
+		vPbPk, err := encoding.PubKeyToProto(val.PubKey)
 		if err != nil {
 			panic(err)
 		}

--- a/internal/state/indexer/block/kv/kv_test.go
+++ b/internal/state/indexer/block/kv/kv_test.go
@@ -6,15 +6,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 	blockidxkv "github.com/tendermint/tendermint/internal/state/indexer/block/kv"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
-	db "github.com/tendermint/tm-db"
 )
 
 func TestBlockIndexer(t *testing.T) {
-	store := db.NewPrefixDB(db.NewMemDB(), []byte("block_events"))
+	store := dbm.NewPrefixDB(dbm.NewMemDB(), []byte("block_events"))
 	indexer := blockidxkv.New(store)
 
 	require.NoError(t, indexer.Index(types.EventDataNewBlockHeader{

--- a/internal/state/indexer/indexer_service_test.go
+++ b/internal/state/indexer/indexer_service_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/adlio/schema"
-	_ "github.com/lib/pq"
+
 	dockertest "github.com/ory/dockertest"
 	"github.com/ory/dockertest/docker"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +22,9 @@ import (
 	psql "github.com/tendermint/tendermint/internal/state/indexer/sink/psql"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/types"
+
+	// Register the Postgre database driver.
+	_ "github.com/lib/pq"
 )
 
 var psqldb *sql.DB

--- a/internal/state/indexer/indexer_service_test.go
+++ b/internal/state/indexer/indexer_service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ory/dockertest/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	indexer "github.com/tendermint/tendermint/internal/state/indexer"
@@ -21,7 +22,6 @@ import (
 	psql "github.com/tendermint/tendermint/internal/state/indexer/sink/psql"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/types"
-	db "github.com/tendermint/tm-db"
 )
 
 var psqldb *sql.DB
@@ -55,7 +55,7 @@ func TestIndexerServiceIndexesBlocks(t *testing.T) {
 	pool, err := setupDB(t)
 	assert.Nil(t, err)
 
-	store := db.NewMemDB()
+	store := dbm.NewMemDB()
 	eventSinks := []indexer.EventSink{kv.NewEventSink(store), pSink}
 	assert.True(t, indexer.KVSinkEnabled(eventSinks))
 	assert.True(t, indexer.IndexingEnabled(eventSinks))

--- a/internal/state/indexer/indexer_service_test.go
+++ b/internal/state/indexer/indexer_service_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/adlio/schema"
-
 	dockertest "github.com/ory/dockertest"
 	"github.com/ory/dockertest/docker"
 	"github.com/stretchr/testify/assert"

--- a/internal/state/indexer/sink/kv/kv.go
+++ b/internal/state/indexer/sink/kv/kv.go
@@ -3,13 +3,14 @@ package kv
 import (
 	"context"
 
+	dbm "github.com/tendermint/tm-db"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/internal/state/indexer"
 	kvb "github.com/tendermint/tendermint/internal/state/indexer/block/kv"
 	kvt "github.com/tendermint/tendermint/internal/state/indexer/tx/kv"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 )
 
 var _ indexer.EventSink = (*EventSink)(nil)

--- a/internal/state/indexer/sink/kv/kv_test.go
+++ b/internal/state/indexer/sink/kv/kv_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	dbm "github.com/tendermint/tm-db"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +15,6 @@ import (
 	kvtx "github.com/tendermint/tendermint/internal/state/indexer/tx/kv"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 )
 
 func TestType(t *testing.T) {

--- a/internal/state/indexer/sink/kv/kv_test.go
+++ b/internal/state/indexer/sink/kv/kv_test.go
@@ -13,21 +13,21 @@ import (
 	kvtx "github.com/tendermint/tendermint/internal/state/indexer/tx/kv"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
-	db "github.com/tendermint/tm-db"
+	dbm "github.com/tendermint/tm-db"
 )
 
 func TestType(t *testing.T) {
-	kvSink := NewEventSink(db.NewMemDB())
+	kvSink := NewEventSink(dbm.NewMemDB())
 	assert.Equal(t, indexer.KV, kvSink.Type())
 }
 
 func TestStop(t *testing.T) {
-	kvSink := NewEventSink(db.NewMemDB())
+	kvSink := NewEventSink(dbm.NewMemDB())
 	assert.Nil(t, kvSink.Stop())
 }
 
 func TestBlockFuncs(t *testing.T) {
-	store := db.NewPrefixDB(db.NewMemDB(), []byte("block_events"))
+	store := dbm.NewPrefixDB(dbm.NewMemDB(), []byte("block_events"))
 	indexer := NewEventSink(store)
 
 	require.NoError(t, indexer.IndexBlockEvents(types.EventDataNewBlockHeader{
@@ -158,7 +158,7 @@ func TestBlockFuncs(t *testing.T) {
 }
 
 func TestTxSearchWithCancelation(t *testing.T) {
-	indexer := NewEventSink(db.NewMemDB())
+	indexer := NewEventSink(dbm.NewMemDB())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
@@ -180,7 +180,7 @@ func TestTxSearchWithCancelation(t *testing.T) {
 }
 
 func TestTxSearchDeprecatedIndexing(t *testing.T) {
-	esdb := db.NewMemDB()
+	esdb := dbm.NewMemDB()
 	indexer := NewEventSink(esdb)
 
 	// index tx using events indexing (composite key)
@@ -260,7 +260,7 @@ func TestTxSearchDeprecatedIndexing(t *testing.T) {
 }
 
 func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
-	indexer := NewEventSink(db.NewMemDB())
+	indexer := NewEventSink(dbm.NewMemDB())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
@@ -282,7 +282,7 @@ func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
 }
 
 func TestTxSearchMultipleTxs(t *testing.T) {
-	indexer := NewEventSink(db.NewMemDB())
+	indexer := NewEventSink(dbm.NewMemDB())
 
 	// indexed first, but bigger height (to test the order of transactions)
 	txResult := txResultWithEvents([]abci.Event{

--- a/internal/state/indexer/tx/kv/kv_test.go
+++ b/internal/state/indexer/tx/kv/kv_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	db "github.com/tendermint/tm-db"
+	dbm "github.com/tendermint/tm-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	indexer "github.com/tendermint/tendermint/internal/state/indexer"
@@ -21,7 +21,7 @@ import (
 )
 
 func TestTxIndex(t *testing.T) {
-	txIndexer := NewTxIndex(db.NewMemDB())
+	txIndexer := NewTxIndex(dbm.NewMemDB())
 
 	tx := types.Tx("HELLO WORLD")
 	txResult := &abci.TxResult{
@@ -67,7 +67,7 @@ func TestTxIndex(t *testing.T) {
 }
 
 func TestTxSearch(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(dbm.NewMemDB())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
@@ -147,7 +147,7 @@ func TestTxSearch(t *testing.T) {
 }
 
 func TestTxSearchWithCancelation(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(dbm.NewMemDB())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
@@ -165,7 +165,7 @@ func TestTxSearchWithCancelation(t *testing.T) {
 }
 
 func TestTxSearchDeprecatedIndexing(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(dbm.NewMemDB())
 
 	// index tx using events indexing (composite key)
 	txResult1 := txResultWithEvents([]abci.Event{
@@ -244,7 +244,7 @@ func TestTxSearchDeprecatedIndexing(t *testing.T) {
 }
 
 func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(dbm.NewMemDB())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
@@ -266,7 +266,7 @@ func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
 }
 
 func TestTxSearchMultipleTxs(t *testing.T) {
-	indexer := NewTxIndex(db.NewMemDB())
+	indexer := NewTxIndex(dbm.NewMemDB())
 
 	// indexed first, but bigger height (to test the order of transactions)
 	txResult := txResultWithEvents([]abci.Event{
@@ -339,7 +339,7 @@ func benchmarkTxIndex(txsCount int64, b *testing.B) {
 	require.NoError(b, err)
 	defer os.RemoveAll(dir)
 
-	store, err := db.NewDB("tx_index", "goleveldb", dir)
+	store, err := dbm.NewDB("tx_index", "goleveldb", dir)
 	require.NoError(b, err)
 	txIndexer := NewTxIndex(store)
 

--- a/internal/state/indexer/tx/kv/kv_test.go
+++ b/internal/state/indexer/tx/kv/kv_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	dbm "github.com/tendermint/tm-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -18,7 +18,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	sm "github.com/tendermint/tendermint/internal/state"
 	sf "github.com/tendermint/tendermint/internal/state/test/factory"
 	tmstate "github.com/tendermint/tendermint/proto/tendermint/state"
@@ -114,7 +114,7 @@ func TestABCIResponsesSaveLoad1(t *testing.T) {
 
 	abciResponses.DeliverTxs[0] = &abci.ResponseDeliverTx{Data: []byte("foo"), Events: nil}
 	abciResponses.DeliverTxs[1] = &abci.ResponseDeliverTx{Data: []byte("bar"), Log: "ok", Events: nil}
-	pbpk, err := cryptoenc.PubKeyToProto(ed25519.GenPrivKey().PubKey())
+	pbpk, err := encoding.PubKeyToProto(ed25519.GenPrivKey().PubKey())
 	require.NoError(t, err)
 	abciResponses.EndBlock = &abci.ResponseEndBlock{ValidatorUpdates: []abci.ValidatorUpdate{{PubKey: pbpk, Power: 10}}}
 
@@ -465,7 +465,7 @@ func TestProposerPriorityDoesNotGetResetToZero(t *testing.T) {
 	// add a validator
 	val2PubKey := ed25519.GenPrivKey().PubKey()
 	val2VotingPower := int64(100)
-	fvp, err := cryptoenc.PubKeyToProto(val2PubKey)
+	fvp, err := encoding.PubKeyToProto(val2PubKey)
 	require.NoError(t, err)
 
 	updateAddVal := abci.ValidatorUpdate{PubKey: fvp, Power: val2VotingPower}
@@ -583,7 +583,7 @@ func TestProposerPriorityProposerAlternates(t *testing.T) {
 
 	// add a validator with the same voting power as the first
 	val2PubKey := ed25519.GenPrivKey().PubKey()
-	fvp, err := cryptoenc.PubKeyToProto(val2PubKey)
+	fvp, err := encoding.PubKeyToProto(val2PubKey)
 	require.NoError(t, err)
 	updateAddVal := abci.ValidatorUpdate{PubKey: fvp, Power: val1VotingPower}
 	validatorUpdates, err = types.PB2TM.ValidatorUpdates([]abci.ValidatorUpdate{updateAddVal})
@@ -769,7 +769,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 	// see: https://github.com/tendermint/tendermint/issues/2960
 	firstAddedValPubKey := ed25519.GenPrivKey().PubKey()
 	firstAddedValVotingPower := int64(10)
-	fvp, err := cryptoenc.PubKeyToProto(firstAddedValPubKey)
+	fvp, err := encoding.PubKeyToProto(firstAddedValPubKey)
 	require.NoError(t, err)
 	firstAddedVal := abci.ValidatorUpdate{PubKey: fvp, Power: firstAddedValVotingPower}
 	validatorUpdates, err := types.PB2TM.ValidatorUpdates([]abci.ValidatorUpdate{firstAddedVal})
@@ -816,7 +816,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 	// add 10 validators with the same voting power as the one added directly after genesis:
 	for i := 0; i < 10; i++ {
 		addedPubKey := ed25519.GenPrivKey().PubKey()
-		ap, err := cryptoenc.PubKeyToProto(addedPubKey)
+		ap, err := encoding.PubKeyToProto(addedPubKey)
 		require.NoError(t, err)
 		addedVal := abci.ValidatorUpdate{PubKey: ap, Power: firstAddedValVotingPower}
 		validatorUpdates, err := types.PB2TM.ValidatorUpdates([]abci.ValidatorUpdate{addedVal})
@@ -834,7 +834,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 	require.Equal(t, 10+2, len(state.NextValidators.Validators))
 
 	// remove genesis validator:
-	gp, err := cryptoenc.PubKeyToProto(genesisPubKey)
+	gp, err := encoding.PubKeyToProto(genesisPubKey)
 	require.NoError(t, err)
 	removeGenesisVal := abci.ValidatorUpdate{PubKey: gp, Power: 0}
 	abciResponses = &tmstate.ABCIResponses{

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -16,7 +16,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/encoding"
 	sm "github.com/tendermint/tendermint/internal/state"
@@ -27,21 +27,21 @@ import (
 
 // setupTestCase does setup common to all test cases.
 func setupTestCase(t *testing.T) (func(t *testing.T), dbm.DB, sm.State) {
-	config := cfg.ResetTestRoot("state_")
-	dbType := dbm.BackendType(config.DBBackend)
-	stateDB, err := dbm.NewDB("state", dbType, config.DBDir())
+	cfg := config.ResetTestRoot("state_")
+	dbType := dbm.BackendType(cfg.DBBackend)
+	stateDB, err := dbm.NewDB("state", dbType, cfg.DBDir())
 	require.NoError(t, err)
 	stateStore := sm.NewStore(stateDB)
 	state, err := stateStore.Load()
 	require.NoError(t, err)
 	require.Empty(t, state)
-	state, err = sm.MakeGenesisStateFromFile(config.GenesisFile())
+	state, err = sm.MakeGenesisStateFromFile(cfg.GenesisFile())
 	assert.NoError(t, err)
 	assert.NotNil(t, state)
 	err = stateStore.Save(state)
 	require.NoError(t, err)
 
-	tearDown := func(t *testing.T) { os.RemoveAll(config.RootDir) }
+	tearDown := func(t *testing.T) { os.RemoveAll(cfg.RootDir) }
 
 	return tearDown, stateDB, state
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/encoding"
 	sm "github.com/tendermint/tendermint/internal/state"
-	sf "github.com/tendermint/tendermint/internal/state/test/factory"
+	statefactory "github.com/tendermint/tendermint/internal/state/test/factory"
 	tmstate "github.com/tendermint/tendermint/proto/tendermint/state"
 	"github.com/tendermint/tendermint/types"
 )
@@ -105,7 +105,7 @@ func TestABCIResponsesSaveLoad1(t *testing.T) {
 	state.LastBlockHeight++
 
 	// Build mock responses.
-	block := sf.MakeBlock(state, 2, new(types.Commit))
+	block := statefactory.MakeBlock(state, 2, new(types.Commit))
 
 	abciResponses := new(tmstate.ABCIResponses)
 	dtxs := make([]*abci.ResponseDeliverTx, 2)
@@ -447,7 +447,7 @@ func TestProposerPriorityDoesNotGetResetToZero(t *testing.T) {
 	// NewValidatorSet calls IncrementProposerPriority but uses on a copy of val1
 	assert.EqualValues(t, 0, val1.ProposerPriority)
 
-	block := sf.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit))
+	block := statefactory.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit))
 	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 	abciResponses := &tmstate.ABCIResponses{
 		BeginBlock: &abci.ResponseBeginBlock{},
@@ -561,7 +561,7 @@ func TestProposerPriorityProposerAlternates(t *testing.T) {
 	// we only have one validator:
 	assert.Equal(t, val1PubKey.Address(), state.Validators.Proposer.Address)
 
-	block := sf.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit))
+	block := statefactory.MakeBlock(state, state.LastBlockHeight+1, new(types.Commit))
 	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 	// no updates:
 	abciResponses := &tmstate.ABCIResponses{
@@ -748,7 +748,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 		validatorUpdates, err := types.PB2TM.ValidatorUpdates(abciResponses.EndBlock.ValidatorUpdates)
 		require.NoError(t, err)
 
-		block := sf.MakeBlock(oldState, oldState.LastBlockHeight+1, new(types.Commit))
+		block := statefactory.MakeBlock(oldState, oldState.LastBlockHeight+1, new(types.Commit))
 		blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 
 		updatedState, err := sm.UpdateState(oldState, blockID, &block.Header, abciResponses, validatorUpdates)
@@ -777,7 +777,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 		BeginBlock: &abci.ResponseBeginBlock{},
 		EndBlock:   &abci.ResponseEndBlock{ValidatorUpdates: []abci.ValidatorUpdate{firstAddedVal}},
 	}
-	block := sf.MakeBlock(oldState, oldState.LastBlockHeight+1, new(types.Commit))
+	block := statefactory.MakeBlock(oldState, oldState.LastBlockHeight+1, new(types.Commit))
 	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 	updatedState, err := sm.UpdateState(oldState, blockID, &block.Header, abciResponses, validatorUpdates)
 	require.NoError(t, err)
@@ -792,7 +792,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 		validatorUpdates, err := types.PB2TM.ValidatorUpdates(abciResponses.EndBlock.ValidatorUpdates)
 		require.NoError(t, err)
 
-		block := sf.MakeBlock(lastState, lastState.LastBlockHeight+1, new(types.Commit))
+		block := statefactory.MakeBlock(lastState, lastState.LastBlockHeight+1, new(types.Commit))
 		blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 
 		updatedStateInner, err := sm.UpdateState(lastState, blockID, &block.Header, abciResponses, validatorUpdates)
@@ -825,7 +825,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 			BeginBlock: &abci.ResponseBeginBlock{},
 			EndBlock:   &abci.ResponseEndBlock{ValidatorUpdates: []abci.ValidatorUpdate{addedVal}},
 		}
-		block := sf.MakeBlock(oldState, oldState.LastBlockHeight+1, new(types.Commit))
+		block := statefactory.MakeBlock(oldState, oldState.LastBlockHeight+1, new(types.Commit))
 		blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 		state, err = sm.UpdateState(state, blockID, &block.Header, abciResponses, validatorUpdates)
 		require.NoError(t, err)
@@ -840,7 +840,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 		BeginBlock: &abci.ResponseBeginBlock{},
 		EndBlock:   &abci.ResponseEndBlock{ValidatorUpdates: []abci.ValidatorUpdate{removeGenesisVal}},
 	}
-	block = sf.MakeBlock(oldState, oldState.LastBlockHeight+1, new(types.Commit))
+	block = statefactory.MakeBlock(oldState, oldState.LastBlockHeight+1, new(types.Commit))
 	blockID = types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 	validatorUpdates, err = types.PB2TM.ValidatorUpdates(abciResponses.EndBlock.ValidatorUpdates)
 	require.NoError(t, err)
@@ -861,7 +861,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 		}
 		validatorUpdates, err = types.PB2TM.ValidatorUpdates(abciResponses.EndBlock.ValidatorUpdates)
 		require.NoError(t, err)
-		block = sf.MakeBlock(curState, curState.LastBlockHeight+1, new(types.Commit))
+		block = statefactory.MakeBlock(curState, curState.LastBlockHeight+1, new(types.Commit))
 		blockID = types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 		curState, err = sm.UpdateState(curState, blockID, &block.Header, abciResponses, validatorUpdates)
 		require.NoError(t, err)
@@ -886,7 +886,7 @@ func TestLargeGenesisValidator(t *testing.T) {
 		validatorUpdates, err := types.PB2TM.ValidatorUpdates(abciResponses.EndBlock.ValidatorUpdates)
 		require.NoError(t, err)
 
-		block := sf.MakeBlock(updatedState, updatedState.LastBlockHeight+1, new(types.Commit))
+		block := statefactory.MakeBlock(updatedState, updatedState.LastBlockHeight+1, new(types.Commit))
 		blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 
 		updatedState, err = sm.UpdateState(updatedState, blockID, &block.Header, abciResponses, validatorUpdates)
@@ -981,7 +981,7 @@ func TestStateMakeBlock(t *testing.T) {
 
 	proposerAddress := state.Validators.GetProposer().Address
 	stateVersion := state.Version.Consensus
-	block := sf.MakeBlock(state, 2, new(types.Commit))
+	block := statefactory.MakeBlock(state, 2, new(types.Commit))
 
 	// test we set some fields
 	assert.Equal(t, stateVersion, block.Version)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	dbm "github.com/tendermint/tm-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	dbm "github.com/tendermint/tm-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -11,7 +11,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	sm "github.com/tendermint/tendermint/internal/state"
@@ -102,13 +102,13 @@ func TestStoreLoadValidators(t *testing.T) {
 func BenchmarkLoadValidators(b *testing.B) {
 	const valSetSize = 100
 
-	config := cfg.ResetTestRoot("state_")
-	defer os.RemoveAll(config.RootDir)
-	dbType := dbm.BackendType(config.DBBackend)
-	stateDB, err := dbm.NewDB("state", dbType, config.DBDir())
+	cfg := config.ResetTestRoot("state_")
+	defer os.RemoveAll(cfg.RootDir)
+	dbType := dbm.BackendType(cfg.DBBackend)
+	stateDB, err := dbm.NewDB("state", dbType, cfg.DBDir())
 	require.NoError(b, err)
 	stateStore := sm.NewStore(stateDB)
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	state, err := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/state/tx_filter.go
+++ b/internal/state/tx_filter.go
@@ -1,22 +1,22 @@
 package state
 
 import (
-	mempl "github.com/tendermint/tendermint/internal/mempool"
+	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/types"
 )
 
 // TxPreCheck returns a function to filter transactions before processing.
 // The function limits the size of a transaction to the block's maximum data size.
-func TxPreCheck(state State) mempl.PreCheckFunc {
+func TxPreCheck(state State) mempool.PreCheckFunc {
 	maxDataBytes := types.MaxDataBytesNoEvidence(
 		state.ConsensusParams.Block.MaxBytes,
 		state.Validators.Size(),
 	)
-	return mempl.PreCheckMaxBytes(maxDataBytes)
+	return mempool.PreCheckMaxBytes(maxDataBytes)
 }
 
 // TxPostCheck returns a function to filter transactions after processing.
 // The function limits the gas wanted by a transaction to the block's maximum total gas.
-func TxPostCheck(state State) mempl.PostCheckFunc {
-	return mempl.PostCheckMaxGas(state.ConsensusParams.Block.MaxGas)
+func TxPostCheck(state State) mempool.PostCheckFunc {
+	return mempool.PostCheckMaxGas(state.ConsensusParams.Block.MaxGas)
 }

--- a/internal/state/validation_test.go
+++ b/internal/state/validation_test.go
@@ -16,8 +16,8 @@ import (
 	memmock "github.com/tendermint/tendermint/internal/mempool/mock"
 	sm "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/internal/state/mocks"
-	sf "github.com/tendermint/tendermint/internal/state/test/factory"
-	"github.com/tendermint/tendermint/internal/test/factory"
+	statefactory "github.com/tendermint/tendermint/internal/state/test/factory"
+	testfactory "github.com/tendermint/tendermint/internal/test/factory"
 	"github.com/tendermint/tendermint/libs/log"
 	tmtime "github.com/tendermint/tendermint/libs/time"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -90,7 +90,7 @@ func TestValidateBlockHeader(t *testing.T) {
 			Invalid blocks don't pass
 		*/
 		for _, tc := range testCases {
-			block := sf.MakeBlock(state, height, lastCommit)
+			block := statefactory.MakeBlock(state, height, lastCommit)
 			tc.malleateBlock(block)
 			err := blockExec.ValidateBlock(state, block)
 			t.Logf("%s: %v", tc.name, err)
@@ -107,7 +107,7 @@ func TestValidateBlockHeader(t *testing.T) {
 	}
 
 	nextHeight := validationTestsStopHeight
-	block := sf.MakeBlock(state, nextHeight, lastCommit)
+	block := statefactory.MakeBlock(state, nextHeight, lastCommit)
 	state.InitialHeight = nextHeight + 1
 	err := blockExec.ValidateBlock(state, block)
 	require.Error(t, err, "expected an error when state is ahead of block")
@@ -141,7 +141,7 @@ func TestValidateBlockCommit(t *testing.T) {
 				#2589: ensure state.LastValidators.VerifyCommit fails here
 			*/
 			// should be height-1 instead of height
-			wrongHeightVote, err := factory.MakeVote(
+			wrongHeightVote, err := testfactory.MakeVote(
 				privVals[proposerAddr.String()],
 				chainID,
 				1,
@@ -158,7 +158,7 @@ func TestValidateBlockCommit(t *testing.T) {
 				state.LastBlockID,
 				[]types.CommitSig{wrongHeightVote.CommitSig()},
 			)
-			block := sf.MakeBlock(state, height, wrongHeightCommit)
+			block := statefactory.MakeBlock(state, height, wrongHeightCommit)
 			err = blockExec.ValidateBlock(state, block)
 			_, isErrInvalidCommitHeight := err.(types.ErrInvalidCommitHeight)
 			require.True(t, isErrInvalidCommitHeight, "expected ErrInvalidCommitHeight at height %d but got: %v", height, err)
@@ -166,7 +166,7 @@ func TestValidateBlockCommit(t *testing.T) {
 			/*
 				#2589: test len(block.LastCommit.Signatures) == state.LastValidators.Size()
 			*/
-			block = sf.MakeBlock(state, height, wrongSigsCommit)
+			block = statefactory.MakeBlock(state, height, wrongSigsCommit)
 			err = blockExec.ValidateBlock(state, block)
 			_, isErrInvalidCommitSignatures := err.(types.ErrInvalidCommitSignatures)
 			require.True(t, isErrInvalidCommitSignatures,
@@ -195,7 +195,7 @@ func TestValidateBlockCommit(t *testing.T) {
 		/*
 			wrongSigsCommit is fine except for the extra bad precommit
 		*/
-		goodVote, err := factory.MakeVote(
+		goodVote, err := testfactory.MakeVote(
 			privVals[proposerAddr.String()],
 			chainID,
 			1,
@@ -278,7 +278,7 @@ func TestValidateBlockEvidence(t *testing.T) {
 				evidence = append(evidence, newEv)
 				currentBytes += int64(len(newEv.Bytes()))
 			}
-			block, _ := state.MakeBlock(height, factory.MakeTenTxs(height), lastCommit, evidence, proposerAddr)
+			block, _ := state.MakeBlock(height, testfactory.MakeTenTxs(height), lastCommit, evidence, proposerAddr)
 			err := blockExec.ValidateBlock(state, block)
 			if assert.Error(t, err) {
 				_, ok := err.(*types.ErrEvidenceOverflow)

--- a/internal/state/validation_test.go
+++ b/internal/state/validation_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -22,7 +23,6 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 )
 
 const validationTestsStopHeight int64 = 10

--- a/internal/statesync/dispatcher.go
+++ b/internal/statesync/dispatcher.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tendermint/tendermint/internal/p2p"
 	"github.com/tendermint/tendermint/light/provider"
 	ssproto "github.com/tendermint/tendermint/proto/tendermint/statesync"
-	proto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -109,7 +109,7 @@ func (d *Dispatcher) dispatch(peer types.NodeID, height int64) (chan *types.Ligh
 // Respond allows the underlying process which receives requests on the
 // requestCh to respond with the respective light block. A nil response is used to
 // represent that the receiver of the request does not have a light block at that height.
-func (d *Dispatcher) Respond(lb *proto.LightBlock, peer types.NodeID) error {
+func (d *Dispatcher) Respond(lb *tmproto.LightBlock, peer types.NodeID) error {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 

--- a/internal/test/factory/genesis.go
+++ b/internal/test/factory/genesis.go
@@ -3,13 +3,13 @@ package factory
 import (
 	"sort"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	tmtime "github.com/tendermint/tendermint/libs/time"
 	"github.com/tendermint/tendermint/types"
 )
 
 func RandGenesisDoc(
-	config *cfg.Config,
+	cfg *config.Config,
 	numValidators int,
 	randPower bool,
 	minPower int64) (*types.GenesisDoc, []types.PrivValidator) {
@@ -29,7 +29,7 @@ func RandGenesisDoc(
 	return &types.GenesisDoc{
 		GenesisTime:   tmtime.Now(),
 		InitialHeight: 1,
-		ChainID:       config.ChainID(),
+		ChainID:       cfg.ChainID(),
 		Validators:    validators,
 	}, privValidators
 }

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/internal/test/factory"

--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tendermint/tendermint/light/provider"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -300,11 +300,11 @@ func (p *http) noBlock(e error) error {
 func (p *http) parseRPCError(e *rpctypes.RPCError) error {
 	switch {
 	// 1) check if the error indicates that the peer doesn't have the block
-	case strings.Contains(e.Data, ctypes.ErrHeightNotAvailable.Error()):
+	case strings.Contains(e.Data, coretypes.ErrHeightNotAvailable.Error()):
 		return p.noBlock(provider.ErrLightBlockNotFound)
 
 	// 2) check if the height requested is too high
-	case strings.Contains(e.Data, ctypes.ErrHeightExceedsChainHead.Error()):
+	case strings.Contains(e.Data, coretypes.ErrHeightExceedsChainHead.Error()):
 		return p.noBlock(provider.ErrHeightTooHigh)
 
 	// 3) check if the provider closed the connection

--- a/light/proxy/routes.go
+++ b/light/proxy/routes.go
@@ -4,7 +4,7 @@ import (
 	"github.com/tendermint/tendermint/libs/bytes"
 	lrpc "github.com/tendermint/tendermint/light/rpc"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpcserver "github.com/tendermint/tendermint/rpc/jsonrpc/server"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
@@ -52,91 +52,91 @@ func RPCRoutes(c *lrpc.Client) map[string]*rpcserver.RPCFunc {
 	}
 }
 
-type rpcHealthFunc func(ctx *rpctypes.Context) (*ctypes.ResultHealth, error)
+type rpcHealthFunc func(ctx *rpctypes.Context) (*coretypes.ResultHealth, error)
 
 func makeHealthFunc(c *lrpc.Client) rpcHealthFunc {
-	return func(ctx *rpctypes.Context) (*ctypes.ResultHealth, error) {
+	return func(ctx *rpctypes.Context) (*coretypes.ResultHealth, error) {
 		return c.Health(ctx.Context())
 	}
 }
 
-type rpcStatusFunc func(ctx *rpctypes.Context) (*ctypes.ResultStatus, error)
+type rpcStatusFunc func(ctx *rpctypes.Context) (*coretypes.ResultStatus, error)
 
 // nolint: interfacer
 func makeStatusFunc(c *lrpc.Client) rpcStatusFunc {
-	return func(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
+	return func(ctx *rpctypes.Context) (*coretypes.ResultStatus, error) {
 		return c.Status(ctx.Context())
 	}
 }
 
-type rpcNetInfoFunc func(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error)
+type rpcNetInfoFunc func(ctx *rpctypes.Context) (*coretypes.ResultNetInfo, error)
 
 func makeNetInfoFunc(c *lrpc.Client) rpcNetInfoFunc {
-	return func(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error) {
+	return func(ctx *rpctypes.Context) (*coretypes.ResultNetInfo, error) {
 		return c.NetInfo(ctx.Context())
 	}
 }
 
-type rpcBlockchainInfoFunc func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error)
+type rpcBlockchainInfoFunc func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error)
 
 func makeBlockchainInfoFunc(c *lrpc.Client) rpcBlockchainInfoFunc {
-	return func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error) {
+	return func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
 		return c.BlockchainInfo(ctx.Context(), minHeight, maxHeight)
 	}
 }
 
-type rpcGenesisFunc func(ctx *rpctypes.Context) (*ctypes.ResultGenesis, error)
+type rpcGenesisFunc func(ctx *rpctypes.Context) (*coretypes.ResultGenesis, error)
 
 func makeGenesisFunc(c *lrpc.Client) rpcGenesisFunc {
-	return func(ctx *rpctypes.Context) (*ctypes.ResultGenesis, error) {
+	return func(ctx *rpctypes.Context) (*coretypes.ResultGenesis, error) {
 		return c.Genesis(ctx.Context())
 	}
 }
 
-type rpcGenesisChunkedFunc func(ctx *rpctypes.Context, chunk uint) (*ctypes.ResultGenesisChunk, error)
+type rpcGenesisChunkedFunc func(ctx *rpctypes.Context, chunk uint) (*coretypes.ResultGenesisChunk, error)
 
 func makeGenesisChunkedFunc(c *lrpc.Client) rpcGenesisChunkedFunc {
-	return func(ctx *rpctypes.Context, chunk uint) (*ctypes.ResultGenesisChunk, error) {
+	return func(ctx *rpctypes.Context, chunk uint) (*coretypes.ResultGenesisChunk, error) {
 		return c.GenesisChunked(ctx.Context(), chunk)
 	}
 }
 
-type rpcBlockFunc func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultBlock, error)
+type rpcBlockFunc func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultBlock, error)
 
 func makeBlockFunc(c *lrpc.Client) rpcBlockFunc {
-	return func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultBlock, error) {
+	return func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultBlock, error) {
 		return c.Block(ctx.Context(), height)
 	}
 }
 
-type rpcBlockByHashFunc func(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error)
+type rpcBlockByHashFunc func(ctx *rpctypes.Context, hash []byte) (*coretypes.ResultBlock, error)
 
 func makeBlockByHashFunc(c *lrpc.Client) rpcBlockByHashFunc {
-	return func(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error) {
+	return func(ctx *rpctypes.Context, hash []byte) (*coretypes.ResultBlock, error) {
 		return c.BlockByHash(ctx.Context(), hash)
 	}
 }
 
-type rpcBlockResultsFunc func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultBlockResults, error)
+type rpcBlockResultsFunc func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultBlockResults, error)
 
 func makeBlockResultsFunc(c *lrpc.Client) rpcBlockResultsFunc {
-	return func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultBlockResults, error) {
+	return func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultBlockResults, error) {
 		return c.BlockResults(ctx.Context(), height)
 	}
 }
 
-type rpcCommitFunc func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultCommit, error)
+type rpcCommitFunc func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultCommit, error)
 
 func makeCommitFunc(c *lrpc.Client) rpcCommitFunc {
-	return func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultCommit, error) {
+	return func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultCommit, error) {
 		return c.Commit(ctx.Context(), height)
 	}
 }
 
-type rpcTxFunc func(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error)
+type rpcTxFunc func(ctx *rpctypes.Context, hash []byte, prove bool) (*coretypes.ResultTx, error)
 
 func makeTxFunc(c *lrpc.Client) rpcTxFunc {
-	return func(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error) {
+	return func(ctx *rpctypes.Context, hash []byte, prove bool) (*coretypes.ResultTx, error) {
 		return c.Tx(ctx.Context(), hash, prove)
 	}
 }
@@ -147,7 +147,7 @@ type rpcTxSearchFunc func(
 	prove bool,
 	page, perPage *int,
 	orderBy string,
-) (*ctypes.ResultTxSearch, error)
+) (*coretypes.ResultTxSearch, error)
 
 func makeTxSearchFunc(c *lrpc.Client) rpcTxSearchFunc {
 	return func(
@@ -156,7 +156,7 @@ func makeTxSearchFunc(c *lrpc.Client) rpcTxSearchFunc {
 		prove bool,
 		page, perPage *int,
 		orderBy string,
-	) (*ctypes.ResultTxSearch, error) {
+	) (*coretypes.ResultTxSearch, error) {
 		return c.TxSearch(ctx.Context(), query, prove, page, perPage, orderBy)
 	}
 }
@@ -167,7 +167,7 @@ type rpcBlockSearchFunc func(
 	prove bool,
 	page, perPage *int,
 	orderBy string,
-) (*ctypes.ResultBlockSearch, error)
+) (*coretypes.ResultBlockSearch, error)
 
 func makeBlockSearchFunc(c *lrpc.Client) rpcBlockSearchFunc {
 	return func(
@@ -176,90 +176,90 @@ func makeBlockSearchFunc(c *lrpc.Client) rpcBlockSearchFunc {
 		prove bool,
 		page, perPage *int,
 		orderBy string,
-	) (*ctypes.ResultBlockSearch, error) {
+	) (*coretypes.ResultBlockSearch, error) {
 		return c.BlockSearch(ctx.Context(), query, page, perPage, orderBy)
 	}
 }
 
 type rpcValidatorsFunc func(ctx *rpctypes.Context, height *int64,
-	page, perPage *int) (*ctypes.ResultValidators, error)
+	page, perPage *int) (*coretypes.ResultValidators, error)
 
 func makeValidatorsFunc(c *lrpc.Client) rpcValidatorsFunc {
-	return func(ctx *rpctypes.Context, height *int64, page, perPage *int) (*ctypes.ResultValidators, error) {
+	return func(ctx *rpctypes.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
 		return c.Validators(ctx.Context(), height, page, perPage)
 	}
 }
 
-type rpcDumpConsensusStateFunc func(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState, error)
+type rpcDumpConsensusStateFunc func(ctx *rpctypes.Context) (*coretypes.ResultDumpConsensusState, error)
 
 func makeDumpConsensusStateFunc(c *lrpc.Client) rpcDumpConsensusStateFunc {
-	return func(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState, error) {
+	return func(ctx *rpctypes.Context) (*coretypes.ResultDumpConsensusState, error) {
 		return c.DumpConsensusState(ctx.Context())
 	}
 }
 
-type rpcConsensusStateFunc func(ctx *rpctypes.Context) (*ctypes.ResultConsensusState, error)
+type rpcConsensusStateFunc func(ctx *rpctypes.Context) (*coretypes.ResultConsensusState, error)
 
 func makeConsensusStateFunc(c *lrpc.Client) rpcConsensusStateFunc {
-	return func(ctx *rpctypes.Context) (*ctypes.ResultConsensusState, error) {
+	return func(ctx *rpctypes.Context) (*coretypes.ResultConsensusState, error) {
 		return c.ConsensusState(ctx.Context())
 	}
 }
 
-type rpcConsensusParamsFunc func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultConsensusParams, error)
+type rpcConsensusParamsFunc func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultConsensusParams, error)
 
 func makeConsensusParamsFunc(c *lrpc.Client) rpcConsensusParamsFunc {
-	return func(ctx *rpctypes.Context, height *int64) (*ctypes.ResultConsensusParams, error) {
+	return func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultConsensusParams, error) {
 		return c.ConsensusParams(ctx.Context(), height)
 	}
 }
 
-type rpcUnconfirmedTxsFunc func(ctx *rpctypes.Context, limit *int) (*ctypes.ResultUnconfirmedTxs, error)
+type rpcUnconfirmedTxsFunc func(ctx *rpctypes.Context, limit *int) (*coretypes.ResultUnconfirmedTxs, error)
 
 func makeUnconfirmedTxsFunc(c *lrpc.Client) rpcUnconfirmedTxsFunc {
-	return func(ctx *rpctypes.Context, limit *int) (*ctypes.ResultUnconfirmedTxs, error) {
+	return func(ctx *rpctypes.Context, limit *int) (*coretypes.ResultUnconfirmedTxs, error) {
 		return c.UnconfirmedTxs(ctx.Context(), limit)
 	}
 }
 
-type rpcNumUnconfirmedTxsFunc func(ctx *rpctypes.Context) (*ctypes.ResultUnconfirmedTxs, error)
+type rpcNumUnconfirmedTxsFunc func(ctx *rpctypes.Context) (*coretypes.ResultUnconfirmedTxs, error)
 
 func makeNumUnconfirmedTxsFunc(c *lrpc.Client) rpcNumUnconfirmedTxsFunc {
-	return func(ctx *rpctypes.Context) (*ctypes.ResultUnconfirmedTxs, error) {
+	return func(ctx *rpctypes.Context) (*coretypes.ResultUnconfirmedTxs, error) {
 		return c.NumUnconfirmedTxs(ctx.Context())
 	}
 }
 
-type rpcBroadcastTxCommitFunc func(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error)
+type rpcBroadcastTxCommitFunc func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error)
 
 func makeBroadcastTxCommitFunc(c *lrpc.Client) rpcBroadcastTxCommitFunc {
-	return func(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+	return func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
 		return c.BroadcastTxCommit(ctx.Context(), tx)
 	}
 }
 
-type rpcBroadcastTxSyncFunc func(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error)
+type rpcBroadcastTxSyncFunc func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error)
 
 func makeBroadcastTxSyncFunc(c *lrpc.Client) rpcBroadcastTxSyncFunc {
-	return func(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+	return func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 		return c.BroadcastTxSync(ctx.Context(), tx)
 	}
 }
 
-type rpcBroadcastTxAsyncFunc func(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error)
+type rpcBroadcastTxAsyncFunc func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error)
 
 func makeBroadcastTxAsyncFunc(c *lrpc.Client) rpcBroadcastTxAsyncFunc {
-	return func(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+	return func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 		return c.BroadcastTxAsync(ctx.Context(), tx)
 	}
 }
 
 type rpcABCIQueryFunc func(ctx *rpctypes.Context, path string,
-	data bytes.HexBytes, height int64, prove bool) (*ctypes.ResultABCIQuery, error)
+	data bytes.HexBytes, height int64, prove bool) (*coretypes.ResultABCIQuery, error)
 
 func makeABCIQueryFunc(c *lrpc.Client) rpcABCIQueryFunc {
 	return func(ctx *rpctypes.Context, path string, data bytes.HexBytes,
-		height int64, prove bool) (*ctypes.ResultABCIQuery, error) {
+		height int64, prove bool) (*coretypes.ResultABCIQuery, error) {
 
 		return c.ABCIQueryWithOptions(ctx.Context(), path, data, rpcclient.ABCIQueryOptions{
 			Height: height,
@@ -268,19 +268,19 @@ func makeABCIQueryFunc(c *lrpc.Client) rpcABCIQueryFunc {
 	}
 }
 
-type rpcABCIInfoFunc func(ctx *rpctypes.Context) (*ctypes.ResultABCIInfo, error)
+type rpcABCIInfoFunc func(ctx *rpctypes.Context) (*coretypes.ResultABCIInfo, error)
 
 func makeABCIInfoFunc(c *lrpc.Client) rpcABCIInfoFunc {
-	return func(ctx *rpctypes.Context) (*ctypes.ResultABCIInfo, error) {
+	return func(ctx *rpctypes.Context) (*coretypes.ResultABCIInfo, error) {
 		return c.ABCIInfo(ctx.Context())
 	}
 }
 
-type rpcBroadcastEvidenceFunc func(ctx *rpctypes.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error)
+type rpcBroadcastEvidenceFunc func(ctx *rpctypes.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error)
 
 // nolint: interfacer
 func makeBroadcastEvidenceFunc(c *lrpc.Client) rpcBroadcastEvidenceFunc {
-	return func(ctx *rpctypes.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
+	return func(ctx *rpctypes.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
 		return c.BroadcastEvidence(ctx.Context(), ev)
 	}
 }

--- a/light/proxy/routes.go
+++ b/light/proxy/routes.go
@@ -77,7 +77,7 @@ func makeNetInfoFunc(c *lrpc.Client) rpcNetInfoFunc {
 	}
 }
 
-type rpcBlockchainInfoFunc func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error)
+type rpcBlockchainInfoFunc func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) //nolint:lll
 
 func makeBlockchainInfoFunc(c *lrpc.Client) rpcBlockchainInfoFunc {
 	return func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -16,7 +16,7 @@ import (
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	service "github.com/tendermint/tendermint/libs/service"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -113,22 +113,22 @@ func (c *Client) OnStop() {
 	}
 }
 
-func (c *Client) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
+func (c *Client) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
 	return c.next.Status(ctx)
 }
 
-func (c *Client) ABCIInfo(ctx context.Context) (*ctypes.ResultABCIInfo, error) {
+func (c *Client) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
 	return c.next.ABCIInfo(ctx)
 }
 
 // ABCIQuery requests proof by default.
-func (c *Client) ABCIQuery(ctx context.Context, path string, data tmbytes.HexBytes) (*ctypes.ResultABCIQuery, error) {
+func (c *Client) ABCIQuery(ctx context.Context, path string, data tmbytes.HexBytes) (*coretypes.ResultABCIQuery, error) {
 	return c.ABCIQueryWithOptions(ctx, path, data, rpcclient.DefaultABCIQueryOptions)
 }
 
 // ABCIQueryWithOptions returns an error if opts.Prove is false.
 func (c *Client) ABCIQueryWithOptions(ctx context.Context, path string, data tmbytes.HexBytes,
-	opts rpcclient.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
+	opts rpcclient.ABCIQueryOptions) (*coretypes.ResultABCIQuery, error) {
 
 	// always request the proof
 	opts.Prove = true
@@ -150,7 +150,7 @@ func (c *Client) ABCIQueryWithOptions(ctx context.Context, path string, data tmb
 		return nil, errors.New("no proof ops")
 	}
 	if resp.Height <= 0 {
-		return nil, ctypes.ErrZeroOrNegativeHeight
+		return nil, coretypes.ErrZeroOrNegativeHeight
 	}
 
 	// Update the light client if we're behind.
@@ -185,46 +185,46 @@ func (c *Client) ABCIQueryWithOptions(ctx context.Context, path string, data tmb
 		}
 	}
 
-	return &ctypes.ResultABCIQuery{Response: resp}, nil
+	return &coretypes.ResultABCIQuery{Response: resp}, nil
 }
 
-func (c *Client) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+func (c *Client) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
 	return c.next.BroadcastTxCommit(ctx, tx)
 }
 
-func (c *Client) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (c *Client) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	return c.next.BroadcastTxAsync(ctx, tx)
 }
 
-func (c *Client) BroadcastTxSync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (c *Client) BroadcastTxSync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	return c.next.BroadcastTxSync(ctx, tx)
 }
 
-func (c *Client) UnconfirmedTxs(ctx context.Context, limit *int) (*ctypes.ResultUnconfirmedTxs, error) {
+func (c *Client) UnconfirmedTxs(ctx context.Context, limit *int) (*coretypes.ResultUnconfirmedTxs, error) {
 	return c.next.UnconfirmedTxs(ctx, limit)
 }
 
-func (c *Client) NumUnconfirmedTxs(ctx context.Context) (*ctypes.ResultUnconfirmedTxs, error) {
+func (c *Client) NumUnconfirmedTxs(ctx context.Context) (*coretypes.ResultUnconfirmedTxs, error) {
 	return c.next.NumUnconfirmedTxs(ctx)
 }
 
-func (c *Client) CheckTx(ctx context.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
+func (c *Client) CheckTx(ctx context.Context, tx types.Tx) (*coretypes.ResultCheckTx, error) {
 	return c.next.CheckTx(ctx, tx)
 }
 
-func (c *Client) NetInfo(ctx context.Context) (*ctypes.ResultNetInfo, error) {
+func (c *Client) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, error) {
 	return c.next.NetInfo(ctx)
 }
 
-func (c *Client) DumpConsensusState(ctx context.Context) (*ctypes.ResultDumpConsensusState, error) {
+func (c *Client) DumpConsensusState(ctx context.Context) (*coretypes.ResultDumpConsensusState, error) {
 	return c.next.DumpConsensusState(ctx)
 }
 
-func (c *Client) ConsensusState(ctx context.Context) (*ctypes.ResultConsensusState, error) {
+func (c *Client) ConsensusState(ctx context.Context) (*coretypes.ResultConsensusState, error) {
 	return c.next.ConsensusState(ctx)
 }
 
-func (c *Client) ConsensusParams(ctx context.Context, height *int64) (*ctypes.ResultConsensusParams, error) {
+func (c *Client) ConsensusParams(ctx context.Context, height *int64) (*coretypes.ResultConsensusParams, error) {
 	res, err := c.next.ConsensusParams(ctx, height)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (c *Client) ConsensusParams(ctx context.Context, height *int64) (*ctypes.Re
 		return nil, err
 	}
 	if res.BlockHeight <= 0 {
-		return nil, ctypes.ErrZeroOrNegativeHeight
+		return nil, coretypes.ErrZeroOrNegativeHeight
 	}
 
 	// Update the light client if we're behind.
@@ -253,13 +253,13 @@ func (c *Client) ConsensusParams(ctx context.Context, height *int64) (*ctypes.Re
 	return res, nil
 }
 
-func (c *Client) Health(ctx context.Context) (*ctypes.ResultHealth, error) {
+func (c *Client) Health(ctx context.Context) (*coretypes.ResultHealth, error) {
 	return c.next.Health(ctx)
 }
 
 // BlockchainInfo calls rpcclient#BlockchainInfo and then verifies every header
 // returned.
-func (c *Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error) {
+func (c *Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
 	res, err := c.next.BlockchainInfo(ctx, minHeight, maxHeight)
 	if err != nil {
 		return nil, err
@@ -298,16 +298,16 @@ func (c *Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64)
 	return res, nil
 }
 
-func (c *Client) Genesis(ctx context.Context) (*ctypes.ResultGenesis, error) {
+func (c *Client) Genesis(ctx context.Context) (*coretypes.ResultGenesis, error) {
 	return c.next.Genesis(ctx)
 }
 
-func (c *Client) GenesisChunked(ctx context.Context, id uint) (*ctypes.ResultGenesisChunk, error) {
+func (c *Client) GenesisChunked(ctx context.Context, id uint) (*coretypes.ResultGenesisChunk, error) {
 	return c.next.GenesisChunked(ctx, id)
 }
 
 // Block calls rpcclient#Block and then verifies the result.
-func (c *Client) Block(ctx context.Context, height *int64) (*ctypes.ResultBlock, error) {
+func (c *Client) Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
 	res, err := c.next.Block(ctx, height)
 	if err != nil {
 		return nil, err
@@ -341,7 +341,7 @@ func (c *Client) Block(ctx context.Context, height *int64) (*ctypes.ResultBlock,
 }
 
 // BlockByHash calls rpcclient#BlockByHash and then verifies the result.
-func (c *Client) BlockByHash(ctx context.Context, hash tmbytes.HexBytes) (*ctypes.ResultBlock, error) {
+func (c *Client) BlockByHash(ctx context.Context, hash tmbytes.HexBytes) (*coretypes.ResultBlock, error) {
 	res, err := c.next.BlockByHash(ctx, hash)
 	if err != nil {
 		return nil, err
@@ -376,7 +376,7 @@ func (c *Client) BlockByHash(ctx context.Context, hash tmbytes.HexBytes) (*ctype
 
 // BlockResults returns the block results for the given height. If no height is
 // provided, the results of the block preceding the latest are returned.
-func (c *Client) BlockResults(ctx context.Context, height *int64) (*ctypes.ResultBlockResults, error) {
+func (c *Client) BlockResults(ctx context.Context, height *int64) (*coretypes.ResultBlockResults, error) {
 	var h int64
 	if height == nil {
 		res, err := c.next.Status(ctx)
@@ -397,7 +397,7 @@ func (c *Client) BlockResults(ctx context.Context, height *int64) (*ctypes.Resul
 
 	// Validate res.
 	if res.Height <= 0 {
-		return nil, ctypes.ErrZeroOrNegativeHeight
+		return nil, coretypes.ErrZeroOrNegativeHeight
 	}
 
 	// Update the light client if we're behind.
@@ -438,7 +438,7 @@ func (c *Client) BlockResults(ctx context.Context, height *int64) (*ctypes.Resul
 	return res, nil
 }
 
-func (c *Client) Commit(ctx context.Context, height *int64) (*ctypes.ResultCommit, error) {
+func (c *Client) Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
 	// Update the light client if we're behind and retrieve the light block at the requested height
 	// or at the latest height if no height is provided.
 	l, err := c.updateLightClientIfNeededTo(ctx, height)
@@ -446,7 +446,7 @@ func (c *Client) Commit(ctx context.Context, height *int64) (*ctypes.ResultCommi
 		return nil, err
 	}
 
-	return &ctypes.ResultCommit{
+	return &coretypes.ResultCommit{
 		SignedHeader:    *l.SignedHeader,
 		CanonicalCommit: true,
 	}, nil
@@ -454,7 +454,7 @@ func (c *Client) Commit(ctx context.Context, height *int64) (*ctypes.ResultCommi
 
 // Tx calls rpcclient#Tx method and then verifies the proof if such was
 // requested.
-func (c *Client) Tx(ctx context.Context, hash tmbytes.HexBytes, prove bool) (*ctypes.ResultTx, error) {
+func (c *Client) Tx(ctx context.Context, hash tmbytes.HexBytes, prove bool) (*coretypes.ResultTx, error) {
 	res, err := c.next.Tx(ctx, hash, prove)
 	if err != nil || !prove {
 		return res, err
@@ -462,7 +462,7 @@ func (c *Client) Tx(ctx context.Context, hash tmbytes.HexBytes, prove bool) (*ct
 
 	// Validate res.
 	if res.Height <= 0 {
-		return nil, ctypes.ErrZeroOrNegativeHeight
+		return nil, coretypes.ErrZeroOrNegativeHeight
 	}
 
 	// Update the light client if we're behind.
@@ -481,7 +481,7 @@ func (c *Client) TxSearch(
 	prove bool,
 	page, perPage *int,
 	orderBy string,
-) (*ctypes.ResultTxSearch, error) {
+) (*coretypes.ResultTxSearch, error) {
 	return c.next.TxSearch(ctx, query, prove, page, perPage, orderBy)
 }
 
@@ -490,7 +490,7 @@ func (c *Client) BlockSearch(
 	query string,
 	page, perPage *int,
 	orderBy string,
-) (*ctypes.ResultBlockSearch, error) {
+) (*coretypes.ResultBlockSearch, error) {
 	return c.next.BlockSearch(ctx, query, page, perPage, orderBy)
 }
 
@@ -499,7 +499,7 @@ func (c *Client) Validators(
 	ctx context.Context,
 	height *int64,
 	pagePtr, perPagePtr *int,
-) (*ctypes.ResultValidators, error) {
+) (*coretypes.ResultValidators, error) {
 
 	// Update the light client if we're behind and retrieve the light block at the
 	// requested height or at the latest height if no height is provided.
@@ -518,19 +518,19 @@ func (c *Client) Validators(
 	skipCount := validateSkipCount(page, perPage)
 	v := l.ValidatorSet.Validators[skipCount : skipCount+tmmath.MinInt(perPage, totalCount-skipCount)]
 
-	return &ctypes.ResultValidators{
+	return &coretypes.ResultValidators{
 		BlockHeight: l.Height,
 		Validators:  v,
 		Count:       len(v),
 		Total:       totalCount}, nil
 }
 
-func (c *Client) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
+func (c *Client) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
 	return c.next.BroadcastEvidence(ctx, ev)
 }
 
 func (c *Client) Subscribe(ctx context.Context, subscriber, query string,
-	outCapacity ...int) (out <-chan ctypes.ResultEvent, err error) {
+	outCapacity ...int) (out <-chan coretypes.ResultEvent, err error) {
 	return c.next.Subscribe(ctx, subscriber, query, outCapacity...)
 }
 
@@ -565,7 +565,7 @@ func (c *Client) RegisterOpDecoder(typ string, dec merkle.OpDecoder) {
 // SubscribeWS subscribes for events using the given query and remote address as
 // a subscriber, but does not verify responses (UNSAFE)!
 // TODO: verify data
-func (c *Client) SubscribeWS(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, error) {
+func (c *Client) SubscribeWS(ctx *rpctypes.Context, query string) (*coretypes.ResultSubscribe, error) {
 	out, err := c.next.Subscribe(context.Background(), ctx.RemoteAddr(), query)
 	if err != nil {
 		return nil, err
@@ -588,27 +588,27 @@ func (c *Client) SubscribeWS(ctx *rpctypes.Context, query string) (*ctypes.Resul
 		}
 	}()
 
-	return &ctypes.ResultSubscribe{}, nil
+	return &coretypes.ResultSubscribe{}, nil
 }
 
 // UnsubscribeWS calls original client's Unsubscribe using remote address as a
 // subscriber.
-func (c *Client) UnsubscribeWS(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe, error) {
+func (c *Client) UnsubscribeWS(ctx *rpctypes.Context, query string) (*coretypes.ResultUnsubscribe, error) {
 	err := c.next.Unsubscribe(context.Background(), ctx.RemoteAddr(), query)
 	if err != nil {
 		return nil, err
 	}
-	return &ctypes.ResultUnsubscribe{}, nil
+	return &coretypes.ResultUnsubscribe{}, nil
 }
 
 // UnsubscribeAllWS calls original client's UnsubscribeAll using remote address
 // as a subscriber.
-func (c *Client) UnsubscribeAllWS(ctx *rpctypes.Context) (*ctypes.ResultUnsubscribe, error) {
+func (c *Client) UnsubscribeAllWS(ctx *rpctypes.Context) (*coretypes.ResultUnsubscribe, error) {
 	err := c.next.UnsubscribeAll(context.Background(), ctx.RemoteAddr())
 	if err != nil {
 		return nil, err
 	}
-	return &ctypes.ResultUnsubscribe{}, nil
+	return &coretypes.ResultUnsubscribe{}, nil
 }
 
 // XXX: Copied from rpc/core/env.go
@@ -620,7 +620,7 @@ const (
 
 func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
 	if perPage < 1 {
-		panic(fmt.Errorf("%w (%d)", ctypes.ErrZeroOrNegativePerPage, perPage))
+		panic(fmt.Errorf("%w (%d)", coretypes.ErrZeroOrNegativePerPage, perPage))
 	}
 
 	if pagePtr == nil { // no page parameter
@@ -633,7 +633,7 @@ func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
 	}
 	page := *pagePtr
 	if page <= 0 || page > pages {
-		return 1, fmt.Errorf("%w expected range: [1, %d], given %d", ctypes.ErrPageOutOfRange, pages, page)
+		return 1, fmt.Errorf("%w expected range: [1, %d], given %d", coretypes.ErrPageOutOfRange, pages, page)
 	}
 
 	return page, nil

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -122,7 +122,7 @@ func (c *Client) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error
 }
 
 // ABCIQuery requests proof by default.
-func (c *Client) ABCIQuery(ctx context.Context, path string, data tmbytes.HexBytes) (*coretypes.ResultABCIQuery, error) {
+func (c *Client) ABCIQuery(ctx context.Context, path string, data tmbytes.HexBytes) (*coretypes.ResultABCIQuery, error) { //nolint:lll
 	return c.ABCIQueryWithOptions(ctx, path, data, rpcclient.DefaultABCIQueryOptions)
 }
 
@@ -259,7 +259,7 @@ func (c *Client) Health(ctx context.Context) (*coretypes.ResultHealth, error) {
 
 // BlockchainInfo calls rpcclient#BlockchainInfo and then verifies every header
 // returned.
-func (c *Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
+func (c *Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) { //nolint:lll
 	res, err := c.next.BlockchainInfo(ctx, minHeight, maxHeight)
 	if err != nil {
 		return nil, err

--- a/light/store/db/db_test.go
+++ b/light/store/db/db_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/crypto"

--- a/node/node.go
+++ b/node/node.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rs/cors"
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	cs "github.com/tendermint/tendermint/internal/consensus"
 	"github.com/tendermint/tendermint/internal/mempool"
@@ -46,7 +46,7 @@ type nodeImpl struct {
 	service.BaseService
 
 	// config
-	config        *cfg.Config
+	config        *config.Config
 	genesisDoc    *types.GenesisDoc   // initial validator set
 	privValidator types.PrivValidator // local node's validator key
 
@@ -81,23 +81,23 @@ type nodeImpl struct {
 // newDefaultNode returns a Tendermint node with default settings for the
 // PrivValidator, ClientCreator, GenesisDoc, and DBProvider.
 // It implements NodeProvider.
-func newDefaultNode(config *cfg.Config, logger log.Logger) (service.Service, error) {
-	nodeKey, err := types.LoadOrGenNodeKey(config.NodeKeyFile())
+func newDefaultNode(cfg *config.Config, logger log.Logger) (service.Service, error) {
+	nodeKey, err := types.LoadOrGenNodeKey(cfg.NodeKeyFile())
 	if err != nil {
-		return nil, fmt.Errorf("failed to load or gen node key %s: %w", config.NodeKeyFile(), err)
+		return nil, fmt.Errorf("failed to load or gen node key %s: %w", cfg.NodeKeyFile(), err)
 	}
-	if config.Mode == cfg.ModeSeed {
-		return makeSeedNode(config,
-			cfg.DefaultDBProvider,
+	if cfg.Mode == config.ModeSeed {
+		return makeSeedNode(cfg,
+			config.DefaultDBProvider,
 			nodeKey,
-			defaultGenesisDocProviderFunc(config),
+			defaultGenesisDocProviderFunc(cfg),
 			logger,
 		)
 	}
 
 	var pval *privval.FilePV
-	if config.Mode == cfg.ModeValidator {
-		pval, err = privval.LoadOrGenFilePV(config.PrivValidator.KeyFile(), config.PrivValidator.StateFile())
+	if cfg.Mode == config.ModeValidator {
+		pval, err = privval.LoadOrGenFilePV(cfg.PrivValidator.KeyFile(), cfg.PrivValidator.StateFile())
 		if err != nil {
 			return nil, err
 		}
@@ -105,27 +105,27 @@ func newDefaultNode(config *cfg.Config, logger log.Logger) (service.Service, err
 		pval = nil
 	}
 
-	appClient, _ := proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir())
-	return makeNode(config,
+	appClient, _ := proxy.DefaultClientCreator(cfg.ProxyApp, cfg.ABCI, cfg.DBDir())
+	return makeNode(cfg,
 		pval,
 		nodeKey,
 		appClient,
-		defaultGenesisDocProviderFunc(config),
-		cfg.DefaultDBProvider,
+		defaultGenesisDocProviderFunc(cfg),
+		config.DefaultDBProvider,
 		logger,
 	)
 }
 
 // makeNode returns a new, ready to go, Tendermint Node.
-func makeNode(config *cfg.Config,
+func makeNode(cfg *config.Config,
 	privValidator types.PrivValidator,
 	nodeKey types.NodeKey,
 	clientCreator abciclient.Creator,
 	genesisDocProvider genesisDocProvider,
-	dbProvider cfg.DBProvider,
+	dbProvider config.DBProvider,
 	logger log.Logger) (service.Service, error) {
 
-	blockStore, stateDB, err := initDBs(config, dbProvider)
+	blockStore, stateDB, err := initDBs(cfg, dbProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -161,31 +161,31 @@ func makeNode(config *cfg.Config,
 		return nil, err
 	}
 
-	indexerService, eventSinks, err := createAndStartIndexerService(config, dbProvider, eventBus, logger, genDoc.ChainID)
+	indexerService, eventSinks, err := createAndStartIndexerService(cfg, dbProvider, eventBus, logger, genDoc.ChainID)
 	if err != nil {
 		return nil, err
 	}
 
 	// If an address is provided, listen on the socket for a connection from an
 	// external signing process.
-	if config.PrivValidator.ListenAddr != "" {
-		protocol, _ := tmnet.ProtocolAndAddress(config.PrivValidator.ListenAddr)
+	if cfg.PrivValidator.ListenAddr != "" {
+		protocol, _ := tmnet.ProtocolAndAddress(cfg.PrivValidator.ListenAddr)
 		// FIXME: we should start services inside OnStart
 		switch protocol {
 		case "grpc":
-			privValidator, err = createAndStartPrivValidatorGRPCClient(config, genDoc.ChainID, logger)
+			privValidator, err = createAndStartPrivValidatorGRPCClient(cfg, genDoc.ChainID, logger)
 			if err != nil {
 				return nil, fmt.Errorf("error with private validator grpc client: %w", err)
 			}
 		default:
-			privValidator, err = createAndStartPrivValidatorSocketClient(config.PrivValidator.ListenAddr, genDoc.ChainID, logger)
+			privValidator, err = createAndStartPrivValidatorSocketClient(cfg.PrivValidator.ListenAddr, genDoc.ChainID, logger)
 			if err != nil {
 				return nil, fmt.Errorf("error with private validator socket client: %w", err)
 			}
 		}
 	}
 	var pubKey crypto.PubKey
-	if config.Mode == cfg.ModeValidator {
+	if cfg.Mode == config.ModeValidator {
 		pubKey, err = privValidator.GetPubKey(context.TODO())
 		if err != nil {
 			return nil, fmt.Errorf("can't get pubkey: %w", err)
@@ -196,7 +196,7 @@ func makeNode(config *cfg.Config,
 	}
 
 	// Determine whether we should attempt state sync.
-	stateSync := config.StateSync.Enable && !onlyValidatorIsUs(state, pubKey)
+	stateSync := cfg.StateSync.Enable && !onlyValidatorIsUs(state, pubKey)
 	if stateSync && state.LastBlockHeight > 0 {
 		logger.Info("Found local state with non-zero height, skipping state sync")
 		stateSync = false
@@ -221,43 +221,43 @@ func makeNode(config *cfg.Config,
 
 	// Determine whether we should do block sync. This must happen after the handshake, since the
 	// app may modify the validator set, specifying ourself as the only validator.
-	blockSync := config.BlockSync.Enable && !onlyValidatorIsUs(state, pubKey)
+	blockSync := cfg.BlockSync.Enable && !onlyValidatorIsUs(state, pubKey)
 
-	logNodeStartupInfo(state, pubKey, logger, consensusLogger, config.Mode)
+	logNodeStartupInfo(state, pubKey, logger, consensusLogger, cfg.Mode)
 
 	// TODO: Fetch and provide real options and do proper p2p bootstrapping.
 	// TODO: Use a persistent peer database.
-	nodeInfo, err := makeNodeInfo(config, nodeKey, eventSinks, genDoc, state)
+	nodeInfo, err := makeNodeInfo(cfg, nodeKey, eventSinks, genDoc, state)
 	if err != nil {
 		return nil, err
 	}
 
 	p2pLogger := logger.With("module", "p2p")
-	transport := createTransport(p2pLogger, config)
+	transport := createTransport(p2pLogger, cfg)
 
-	peerManager, err := createPeerManager(config, dbProvider, p2pLogger, nodeKey.ID)
+	peerManager, err := createPeerManager(cfg, dbProvider, p2pLogger, nodeKey.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create peer manager: %w", err)
 	}
 
 	nodeMetrics :=
-		defaultMetricsProvider(config.Instrumentation)(genDoc.ChainID)
+		defaultMetricsProvider(cfg.Instrumentation)(genDoc.ChainID)
 
 	router, err := createRouter(p2pLogger, nodeMetrics.p2p, nodeInfo, nodeKey.PrivKey,
-		peerManager, transport, getRouterConfig(config, proxyApp))
+		peerManager, transport, getRouterConfig(cfg, proxyApp))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create router: %w", err)
 	}
 
 	mpReactorShim, mpReactor, mp, err := createMempoolReactor(
-		config, proxyApp, state, nodeMetrics.mempool, peerManager, router, logger,
+		cfg, proxyApp, state, nodeMetrics.mempool, peerManager, router, logger,
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	evReactorShim, evReactor, evPool, err := createEvidenceReactor(
-		config, dbProvider, stateDB, blockStore, peerManager, router, logger,
+		cfg, dbProvider, stateDB, blockStore, peerManager, router, logger,
 	)
 	if err != nil {
 		return nil, err
@@ -275,7 +275,7 @@ func makeNode(config *cfg.Config,
 	)
 
 	csReactorShim, csReactor, csState := createConsensusReactor(
-		config, state, blockExec, blockStore, mp, evPool,
+		cfg, state, blockExec, blockStore, mp, evPool,
 		privValidator, nodeMetrics.cs, stateSync || blockSync, eventBus,
 		peerManager, router, consensusLogger,
 	)
@@ -283,7 +283,7 @@ func makeNode(config *cfg.Config,
 	// Create the blockchain reactor. Note, we do not start block sync if we're
 	// doing a state sync first.
 	bcReactorShim, bcReactor, err := createBlockchainReactor(
-		logger, config, state, blockExec, blockStore, csReactor,
+		logger, cfg, state, blockExec, blockStore, csReactor,
 		peerManager, router, blockSync && !stateSync, nodeMetrics.cs,
 	)
 	if err != nil {
@@ -320,7 +320,7 @@ func makeNode(config *cfg.Config,
 
 	stateSyncReactorShim = p2p.NewReactorShim(logger.With("module", "statesync"), "StateSyncShim", statesync.ChannelShims)
 
-	if config.P2P.UseLegacy {
+	if cfg.P2P.UseLegacy {
 		channels = getChannelsFromShim(stateSyncReactorShim)
 		peerUpdates = stateSyncReactorShim.PeerUpdates
 	} else {
@@ -331,7 +331,7 @@ func makeNode(config *cfg.Config,
 	stateSyncReactor = statesync.NewReactor(
 		genDoc.ChainID,
 		genDoc.InitialHeight,
-		*config.StateSync,
+		*cfg.StateSync,
 		stateSyncReactorShim.Logger,
 		proxyApp.Snapshot(),
 		proxyApp.Query(),
@@ -342,7 +342,7 @@ func makeNode(config *cfg.Config,
 		peerUpdates,
 		stateStore,
 		blockStore,
-		config.StateSync.TempDir,
+		cfg.StateSync.TempDir,
 		nodeMetrics.statesync,
 	)
 
@@ -378,46 +378,46 @@ func makeNode(config *cfg.Config,
 	pexCh := pex.ChannelDescriptor()
 	transport.AddChannelDescriptors([]*p2p.ChannelDescriptor{&pexCh})
 
-	if config.P2P.UseLegacy {
+	if cfg.P2P.UseLegacy {
 		// setup Transport and Switch
 		sw = createSwitch(
-			config, transport, nodeMetrics.p2p, mpReactorShim, bcReactorForSwitch,
+			cfg, transport, nodeMetrics.p2p, mpReactorShim, bcReactorForSwitch,
 			stateSyncReactorShim, csReactorShim, evReactorShim, proxyApp, nodeInfo, nodeKey, p2pLogger,
 		)
 
-		err = sw.AddPersistentPeers(strings.SplitAndTrimEmpty(config.P2P.PersistentPeers, ",", " "))
+		err = sw.AddPersistentPeers(strings.SplitAndTrimEmpty(cfg.P2P.PersistentPeers, ",", " "))
 		if err != nil {
 			return nil, fmt.Errorf("could not add peers from persistent-peers field: %w", err)
 		}
 
-		err = sw.AddUnconditionalPeerIDs(strings.SplitAndTrimEmpty(config.P2P.UnconditionalPeerIDs, ",", " "))
+		err = sw.AddUnconditionalPeerIDs(strings.SplitAndTrimEmpty(cfg.P2P.UnconditionalPeerIDs, ",", " "))
 		if err != nil {
 			return nil, fmt.Errorf("could not add peer ids from unconditional_peer_ids field: %w", err)
 		}
 
-		addrBook, err = createAddrBookAndSetOnSwitch(config, sw, p2pLogger, nodeKey)
+		addrBook, err = createAddrBookAndSetOnSwitch(cfg, sw, p2pLogger, nodeKey)
 		if err != nil {
 			return nil, fmt.Errorf("could not create addrbook: %w", err)
 		}
 
-		pexReactor = createPEXReactorAndAddToSwitch(addrBook, config, sw, logger)
+		pexReactor = createPEXReactorAndAddToSwitch(addrBook, cfg, sw, logger)
 	} else {
 		addrBook = nil
-		pexReactor, err = createPEXReactorV2(config, logger, peerManager, router)
+		pexReactor, err = createPEXReactorV2(cfg, logger, peerManager, router)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if config.RPC.PprofListenAddress != "" {
+	if cfg.RPC.PprofListenAddress != "" {
 		go func() {
-			logger.Info("Starting pprof server", "laddr", config.RPC.PprofListenAddress)
-			logger.Error("pprof server error", "err", http.ListenAndServe(config.RPC.PprofListenAddress, nil))
+			logger.Info("Starting pprof server", "laddr", cfg.RPC.PprofListenAddress)
+			logger.Error("pprof server error", "err", http.ListenAndServe(cfg.RPC.PprofListenAddress, nil))
 		}()
 	}
 
 	node := &nodeImpl{
-		config:        config,
+		config:        cfg,
 		genesisDoc:    genDoc,
 		privValidator: privValidator,
 
@@ -462,7 +462,7 @@ func makeNode(config *cfg.Config,
 			EventBus:   eventBus,
 			Mempool:    mp,
 			Logger:     logger.With("module", "rpc"),
-			Config:     *config.RPC,
+			Config:     *cfg.RPC,
 		},
 	}
 
@@ -485,8 +485,8 @@ func makeNode(config *cfg.Config,
 }
 
 // makeSeedNode returns a new seed node, containing only p2p, pex reactor
-func makeSeedNode(config *cfg.Config,
-	dbProvider cfg.DBProvider,
+func makeSeedNode(cfg *config.Config,
+	dbProvider config.DBProvider,
 	nodeKey types.NodeKey,
 	genesisDocProvider genesisDocProvider,
 	logger log.Logger,
@@ -502,23 +502,23 @@ func makeSeedNode(config *cfg.Config,
 		return nil, err
 	}
 
-	nodeInfo, err := makeSeedNodeInfo(config, nodeKey, genDoc, state)
+	nodeInfo, err := makeSeedNodeInfo(cfg, nodeKey, genDoc, state)
 	if err != nil {
 		return nil, err
 	}
 
 	// Setup Transport and Switch.
-	p2pMetrics := p2p.PrometheusMetrics(config.Instrumentation.Namespace, "chain_id", genDoc.ChainID)
+	p2pMetrics := p2p.PrometheusMetrics(cfg.Instrumentation.Namespace, "chain_id", genDoc.ChainID)
 	p2pLogger := logger.With("module", "p2p")
-	transport := createTransport(p2pLogger, config)
+	transport := createTransport(p2pLogger, cfg)
 
-	peerManager, err := createPeerManager(config, dbProvider, p2pLogger, nodeKey.ID)
+	peerManager, err := createPeerManager(cfg, dbProvider, p2pLogger, nodeKey.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create peer manager: %w", err)
 	}
 
 	router, err := createRouter(p2pLogger, p2pMetrics, nodeInfo, nodeKey.PrivKey,
-		peerManager, transport, getRouterConfig(config, nil))
+		peerManager, transport, getRouterConfig(cfg, nil))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create router: %w", err)
 	}
@@ -536,44 +536,44 @@ func makeSeedNode(config *cfg.Config,
 	pexCh := pex.ChannelDescriptor()
 	transport.AddChannelDescriptors([]*p2p.ChannelDescriptor{&pexCh})
 
-	if config.P2P.UseLegacy {
+	if cfg.P2P.UseLegacy {
 		sw = createSwitch(
-			config, transport, p2pMetrics, nil, nil,
+			cfg, transport, p2pMetrics, nil, nil,
 			nil, nil, nil, nil, nodeInfo, nodeKey, p2pLogger,
 		)
 
-		err = sw.AddPersistentPeers(strings.SplitAndTrimEmpty(config.P2P.PersistentPeers, ",", " "))
+		err = sw.AddPersistentPeers(strings.SplitAndTrimEmpty(cfg.P2P.PersistentPeers, ",", " "))
 		if err != nil {
 			return nil, fmt.Errorf("could not add peers from persistent_peers field: %w", err)
 		}
 
-		err = sw.AddUnconditionalPeerIDs(strings.SplitAndTrimEmpty(config.P2P.UnconditionalPeerIDs, ",", " "))
+		err = sw.AddUnconditionalPeerIDs(strings.SplitAndTrimEmpty(cfg.P2P.UnconditionalPeerIDs, ",", " "))
 		if err != nil {
 			return nil, fmt.Errorf("could not add peer ids from unconditional_peer_ids field: %w", err)
 		}
 
-		addrBook, err = createAddrBookAndSetOnSwitch(config, sw, p2pLogger, nodeKey)
+		addrBook, err = createAddrBookAndSetOnSwitch(cfg, sw, p2pLogger, nodeKey)
 		if err != nil {
 			return nil, fmt.Errorf("could not create addrbook: %w", err)
 		}
 
-		pexReactor = createPEXReactorAndAddToSwitch(addrBook, config, sw, logger)
+		pexReactor = createPEXReactorAndAddToSwitch(addrBook, cfg, sw, logger)
 	} else {
-		pexReactor, err = createPEXReactorV2(config, logger, peerManager, router)
+		pexReactor, err = createPEXReactorV2(cfg, logger, peerManager, router)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if config.RPC.PprofListenAddress != "" {
+	if cfg.RPC.PprofListenAddress != "" {
 		go func() {
-			logger.Info("Starting pprof server", "laddr", config.RPC.PprofListenAddress)
-			logger.Error("pprof server error", "err", http.ListenAndServe(config.RPC.PprofListenAddress, nil))
+			logger.Info("Starting pprof server", "laddr", cfg.RPC.PprofListenAddress)
+			logger.Error("pprof server error", "err", http.ListenAndServe(cfg.RPC.PprofListenAddress, nil))
 		}()
 	}
 
 	node := &nodeImpl{
-		config:     config,
+		config:     cfg,
 		genesisDoc: genDoc,
 
 		transport:   transport,
@@ -602,7 +602,7 @@ func (n *nodeImpl) OnStart() error {
 
 	// Start the RPC server before the P2P server
 	// so we can eg. receive txs for the first block
-	if n.config.RPC.ListenAddress != "" && n.config.Mode != cfg.ModeSeed {
+	if n.config.RPC.ListenAddress != "" && n.config.Mode != config.ModeSeed {
 		listeners, err := n.startRPC()
 		if err != nil {
 			return err
@@ -637,8 +637,8 @@ func (n *nodeImpl) OnStart() error {
 		return err
 	}
 
-	if n.config.Mode != cfg.ModeSeed {
-		if n.config.BlockSync.Version == cfg.BlockSyncV0 {
+	if n.config.Mode != config.ModeSeed {
+		if n.config.BlockSync.Version == config.BlockSyncV0 {
 			if err := n.bcReactor.Start(); err != nil {
 				return err
 			}
@@ -758,9 +758,9 @@ func (n *nodeImpl) OnStop() {
 		n.Logger.Error("Error closing indexerService", "err", err)
 	}
 
-	if n.config.Mode != cfg.ModeSeed {
+	if n.config.Mode != config.ModeSeed {
 		// now stop the reactors
-		if n.config.BlockSync.Version == cfg.BlockSyncV0 {
+		if n.config.BlockSync.Version == config.BlockSyncV0 {
 			// Stop the real blockchain reactor separately since the switch uses the shim.
 			if err := n.bcReactor.Stop(); err != nil {
 				n.Logger.Error("failed to stop the blockchain reactor", "err", err)
@@ -831,7 +831,7 @@ func (n *nodeImpl) OnStop() {
 }
 
 func (n *nodeImpl) startRPC() ([]net.Listener, error) {
-	if n.config.Mode == cfg.ModeValidator {
+	if n.config.Mode == config.ModeValidator {
 		pubKey, err := n.privValidator.GetPubKey(context.TODO())
 		if pubKey == nil || err != nil {
 			return nil, fmt.Errorf("can't get pubkey: %w", err)
@@ -849,15 +849,15 @@ func (n *nodeImpl) startRPC() ([]net.Listener, error) {
 		n.rpcEnv.AddUnsafe(routes)
 	}
 
-	config := rpcserver.DefaultConfig()
-	config.MaxBodyBytes = n.config.RPC.MaxBodyBytes
-	config.MaxHeaderBytes = n.config.RPC.MaxHeaderBytes
-	config.MaxOpenConnections = n.config.RPC.MaxOpenConnections
+	cfg := rpcserver.DefaultConfig()
+	cfg.MaxBodyBytes = n.config.RPC.MaxBodyBytes
+	cfg.MaxHeaderBytes = n.config.RPC.MaxHeaderBytes
+	cfg.MaxOpenConnections = n.config.RPC.MaxOpenConnections
 	// If necessary adjust global WriteTimeout to ensure it's greater than
 	// TimeoutBroadcastTxCommit.
 	// See https://github.com/tendermint/tendermint/issues/3435
-	if config.WriteTimeout <= n.config.RPC.TimeoutBroadcastTxCommit {
-		config.WriteTimeout = n.config.RPC.TimeoutBroadcastTxCommit + 1*time.Second
+	if cfg.WriteTimeout <= n.config.RPC.TimeoutBroadcastTxCommit {
+		cfg.WriteTimeout = n.config.RPC.TimeoutBroadcastTxCommit + 1*time.Second
 	}
 
 	// we may expose the rpc over both a unix and tcp socket
@@ -873,14 +873,14 @@ func (n *nodeImpl) startRPC() ([]net.Listener, error) {
 					wmLogger.Error("Failed to unsubscribe addr from events", "addr", remoteAddr, "err", err)
 				}
 			}),
-			rpcserver.ReadLimit(config.MaxBodyBytes),
+			rpcserver.ReadLimit(cfg.MaxBodyBytes),
 		)
 		wm.SetLogger(wmLogger)
 		mux.HandleFunc("/websocket", wm.WebsocketHandler)
 		rpcserver.RegisterRPCFuncs(mux, routes, rpcLogger)
 		listener, err := rpcserver.Listen(
 			listenAddr,
-			config.MaxOpenConnections,
+			cfg.MaxOpenConnections,
 		)
 		if err != nil {
 			return nil, err
@@ -903,7 +903,7 @@ func (n *nodeImpl) startRPC() ([]net.Listener, error) {
 					n.config.RPC.CertFile(),
 					n.config.RPC.KeyFile(),
 					rpcLogger,
-					config,
+					cfg,
 				); err != nil {
 					n.Logger.Error("Error serving server with TLS", "err", err)
 				}
@@ -914,7 +914,7 @@ func (n *nodeImpl) startRPC() ([]net.Listener, error) {
 					listener,
 					rootHandler,
 					rpcLogger,
-					config,
+					cfg,
 				); err != nil {
 					n.Logger.Error("Error serving server", "err", err)
 				}
@@ -927,18 +927,18 @@ func (n *nodeImpl) startRPC() ([]net.Listener, error) {
 	// we expose a simplified api over grpc for convenience to app devs
 	grpcListenAddr := n.config.RPC.GRPCListenAddress
 	if grpcListenAddr != "" {
-		config := rpcserver.DefaultConfig()
-		config.MaxBodyBytes = n.config.RPC.MaxBodyBytes
-		config.MaxHeaderBytes = n.config.RPC.MaxHeaderBytes
+		cfg := rpcserver.DefaultConfig()
+		cfg.MaxBodyBytes = n.config.RPC.MaxBodyBytes
+		cfg.MaxHeaderBytes = n.config.RPC.MaxHeaderBytes
 		// NOTE: GRPCMaxOpenConnections is used, not MaxOpenConnections
-		config.MaxOpenConnections = n.config.RPC.GRPCMaxOpenConnections
+		cfg.MaxOpenConnections = n.config.RPC.GRPCMaxOpenConnections
 		// If necessary adjust global WriteTimeout to ensure it's greater than
 		// TimeoutBroadcastTxCommit.
 		// See https://github.com/tendermint/tendermint/issues/3435
-		if config.WriteTimeout <= n.config.RPC.TimeoutBroadcastTxCommit {
-			config.WriteTimeout = n.config.RPC.TimeoutBroadcastTxCommit + 1*time.Second
+		if cfg.WriteTimeout <= n.config.RPC.TimeoutBroadcastTxCommit {
+			cfg.WriteTimeout = n.config.RPC.TimeoutBroadcastTxCommit + 1*time.Second
 		}
-		listener, err := rpcserver.Listen(grpcListenAddr, config.MaxOpenConnections)
+		listener, err := rpcserver.Listen(grpcListenAddr, cfg.MaxOpenConnections)
 		if err != nil {
 			return nil, err
 		}
@@ -1031,9 +1031,9 @@ type genesisDocProvider func() (*types.GenesisDoc, error)
 
 // defaultGenesisDocProviderFunc returns a GenesisDocProvider that loads
 // the GenesisDoc from the config.GenesisFile() on the filesystem.
-func defaultGenesisDocProviderFunc(config *cfg.Config) genesisDocProvider {
+func defaultGenesisDocProviderFunc(cfg *config.Config) genesisDocProvider {
 	return func() (*types.GenesisDoc, error) {
-		return types.GenesisDocFromFile(config.GenesisFile())
+		return types.GenesisDocFromFile(cfg.GenesisFile())
 	}
 }
 
@@ -1050,15 +1050,15 @@ type metricsProvider func(chainID string) *nodeMetrics
 
 // defaultMetricsProvider returns Metrics build using Prometheus client library
 // if Prometheus is enabled. Otherwise, it returns no-op Metrics.
-func defaultMetricsProvider(config *cfg.InstrumentationConfig) metricsProvider {
+func defaultMetricsProvider(cfg *config.InstrumentationConfig) metricsProvider {
 	return func(chainID string) *nodeMetrics {
-		if config.Prometheus {
+		if cfg.Prometheus {
 			return &nodeMetrics{
-				cs.PrometheusMetrics(config.Namespace, "chain_id", chainID),
-				p2p.PrometheusMetrics(config.Namespace, "chain_id", chainID),
-				mempool.PrometheusMetrics(config.Namespace, "chain_id", chainID),
-				sm.PrometheusMetrics(config.Namespace, "chain_id", chainID),
-				statesync.PrometheusMetrics(config.Namespace, "chain_id", chainID),
+				cs.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				p2p.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				mempool.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				sm.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				statesync.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
 			}
 		}
 		return &nodeMetrics{
@@ -1130,15 +1130,15 @@ func createAndStartPrivValidatorSocketClient(
 }
 
 func createAndStartPrivValidatorGRPCClient(
-	config *cfg.Config,
+	cfg *config.Config,
 	chainID string,
 	logger log.Logger,
 ) (types.PrivValidator, error) {
 	pvsc, err := tmgrpc.DialRemoteSigner(
-		config.PrivValidator,
+		cfg.PrivValidator,
 		chainID,
 		logger,
-		config.Instrumentation.Prometheus,
+		cfg.Instrumentation.Prometheus,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start private validator: %w", err)
@@ -1153,7 +1153,7 @@ func createAndStartPrivValidatorGRPCClient(
 	return pvsc, nil
 }
 
-func getRouterConfig(conf *cfg.Config, proxyApp proxy.AppConns) p2p.RouterOptions {
+func getRouterConfig(conf *config.Config, proxyApp proxy.AppConns) p2p.RouterOptions {
 	opts := p2p.RouterOptions{
 		QueueType: conf.P2P.QueueType,
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -6,11 +6,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	_ "net/http/pprof" // nolint: gosec // securely exposed on separate, optional port
 	"strconv"
 	"time"
 
-	_ "github.com/lib/pq" // provide the psql db driver
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
@@ -38,6 +36,10 @@ import (
 	rpcserver "github.com/tendermint/tendermint/rpc/jsonrpc/server"
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
+
+	_ "net/http/pprof" // nolint: gosec // securely exposed on separate, optional port
+
+	_ "github.com/lib/pq" // provide the psql db driver
 )
 
 // nodeImpl is the highest level interface to a full Tendermint node.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	dbm "github.com/tendermint/tm-db"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -18,7 +18,7 @@ import (
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/tmhash"
@@ -38,12 +38,12 @@ import (
 )
 
 func TestNodeStartStop(t *testing.T) {
-	config := cfg.ResetTestRoot("node_node_test")
+	cfg := config.ResetTestRoot("node_node_test")
 
-	defer os.RemoveAll(config.RootDir)
+	defer os.RemoveAll(cfg.RootDir)
 
 	// create & start node
-	ns, err := newDefaultNode(config, log.TestingLogger())
+	ns, err := newDefaultNode(cfg, log.TestingLogger())
 	require.NoError(t, err)
 	require.NoError(t, ns.Start())
 
@@ -81,7 +81,7 @@ func TestNodeStartStop(t *testing.T) {
 	}
 }
 
-func getTestNode(t *testing.T, conf *cfg.Config, logger log.Logger) *nodeImpl {
+func getTestNode(t *testing.T, conf *config.Config, logger log.Logger) *nodeImpl {
 	t.Helper()
 	ns, err := newDefaultNode(conf, logger)
 	require.NoError(t, err)
@@ -92,12 +92,12 @@ func getTestNode(t *testing.T, conf *cfg.Config, logger log.Logger) *nodeImpl {
 }
 
 func TestNodeDelayedStart(t *testing.T) {
-	config := cfg.ResetTestRoot("node_delayed_start_test")
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("node_delayed_start_test")
+	defer os.RemoveAll(cfg.RootDir)
 	now := tmtime.Now()
 
 	// create & start node
-	n := getTestNode(t, config, log.TestingLogger())
+	n := getTestNode(t, cfg, log.TestingLogger())
 	n.GenesisDoc().GenesisTime = now.Add(2 * time.Second)
 
 	require.NoError(t, n.Start())
@@ -108,11 +108,11 @@ func TestNodeDelayedStart(t *testing.T) {
 }
 
 func TestNodeSetAppVersion(t *testing.T) {
-	config := cfg.ResetTestRoot("node_app_version_test")
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("node_app_version_test")
+	defer os.RemoveAll(cfg.RootDir)
 
 	// create node
-	n := getTestNode(t, config, log.TestingLogger())
+	n := getTestNode(t, cfg, log.TestingLogger())
 
 	// default config uses the kvstore app
 	var appVersion uint64 = kvstore.ProtocolVersion
@@ -129,9 +129,9 @@ func TestNodeSetAppVersion(t *testing.T) {
 func TestNodeSetPrivValTCP(t *testing.T) {
 	addr := "tcp://" + testFreeAddr(t)
 
-	config := cfg.ResetTestRoot("node_priv_val_tcp_test")
-	defer os.RemoveAll(config.RootDir)
-	config.PrivValidator.ListenAddr = addr
+	cfg := config.ResetTestRoot("node_priv_val_tcp_test")
+	defer os.RemoveAll(cfg.RootDir)
+	cfg.PrivValidator.ListenAddr = addr
 
 	dialer := privval.DialTCPFn(addr, 100*time.Millisecond, ed25519.GenPrivKey())
 	dialerEndpoint := privval.NewSignerDialerEndpoint(
@@ -142,7 +142,7 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 
 	signerServer := privval.NewSignerServer(
 		dialerEndpoint,
-		config.ChainID(),
+		cfg.ChainID(),
 		types.NewMockPV(),
 	)
 
@@ -154,7 +154,7 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 	}()
 	defer signerServer.Stop() //nolint:errcheck // ignore for tests
 
-	n := getTestNode(t, config, log.TestingLogger())
+	n := getTestNode(t, cfg, log.TestingLogger())
 	assert.IsType(t, &privval.RetrySignerClient{}, n.PrivValidator())
 }
 
@@ -162,11 +162,11 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 func TestPrivValidatorListenAddrNoProtocol(t *testing.T) {
 	addrNoPrefix := testFreeAddr(t)
 
-	config := cfg.ResetTestRoot("node_priv_val_tcp_test")
-	defer os.RemoveAll(config.RootDir)
-	config.PrivValidator.ListenAddr = addrNoPrefix
+	cfg := config.ResetTestRoot("node_priv_val_tcp_test")
+	defer os.RemoveAll(cfg.RootDir)
+	cfg.PrivValidator.ListenAddr = addrNoPrefix
 
-	_, err := newDefaultNode(config, log.TestingLogger())
+	_, err := newDefaultNode(cfg, log.TestingLogger())
 	assert.Error(t, err)
 }
 
@@ -174,9 +174,9 @@ func TestNodeSetPrivValIPC(t *testing.T) {
 	tmpfile := "/tmp/kms." + tmrand.Str(6) + ".sock"
 	defer os.Remove(tmpfile) // clean up
 
-	config := cfg.ResetTestRoot("node_priv_val_tcp_test")
-	defer os.RemoveAll(config.RootDir)
-	config.PrivValidator.ListenAddr = "unix://" + tmpfile
+	cfg := config.ResetTestRoot("node_priv_val_tcp_test")
+	defer os.RemoveAll(cfg.RootDir)
+	cfg.PrivValidator.ListenAddr = "unix://" + tmpfile
 
 	dialer := privval.DialUnixFn(tmpfile)
 	dialerEndpoint := privval.NewSignerDialerEndpoint(
@@ -187,7 +187,7 @@ func TestNodeSetPrivValIPC(t *testing.T) {
 
 	pvsc := privval.NewSignerServer(
 		dialerEndpoint,
-		config.ChainID(),
+		cfg.ChainID(),
 		types.NewMockPV(),
 	)
 
@@ -196,7 +196,7 @@ func TestNodeSetPrivValIPC(t *testing.T) {
 		require.NoError(t, err)
 	}()
 	defer pvsc.Stop() //nolint:errcheck // ignore for tests
-	n := getTestNode(t, config, log.TestingLogger())
+	n := getTestNode(t, cfg, log.TestingLogger())
 	assert.IsType(t, &privval.RetrySignerClient{}, n.PrivValidator())
 }
 
@@ -212,8 +212,8 @@ func testFreeAddr(t *testing.T) string {
 // create a proposal block using real and full
 // mempool and evidence pool and validate it.
 func TestCreateProposalBlock(t *testing.T) {
-	config := cfg.ResetTestRoot("node_create_proposal")
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("node_create_proposal")
+	defer os.RemoveAll(cfg.RootDir)
 	cc := abciclient.NewLocalCreator(kvstore.NewApplication())
 	proxyApp := proxy.NewAppConns(cc)
 	err := proxyApp.Start()
@@ -233,7 +233,7 @@ func TestCreateProposalBlock(t *testing.T) {
 	proposerAddr, _ := state.Validators.GetByIndex(0)
 
 	mp := mempoolv0.NewCListMempool(
-		config.Mempool,
+		cfg.Mempool,
 		proxyApp.Mempool(),
 		state.LastBlockHeight,
 		mempoolv0.WithMetrics(mempool.NopMetrics()),
@@ -304,8 +304,8 @@ func TestCreateProposalBlock(t *testing.T) {
 }
 
 func TestMaxTxsProposalBlockSize(t *testing.T) {
-	config := cfg.ResetTestRoot("node_create_proposal")
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("node_create_proposal")
+	defer os.RemoveAll(cfg.RootDir)
 	cc := abciclient.NewLocalCreator(kvstore.NewApplication())
 	proxyApp := proxy.NewAppConns(cc)
 	err := proxyApp.Start()
@@ -325,7 +325,7 @@ func TestMaxTxsProposalBlockSize(t *testing.T) {
 
 	// Make Mempool
 	mp := mempoolv0.NewCListMempool(
-		config.Mempool,
+		cfg.Mempool,
 		proxyApp.Mempool(),
 		state.LastBlockHeight,
 		mempoolv0.WithMetrics(mempool.NopMetrics()),
@@ -366,8 +366,8 @@ func TestMaxTxsProposalBlockSize(t *testing.T) {
 }
 
 func TestMaxProposalBlockSize(t *testing.T) {
-	config := cfg.ResetTestRoot("node_create_proposal")
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("node_create_proposal")
+	defer os.RemoveAll(cfg.RootDir)
 	cc := abciclient.NewLocalCreator(kvstore.NewApplication())
 	proxyApp := proxy.NewAppConns(cc)
 	err := proxyApp.Start()
@@ -385,7 +385,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 
 	// Make Mempool
 	mp := mempoolv0.NewCListMempool(
-		config.Mempool,
+		cfg.Mempool,
 		proxyApp.Mempool(),
 		state.LastBlockHeight,
 		mempoolv0.WithMetrics(mempool.NopMetrics()),
@@ -481,17 +481,17 @@ func TestMaxProposalBlockSize(t *testing.T) {
 }
 
 func TestNodeNewSeedNode(t *testing.T) {
-	config := cfg.ResetTestRoot("node_new_node_custom_reactors_test")
-	config.Mode = cfg.ModeSeed
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("node_new_node_custom_reactors_test")
+	cfg.Mode = config.ModeSeed
+	defer os.RemoveAll(cfg.RootDir)
 
-	nodeKey, err := types.LoadOrGenNodeKey(config.NodeKeyFile())
+	nodeKey, err := types.LoadOrGenNodeKey(cfg.NodeKeyFile())
 	require.NoError(t, err)
 
-	ns, err := makeSeedNode(config,
-		cfg.DefaultDBProvider,
+	ns, err := makeSeedNode(cfg,
+		config.DefaultDBProvider,
 		nodeKey,
-		defaultGenesisDocProviderFunc(config),
+		defaultGenesisDocProviderFunc(cfg),
 		log.TestingLogger(),
 	)
 	require.NoError(t, err)
@@ -505,68 +505,68 @@ func TestNodeNewSeedNode(t *testing.T) {
 }
 
 func TestNodeSetEventSink(t *testing.T) {
-	config := cfg.ResetTestRoot("node_app_version_test")
-	defer os.RemoveAll(config.RootDir)
+	cfg := config.ResetTestRoot("node_app_version_test")
+	defer os.RemoveAll(cfg.RootDir)
 
 	logger := log.TestingLogger()
-	setupTest := func(t *testing.T, conf *cfg.Config) []indexer.EventSink {
+	setupTest := func(t *testing.T, conf *config.Config) []indexer.EventSink {
 		eventBus, err := createAndStartEventBus(logger)
 		require.NoError(t, err)
 
-		genDoc, err := types.GenesisDocFromFile(config.GenesisFile())
+		genDoc, err := types.GenesisDocFromFile(cfg.GenesisFile())
 		require.NoError(t, err)
 
-		indexService, eventSinks, err := createAndStartIndexerService(config,
-			cfg.DefaultDBProvider, eventBus, logger, genDoc.ChainID)
+		indexService, eventSinks, err := createAndStartIndexerService(cfg,
+			config.DefaultDBProvider, eventBus, logger, genDoc.ChainID)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, indexService.Stop()) })
 		return eventSinks
 	}
 
-	eventSinks := setupTest(t, config)
+	eventSinks := setupTest(t, cfg)
 	assert.Equal(t, 1, len(eventSinks))
 	assert.Equal(t, indexer.KV, eventSinks[0].Type())
 
-	config.TxIndex.Indexer = []string{"null"}
-	eventSinks = setupTest(t, config)
+	cfg.TxIndex.Indexer = []string{"null"}
+	eventSinks = setupTest(t, cfg)
 
 	assert.Equal(t, 1, len(eventSinks))
 	assert.Equal(t, indexer.NULL, eventSinks[0].Type())
 
-	config.TxIndex.Indexer = []string{"null", "kv"}
-	eventSinks = setupTest(t, config)
+	cfg.TxIndex.Indexer = []string{"null", "kv"}
+	eventSinks = setupTest(t, cfg)
 
 	assert.Equal(t, 1, len(eventSinks))
 	assert.Equal(t, indexer.NULL, eventSinks[0].Type())
 
-	config.TxIndex.Indexer = []string{"kvv"}
-	ns, err := newDefaultNode(config, logger)
+	cfg.TxIndex.Indexer = []string{"kvv"}
+	ns, err := newDefaultNode(cfg, logger)
 	assert.Nil(t, ns)
 	assert.Equal(t, errors.New("unsupported event sink type"), err)
 
-	config.TxIndex.Indexer = []string{}
-	eventSinks = setupTest(t, config)
+	cfg.TxIndex.Indexer = []string{}
+	eventSinks = setupTest(t, cfg)
 
 	assert.Equal(t, 1, len(eventSinks))
 	assert.Equal(t, indexer.NULL, eventSinks[0].Type())
 
-	config.TxIndex.Indexer = []string{"psql"}
-	ns, err = newDefaultNode(config, logger)
+	cfg.TxIndex.Indexer = []string{"psql"}
+	ns, err = newDefaultNode(cfg, logger)
 	assert.Nil(t, ns)
 	assert.Equal(t, errors.New("the psql connection settings cannot be empty"), err)
 
 	var psqlConn = "test"
 
-	config.TxIndex.Indexer = []string{"psql"}
-	config.TxIndex.PsqlConn = psqlConn
-	eventSinks = setupTest(t, config)
+	cfg.TxIndex.Indexer = []string{"psql"}
+	cfg.TxIndex.PsqlConn = psqlConn
+	eventSinks = setupTest(t, cfg)
 
 	assert.Equal(t, 1, len(eventSinks))
 	assert.Equal(t, indexer.PSQL, eventSinks[0].Type())
 
-	config.TxIndex.Indexer = []string{"psql", "kv"}
-	config.TxIndex.PsqlConn = psqlConn
-	eventSinks = setupTest(t, config)
+	cfg.TxIndex.Indexer = []string{"psql", "kv"}
+	cfg.TxIndex.PsqlConn = psqlConn
+	eventSinks = setupTest(t, cfg)
 
 	assert.Equal(t, 2, len(eventSinks))
 	// we use map to filter the duplicated sinks, so it's not guarantee the order when append sinks.
@@ -577,9 +577,9 @@ func TestNodeSetEventSink(t *testing.T) {
 		assert.Equal(t, indexer.KV, eventSinks[1].Type())
 	}
 
-	config.TxIndex.Indexer = []string{"kv", "psql"}
-	config.TxIndex.PsqlConn = psqlConn
-	eventSinks = setupTest(t, config)
+	cfg.TxIndex.Indexer = []string{"kv", "psql"}
+	cfg.TxIndex.PsqlConn = psqlConn
+	eventSinks = setupTest(t, cfg)
 
 	assert.Equal(t, 2, len(eventSinks))
 	if eventSinks[0].Type() == indexer.KV {
@@ -590,15 +590,15 @@ func TestNodeSetEventSink(t *testing.T) {
 	}
 
 	var e = errors.New("found duplicated sinks, please check the tx-index section in the config.toml")
-	config.TxIndex.Indexer = []string{"psql", "kv", "Kv"}
-	config.TxIndex.PsqlConn = psqlConn
-	_, err = newDefaultNode(config, logger)
+	cfg.TxIndex.Indexer = []string{"psql", "kv", "Kv"}
+	cfg.TxIndex.PsqlConn = psqlConn
+	_, err = newDefaultNode(cfg, logger)
 	require.Error(t, err)
 	assert.Equal(t, e, err)
 
-	config.TxIndex.Indexer = []string{"Psql", "kV", "kv", "pSql"}
-	config.TxIndex.PsqlConn = psqlConn
-	_, err = newDefaultNode(config, logger)
+	cfg.TxIndex.Indexer = []string{"Psql", "kV", "kv", "pSql"}
+	cfg.TxIndex.PsqlConn = psqlConn
+	_, err = newDefaultNode(cfg, logger)
 	require.Error(t, err)
 	assert.Equal(t, e, err)
 }
@@ -648,13 +648,13 @@ func loadStatefromGenesis(t *testing.T) sm.State {
 
 	stateDB := dbm.NewMemDB()
 	stateStore := sm.NewStore(stateDB)
-	config := cfg.ResetTestRoot("load_state_from_genesis")
+	cfg := config.ResetTestRoot("load_state_from_genesis")
 
 	loadedState, err := stateStore.Load()
 	require.NoError(t, err)
 	require.True(t, loadedState.IsEmpty())
 
-	genDoc, _ := factory.RandGenesisDoc(config, 0, false, 10)
+	genDoc, _ := factory.RandGenesisDoc(cfg, 0, false, 10)
 
 	state, err := loadStateFromDBOrGenesisDocProvider(
 		stateStore,

--- a/node/setup.go
+++ b/node/setup.go
@@ -40,7 +40,7 @@ import (
 	_ "net/http/pprof" // nolint: gosec // securely exposed on separate, optional port
 )
 
-func initDBs(cfg *config.Config, dbProvider config.DBProvider) (blockStore *store.BlockStore, stateDB dbm.DB, err error) {
+func initDBs(cfg *config.Config, dbProvider config.DBProvider) (blockStore *store.BlockStore, stateDB dbm.DB, err error) { //nolint:lll
 	var blockStoreDB dbm.DB
 	blockStoreDB, err = dbProvider(&config.DBContext{ID: "blockstore", Config: cfg})
 	if err != nil {

--- a/node/setup.go
+++ b/node/setup.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	_ "net/http/pprof" // nolint: gosec // securely exposed on separate, optional port
 	"time"
 
 	dbm "github.com/tendermint/tm-db"
@@ -37,6 +36,8 @@ import (
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
 	"github.com/tendermint/tendermint/version"
+
+	_ "net/http/pprof" // nolint: gosec // securely exposed on separate, optional port
 )
 
 func initDBs(cfg *config.Config, dbProvider config.DBProvider) (blockStore *store.BlockStore, stateDB dbm.DB, err error) {

--- a/privval/grpc/client.go
+++ b/privval/grpc/client.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/tendermint/tendermint/crypto"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/libs/log"
 	privvalproto "github.com/tendermint/tendermint/proto/tendermint/privval"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -62,7 +62,7 @@ func (sc *SignerClient) GetPubKey(ctx context.Context) (crypto.PubKey, error) {
 		return nil, errStatus.Err()
 	}
 
-	pk, err := cryptoenc.PubKeyFromProto(resp.PubKey)
+	pk, err := encoding.PubKeyFromProto(resp.PubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/privval/grpc/server.go
+++ b/privval/grpc/server.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/tendermint/tendermint/crypto"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/libs/log"
 	privvalproto "github.com/tendermint/tendermint/proto/tendermint/privval"
 	"github.com/tendermint/tendermint/types"
@@ -44,7 +44,7 @@ func (ss *SignerServer) GetPubKey(ctx context.Context, req *privvalproto.PubKeyR
 		return nil, status.Errorf(codes.NotFound, "error getting pubkey: %v", err)
 	}
 
-	pk, err := cryptoenc.PubKeyToProto(pubKey)
+	pk, err := encoding.PubKeyToProto(pubKey)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "error transitioning pubkey to proto: %v", err)
 	}

--- a/privval/grpc/util.go
+++ b/privval/grpc/util.go
@@ -11,7 +11,7 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/log"
 	tmnet "github.com/tendermint/tendermint/libs/net"
 	grpc "google.golang.org/grpc"
@@ -88,15 +88,15 @@ func GenerateTLS(certPath, keyPath, ca string, log log.Logger) grpc.DialOption {
 
 // DialRemoteSigner is  a generalized function to dial the gRPC server.
 func DialRemoteSigner(
-	config *cfg.PrivValidatorConfig,
+	cfg *config.PrivValidatorConfig,
 	chainID string,
 	logger log.Logger,
 	usePrometheus bool,
 ) (*SignerClient, error) {
 	var transportSecurity grpc.DialOption
-	if config.AreSecurityOptionsPresent() {
-		transportSecurity = GenerateTLS(config.ClientCertificateFile(),
-			config.ClientKeyFile(), config.RootCAFile(), logger)
+	if cfg.AreSecurityOptionsPresent() {
+		transportSecurity = GenerateTLS(cfg.ClientCertificateFile(),
+			cfg.ClientKeyFile(), cfg.RootCAFile(), logger)
 	} else {
 		transportSecurity = grpc.WithInsecure()
 		logger.Info("Using an insecure gRPC connection!")
@@ -111,7 +111,7 @@ func DialRemoteSigner(
 	dialOptions = append(dialOptions, transportSecurity)
 
 	ctx := context.Background()
-	_, address := tmnet.ProtocolAndAddress(config.ListenAddr)
+	_, address := tmnet.ProtocolAndAddress(cfg.ListenAddr)
 	conn, err := grpc.DialContext(ctx, address, dialOptions...)
 	if err != nil {
 		logger.Error("unable to connect to server", "target", address, "err", err)

--- a/privval/msgs_test.go
+++ b/privval/msgs_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	cryptoproto "github.com/tendermint/tendermint/proto/tendermint/crypto"
 	privproto "github.com/tendermint/tendermint/proto/tendermint/privval"
@@ -60,7 +60,7 @@ func exampleProposal() *types.Proposal {
 // nolint:lll // ignore line length for tests
 func TestPrivvalVectors(t *testing.T) {
 	pk := ed25519.GenPrivKeyFromSecret([]byte("it's a secret")).PubKey()
-	ppk, err := cryptoenc.PubKeyToProto(pk)
+	ppk, err := encoding.PubKeyToProto(pk)
 	require.NoError(t, err)
 
 	// Generate a simple vote

--- a/privval/secret_connection.go
+++ b/privval/secret_connection.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/internal/libs/protoio"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/libs/async"
@@ -408,7 +408,7 @@ func shareAuthSignature(sc io.ReadWriter, pubKey crypto.PubKey, signature []byte
 	// Send our info and receive theirs in tandem.
 	var trs, _ = async.Parallel(
 		func(_ int) (val interface{}, abort bool, err error) {
-			pbpk, err := cryptoenc.PubKeyToProto(pubKey)
+			pbpk, err := encoding.PubKeyToProto(pubKey)
 			if err != nil {
 				return nil, true, err
 			}
@@ -425,7 +425,7 @@ func shareAuthSignature(sc io.ReadWriter, pubKey crypto.PubKey, signature []byte
 				return nil, true, err // abort
 			}
 
-			pk, err := cryptoenc.PubKeyFromProto(pba.PubKey)
+			pk, err := encoding.PubKeyFromProto(pba.PubKey)
 			if err != nil {
 				return nil, true, err // abort
 			}

--- a/privval/signer_client.go
+++ b/privval/signer_client.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/tendermint/tendermint/crypto"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	privvalproto "github.com/tendermint/tendermint/proto/tendermint/privval"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
@@ -83,7 +83,7 @@ func (sc *SignerClient) GetPubKey(ctx context.Context) (crypto.PubKey, error) {
 		return nil, &RemoteSignerError{Code: int(resp.Error.Code), Description: resp.Error.Description}
 	}
 
-	pk, err := cryptoenc.PubKeyFromProto(resp.PubKey)
+	pk, err := encoding.PubKeyFromProto(resp.PubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/privval/signer_requestHandler.go
+++ b/privval/signer_requestHandler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/tendermint/tendermint/crypto"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	cryptoproto "github.com/tendermint/tendermint/proto/tendermint/crypto"
 	privvalproto "github.com/tendermint/tendermint/proto/tendermint/privval"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -37,7 +37,7 @@ func DefaultValidationRequestHandler(
 		if err != nil {
 			return res, err
 		}
-		pk, err := cryptoenc.PubKeyToProto(pubKey)
+		pk, err := encoding.PubKeyToProto(pubKey)
 		if err != nil {
 			return res, err
 		}

--- a/proto/tendermint/blocksync/message.go
+++ b/proto/tendermint/blocksync/message.go
@@ -2,9 +2,9 @@ package blocksync
 
 import (
 	"errors"
-	fmt "fmt"
+	"fmt"
 
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 )
 
 const (

--- a/proto/tendermint/blocksync/message_test.go
+++ b/proto/tendermint/blocksync/message_test.go
@@ -5,7 +5,7 @@ import (
 	math "math"
 	"testing"
 
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 
 	bcproto "github.com/tendermint/tendermint/proto/tendermint/blocksync"

--- a/proto/tendermint/consensus/message.go
+++ b/proto/tendermint/consensus/message.go
@@ -1,9 +1,9 @@
 package consensus
 
 import (
-	fmt "fmt"
+	"fmt"
 
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 )
 
 // Wrap implements the p2p Wrapper interface and wraps a consensus proto message.

--- a/proto/tendermint/mempool/message.go
+++ b/proto/tendermint/mempool/message.go
@@ -1,9 +1,9 @@
 package mempool
 
 import (
-	fmt "fmt"
+	"fmt"
 
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 )
 
 // Wrap implements the p2p Wrapper interface and wraps a mempool message.

--- a/proto/tendermint/p2p/pex.go
+++ b/proto/tendermint/p2p/pex.go
@@ -1,9 +1,9 @@
 package p2p
 
 import (
-	fmt "fmt"
+	"fmt"
 
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 )
 
 // Wrap implements the p2p Wrapper interface and wraps a PEX message.

--- a/proto/tendermint/statesync/message.go
+++ b/proto/tendermint/statesync/message.go
@@ -2,9 +2,9 @@ package statesync
 
 import (
 	"errors"
-	fmt "fmt"
+	"fmt"
 
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 )
 
 // Wrap implements the p2p Wrapper interface and wraps a state sync proto message.

--- a/proto/tendermint/statesync/message_test.go
+++ b/proto/tendermint/statesync/message_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 
 	ssproto "github.com/tendermint/tendermint/proto/tendermint/statesync"

--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -13,7 +13,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	"github.com/tendermint/tendermint/rpc/client"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -127,7 +127,7 @@ func testTxEventsSent(t *testing.T, broadcastMethod string) {
 			// send
 			go func() {
 				var (
-					txres *ctypes.ResultBroadcastTx
+					txres *coretypes.ResultBroadcastTx
 					err   error
 					ctx   = context.Background()
 				)

--- a/rpc/client/evidence_test.go
+++ b/rpc/client/evidence_test.go
@@ -11,7 +11,7 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	"github.com/tendermint/tendermint/privval"
@@ -150,7 +150,7 @@ func TestBroadcastEvidence_DuplicateVoteEvidence(t *testing.T) {
 		err = abci.ReadMessage(bytes.NewReader(qres.Value), &v)
 		require.NoError(t, err, "Error reading query result, value %v", qres.Value)
 
-		pk, err := cryptoenc.PubKeyFromProto(v.PubKey)
+		pk, err := encoding.PubKeyFromProto(v.PubKey)
 		require.NoError(t, err)
 
 		require.EqualValues(t, rawpub, pk, "Stored PubKey not equal with expected, value %v", string(qres.Value))

--- a/rpc/client/examples_test.go
+++ b/rpc/client/examples_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctest "github.com/tendermint/tendermint/rpc/test"
 )
 
@@ -138,7 +138,7 @@ func ExampleHTTP_batching() {
 	// Each result in the returned list is the deserialized result of each
 	// respective ABCIQuery response
 	for _, result := range results {
-		qr, ok := result.(*ctypes.ResultABCIQuery)
+		qr, ok := result.(*coretypes.ResultABCIQuery)
 		if !ok {
 			log.Fatal("invalid result type from ABCIQuery request")
 		}

--- a/rpc/client/helpers_test.go
+++ b/rpc/client/helpers_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/client/mock"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 )
 
 func TestWaitForHeight(t *testing.T) {
@@ -33,7 +33,7 @@ func TestWaitForHeight(t *testing.T) {
 
 	// now set current block height to 10
 	m.Call = mock.Call{
-		Response: &ctypes.ResultStatus{SyncInfo: ctypes.SyncInfo{LatestBlockHeight: 10}},
+		Response: &coretypes.ResultStatus{SyncInfo: coretypes.SyncInfo{LatestBlockHeight: 10}},
 	}
 
 	// we will not wait for more than 10 blocks
@@ -53,7 +53,7 @@ func TestWaitForHeight(t *testing.T) {
 	// we use the callback to update the status height
 	myWaiter := func(delta int64) error {
 		// update the height for the next call
-		m.Call.Response = &ctypes.ResultStatus{SyncInfo: ctypes.SyncInfo{LatestBlockHeight: 15}}
+		m.Call.Response = &coretypes.ResultStatus{SyncInfo: coretypes.SyncInfo{LatestBlockHeight: 15}}
 		return client.DefaultWaitStrategy(delta)
 	}
 
@@ -65,13 +65,13 @@ func TestWaitForHeight(t *testing.T) {
 
 	pre := r.Calls[3]
 	require.Nil(pre.Error)
-	prer, ok := pre.Response.(*ctypes.ResultStatus)
+	prer, ok := pre.Response.(*coretypes.ResultStatus)
 	require.True(ok)
 	assert.Equal(int64(10), prer.SyncInfo.LatestBlockHeight)
 
 	post := r.Calls[4]
 	require.Nil(post.Error)
-	postr, ok := post.Response.(*ctypes.ResultStatus)
+	postr, ok := post.Response.(*coretypes.ResultStatus)
 	require.True(ok)
 	assert.Equal(int64(15), postr.SyncInfo.LatestBlockHeight)
 }

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/tendermint/tendermint/libs/bytes"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	jsonrpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
 	"github.com/tendermint/tendermint/types"
 )
@@ -198,8 +198,8 @@ func (b *BatchHTTP) Count() int {
 //-----------------------------------------------------------------------------
 // baseRPCClient
 
-func (c *baseRPCClient) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
-	result := new(ctypes.ResultStatus)
+func (c *baseRPCClient) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
+	result := new(coretypes.ResultStatus)
 	_, err := c.caller.Call(ctx, "status", map[string]interface{}{}, result)
 	if err != nil {
 		return nil, err
@@ -208,8 +208,8 @@ func (c *baseRPCClient) Status(ctx context.Context) (*ctypes.ResultStatus, error
 	return result, nil
 }
 
-func (c *baseRPCClient) ABCIInfo(ctx context.Context) (*ctypes.ResultABCIInfo, error) {
-	result := new(ctypes.ResultABCIInfo)
+func (c *baseRPCClient) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
+	result := new(coretypes.ResultABCIInfo)
 	_, err := c.caller.Call(ctx, "abci_info", map[string]interface{}{}, result)
 	if err != nil {
 		return nil, err
@@ -222,7 +222,7 @@ func (c *baseRPCClient) ABCIQuery(
 	ctx context.Context,
 	path string,
 	data bytes.HexBytes,
-) (*ctypes.ResultABCIQuery, error) {
+) (*coretypes.ResultABCIQuery, error) {
 	return c.ABCIQueryWithOptions(ctx, path, data, rpcclient.DefaultABCIQueryOptions)
 }
 
@@ -230,8 +230,8 @@ func (c *baseRPCClient) ABCIQueryWithOptions(
 	ctx context.Context,
 	path string,
 	data bytes.HexBytes,
-	opts rpcclient.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
-	result := new(ctypes.ResultABCIQuery)
+	opts rpcclient.ABCIQueryOptions) (*coretypes.ResultABCIQuery, error) {
+	result := new(coretypes.ResultABCIQuery)
 	_, err := c.caller.Call(ctx, "abci_query",
 		map[string]interface{}{"path": path, "data": data, "height": opts.Height, "prove": opts.Prove},
 		result)
@@ -245,8 +245,8 @@ func (c *baseRPCClient) ABCIQueryWithOptions(
 func (c *baseRPCClient) BroadcastTxCommit(
 	ctx context.Context,
 	tx types.Tx,
-) (*ctypes.ResultBroadcastTxCommit, error) {
-	result := new(ctypes.ResultBroadcastTxCommit)
+) (*coretypes.ResultBroadcastTxCommit, error) {
+	result := new(coretypes.ResultBroadcastTxCommit)
 	_, err := c.caller.Call(ctx, "broadcast_tx_commit", map[string]interface{}{"tx": tx}, result)
 	if err != nil {
 		return nil, err
@@ -257,14 +257,14 @@ func (c *baseRPCClient) BroadcastTxCommit(
 func (c *baseRPCClient) BroadcastTxAsync(
 	ctx context.Context,
 	tx types.Tx,
-) (*ctypes.ResultBroadcastTx, error) {
+) (*coretypes.ResultBroadcastTx, error) {
 	return c.broadcastTX(ctx, "broadcast_tx_async", tx)
 }
 
 func (c *baseRPCClient) BroadcastTxSync(
 	ctx context.Context,
 	tx types.Tx,
-) (*ctypes.ResultBroadcastTx, error) {
+) (*coretypes.ResultBroadcastTx, error) {
 	return c.broadcastTX(ctx, "broadcast_tx_sync", tx)
 }
 
@@ -272,8 +272,8 @@ func (c *baseRPCClient) broadcastTX(
 	ctx context.Context,
 	route string,
 	tx types.Tx,
-) (*ctypes.ResultBroadcastTx, error) {
-	result := new(ctypes.ResultBroadcastTx)
+) (*coretypes.ResultBroadcastTx, error) {
+	result := new(coretypes.ResultBroadcastTx)
 	_, err := c.caller.Call(ctx, route, map[string]interface{}{"tx": tx}, result)
 	if err != nil {
 		return nil, err
@@ -284,8 +284,8 @@ func (c *baseRPCClient) broadcastTX(
 func (c *baseRPCClient) UnconfirmedTxs(
 	ctx context.Context,
 	limit *int,
-) (*ctypes.ResultUnconfirmedTxs, error) {
-	result := new(ctypes.ResultUnconfirmedTxs)
+) (*coretypes.ResultUnconfirmedTxs, error) {
+	result := new(coretypes.ResultUnconfirmedTxs)
 	params := make(map[string]interface{})
 	if limit != nil {
 		params["limit"] = limit
@@ -297,8 +297,8 @@ func (c *baseRPCClient) UnconfirmedTxs(
 	return result, nil
 }
 
-func (c *baseRPCClient) NumUnconfirmedTxs(ctx context.Context) (*ctypes.ResultUnconfirmedTxs, error) {
-	result := new(ctypes.ResultUnconfirmedTxs)
+func (c *baseRPCClient) NumUnconfirmedTxs(ctx context.Context) (*coretypes.ResultUnconfirmedTxs, error) {
+	result := new(coretypes.ResultUnconfirmedTxs)
 	_, err := c.caller.Call(ctx, "num_unconfirmed_txs", map[string]interface{}{}, result)
 	if err != nil {
 		return nil, err
@@ -306,8 +306,8 @@ func (c *baseRPCClient) NumUnconfirmedTxs(ctx context.Context) (*ctypes.ResultUn
 	return result, nil
 }
 
-func (c *baseRPCClient) CheckTx(ctx context.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
-	result := new(ctypes.ResultCheckTx)
+func (c *baseRPCClient) CheckTx(ctx context.Context, tx types.Tx) (*coretypes.ResultCheckTx, error) {
+	result := new(coretypes.ResultCheckTx)
 	_, err := c.caller.Call(ctx, "check_tx", map[string]interface{}{"tx": tx}, result)
 	if err != nil {
 		return nil, err
@@ -315,8 +315,8 @@ func (c *baseRPCClient) CheckTx(ctx context.Context, tx types.Tx) (*ctypes.Resul
 	return result, nil
 }
 
-func (c *baseRPCClient) NetInfo(ctx context.Context) (*ctypes.ResultNetInfo, error) {
-	result := new(ctypes.ResultNetInfo)
+func (c *baseRPCClient) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, error) {
+	result := new(coretypes.ResultNetInfo)
 	_, err := c.caller.Call(ctx, "net_info", map[string]interface{}{}, result)
 	if err != nil {
 		return nil, err
@@ -324,8 +324,8 @@ func (c *baseRPCClient) NetInfo(ctx context.Context) (*ctypes.ResultNetInfo, err
 	return result, nil
 }
 
-func (c *baseRPCClient) DumpConsensusState(ctx context.Context) (*ctypes.ResultDumpConsensusState, error) {
-	result := new(ctypes.ResultDumpConsensusState)
+func (c *baseRPCClient) DumpConsensusState(ctx context.Context) (*coretypes.ResultDumpConsensusState, error) {
+	result := new(coretypes.ResultDumpConsensusState)
 	_, err := c.caller.Call(ctx, "dump_consensus_state", map[string]interface{}{}, result)
 	if err != nil {
 		return nil, err
@@ -333,8 +333,8 @@ func (c *baseRPCClient) DumpConsensusState(ctx context.Context) (*ctypes.ResultD
 	return result, nil
 }
 
-func (c *baseRPCClient) ConsensusState(ctx context.Context) (*ctypes.ResultConsensusState, error) {
-	result := new(ctypes.ResultConsensusState)
+func (c *baseRPCClient) ConsensusState(ctx context.Context) (*coretypes.ResultConsensusState, error) {
+	result := new(coretypes.ResultConsensusState)
 	_, err := c.caller.Call(ctx, "consensus_state", map[string]interface{}{}, result)
 	if err != nil {
 		return nil, err
@@ -345,8 +345,8 @@ func (c *baseRPCClient) ConsensusState(ctx context.Context) (*ctypes.ResultConse
 func (c *baseRPCClient) ConsensusParams(
 	ctx context.Context,
 	height *int64,
-) (*ctypes.ResultConsensusParams, error) {
-	result := new(ctypes.ResultConsensusParams)
+) (*coretypes.ResultConsensusParams, error) {
+	result := new(coretypes.ResultConsensusParams)
 	params := make(map[string]interface{})
 	if height != nil {
 		params["height"] = height
@@ -358,8 +358,8 @@ func (c *baseRPCClient) ConsensusParams(
 	return result, nil
 }
 
-func (c *baseRPCClient) Health(ctx context.Context) (*ctypes.ResultHealth, error) {
-	result := new(ctypes.ResultHealth)
+func (c *baseRPCClient) Health(ctx context.Context) (*coretypes.ResultHealth, error) {
+	result := new(coretypes.ResultHealth)
 	_, err := c.caller.Call(ctx, "health", map[string]interface{}{}, result)
 	if err != nil {
 		return nil, err
@@ -371,8 +371,8 @@ func (c *baseRPCClient) BlockchainInfo(
 	ctx context.Context,
 	minHeight,
 	maxHeight int64,
-) (*ctypes.ResultBlockchainInfo, error) {
-	result := new(ctypes.ResultBlockchainInfo)
+) (*coretypes.ResultBlockchainInfo, error) {
+	result := new(coretypes.ResultBlockchainInfo)
 	_, err := c.caller.Call(ctx, "blockchain",
 		map[string]interface{}{"minHeight": minHeight, "maxHeight": maxHeight},
 		result)
@@ -382,8 +382,8 @@ func (c *baseRPCClient) BlockchainInfo(
 	return result, nil
 }
 
-func (c *baseRPCClient) Genesis(ctx context.Context) (*ctypes.ResultGenesis, error) {
-	result := new(ctypes.ResultGenesis)
+func (c *baseRPCClient) Genesis(ctx context.Context) (*coretypes.ResultGenesis, error) {
+	result := new(coretypes.ResultGenesis)
 	_, err := c.caller.Call(ctx, "genesis", map[string]interface{}{}, result)
 	if err != nil {
 		return nil, err
@@ -391,8 +391,8 @@ func (c *baseRPCClient) Genesis(ctx context.Context) (*ctypes.ResultGenesis, err
 	return result, nil
 }
 
-func (c *baseRPCClient) GenesisChunked(ctx context.Context, id uint) (*ctypes.ResultGenesisChunk, error) {
-	result := new(ctypes.ResultGenesisChunk)
+func (c *baseRPCClient) GenesisChunked(ctx context.Context, id uint) (*coretypes.ResultGenesisChunk, error) {
+	result := new(coretypes.ResultGenesisChunk)
 	_, err := c.caller.Call(ctx, "genesis_chunked", map[string]interface{}{"chunk": id}, result)
 	if err != nil {
 		return nil, err
@@ -400,8 +400,8 @@ func (c *baseRPCClient) GenesisChunked(ctx context.Context, id uint) (*ctypes.Re
 	return result, nil
 }
 
-func (c *baseRPCClient) Block(ctx context.Context, height *int64) (*ctypes.ResultBlock, error) {
-	result := new(ctypes.ResultBlock)
+func (c *baseRPCClient) Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
+	result := new(coretypes.ResultBlock)
 	params := make(map[string]interface{})
 	if height != nil {
 		params["height"] = height
@@ -413,8 +413,8 @@ func (c *baseRPCClient) Block(ctx context.Context, height *int64) (*ctypes.Resul
 	return result, nil
 }
 
-func (c *baseRPCClient) BlockByHash(ctx context.Context, hash bytes.HexBytes) (*ctypes.ResultBlock, error) {
-	result := new(ctypes.ResultBlock)
+func (c *baseRPCClient) BlockByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error) {
+	result := new(coretypes.ResultBlock)
 	params := map[string]interface{}{
 		"hash": hash,
 	}
@@ -428,8 +428,8 @@ func (c *baseRPCClient) BlockByHash(ctx context.Context, hash bytes.HexBytes) (*
 func (c *baseRPCClient) BlockResults(
 	ctx context.Context,
 	height *int64,
-) (*ctypes.ResultBlockResults, error) {
-	result := new(ctypes.ResultBlockResults)
+) (*coretypes.ResultBlockResults, error) {
+	result := new(coretypes.ResultBlockResults)
 	params := make(map[string]interface{})
 	if height != nil {
 		params["height"] = height
@@ -441,8 +441,8 @@ func (c *baseRPCClient) BlockResults(
 	return result, nil
 }
 
-func (c *baseRPCClient) Commit(ctx context.Context, height *int64) (*ctypes.ResultCommit, error) {
-	result := new(ctypes.ResultCommit)
+func (c *baseRPCClient) Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
+	result := new(coretypes.ResultCommit)
 	params := make(map[string]interface{})
 	if height != nil {
 		params["height"] = height
@@ -454,8 +454,8 @@ func (c *baseRPCClient) Commit(ctx context.Context, height *int64) (*ctypes.Resu
 	return result, nil
 }
 
-func (c *baseRPCClient) Tx(ctx context.Context, hash bytes.HexBytes, prove bool) (*ctypes.ResultTx, error) {
-	result := new(ctypes.ResultTx)
+func (c *baseRPCClient) Tx(ctx context.Context, hash bytes.HexBytes, prove bool) (*coretypes.ResultTx, error) {
+	result := new(coretypes.ResultTx)
 	params := map[string]interface{}{
 		"hash":  hash,
 		"prove": prove,
@@ -474,9 +474,9 @@ func (c *baseRPCClient) TxSearch(
 	page,
 	perPage *int,
 	orderBy string,
-) (*ctypes.ResultTxSearch, error) {
+) (*coretypes.ResultTxSearch, error) {
 
-	result := new(ctypes.ResultTxSearch)
+	result := new(coretypes.ResultTxSearch)
 	params := map[string]interface{}{
 		"query":    query,
 		"prove":    prove,
@@ -503,9 +503,9 @@ func (c *baseRPCClient) BlockSearch(
 	query string,
 	page, perPage *int,
 	orderBy string,
-) (*ctypes.ResultBlockSearch, error) {
+) (*coretypes.ResultBlockSearch, error) {
 
-	result := new(ctypes.ResultBlockSearch)
+	result := new(coretypes.ResultBlockSearch)
 	params := map[string]interface{}{
 		"query":    query,
 		"order_by": orderBy,
@@ -531,8 +531,8 @@ func (c *baseRPCClient) Validators(
 	height *int64,
 	page,
 	perPage *int,
-) (*ctypes.ResultValidators, error) {
-	result := new(ctypes.ResultValidators)
+) (*coretypes.ResultValidators, error) {
+	result := new(coretypes.ResultValidators)
 	params := make(map[string]interface{})
 	if page != nil {
 		params["page"] = page
@@ -553,8 +553,8 @@ func (c *baseRPCClient) Validators(
 func (c *baseRPCClient) BroadcastEvidence(
 	ctx context.Context,
 	ev types.Evidence,
-) (*ctypes.ResultBroadcastEvidence, error) {
-	result := new(ctypes.ResultBroadcastEvidence)
+) (*coretypes.ResultBroadcastEvidence, error) {
+	result := new(coretypes.ResultBroadcastEvidence)
 	_, err := c.caller.Call(ctx, "broadcast_evidence", map[string]interface{}{"evidence": ev}, result)
 	if err != nil {
 		return nil, err

--- a/rpc/client/http/ws.go
+++ b/rpc/client/http/ws.go
@@ -9,7 +9,7 @@ import (
 
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	tmjson "github.com/tendermint/tendermint/libs/json"
-	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
+	"github.com/tendermint/tendermint/libs/pubsub"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/coretypes"
 	jsonrpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
@@ -213,7 +213,7 @@ func (w *wsEvents) redoSubscriptionsAfter(d time.Duration) {
 }
 
 func isErrAlreadySubscribed(err error) bool {
-	return strings.Contains(err.Error(), tmpubsub.ErrAlreadySubscribed.Error())
+	return strings.Contains(err.Error(), pubsub.ErrAlreadySubscribed.Error())
 }
 
 func (w *wsEvents) eventListener() {

--- a/rpc/client/http/ws.go
+++ b/rpc/client/http/ws.go
@@ -11,7 +11,7 @@ import (
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	jsonrpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
 )
 
@@ -53,7 +53,7 @@ type wsEvents struct {
 }
 
 type wsSubscription struct {
-	res   chan ctypes.ResultEvent
+	res   chan coretypes.ResultEvent
 	id    string
 	query string
 }
@@ -119,7 +119,7 @@ func (w *wsEvents) Stop() error { return w.ws.Stop() }
 //
 // It returns an error if wsEvents is not running.
 func (w *wsEvents) Subscribe(ctx context.Context, subscriber, query string,
-	outCapacity ...int) (out <-chan ctypes.ResultEvent, err error) {
+	outCapacity ...int) (out <-chan coretypes.ResultEvent, err error) {
 
 	if !w.IsRunning() {
 		return nil, rpcclient.ErrClientNotRunning
@@ -134,7 +134,7 @@ func (w *wsEvents) Subscribe(ctx context.Context, subscriber, query string,
 		outCap = outCapacity[0]
 	}
 
-	outc := make(chan ctypes.ResultEvent, outCap)
+	outc := make(chan coretypes.ResultEvent, outCap)
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
 	// subscriber param is ignored because Tendermint will override it with
@@ -238,7 +238,7 @@ func (w *wsEvents) eventListener() {
 				continue
 			}
 
-			result := new(ctypes.ResultEvent)
+			result := new(coretypes.ResultEvent)
 			err := tmjson.Unmarshal(resp.Result, result)
 			if err != nil {
 				w.Logger.Error("failed to unmarshal response", "err", err)

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -24,7 +24,7 @@ import (
 	"context"
 
 	"github.com/tendermint/tendermint/libs/bytes"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -61,26 +61,26 @@ type Client interface {
 // is easier to mock.
 type ABCIClient interface {
 	// Reading from abci app
-	ABCIInfo(context.Context) (*ctypes.ResultABCIInfo, error)
-	ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*ctypes.ResultABCIQuery, error)
+	ABCIInfo(context.Context) (*coretypes.ResultABCIInfo, error)
+	ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*coretypes.ResultABCIQuery, error)
 	ABCIQueryWithOptions(ctx context.Context, path string, data bytes.HexBytes,
-		opts ABCIQueryOptions) (*ctypes.ResultABCIQuery, error)
+		opts ABCIQueryOptions) (*coretypes.ResultABCIQuery, error)
 
 	// Writing to abci app
-	BroadcastTxCommit(context.Context, types.Tx) (*ctypes.ResultBroadcastTxCommit, error)
-	BroadcastTxAsync(context.Context, types.Tx) (*ctypes.ResultBroadcastTx, error)
-	BroadcastTxSync(context.Context, types.Tx) (*ctypes.ResultBroadcastTx, error)
+	BroadcastTxCommit(context.Context, types.Tx) (*coretypes.ResultBroadcastTxCommit, error)
+	BroadcastTxAsync(context.Context, types.Tx) (*coretypes.ResultBroadcastTx, error)
+	BroadcastTxSync(context.Context, types.Tx) (*coretypes.ResultBroadcastTx, error)
 }
 
 // SignClient groups together the functionality needed to get valid signatures
 // and prove anything about the chain.
 type SignClient interface {
-	Block(ctx context.Context, height *int64) (*ctypes.ResultBlock, error)
-	BlockByHash(ctx context.Context, hash bytes.HexBytes) (*ctypes.ResultBlock, error)
-	BlockResults(ctx context.Context, height *int64) (*ctypes.ResultBlockResults, error)
-	Commit(ctx context.Context, height *int64) (*ctypes.ResultCommit, error)
-	Validators(ctx context.Context, height *int64, page, perPage *int) (*ctypes.ResultValidators, error)
-	Tx(ctx context.Context, hash bytes.HexBytes, prove bool) (*ctypes.ResultTx, error)
+	Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error)
+	BlockByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error)
+	BlockResults(ctx context.Context, height *int64) (*coretypes.ResultBlockResults, error)
+	Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error)
+	Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error)
+	Tx(ctx context.Context, hash bytes.HexBytes, prove bool) (*coretypes.ResultTx, error)
 
 	// TxSearch defines a method to search for a paginated set of transactions by
 	// DeliverTx event search criteria.
@@ -90,7 +90,7 @@ type SignClient interface {
 		prove bool,
 		page, perPage *int,
 		orderBy string,
-	) (*ctypes.ResultTxSearch, error)
+	) (*coretypes.ResultTxSearch, error)
 
 	// BlockSearch defines a method to search for a paginated set of blocks by
 	// BeginBlock and EndBlock event search criteria.
@@ -99,29 +99,29 @@ type SignClient interface {
 		query string,
 		page, perPage *int,
 		orderBy string,
-	) (*ctypes.ResultBlockSearch, error)
+	) (*coretypes.ResultBlockSearch, error)
 }
 
 // HistoryClient provides access to data from genesis to now in large chunks.
 type HistoryClient interface {
-	Genesis(context.Context) (*ctypes.ResultGenesis, error)
-	GenesisChunked(context.Context, uint) (*ctypes.ResultGenesisChunk, error)
-	BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error)
+	Genesis(context.Context) (*coretypes.ResultGenesis, error)
+	GenesisChunked(context.Context, uint) (*coretypes.ResultGenesisChunk, error)
+	BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error)
 }
 
 // StatusClient provides access to general chain info.
 type StatusClient interface {
-	Status(context.Context) (*ctypes.ResultStatus, error)
+	Status(context.Context) (*coretypes.ResultStatus, error)
 }
 
 // NetworkClient is general info about the network state. May not be needed
 // usually.
 type NetworkClient interface {
-	NetInfo(context.Context) (*ctypes.ResultNetInfo, error)
-	DumpConsensusState(context.Context) (*ctypes.ResultDumpConsensusState, error)
-	ConsensusState(context.Context) (*ctypes.ResultConsensusState, error)
-	ConsensusParams(ctx context.Context, height *int64) (*ctypes.ResultConsensusParams, error)
-	Health(context.Context) (*ctypes.ResultHealth, error)
+	NetInfo(context.Context) (*coretypes.ResultNetInfo, error)
+	DumpConsensusState(context.Context) (*coretypes.ResultDumpConsensusState, error)
+	ConsensusState(context.Context) (*coretypes.ResultConsensusState, error)
+	ConsensusParams(ctx context.Context, height *int64) (*coretypes.ResultConsensusParams, error)
+	Health(context.Context) (*coretypes.ResultHealth, error)
 }
 
 // EventsClient is reactive, you can subscribe to any message, given the proper
@@ -134,7 +134,7 @@ type EventsClient interface {
 	//
 	// ctx cannot be used to unsubscribe. To unsubscribe, use either Unsubscribe
 	// or UnsubscribeAll.
-	Subscribe(ctx context.Context, subscriber, query string, outCapacity ...int) (out <-chan ctypes.ResultEvent, err error)
+	Subscribe(ctx context.Context, subscriber, query string, outCapacity ...int) (out <-chan coretypes.ResultEvent, err error)
 	// Unsubscribe unsubscribes given subscriber from query.
 	Unsubscribe(ctx context.Context, subscriber, query string) error
 	// UnsubscribeAll unsubscribes given subscriber from all the queries.
@@ -143,15 +143,15 @@ type EventsClient interface {
 
 // MempoolClient shows us data about current mempool state.
 type MempoolClient interface {
-	UnconfirmedTxs(ctx context.Context, limit *int) (*ctypes.ResultUnconfirmedTxs, error)
-	NumUnconfirmedTxs(context.Context) (*ctypes.ResultUnconfirmedTxs, error)
-	CheckTx(context.Context, types.Tx) (*ctypes.ResultCheckTx, error)
+	UnconfirmedTxs(ctx context.Context, limit *int) (*coretypes.ResultUnconfirmedTxs, error)
+	NumUnconfirmedTxs(context.Context) (*coretypes.ResultUnconfirmedTxs, error)
+	CheckTx(context.Context, types.Tx) (*coretypes.ResultCheckTx, error)
 }
 
 // EvidenceClient is used for submitting an evidence of the malicious
 // behavior.
 type EvidenceClient interface {
-	BroadcastEvidence(context.Context, types.Evidence) (*ctypes.ResultBroadcastEvidence, error)
+	BroadcastEvidence(context.Context, types.Evidence) (*coretypes.ResultBroadcastEvidence, error)
 }
 
 // RemoteClient is a Client, which can also return the remote network address.

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -134,7 +134,7 @@ type EventsClient interface {
 	//
 	// ctx cannot be used to unsubscribe. To unsubscribe, use either Unsubscribe
 	// or UnsubscribeAll.
-	Subscribe(ctx context.Context, subscriber, query string, outCapacity ...int) (out <-chan coretypes.ResultEvent, err error)
+	Subscribe(ctx context.Context, subscriber, query string, outCapacity ...int) (out <-chan coretypes.ResultEvent, err error) //nolint:lll
 	// Unsubscribe unsubscribes given subscriber from query.
 	Unsubscribe(ctx context.Context, subscriber, query string) error
 	// UnsubscribeAll unsubscribes given subscriber from all the queries.

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -9,7 +9,7 @@ import (
 	rpccore "github.com/tendermint/tendermint/internal/rpc/core"
 	"github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/libs/log"
-	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
+	"github.com/tendermint/tendermint/libs/pubsub"
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/coretypes"
@@ -244,7 +244,7 @@ func (c *Local) Subscribe(
 func (c *Local) eventsRoutine(
 	sub types.Subscription,
 	subscriber string,
-	q tmpubsub.Query,
+	q pubsub.Query,
 	outc chan<- coretypes.ResultEvent) {
 	for {
 		select {
@@ -266,7 +266,7 @@ func (c *Local) eventsRoutine(
 				}
 			}
 		case <-sub.Canceled():
-			if sub.Err() == tmpubsub.ErrUnsubscribed {
+			if sub.Err() == pubsub.ErrUnsubscribed {
 				return
 			}
 
@@ -282,7 +282,7 @@ func (c *Local) eventsRoutine(
 }
 
 // Try to resubscribe with exponential backoff.
-func (c *Local) resubscribe(subscriber string, q tmpubsub.Query) types.Subscription {
+func (c *Local) resubscribe(subscriber string, q pubsub.Query) types.Subscription {
 	attempts := 0
 	for {
 		if !c.IsRunning() {
@@ -300,7 +300,7 @@ func (c *Local) resubscribe(subscriber string, q tmpubsub.Query) types.Subscript
 }
 
 func (c *Local) Unsubscribe(ctx context.Context, subscriber, query string) error {
-	args := tmpubsub.UnsubscribeArgs{Subscriber: subscriber}
+	args := pubsub.UnsubscribeArgs{Subscriber: subscriber}
 	var err error
 	args.Query, err = tmquery.New(query)
 	if err != nil {

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -150,7 +150,7 @@ func (c *Local) DialPeers(
 	return c.env.UnsafeDialPeers(c.ctx, peers, persistent, unconditional, private)
 }
 
-func (c *Local) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
+func (c *Local) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) { //nolint:lll
 	return c.env.BlockchainInfo(c.ctx, minHeight, maxHeight)
 }
 
@@ -178,7 +178,7 @@ func (c *Local) Commit(ctx context.Context, height *int64) (*coretypes.ResultCom
 	return c.env.Commit(c.ctx, height)
 }
 
-func (c *Local) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
+func (c *Local) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) { //nolint:lll
 	return c.env.Validators(c.ctx, height, page, perPage)
 }
 

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -12,7 +12,7 @@ import (
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -72,15 +72,15 @@ func (c *Local) SetLogger(l log.Logger) {
 	c.Logger = l
 }
 
-func (c *Local) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
+func (c *Local) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
 	return c.env.Status(c.ctx)
 }
 
-func (c *Local) ABCIInfo(ctx context.Context) (*ctypes.ResultABCIInfo, error) {
+func (c *Local) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
 	return c.env.ABCIInfo(c.ctx)
 }
 
-func (c *Local) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*ctypes.ResultABCIQuery, error) {
+func (c *Local) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*coretypes.ResultABCIQuery, error) {
 	return c.ABCIQueryWithOptions(ctx, path, data, rpcclient.DefaultABCIQueryOptions)
 }
 
@@ -88,55 +88,55 @@ func (c *Local) ABCIQueryWithOptions(
 	ctx context.Context,
 	path string,
 	data bytes.HexBytes,
-	opts rpcclient.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
+	opts rpcclient.ABCIQueryOptions) (*coretypes.ResultABCIQuery, error) {
 	return c.env.ABCIQuery(c.ctx, path, data, opts.Height, opts.Prove)
 }
 
-func (c *Local) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+func (c *Local) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
 	return c.env.BroadcastTxCommit(c.ctx, tx)
 }
 
-func (c *Local) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (c *Local) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	return c.env.BroadcastTxAsync(c.ctx, tx)
 }
 
-func (c *Local) BroadcastTxSync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (c *Local) BroadcastTxSync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	return c.env.BroadcastTxSync(c.ctx, tx)
 }
 
-func (c *Local) UnconfirmedTxs(ctx context.Context, limit *int) (*ctypes.ResultUnconfirmedTxs, error) {
+func (c *Local) UnconfirmedTxs(ctx context.Context, limit *int) (*coretypes.ResultUnconfirmedTxs, error) {
 	return c.env.UnconfirmedTxs(c.ctx, limit)
 }
 
-func (c *Local) NumUnconfirmedTxs(ctx context.Context) (*ctypes.ResultUnconfirmedTxs, error) {
+func (c *Local) NumUnconfirmedTxs(ctx context.Context) (*coretypes.ResultUnconfirmedTxs, error) {
 	return c.env.NumUnconfirmedTxs(c.ctx)
 }
 
-func (c *Local) CheckTx(ctx context.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
+func (c *Local) CheckTx(ctx context.Context, tx types.Tx) (*coretypes.ResultCheckTx, error) {
 	return c.env.CheckTx(c.ctx, tx)
 }
 
-func (c *Local) NetInfo(ctx context.Context) (*ctypes.ResultNetInfo, error) {
+func (c *Local) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, error) {
 	return c.env.NetInfo(c.ctx)
 }
 
-func (c *Local) DumpConsensusState(ctx context.Context) (*ctypes.ResultDumpConsensusState, error) {
+func (c *Local) DumpConsensusState(ctx context.Context) (*coretypes.ResultDumpConsensusState, error) {
 	return c.env.DumpConsensusState(c.ctx)
 }
 
-func (c *Local) ConsensusState(ctx context.Context) (*ctypes.ResultConsensusState, error) {
+func (c *Local) ConsensusState(ctx context.Context) (*coretypes.ResultConsensusState, error) {
 	return c.env.GetConsensusState(c.ctx)
 }
 
-func (c *Local) ConsensusParams(ctx context.Context, height *int64) (*ctypes.ResultConsensusParams, error) {
+func (c *Local) ConsensusParams(ctx context.Context, height *int64) (*coretypes.ResultConsensusParams, error) {
 	return c.env.ConsensusParams(c.ctx, height)
 }
 
-func (c *Local) Health(ctx context.Context) (*ctypes.ResultHealth, error) {
+func (c *Local) Health(ctx context.Context) (*coretypes.ResultHealth, error) {
 	return c.env.Health(c.ctx)
 }
 
-func (c *Local) DialSeeds(ctx context.Context, seeds []string) (*ctypes.ResultDialSeeds, error) {
+func (c *Local) DialSeeds(ctx context.Context, seeds []string) (*coretypes.ResultDialSeeds, error) {
 	return c.env.UnsafeDialSeeds(c.ctx, seeds)
 }
 
@@ -146,43 +146,43 @@ func (c *Local) DialPeers(
 	persistent,
 	unconditional,
 	private bool,
-) (*ctypes.ResultDialPeers, error) {
+) (*coretypes.ResultDialPeers, error) {
 	return c.env.UnsafeDialPeers(c.ctx, peers, persistent, unconditional, private)
 }
 
-func (c *Local) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error) {
+func (c *Local) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
 	return c.env.BlockchainInfo(c.ctx, minHeight, maxHeight)
 }
 
-func (c *Local) Genesis(ctx context.Context) (*ctypes.ResultGenesis, error) {
+func (c *Local) Genesis(ctx context.Context) (*coretypes.ResultGenesis, error) {
 	return c.env.Genesis(c.ctx)
 }
 
-func (c *Local) GenesisChunked(ctx context.Context, id uint) (*ctypes.ResultGenesisChunk, error) {
+func (c *Local) GenesisChunked(ctx context.Context, id uint) (*coretypes.ResultGenesisChunk, error) {
 	return c.env.GenesisChunked(c.ctx, id)
 }
 
-func (c *Local) Block(ctx context.Context, height *int64) (*ctypes.ResultBlock, error) {
+func (c *Local) Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
 	return c.env.Block(c.ctx, height)
 }
 
-func (c *Local) BlockByHash(ctx context.Context, hash bytes.HexBytes) (*ctypes.ResultBlock, error) {
+func (c *Local) BlockByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error) {
 	return c.env.BlockByHash(c.ctx, hash)
 }
 
-func (c *Local) BlockResults(ctx context.Context, height *int64) (*ctypes.ResultBlockResults, error) {
+func (c *Local) BlockResults(ctx context.Context, height *int64) (*coretypes.ResultBlockResults, error) {
 	return c.env.BlockResults(c.ctx, height)
 }
 
-func (c *Local) Commit(ctx context.Context, height *int64) (*ctypes.ResultCommit, error) {
+func (c *Local) Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
 	return c.env.Commit(c.ctx, height)
 }
 
-func (c *Local) Validators(ctx context.Context, height *int64, page, perPage *int) (*ctypes.ResultValidators, error) {
+func (c *Local) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
 	return c.env.Validators(c.ctx, height, page, perPage)
 }
 
-func (c *Local) Tx(ctx context.Context, hash bytes.HexBytes, prove bool) (*ctypes.ResultTx, error) {
+func (c *Local) Tx(ctx context.Context, hash bytes.HexBytes, prove bool) (*coretypes.ResultTx, error) {
 	return c.env.Tx(c.ctx, hash, prove)
 }
 
@@ -193,7 +193,7 @@ func (c *Local) TxSearch(
 	page,
 	perPage *int,
 	orderBy string,
-) (*ctypes.ResultTxSearch, error) {
+) (*coretypes.ResultTxSearch, error) {
 	return c.env.TxSearch(c.ctx, query, prove, page, perPage, orderBy)
 }
 
@@ -202,11 +202,11 @@ func (c *Local) BlockSearch(
 	query string,
 	page, perPage *int,
 	orderBy string,
-) (*ctypes.ResultBlockSearch, error) {
+) (*coretypes.ResultBlockSearch, error) {
 	return c.env.BlockSearch(c.ctx, query, page, perPage, orderBy)
 }
 
-func (c *Local) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
+func (c *Local) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
 	return c.env.BroadcastEvidence(c.ctx, ev)
 }
 
@@ -214,7 +214,7 @@ func (c *Local) Subscribe(
 	ctx context.Context,
 	subscriber,
 	query string,
-	outCapacity ...int) (out <-chan ctypes.ResultEvent, err error) {
+	outCapacity ...int) (out <-chan coretypes.ResultEvent, err error) {
 	q, err := tmquery.New(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query: %w", err)
@@ -235,7 +235,7 @@ func (c *Local) Subscribe(
 		return nil, fmt.Errorf("failed to subscribe: %w", err)
 	}
 
-	outc := make(chan ctypes.ResultEvent, outCap)
+	outc := make(chan coretypes.ResultEvent, outCap)
 	go c.eventsRoutine(sub, subscriber, q, outc)
 
 	return outc, nil
@@ -245,11 +245,11 @@ func (c *Local) eventsRoutine(
 	sub types.Subscription,
 	subscriber string,
 	q tmpubsub.Query,
-	outc chan<- ctypes.ResultEvent) {
+	outc chan<- coretypes.ResultEvent) {
 	for {
 		select {
 		case msg := <-sub.Out():
-			result := ctypes.ResultEvent{
+			result := coretypes.ResultEvent{
 				SubscriptionID: msg.SubscriptionID(),
 				Query:          q.String(),
 				Data:           msg.Data(),

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/libs/pubsub"
-	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
+	"github.com/tendermint/tendermint/libs/pubsub/query"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
@@ -188,22 +188,22 @@ func (c *Local) Tx(ctx context.Context, hash bytes.HexBytes, prove bool) (*coret
 
 func (c *Local) TxSearch(
 	_ context.Context,
-	query string,
+	queryString string,
 	prove bool,
 	page,
 	perPage *int,
 	orderBy string,
 ) (*coretypes.ResultTxSearch, error) {
-	return c.env.TxSearch(c.ctx, query, prove, page, perPage, orderBy)
+	return c.env.TxSearch(c.ctx, queryString, prove, page, perPage, orderBy)
 }
 
 func (c *Local) BlockSearch(
 	_ context.Context,
-	query string,
+	queryString string,
 	page, perPage *int,
 	orderBy string,
 ) (*coretypes.ResultBlockSearch, error) {
-	return c.env.BlockSearch(c.ctx, query, page, perPage, orderBy)
+	return c.env.BlockSearch(c.ctx, queryString, page, perPage, orderBy)
 }
 
 func (c *Local) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
@@ -213,9 +213,9 @@ func (c *Local) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*core
 func (c *Local) Subscribe(
 	ctx context.Context,
 	subscriber,
-	query string,
+	queryString string,
 	outCapacity ...int) (out <-chan coretypes.ResultEvent, err error) {
-	q, err := tmquery.New(query)
+	q, err := query.New(queryString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query: %w", err)
 	}
@@ -299,17 +299,17 @@ func (c *Local) resubscribe(subscriber string, q pubsub.Query) types.Subscriptio
 	}
 }
 
-func (c *Local) Unsubscribe(ctx context.Context, subscriber, query string) error {
+func (c *Local) Unsubscribe(ctx context.Context, subscriber, queryString string) error {
 	args := pubsub.UnsubscribeArgs{Subscriber: subscriber}
 	var err error
-	args.Query, err = tmquery.New(query)
+	args.Query, err = query.New(queryString)
 	if err != nil {
 		// if this isn't a valid query it might be an ID, so
 		// we'll try that. It'll turn into an error when we
 		// try to unsubscribe. Eventually, perhaps, we'll want
 		// to change the interface to only allow
 		// unsubscription by ID, but that's a larger change.
-		args.ID = query
+		args.ID = queryString
 	}
 	return c.EventBus.Unsubscribe(ctx, args)
 }

--- a/rpc/client/mock/abci.go
+++ b/rpc/client/mock/abci.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tendermint/tendermint/internal/proxy"
 	"github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/rpc/client"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -24,11 +24,11 @@ var (
 	_ client.ABCIClient = (*ABCIRecorder)(nil)
 )
 
-func (a ABCIApp) ABCIInfo(ctx context.Context) (*ctypes.ResultABCIInfo, error) {
-	return &ctypes.ResultABCIInfo{Response: a.App.Info(proxy.RequestInfo)}, nil
+func (a ABCIApp) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
+	return &coretypes.ResultABCIInfo{Response: a.App.Info(proxy.RequestInfo)}, nil
 }
 
-func (a ABCIApp) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*ctypes.ResultABCIQuery, error) {
+func (a ABCIApp) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*coretypes.ResultABCIQuery, error) {
 	return a.ABCIQueryWithOptions(ctx, path, data, client.DefaultABCIQueryOptions)
 }
 
@@ -36,21 +36,21 @@ func (a ABCIApp) ABCIQueryWithOptions(
 	ctx context.Context,
 	path string,
 	data bytes.HexBytes,
-	opts client.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
+	opts client.ABCIQueryOptions) (*coretypes.ResultABCIQuery, error) {
 	q := a.App.Query(abci.RequestQuery{
 		Data:   data,
 		Path:   path,
 		Height: opts.Height,
 		Prove:  opts.Prove,
 	})
-	return &ctypes.ResultABCIQuery{Response: q}, nil
+	return &coretypes.ResultABCIQuery{Response: q}, nil
 }
 
 // NOTE: Caller should call a.App.Commit() separately,
 // this function does not actually wait for a commit.
 // TODO: Make it wait for a commit and set res.Height appropriately.
-func (a ABCIApp) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
-	res := ctypes.ResultBroadcastTxCommit{}
+func (a ABCIApp) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
+	res := coretypes.ResultBroadcastTxCommit{}
 	res.CheckTx = a.App.CheckTx(abci.RequestCheckTx{Tx: tx})
 	if res.CheckTx.IsErr() {
 		return &res, nil
@@ -60,13 +60,13 @@ func (a ABCIApp) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*ctypes.Re
 	return &res, nil
 }
 
-func (a ABCIApp) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (a ABCIApp) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	c := a.App.CheckTx(abci.RequestCheckTx{Tx: tx})
 	// and this gets written in a background thread...
 	if !c.IsErr() {
 		go func() { a.App.DeliverTx(abci.RequestDeliverTx{Tx: tx}) }()
 	}
-	return &ctypes.ResultBroadcastTx{
+	return &coretypes.ResultBroadcastTx{
 		Code:      c.Code,
 		Data:      c.Data,
 		Log:       c.Log,
@@ -75,13 +75,13 @@ func (a ABCIApp) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.Res
 	}, nil
 }
 
-func (a ABCIApp) BroadcastTxSync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (a ABCIApp) BroadcastTxSync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	c := a.App.CheckTx(abci.RequestCheckTx{Tx: tx})
 	// and this gets written in a background thread...
 	if !c.IsErr() {
 		go func() { a.App.DeliverTx(abci.RequestDeliverTx{Tx: tx}) }()
 	}
-	return &ctypes.ResultBroadcastTx{
+	return &coretypes.ResultBroadcastTx{
 		Code:      c.Code,
 		Data:      c.Data,
 		Log:       c.Log,
@@ -100,15 +100,15 @@ type ABCIMock struct {
 	Broadcast       Call
 }
 
-func (m ABCIMock) ABCIInfo(ctx context.Context) (*ctypes.ResultABCIInfo, error) {
+func (m ABCIMock) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
 	res, err := m.Info.GetResponse(nil)
 	if err != nil {
 		return nil, err
 	}
-	return &ctypes.ResultABCIInfo{Response: res.(abci.ResponseInfo)}, nil
+	return &coretypes.ResultABCIInfo{Response: res.(abci.ResponseInfo)}, nil
 }
 
-func (m ABCIMock) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*ctypes.ResultABCIQuery, error) {
+func (m ABCIMock) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*coretypes.ResultABCIQuery, error) {
 	return m.ABCIQueryWithOptions(ctx, path, data, client.DefaultABCIQueryOptions)
 }
 
@@ -116,37 +116,37 @@ func (m ABCIMock) ABCIQueryWithOptions(
 	ctx context.Context,
 	path string,
 	data bytes.HexBytes,
-	opts client.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
+	opts client.ABCIQueryOptions) (*coretypes.ResultABCIQuery, error) {
 	res, err := m.Query.GetResponse(QueryArgs{path, data, opts.Height, opts.Prove})
 	if err != nil {
 		return nil, err
 	}
 	resQuery := res.(abci.ResponseQuery)
-	return &ctypes.ResultABCIQuery{Response: resQuery}, nil
+	return &coretypes.ResultABCIQuery{Response: resQuery}, nil
 }
 
-func (m ABCIMock) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+func (m ABCIMock) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
 	res, err := m.BroadcastCommit.GetResponse(tx)
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultBroadcastTxCommit), nil
+	return res.(*coretypes.ResultBroadcastTxCommit), nil
 }
 
-func (m ABCIMock) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (m ABCIMock) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	res, err := m.Broadcast.GetResponse(tx)
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultBroadcastTx), nil
+	return res.(*coretypes.ResultBroadcastTx), nil
 }
 
-func (m ABCIMock) BroadcastTxSync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (m ABCIMock) BroadcastTxSync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	res, err := m.Broadcast.GetResponse(tx)
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultBroadcastTx), nil
+	return res.(*coretypes.ResultBroadcastTx), nil
 }
 
 // ABCIRecorder can wrap another type (ABCIApp, ABCIMock, or Client)
@@ -174,7 +174,7 @@ func (r *ABCIRecorder) addCall(call Call) {
 	r.Calls = append(r.Calls, call)
 }
 
-func (r *ABCIRecorder) ABCIInfo(ctx context.Context) (*ctypes.ResultABCIInfo, error) {
+func (r *ABCIRecorder) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
 	res, err := r.Client.ABCIInfo(ctx)
 	r.addCall(Call{
 		Name:     "abci_info",
@@ -188,7 +188,7 @@ func (r *ABCIRecorder) ABCIQuery(
 	ctx context.Context,
 	path string,
 	data bytes.HexBytes,
-) (*ctypes.ResultABCIQuery, error) {
+) (*coretypes.ResultABCIQuery, error) {
 	return r.ABCIQueryWithOptions(ctx, path, data, client.DefaultABCIQueryOptions)
 }
 
@@ -196,7 +196,7 @@ func (r *ABCIRecorder) ABCIQueryWithOptions(
 	ctx context.Context,
 	path string,
 	data bytes.HexBytes,
-	opts client.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
+	opts client.ABCIQueryOptions) (*coretypes.ResultABCIQuery, error) {
 	res, err := r.Client.ABCIQueryWithOptions(ctx, path, data, opts)
 	r.addCall(Call{
 		Name:     "abci_query",
@@ -207,7 +207,7 @@ func (r *ABCIRecorder) ABCIQueryWithOptions(
 	return res, err
 }
 
-func (r *ABCIRecorder) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+func (r *ABCIRecorder) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
 	res, err := r.Client.BroadcastTxCommit(ctx, tx)
 	r.addCall(Call{
 		Name:     "broadcast_tx_commit",
@@ -218,7 +218,7 @@ func (r *ABCIRecorder) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*cty
 	return res, err
 }
 
-func (r *ABCIRecorder) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (r *ABCIRecorder) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	res, err := r.Client.BroadcastTxAsync(ctx, tx)
 	r.addCall(Call{
 		Name:     "broadcast_tx_async",
@@ -229,7 +229,7 @@ func (r *ABCIRecorder) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctyp
 	return res, err
 }
 
-func (r *ABCIRecorder) BroadcastTxSync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (r *ABCIRecorder) BroadcastTxSync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	res, err := r.Client.BroadcastTxSync(ctx, tx)
 	r.addCall(Call{
 		Name:     "broadcast_tx_sync",

--- a/rpc/client/mock/abci_test.go
+++ b/rpc/client/mock/abci_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/client/mock"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -36,7 +36,7 @@ func TestABCIMock(t *testing.T) {
 		// Broadcast commit depends on call
 		BroadcastCommit: mock.Call{
 			Args: goodTx,
-			Response: &ctypes.ResultBroadcastTxCommit{
+			Response: &coretypes.ResultBroadcastTxCommit{
 				CheckTx:   abci.ResponseCheckTx{Data: bytes.HexBytes("stand")},
 				DeliverTx: abci.ResponseDeliverTx{Data: bytes.HexBytes("deliver")},
 			},
@@ -112,7 +112,7 @@ func TestABCIRecorder(t *testing.T) {
 	assert.Nil(info.Error)
 	assert.Nil(info.Args)
 	require.NotNil(info.Response)
-	ir, ok := info.Response.(*ctypes.ResultABCIInfo)
+	ir, ok := info.Response.(*coretypes.ResultABCIInfo)
 	require.True(ok)
 	assert.Equal("data", ir.Response.Data)
 	assert.Equal("v0.9.9", ir.Response.Version)

--- a/rpc/client/mock/client.go
+++ b/rpc/client/mock/client.go
@@ -145,7 +145,7 @@ func (c Client) DialPeers(
 	return c.env.UnsafeDialPeers(&rpctypes.Context{}, peers, persistent, unconditional, private)
 }
 
-func (c Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
+func (c Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) { //nolint:lll
 	return c.env.BlockchainInfo(&rpctypes.Context{}, minHeight, maxHeight)
 }
 
@@ -165,7 +165,7 @@ func (c Client) Commit(ctx context.Context, height *int64) (*coretypes.ResultCom
 	return c.env.Commit(&rpctypes.Context{}, height)
 }
 
-func (c Client) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
+func (c Client) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) { //nolint:lll
 	return c.env.Validators(&rpctypes.Context{}, height, page, perPage)
 }
 

--- a/rpc/client/mock/client.go
+++ b/rpc/client/mock/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/tendermint/tendermint/internal/rpc/core"
 	"github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/rpc/client"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -75,15 +75,15 @@ func (c Call) GetResponse(args interface{}) (interface{}, error) {
 	return nil, c.Error
 }
 
-func (c Client) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
+func (c Client) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
 	return c.env.Status(&rpctypes.Context{})
 }
 
-func (c Client) ABCIInfo(ctx context.Context) (*ctypes.ResultABCIInfo, error) {
+func (c Client) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
 	return c.env.ABCIInfo(&rpctypes.Context{})
 }
 
-func (c Client) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*ctypes.ResultABCIQuery, error) {
+func (c Client) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*coretypes.ResultABCIQuery, error) {
 	return c.ABCIQueryWithOptions(ctx, path, data, client.DefaultABCIQueryOptions)
 }
 
@@ -91,47 +91,47 @@ func (c Client) ABCIQueryWithOptions(
 	ctx context.Context,
 	path string,
 	data bytes.HexBytes,
-	opts client.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
+	opts client.ABCIQueryOptions) (*coretypes.ResultABCIQuery, error) {
 	return c.env.ABCIQuery(&rpctypes.Context{}, path, data, opts.Height, opts.Prove)
 }
 
-func (c Client) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+func (c Client) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
 	return c.env.BroadcastTxCommit(&rpctypes.Context{}, tx)
 }
 
-func (c Client) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (c Client) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	return c.env.BroadcastTxAsync(&rpctypes.Context{}, tx)
 }
 
-func (c Client) BroadcastTxSync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+func (c Client) BroadcastTxSync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
 	return c.env.BroadcastTxSync(&rpctypes.Context{}, tx)
 }
 
-func (c Client) CheckTx(ctx context.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
+func (c Client) CheckTx(ctx context.Context, tx types.Tx) (*coretypes.ResultCheckTx, error) {
 	return c.env.CheckTx(&rpctypes.Context{}, tx)
 }
 
-func (c Client) NetInfo(ctx context.Context) (*ctypes.ResultNetInfo, error) {
+func (c Client) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, error) {
 	return c.env.NetInfo(&rpctypes.Context{})
 }
 
-func (c Client) ConsensusState(ctx context.Context) (*ctypes.ResultConsensusState, error) {
+func (c Client) ConsensusState(ctx context.Context) (*coretypes.ResultConsensusState, error) {
 	return c.env.GetConsensusState(&rpctypes.Context{})
 }
 
-func (c Client) DumpConsensusState(ctx context.Context) (*ctypes.ResultDumpConsensusState, error) {
+func (c Client) DumpConsensusState(ctx context.Context) (*coretypes.ResultDumpConsensusState, error) {
 	return c.env.DumpConsensusState(&rpctypes.Context{})
 }
 
-func (c Client) ConsensusParams(ctx context.Context, height *int64) (*ctypes.ResultConsensusParams, error) {
+func (c Client) ConsensusParams(ctx context.Context, height *int64) (*coretypes.ResultConsensusParams, error) {
 	return c.env.ConsensusParams(&rpctypes.Context{}, height)
 }
 
-func (c Client) Health(ctx context.Context) (*ctypes.ResultHealth, error) {
+func (c Client) Health(ctx context.Context) (*coretypes.ResultHealth, error) {
 	return c.env.Health(&rpctypes.Context{})
 }
 
-func (c Client) DialSeeds(ctx context.Context, seeds []string) (*ctypes.ResultDialSeeds, error) {
+func (c Client) DialSeeds(ctx context.Context, seeds []string) (*coretypes.ResultDialSeeds, error) {
 	return c.env.UnsafeDialSeeds(&rpctypes.Context{}, seeds)
 }
 
@@ -141,34 +141,34 @@ func (c Client) DialPeers(
 	persistent,
 	unconditional,
 	private bool,
-) (*ctypes.ResultDialPeers, error) {
+) (*coretypes.ResultDialPeers, error) {
 	return c.env.UnsafeDialPeers(&rpctypes.Context{}, peers, persistent, unconditional, private)
 }
 
-func (c Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error) {
+func (c Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
 	return c.env.BlockchainInfo(&rpctypes.Context{}, minHeight, maxHeight)
 }
 
-func (c Client) Genesis(ctx context.Context) (*ctypes.ResultGenesis, error) {
+func (c Client) Genesis(ctx context.Context) (*coretypes.ResultGenesis, error) {
 	return c.env.Genesis(&rpctypes.Context{})
 }
 
-func (c Client) Block(ctx context.Context, height *int64) (*ctypes.ResultBlock, error) {
+func (c Client) Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
 	return c.env.Block(&rpctypes.Context{}, height)
 }
 
-func (c Client) BlockByHash(ctx context.Context, hash bytes.HexBytes) (*ctypes.ResultBlock, error) {
+func (c Client) BlockByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error) {
 	return c.env.BlockByHash(&rpctypes.Context{}, hash)
 }
 
-func (c Client) Commit(ctx context.Context, height *int64) (*ctypes.ResultCommit, error) {
+func (c Client) Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
 	return c.env.Commit(&rpctypes.Context{}, height)
 }
 
-func (c Client) Validators(ctx context.Context, height *int64, page, perPage *int) (*ctypes.ResultValidators, error) {
+func (c Client) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
 	return c.env.Validators(&rpctypes.Context{}, height, page, perPage)
 }
 
-func (c Client) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
+func (c Client) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
 	return c.env.BroadcastEvidence(&rpctypes.Context{}, ev)
 }

--- a/rpc/client/mock/status.go
+++ b/rpc/client/mock/status.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/tendermint/tendermint/rpc/client"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 )
 
 // StatusMock returns the result specified by the Call
@@ -17,12 +17,12 @@ var (
 	_ client.StatusClient = (*StatusRecorder)(nil)
 )
 
-func (m *StatusMock) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
+func (m *StatusMock) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
 	res, err := m.GetResponse(nil)
 	if err != nil {
 		return nil, err
 	}
-	return res.(*ctypes.ResultStatus), nil
+	return res.(*coretypes.ResultStatus), nil
 }
 
 // StatusRecorder can wrap another type (StatusMock, full client)
@@ -43,7 +43,7 @@ func (r *StatusRecorder) addCall(call Call) {
 	r.Calls = append(r.Calls, call)
 }
 
-func (r *StatusRecorder) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
+func (r *StatusRecorder) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
 	res, err := r.Client.Status(ctx)
 	r.addCall(Call{
 		Name:     "status",

--- a/rpc/client/mock/status_test.go
+++ b/rpc/client/mock/status_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/rpc/client/mock"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 )
 
 func TestStatus(t *testing.T) {
@@ -18,8 +18,8 @@ func TestStatus(t *testing.T) {
 
 	m := &mock.StatusMock{
 		Call: mock.Call{
-			Response: &ctypes.ResultStatus{
-				SyncInfo: ctypes.SyncInfo{
+			Response: &coretypes.ResultStatus{
+				SyncInfo: coretypes.SyncInfo{
 					LatestBlockHash:     bytes.HexBytes("block"),
 					LatestAppHash:       bytes.HexBytes("app"),
 					LatestBlockHeight:   10,
@@ -56,7 +56,7 @@ func TestStatus(t *testing.T) {
 	assert.Nil(rs.Args)
 	assert.Nil(rs.Error)
 	require.NotNil(rs.Response)
-	st, ok := rs.Response.(*ctypes.ResultStatus)
+	st, ok := rs.Response.(*coretypes.ResultStatus)
 	require.True(ok)
 	assert.EqualValues("block", st.SyncInfo.LatestBlockHash)
 	assert.EqualValues(10, st.SyncInfo.LatestBlockHeight)

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/tendermint/tendermint/rpc/client"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	rpclocal "github.com/tendermint/tendermint/rpc/client/local"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
 	"github.com/tendermint/tendermint/types"
 )
@@ -781,10 +781,10 @@ func testBatchedJSONRPCCalls(ctx context.Context, t *testing.T, c *rpchttp.HTTP)
 	require.Len(t, bresults, 2)
 	require.Equal(t, 0, batch.Count())
 
-	bresult1, ok := bresults[0].(*ctypes.ResultBroadcastTxCommit)
+	bresult1, ok := bresults[0].(*coretypes.ResultBroadcastTxCommit)
 	require.True(t, ok)
 	require.Equal(t, *bresult1, *r1)
-	bresult2, ok := bresults[1].(*ctypes.ResultBroadcastTxCommit)
+	bresult2, ok := bresults[1].(*coretypes.ResultBroadcastTxCommit)
 	require.True(t, ok)
 	require.Equal(t, *bresult2, *r2)
 	apph := tmmath.MaxInt64(bresult1.Height, bresult2.Height) + 1
@@ -802,10 +802,10 @@ func testBatchedJSONRPCCalls(ctx context.Context, t *testing.T, c *rpchttp.HTTP)
 	require.Len(t, qresults, 2)
 	require.Equal(t, 0, batch.Count())
 
-	qresult1, ok := qresults[0].(*ctypes.ResultABCIQuery)
+	qresult1, ok := qresults[0].(*coretypes.ResultABCIQuery)
 	require.True(t, ok)
 	require.Equal(t, *qresult1, *q1)
-	qresult2, ok := qresults[1].(*ctypes.ResultABCIQuery)
+	qresult2, ok := qresults[1].(*coretypes.ResultABCIQuery)
 	require.True(t, ok)
 	require.Equal(t, *qresult2, *q2)
 

--- a/rpc/grpc/api.go
+++ b/rpc/grpc/api.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	abci "github.com/tendermint/tendermint/abci/types"
-	core "github.com/tendermint/tendermint/internal/rpc/core"
+	"github.com/tendermint/tendermint/internal/rpc/core"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 

--- a/rpc/grpc/grpc_test.go
+++ b/rpc/grpc/grpc_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/service"
-	core_grpc "github.com/tendermint/tendermint/rpc/grpc"
+	coregrpc "github.com/tendermint/tendermint/rpc/grpc"
 	rpctest "github.com/tendermint/tendermint/rpc/test"
 )
 
@@ -37,7 +37,7 @@ func TestBroadcastTx(t *testing.T) {
 
 	res, err := rpctest.GetGRPCClient(conf).BroadcastTx(
 		context.Background(),
-		&core_grpc.RequestBroadcastTx{Tx: []byte("this is a tx")},
+		&coregrpc.RequestBroadcastTx{Tx: []byte("this is a tx")},
 	)
 	require.NoError(t, err)
 	require.EqualValues(t, 0, res.CheckTx.Code)

--- a/rpc/jsonrpc/client/decode.go
+++ b/rpc/jsonrpc/client/decode.go
@@ -6,18 +6,18 @@ import (
 	"fmt"
 
 	tmjson "github.com/tendermint/tendermint/libs/json"
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 func unmarshalResponseBytes(
 	responseBytes []byte,
-	expectedID types.JSONRPCIntID,
+	expectedID rpctypes.JSONRPCIntID,
 	result interface{},
 ) (interface{}, error) {
 
 	// Read response.  If rpc/core/types is imported, the result will unmarshal
 	// into the correct type.
-	response := &types.RPCResponse{}
+	response := &rpctypes.RPCResponse{}
 	if err := json.Unmarshal(responseBytes, response); err != nil {
 		return nil, fmt.Errorf("error unmarshaling: %w", err)
 	}
@@ -40,12 +40,12 @@ func unmarshalResponseBytes(
 
 func unmarshalResponseBytesArray(
 	responseBytes []byte,
-	expectedIDs []types.JSONRPCIntID,
+	expectedIDs []rpctypes.JSONRPCIntID,
 	results []interface{},
 ) ([]interface{}, error) {
 
 	var (
-		responses []types.RPCResponse
+		responses []rpctypes.RPCResponse
 	)
 
 	if err := json.Unmarshal(responseBytes, &responses); err != nil {
@@ -64,10 +64,10 @@ func unmarshalResponseBytesArray(
 	}
 
 	// Intersect IDs from responses with expectedIDs.
-	ids := make([]types.JSONRPCIntID, len(responses))
+	ids := make([]rpctypes.JSONRPCIntID, len(responses))
 	var ok bool
 	for i, resp := range responses {
-		ids[i], ok = resp.ID.(types.JSONRPCIntID)
+		ids[i], ok = resp.ID.(rpctypes.JSONRPCIntID)
 		if !ok {
 			return nil, fmt.Errorf("expected JSONRPCIntID, got %T", resp.ID)
 		}
@@ -85,8 +85,8 @@ func unmarshalResponseBytesArray(
 	return results, nil
 }
 
-func validateResponseIDs(ids, expectedIDs []types.JSONRPCIntID) error {
-	m := make(map[types.JSONRPCIntID]bool, len(expectedIDs))
+func validateResponseIDs(ids, expectedIDs []rpctypes.JSONRPCIntID) error {
+	m := make(map[rpctypes.JSONRPCIntID]bool, len(expectedIDs))
 	for _, expectedID := range expectedIDs {
 		m[expectedID] = true
 	}
@@ -104,11 +104,11 @@ func validateResponseIDs(ids, expectedIDs []types.JSONRPCIntID) error {
 
 // From the JSON-RPC 2.0 spec:
 // id: It MUST be the same as the value of the id member in the Request Object.
-func validateAndVerifyID(res *types.RPCResponse, expectedID types.JSONRPCIntID) error {
+func validateAndVerifyID(res *rpctypes.RPCResponse, expectedID rpctypes.JSONRPCIntID) error {
 	if err := validateResponseID(res.ID); err != nil {
 		return err
 	}
-	if expectedID != res.ID.(types.JSONRPCIntID) { // validateResponseID ensured res.ID has the right type
+	if expectedID != res.ID.(rpctypes.JSONRPCIntID) { // validateResponseID ensured res.ID has the right type
 		return fmt.Errorf("response ID (%d) does not match request ID (%d)", res.ID, expectedID)
 	}
 	return nil
@@ -118,7 +118,7 @@ func validateResponseID(id interface{}) error {
 	if id == nil {
 		return errors.New("no ID")
 	}
-	_, ok := id.(types.JSONRPCIntID)
+	_, ok := id.(rpctypes.JSONRPCIntID)
 	if !ok {
 		return fmt.Errorf("expected JSONRPCIntID, but got: %T", id)
 	}

--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 const (
@@ -189,7 +189,7 @@ func (c *Client) Call(
 ) (interface{}, error) {
 	id := c.nextRequestID()
 
-	request, err := types.MapToRequest(id, method, params)
+	request, err := rpctypes.MapToRequest(id, method, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode params: %w", err)
 	}
@@ -235,7 +235,7 @@ func (c *Client) NewRequestBatch() *RequestBatch {
 }
 
 func (c *Client) sendBatch(ctx context.Context, requests []*jsonRPCBufferedRequest) ([]interface{}, error) {
-	reqs := make([]types.RPCRequest, 0, len(requests))
+	reqs := make([]rpctypes.RPCRequest, 0, len(requests))
 	results := make([]interface{}, 0, len(requests))
 	for _, req := range requests {
 		reqs = append(reqs, req.request)
@@ -272,20 +272,20 @@ func (c *Client) sendBatch(ctx context.Context, requests []*jsonRPCBufferedReque
 	}
 
 	// collect ids to check responses IDs in unmarshalResponseBytesArray
-	ids := make([]types.JSONRPCIntID, len(requests))
+	ids := make([]rpctypes.JSONRPCIntID, len(requests))
 	for i, req := range requests {
-		ids[i] = req.request.ID.(types.JSONRPCIntID)
+		ids[i] = req.request.ID.(rpctypes.JSONRPCIntID)
 	}
 
 	return unmarshalResponseBytesArray(responseBytes, ids, results)
 }
 
-func (c *Client) nextRequestID() types.JSONRPCIntID {
+func (c *Client) nextRequestID() rpctypes.JSONRPCIntID {
 	c.mtx.Lock()
 	id := c.nextReqID
 	c.nextReqID++
 	c.mtx.Unlock()
-	return types.JSONRPCIntID(id)
+	return rpctypes.JSONRPCIntID(id)
 }
 
 //------------------------------------------------------------------------------------
@@ -293,7 +293,7 @@ func (c *Client) nextRequestID() types.JSONRPCIntID {
 // jsonRPCBufferedRequest encapsulates a single buffered request, as well as its
 // anticipated response structure.
 type jsonRPCBufferedRequest struct {
-	request types.RPCRequest
+	request rpctypes.RPCRequest
 	result  interface{} // The result will be deserialized into this object.
 }
 
@@ -354,7 +354,7 @@ func (b *RequestBatch) Call(
 	result interface{},
 ) (interface{}, error) {
 	id := b.client.nextRequestID()
-	request, err := types.MapToRequest(id, method, params)
+	request, err := rpctypes.MapToRequest(id, method, params)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/client/http_uri_client.go
+++ b/rpc/jsonrpc/client/http_uri_client.go
@@ -7,12 +7,12 @@ import (
 	"net/http"
 	"strings"
 
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 const (
 	// URIClientRequestID in a request ID used by URIClient
-	URIClientRequestID = types.JSONRPCIntID(-1)
+	URIClientRequestID = rpctypes.JSONRPCIntID(-1)
 )
 
 // URIClient is a JSON-RPC client, which sends POST form HTTP requests to the

--- a/rpc/jsonrpc/client/ws_client_test.go
+++ b/rpc/jsonrpc/client/ws_client_test.go
@@ -14,7 +14,7 @@ import (
 
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/libs/log"
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 var wsCallTimeout = 5 * time.Second
@@ -41,7 +41,7 @@ func (h *myHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		var req types.RPCRequest
+		var req rpctypes.RPCRequest
 		err = json.Unmarshal(in, &req)
 		if err != nil {
 			panic(err)
@@ -56,7 +56,7 @@ func (h *myHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.mtx.RUnlock()
 
 		res := json.RawMessage(`{}`)
-		emptyRespBytes, _ := json.Marshal(types.RPCResponse{Result: res, ID: req.ID})
+		emptyRespBytes, _ := json.Marshal(rpctypes.RPCResponse{Result: res, ID: req.ID})
 		if err := conn.WriteMessage(messageType, emptyRespBytes); err != nil {
 			return
 		}

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	client "github.com/tendermint/tendermint/rpc/jsonrpc/client"
 	server "github.com/tendermint/tendermint/rpc/jsonrpc/server"
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // Client and Server should work over tcp or unix sockets
@@ -64,23 +64,23 @@ var Routes = map[string]*server.RPCFunc{
 	"echo_int":        server.NewRPCFunc(EchoIntResult, "arg", false),
 }
 
-func EchoResult(ctx *types.Context, v string) (*ResultEcho, error) {
+func EchoResult(ctx *rpctypes.Context, v string) (*ResultEcho, error) {
 	return &ResultEcho{v}, nil
 }
 
-func EchoWSResult(ctx *types.Context, v string) (*ResultEcho, error) {
+func EchoWSResult(ctx *rpctypes.Context, v string) (*ResultEcho, error) {
 	return &ResultEcho{v}, nil
 }
 
-func EchoIntResult(ctx *types.Context, v int) (*ResultEchoInt, error) {
+func EchoIntResult(ctx *rpctypes.Context, v int) (*ResultEchoInt, error) {
 	return &ResultEchoInt{v}, nil
 }
 
-func EchoBytesResult(ctx *types.Context, v []byte) (*ResultEchoBytes, error) {
+func EchoBytesResult(ctx *rpctypes.Context, v []byte) (*ResultEchoBytes, error) {
 	return &ResultEchoBytes{v}, nil
 }
 
-func EchoDataBytesResult(ctx *types.Context, v tmbytes.HexBytes) (*ResultEchoDataBytes, error) {
+func EchoDataBytesResult(ctx *rpctypes.Context, v tmbytes.HexBytes) (*ResultEchoDataBytes, error) {
 	return &ResultEchoDataBytes{v}, nil
 }
 

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -18,8 +18,8 @@ import (
 
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/libs/log"
-	client "github.com/tendermint/tendermint/rpc/jsonrpc/client"
-	server "github.com/tendermint/tendermint/rpc/jsonrpc/server"
+	"github.com/tendermint/tendermint/rpc/jsonrpc/client"
+	"github.com/tendermint/tendermint/rpc/jsonrpc/server"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -12,7 +12,7 @@ import (
 
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	"github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
@@ -123,8 +123,8 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 			default: // we need to unwrap the error and parse it accordingly
 				switch errors.Unwrap(err) {
 				// check if the error was due to an invald request
-				case ctypes.ErrZeroOrNegativeHeight, ctypes.ErrZeroOrNegativePerPage,
-					ctypes.ErrPageOutOfRange, ctypes.ErrInvalidRequest:
+				case coretypes.ErrZeroOrNegativeHeight, coretypes.ErrZeroOrNegativePerPage,
+					coretypes.ErrPageOutOfRange, coretypes.ErrInvalidRequest:
 					responses = append(responses, types.RPCInvalidRequestError(request.ID, err))
 					c = false
 				// lastly default all remaining errors as internal errors

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -13,7 +13,7 @@ import (
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	"github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // HTTP + JSON handler
@@ -23,7 +23,7 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 	return func(w http.ResponseWriter, r *http.Request) {
 		b, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			res := types.RPCInvalidRequestError(nil,
+			res := rpctypes.RPCInvalidRequestError(nil,
 				fmt.Errorf("error reading request body: %w", err),
 			)
 			if wErr := WriteRPCResponseHTTPError(w, res); wErr != nil {
@@ -41,20 +41,20 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 
 		// first try to unmarshal the incoming request as an array of RPC requests
 		var (
-			requests  []types.RPCRequest
-			responses []types.RPCResponse
+			requests  []rpctypes.RPCRequest
+			responses []rpctypes.RPCResponse
 		)
 		if err := json.Unmarshal(b, &requests); err != nil {
 			// next, try to unmarshal as a single request
-			var request types.RPCRequest
+			var request rpctypes.RPCRequest
 			if err := json.Unmarshal(b, &request); err != nil {
-				res := types.RPCParseError(fmt.Errorf("error unmarshaling request: %w", err))
+				res := rpctypes.RPCParseError(fmt.Errorf("error unmarshaling request: %w", err))
 				if wErr := WriteRPCResponseHTTPError(w, res); wErr != nil {
 					logger.Error("failed to write response", "res", res, "err", wErr)
 				}
 				return
 			}
-			requests = []types.RPCRequest{request}
+			requests = []rpctypes.RPCRequest{request}
 		}
 
 		// Set the default response cache to true unless
@@ -77,25 +77,25 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 			if len(r.URL.Path) > 1 {
 				responses = append(
 					responses,
-					types.RPCInvalidRequestError(request.ID, fmt.Errorf("path %s is invalid", r.URL.Path)),
+					rpctypes.RPCInvalidRequestError(request.ID, fmt.Errorf("path %s is invalid", r.URL.Path)),
 				)
 				c = false
 				continue
 			}
 			rpcFunc, ok := funcMap[request.Method]
 			if !ok || rpcFunc.ws {
-				responses = append(responses, types.RPCMethodNotFoundError(request.ID))
+				responses = append(responses, rpctypes.RPCMethodNotFoundError(request.ID))
 				c = false
 				continue
 			}
-			ctx := &types.Context{JSONReq: &request, HTTPReq: r}
+			ctx := &rpctypes.Context{JSONReq: &request, HTTPReq: r}
 			args := []reflect.Value{reflect.ValueOf(ctx)}
 			if len(request.Params) > 0 {
 				fnArgs, err := jsonParamsToArgs(rpcFunc, request.Params)
 				if err != nil {
 					responses = append(
 						responses,
-						types.RPCInvalidParamsError(request.ID, fmt.Errorf("error converting json params to arguments: %w", err)),
+						rpctypes.RPCInvalidParamsError(request.ID, fmt.Errorf("error converting json params to arguments: %w", err)),
 					)
 					c = false
 					continue
@@ -114,22 +114,22 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 			switch e := err.(type) {
 			// if no error then return a success response
 			case nil:
-				responses = append(responses, types.NewRPCSuccessResponse(request.ID, result))
+				responses = append(responses, rpctypes.NewRPCSuccessResponse(request.ID, result))
 
 			// if this already of type RPC error then forward that error
-			case *types.RPCError:
-				responses = append(responses, types.NewRPCErrorResponse(request.ID, e.Code, e.Message, e.Data))
+			case *rpctypes.RPCError:
+				responses = append(responses, rpctypes.NewRPCErrorResponse(request.ID, e.Code, e.Message, e.Data))
 				c = false
 			default: // we need to unwrap the error and parse it accordingly
 				switch errors.Unwrap(err) {
 				// check if the error was due to an invald request
 				case coretypes.ErrZeroOrNegativeHeight, coretypes.ErrZeroOrNegativePerPage,
 					coretypes.ErrPageOutOfRange, coretypes.ErrInvalidRequest:
-					responses = append(responses, types.RPCInvalidRequestError(request.ID, err))
+					responses = append(responses, rpctypes.RPCInvalidRequestError(request.ID, err))
 					c = false
 				// lastly default all remaining errors as internal errors
 				default: // includes ctypes.ErrHeightNotAvailable and ctypes.ErrHeightExceedsChainHead
-					responses = append(responses, types.RPCInternalError(request.ID, err))
+					responses = append(responses, rpctypes.RPCInternalError(request.ID, err))
 					c = false
 				}
 			}
@@ -277,7 +277,7 @@ func writeListOfEndpoints(w http.ResponseWriter, r *http.Request, funcMap map[st
 	w.Write(buf.Bytes()) // nolint: errcheck
 }
 
-func hasDefaultHeight(r types.RPCRequest, h []reflect.Value) bool {
+func hasDefaultHeight(r rpctypes.RPCRequest, h []reflect.Value) bool {
 	switch r.Method {
 	case "block", "block_results", "commit", "consensus_params", "validators":
 		return len(h) < 2 || h[1].IsZero()

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/libs/log"
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 func testMux() *http.ServeMux {
 	funcMap := map[string]*RPCFunc{
-		"c":     NewRPCFunc(func(ctx *types.Context, s string, i int) (string, error) { return "foo", nil }, "s,i", false),
-		"block": NewRPCFunc(func(ctx *types.Context, h int) (string, error) { return "block", nil }, "height", true),
+		"c":     NewRPCFunc(func(ctx *rpctypes.Context, s string, i int) (string, error) { return "foo", nil }, "s,i", false),
+		"block": NewRPCFunc(func(ctx *rpctypes.Context, h int) (string, error) { return "block", nil }, "height", true),
 	}
 	mux := http.NewServeMux()
 	logger := log.NewNopLogger()
@@ -40,21 +40,21 @@ func TestRPCParams(t *testing.T) {
 		expectedID interface{}
 	}{
 		// bad
-		{`{"jsonrpc": "2.0", "id": "0"}`, "Method not found", types.JSONRPCStringID("0")},
-		{`{"jsonrpc": "2.0", "method": "y", "id": "0"}`, "Method not found", types.JSONRPCStringID("0")},
+		{`{"jsonrpc": "2.0", "id": "0"}`, "Method not found", rpctypes.JSONRPCStringID("0")},
+		{`{"jsonrpc": "2.0", "method": "y", "id": "0"}`, "Method not found", rpctypes.JSONRPCStringID("0")},
 		// id not captured in JSON parsing failures
 		{`{"method": "c", "id": "0", "params": a}`, "invalid character", nil},
-		{`{"method": "c", "id": "0", "params": ["a"]}`, "got 1", types.JSONRPCStringID("0")},
-		{`{"method": "c", "id": "0", "params": ["a", "b"]}`, "invalid character", types.JSONRPCStringID("0")},
-		{`{"method": "c", "id": "0", "params": [1, 1]}`, "of type string", types.JSONRPCStringID("0")},
+		{`{"method": "c", "id": "0", "params": ["a"]}`, "got 1", rpctypes.JSONRPCStringID("0")},
+		{`{"method": "c", "id": "0", "params": ["a", "b"]}`, "invalid character", rpctypes.JSONRPCStringID("0")},
+		{`{"method": "c", "id": "0", "params": [1, 1]}`, "of type string", rpctypes.JSONRPCStringID("0")},
 
 		// no ID - notification
 		// {`{"jsonrpc": "2.0", "method": "c", "params": ["a", "10"]}`, false, nil},
 
 		// good
-		{`{"jsonrpc": "2.0", "method": "c", "id": "0", "params": null}`, "", types.JSONRPCStringID("0")},
-		{`{"method": "c", "id": "0", "params": {}}`, "", types.JSONRPCStringID("0")},
-		{`{"method": "c", "id": "0", "params": ["a", "10"]}`, "", types.JSONRPCStringID("0")},
+		{`{"jsonrpc": "2.0", "method": "c", "id": "0", "params": null}`, "", rpctypes.JSONRPCStringID("0")},
+		{`{"method": "c", "id": "0", "params": {}}`, "", rpctypes.JSONRPCStringID("0")},
+		{`{"method": "c", "id": "0", "params": ["a", "10"]}`, "", rpctypes.JSONRPCStringID("0")},
 	}
 
 	for i, tt := range tests {
@@ -71,9 +71,9 @@ func TestRPCParams(t *testing.T) {
 			continue
 		}
 
-		recv := new(types.RPCResponse)
+		recv := new(rpctypes.RPCResponse)
 		assert.Nil(t, json.Unmarshal(blob, recv), "#%d: expecting successful parsing of an RPCResponse:\nblob: %s", i, blob)
-		assert.NotEqual(t, recv, new(types.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
+		assert.NotEqual(t, recv, new(rpctypes.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
 		assert.Equal(t, tt.expectedID, recv.ID, "#%d: expected ID not matched in RPCResponse", i)
 		if tt.wantErr == "" {
 			assert.Nil(t, recv.Error, "#%d: not expecting an error", i)
@@ -93,12 +93,12 @@ func TestJSONRPCID(t *testing.T) {
 		expectedID interface{}
 	}{
 		// good id
-		{`{"jsonrpc": "2.0", "method": "c", "id": "0", "params": ["a", "10"]}`, false, types.JSONRPCStringID("0")},
-		{`{"jsonrpc": "2.0", "method": "c", "id": "abc", "params": ["a", "10"]}`, false, types.JSONRPCStringID("abc")},
-		{`{"jsonrpc": "2.0", "method": "c", "id": 0, "params": ["a", "10"]}`, false, types.JSONRPCIntID(0)},
-		{`{"jsonrpc": "2.0", "method": "c", "id": 1, "params": ["a", "10"]}`, false, types.JSONRPCIntID(1)},
-		{`{"jsonrpc": "2.0", "method": "c", "id": 1.3, "params": ["a", "10"]}`, false, types.JSONRPCIntID(1)},
-		{`{"jsonrpc": "2.0", "method": "c", "id": -1, "params": ["a", "10"]}`, false, types.JSONRPCIntID(-1)},
+		{`{"jsonrpc": "2.0", "method": "c", "id": "0", "params": ["a", "10"]}`, false, rpctypes.JSONRPCStringID("0")},
+		{`{"jsonrpc": "2.0", "method": "c", "id": "abc", "params": ["a", "10"]}`, false, rpctypes.JSONRPCStringID("abc")},
+		{`{"jsonrpc": "2.0", "method": "c", "id": 0, "params": ["a", "10"]}`, false, rpctypes.JSONRPCIntID(0)},
+		{`{"jsonrpc": "2.0", "method": "c", "id": 1, "params": ["a", "10"]}`, false, rpctypes.JSONRPCIntID(1)},
+		{`{"jsonrpc": "2.0", "method": "c", "id": 1.3, "params": ["a", "10"]}`, false, rpctypes.JSONRPCIntID(1)},
+		{`{"jsonrpc": "2.0", "method": "c", "id": -1, "params": ["a", "10"]}`, false, rpctypes.JSONRPCIntID(-1)},
 
 		// bad id
 		{`{"jsonrpc": "2.0", "method": "c", "id": {}, "params": ["a", "10"]}`, true, nil},
@@ -119,11 +119,11 @@ func TestJSONRPCID(t *testing.T) {
 		}
 		res.Body.Close()
 
-		recv := new(types.RPCResponse)
+		recv := new(rpctypes.RPCResponse)
 		err = json.Unmarshal(blob, recv)
 		assert.Nil(t, err, "#%d: expecting successful parsing of an RPCResponse:\nblob: %s", i, blob)
 		if !tt.wantErr {
-			assert.NotEqual(t, recv, new(types.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
+			assert.NotEqual(t, recv, new(rpctypes.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
 			assert.Equal(t, tt.expectedID, recv.ID, "#%d: expected ID not matched in RPCResponse", i)
 			assert.Nil(t, recv.Error, "#%d: not expecting an error", i)
 		} else {
@@ -185,7 +185,7 @@ func TestRPCNotificationInBatch(t *testing.T) {
 		}
 		res.Body.Close()
 
-		var responses []types.RPCResponse
+		var responses []rpctypes.RPCResponse
 		// try to unmarshal an array first
 		err = json.Unmarshal(blob, &responses)
 		if err != nil {
@@ -195,14 +195,14 @@ func TestRPCNotificationInBatch(t *testing.T) {
 				continue
 			} else {
 				// we were expecting an error here, so let's unmarshal a single response
-				var response types.RPCResponse
+				var response rpctypes.RPCResponse
 				err = json.Unmarshal(blob, &response)
 				if err != nil {
 					t.Errorf("#%d: expected successful parsing of an RPCResponse\nblob: %s", i, blob)
 					continue
 				}
 				// have a single-element result
-				responses = []types.RPCResponse{response}
+				responses = []rpctypes.RPCResponse{response}
 			}
 		}
 		if tt.expectCount != len(responses) {
@@ -210,7 +210,7 @@ func TestRPCNotificationInBatch(t *testing.T) {
 			continue
 		}
 		for _, response := range responses {
-			assert.NotEqual(t, response, new(types.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
+			assert.NotEqual(t, response, new(rpctypes.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
 		}
 	}
 }

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/net/netutil"
 
 	"github.com/tendermint/tendermint/libs/log"
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // Config is a RPC server configuration.
@@ -105,7 +105,7 @@ func ServeTLS(
 // source: https://www.jsonrpc.org/historical/json-rpc-over-http.html
 func WriteRPCResponseHTTPError(
 	w http.ResponseWriter,
-	res types.RPCResponse,
+	res rpctypes.RPCResponse,
 ) error {
 	if res.Error == nil {
 		panic("tried to write http error response without RPC error")
@@ -134,7 +134,7 @@ func WriteRPCResponseHTTPError(
 
 // WriteRPCResponseHTTP marshals res as JSON (with indent) and writes it to w.
 // If the rpc response can be cached, add cache-control to the response header.
-func WriteRPCResponseHTTP(w http.ResponseWriter, c bool, res ...types.RPCResponse) error {
+func WriteRPCResponseHTTP(w http.ResponseWriter, c bool, res ...rpctypes.RPCResponse) error {
 	var v interface{}
 	if len(res) == 1 {
 		v = res[0]
@@ -189,7 +189,7 @@ func RecoverAndLogHandler(handler http.Handler, logger log.Logger) http.Handler 
 			if e := recover(); e != nil {
 
 				// If RPCResponse
-				if res, ok := e.(types.RPCResponse); ok {
+				if res, ok := e.(rpctypes.RPCResponse); ok {
 					if wErr := WriteRPCResponseHTTP(rww, false, res); wErr != nil {
 						logger.Error("failed to write response", "res", res, "err", wErr)
 					}
@@ -208,7 +208,7 @@ func RecoverAndLogHandler(handler http.Handler, logger log.Logger) http.Handler 
 
 					logger.Error("panic in RPC HTTP handler", "err", e, "stack", string(debug.Stack()))
 
-					res := types.RPCInternalError(types.JSONRPCIntID(-1), err)
+					res := rpctypes.RPCInternalError(rpctypes.JSONRPCIntID(-1), err)
 					if wErr := WriteRPCResponseHTTPError(rww, res); wErr != nil {
 						logger.Error("failed to write response", "res", res, "err", wErr)
 					}

--- a/rpc/jsonrpc/server/http_server_test.go
+++ b/rpc/jsonrpc/server/http_server_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/libs/log"
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 type sampleResult struct {
@@ -107,11 +107,11 @@ func TestServeTLS(t *testing.T) {
 }
 
 func TestWriteRPCResponseHTTP(t *testing.T) {
-	id := types.JSONRPCIntID(-1)
+	id := rpctypes.JSONRPCIntID(-1)
 
 	// one argument
 	w := httptest.NewRecorder()
-	err := WriteRPCResponseHTTP(w, true, types.NewRPCSuccessResponse(id, &sampleResult{"hello"}))
+	err := WriteRPCResponseHTTP(w, true, rpctypes.NewRPCSuccessResponse(id, &sampleResult{"hello"}))
 	require.NoError(t, err)
 	resp := w.Result()
 	body, err := ioutil.ReadAll(resp.Body)
@@ -132,8 +132,8 @@ func TestWriteRPCResponseHTTP(t *testing.T) {
 	w = httptest.NewRecorder()
 	err = WriteRPCResponseHTTP(w,
 		false,
-		types.NewRPCSuccessResponse(id, &sampleResult{"hello"}),
-		types.NewRPCSuccessResponse(id, &sampleResult{"world"}))
+		rpctypes.NewRPCSuccessResponse(id, &sampleResult{"hello"}),
+		rpctypes.NewRPCSuccessResponse(id, &sampleResult{"world"}))
 	require.NoError(t, err)
 	resp = w.Result()
 	body, err = ioutil.ReadAll(resp.Body)
@@ -162,7 +162,7 @@ func TestWriteRPCResponseHTTP(t *testing.T) {
 
 func TestWriteRPCResponseHTTPError(t *testing.T) {
 	w := httptest.NewRecorder()
-	err := WriteRPCResponseHTTPError(w, types.RPCInternalError(types.JSONRPCIntID(-1), errors.New("foo")))
+	err := WriteRPCResponseHTTPError(w, rpctypes.RPCInternalError(rpctypes.JSONRPCIntID(-1), errors.New("foo")))
 	require.NoError(t, err)
 	resp := w.Result()
 	body, err := ioutil.ReadAll(resp.Body)

--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -11,7 +11,7 @@ import (
 
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
@@ -76,10 +76,10 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 			var res types.RPCResponse
 
 			switch errors.Unwrap(err) {
-			case ctypes.ErrZeroOrNegativeHeight,
-				ctypes.ErrZeroOrNegativePerPage,
-				ctypes.ErrPageOutOfRange,
-				ctypes.ErrInvalidRequest:
+			case coretypes.ErrZeroOrNegativeHeight,
+				coretypes.ErrZeroOrNegativePerPage,
+				coretypes.ErrPageOutOfRange,
+				coretypes.ErrInvalidRequest:
 				res = types.RPCInvalidRequestError(dummyID, err)
 			default: // ctypes.ErrHeightNotAvailable, ctypes.ErrHeightExceedsChainHead:
 				res = types.RPCInternalError(dummyID, err)

--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -12,7 +12,7 @@ import (
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // HTTP + URI handler
@@ -22,12 +22,12 @@ var reInt = regexp.MustCompile(`^-?[0-9]+$`)
 // convert from a function name to the http handler
 func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWriter, *http.Request) {
 	// Always return -1 as there's no ID here.
-	dummyID := types.JSONRPCIntID(-1) // URIClientRequestID
+	dummyID := rpctypes.JSONRPCIntID(-1) // URIClientRequestID
 
 	// Exception for websocket endpoints
 	if rpcFunc.ws {
 		return func(w http.ResponseWriter, r *http.Request) {
-			res := types.RPCMethodNotFoundError(dummyID)
+			res := rpctypes.RPCMethodNotFoundError(dummyID)
 			if wErr := WriteRPCResponseHTTPError(w, res); wErr != nil {
 				logger.Error("failed to write response", "res", res, "err", wErr)
 			}
@@ -38,12 +38,12 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger.Debug("HTTP HANDLER", "req", r)
 
-		ctx := &types.Context{HTTPReq: r}
+		ctx := &rpctypes.Context{HTTPReq: r}
 		args := []reflect.Value{reflect.ValueOf(ctx)}
 
 		fnArgs, err := httpParamsToArgs(rpcFunc, r)
 		if err != nil {
-			res := types.RPCInvalidParamsError(dummyID,
+			res := rpctypes.RPCInvalidParamsError(dummyID,
 				fmt.Errorf("error converting http params to arguments: %w", err),
 			)
 			if wErr := WriteRPCResponseHTTPError(w, res); wErr != nil {
@@ -60,29 +60,29 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 		switch e := err.(type) {
 		// if no error then return a success response
 		case nil:
-			res := types.NewRPCSuccessResponse(dummyID, result)
+			res := rpctypes.NewRPCSuccessResponse(dummyID, result)
 			if wErr := WriteRPCResponseHTTP(w, rpcFunc.cache, res); wErr != nil {
 				logger.Error("failed to write response", "res", res, "err", wErr)
 			}
 
 		// if this already of type RPC error then forward that error.
-		case *types.RPCError:
-			res := types.NewRPCErrorResponse(dummyID, e.Code, e.Message, e.Data)
+		case *rpctypes.RPCError:
+			res := rpctypes.NewRPCErrorResponse(dummyID, e.Code, e.Message, e.Data)
 			if wErr := WriteRPCResponseHTTPError(w, res); wErr != nil {
 				logger.Error("failed to write response", "res", res, "err", wErr)
 			}
 
 		default: // we need to unwrap the error and parse it accordingly
-			var res types.RPCResponse
+			var res rpctypes.RPCResponse
 
 			switch errors.Unwrap(err) {
 			case coretypes.ErrZeroOrNegativeHeight,
 				coretypes.ErrZeroOrNegativePerPage,
 				coretypes.ErrPageOutOfRange,
 				coretypes.ErrInvalidRequest:
-				res = types.RPCInvalidRequestError(dummyID, err)
+				res = rpctypes.RPCInvalidRequestError(dummyID, err)
 			default: // ctypes.ErrHeightNotAvailable, ctypes.ErrHeightExceedsChainHead:
-				res = types.RPCInternalError(dummyID, err)
+				res = rpctypes.RPCInternalError(dummyID, err)
 			}
 
 			if wErr := WriteRPCResponseHTTPError(w, res); wErr != nil {

--- a/rpc/jsonrpc/server/parse_test.go
+++ b/rpc/jsonrpc/server/parse_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/tendermint/tendermint/libs/bytes"
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 func TestParseJSONMap(t *testing.T) {
@@ -134,7 +134,7 @@ func TestParseJSONArray(t *testing.T) {
 }
 
 func TestParseJSONRPC(t *testing.T) {
-	demo := func(ctx *types.Context, height int, name string) {}
+	demo := func(ctx *rpctypes.Context, height int, name string) {}
 	call := NewRPCFunc(demo, "height,name", false)
 
 	cases := []struct {
@@ -171,7 +171,7 @@ func TestParseJSONRPC(t *testing.T) {
 }
 
 func TestParseURI(t *testing.T) {
-	demo := func(ctx *types.Context, height int, name string) {}
+	demo := func(ctx *rpctypes.Context, height int, name string) {}
 	call := NewRPCFunc(demo, "height,name", false)
 
 	cases := []struct {

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/rpc/client"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
@@ -403,8 +403,8 @@ func (wsc *wsConnection) readRoutine() {
 			default: // we need to unwrap the error and parse it accordingly
 				switch errors.Unwrap(err) {
 				// check if the error was due to an invald request
-				case ctypes.ErrZeroOrNegativeHeight, ctypes.ErrZeroOrNegativePerPage,
-					ctypes.ErrPageOutOfRange, ctypes.ErrInvalidRequest:
+				case coretypes.ErrZeroOrNegativeHeight, coretypes.ErrZeroOrNegativePerPage,
+					coretypes.ErrPageOutOfRange, coretypes.ErrInvalidRequest:
 					resp = types.RPCInvalidRequestError(request.ID, err)
 
 				// lastly default all remaining errors as internal errors

--- a/rpc/jsonrpc/server/ws_handler_test.go
+++ b/rpc/jsonrpc/server/ws_handler_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/libs/log"
-	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 func TestWebsocketManagerHandler(t *testing.T) {
@@ -26,8 +26,8 @@ func TestWebsocketManagerHandler(t *testing.T) {
 	}
 
 	// check basic functionality works
-	req, err := types.MapToRequest(
-		types.JSONRPCStringID("TestWebsocketManager"),
+	req, err := rpctypes.MapToRequest(
+		rpctypes.JSONRPCStringID("TestWebsocketManager"),
 		"c",
 		map[string]interface{}{"s": "a", "i": 10},
 	)
@@ -35,7 +35,7 @@ func TestWebsocketManagerHandler(t *testing.T) {
 	err = c.WriteJSON(req)
 	require.NoError(t, err)
 
-	var resp types.RPCResponse
+	var resp rpctypes.RPCResponse
 	err = c.ReadJSON(&resp)
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -44,7 +44,7 @@ func TestWebsocketManagerHandler(t *testing.T) {
 
 func newWSServer() *httptest.Server {
 	funcMap := map[string]*RPCFunc{
-		"c": NewWSRPCFunc(func(ctx *types.Context, s string, i int) (string, error) { return "foo", nil }, "s,i"),
+		"c": NewWSRPCFunc(func(ctx *rpctypes.Context, s string, i int) (string, error) { return "foo", nil }, "s,i"),
 	}
 	wm := NewWebsocketManager(funcMap)
 	wm.SetLogger(log.TestingLogger())

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -13,7 +13,7 @@ import (
 	tmnet "github.com/tendermint/tendermint/libs/net"
 	"github.com/tendermint/tendermint/libs/service"
 	nm "github.com/tendermint/tendermint/node"
-	ctypes "github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 	core_grpc "github.com/tendermint/tendermint/rpc/grpc"
 	rpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
 )
@@ -30,7 +30,7 @@ func waitForRPC(ctx context.Context, conf *cfg.Config) {
 	if err != nil {
 		panic(err)
 	}
-	result := new(ctypes.ResultStatus)
+	result := new(coretypes.ResultStatus)
 	for {
 		_, err := client.Call(ctx, "status", map[string]interface{}{}, result)
 		if err == nil {

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -8,7 +8,7 @@ import (
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/log"
 	tmnet "github.com/tendermint/tendermint/libs/net"
 	"github.com/tendermint/tendermint/libs/service"
@@ -24,7 +24,7 @@ type Options struct {
 	suppressStdout bool
 }
 
-func waitForRPC(ctx context.Context, conf *cfg.Config) {
+func waitForRPC(ctx context.Context, conf *config.Config) {
 	laddr := conf.RPC.ListenAddress
 	client, err := rpcclient.New(laddr)
 	if err != nil {
@@ -42,7 +42,7 @@ func waitForRPC(ctx context.Context, conf *cfg.Config) {
 	}
 }
 
-func waitForGRPC(ctx context.Context, conf *cfg.Config) {
+func waitForGRPC(ctx context.Context, conf *config.Config) {
 	client := GetGRPCClient(conf)
 	for {
 		_, err := client.Ping(ctx, &core_grpc.RequestPing{})
@@ -66,8 +66,8 @@ func makeAddrs() (string, string, string) {
 		fmt.Sprintf("tcp://127.0.0.1:%d", randPort())
 }
 
-func CreateConfig(testName string) *cfg.Config {
-	c := cfg.ResetTestRoot(testName)
+func CreateConfig(testName string) *config.Config {
+	c := config.ResetTestRoot(testName)
 
 	// and we use random ports to run in parallel
 	tm, rpc, grpc := makeAddrs()
@@ -78,7 +78,7 @@ func CreateConfig(testName string) *cfg.Config {
 	return c
 }
 
-func GetGRPCClient(conf *cfg.Config) core_grpc.BroadcastAPIClient {
+func GetGRPCClient(conf *config.Config) core_grpc.BroadcastAPIClient {
 	grpcAddr := conf.RPC.GRPCListenAddress
 	return core_grpc.StartGRPCClient(grpcAddr)
 }
@@ -86,7 +86,7 @@ func GetGRPCClient(conf *cfg.Config) core_grpc.BroadcastAPIClient {
 type ServiceCloser func(context.Context) error
 
 func StartTendermint(ctx context.Context,
-	conf *cfg.Config,
+	conf *config.Config,
 	app abci.Application,
 	opts ...func(*Options)) (service.Service, ServiceCloser, error) {
 

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmnet "github.com/tendermint/tendermint/libs/net"
 	"github.com/tendermint/tendermint/libs/service"
-	nm "github.com/tendermint/tendermint/node"
+	"github.com/tendermint/tendermint/node"
 	"github.com/tendermint/tendermint/rpc/coretypes"
 	core_grpc "github.com/tendermint/tendermint/rpc/grpc"
 	rpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
@@ -101,12 +101,12 @@ func StartTendermint(ctx context.Context,
 		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
 	}
 	papp := abciclient.NewLocalCreator(app)
-	node, err := nm.New(conf, logger, papp, nil)
+	tmNode, err := node.New(conf, logger, papp, nil)
 	if err != nil {
 		return nil, func(_ context.Context) error { return nil }, err
 	}
 
-	err = node.Start()
+	err = tmNode.Start()
 	if err != nil {
 		return nil, func(_ context.Context) error { return nil }, err
 	}
@@ -119,11 +119,11 @@ func StartTendermint(ctx context.Context,
 		fmt.Println("Tendermint running!")
 	}
 
-	return node, func(ctx context.Context) error {
-		if err := node.Stop(); err != nil {
+	return tmNode, func(ctx context.Context) error {
+		if err := tmNode.Stop(); err != nil {
 			logger.Error("Error when trying to stop node", "err", err)
 		}
-		node.Wait()
+		tmNode.Wait()
 		os.RemoveAll(conf.RootDir)
 		return nil
 	}, nil

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tendermint/tendermint/libs/service"
 	"github.com/tendermint/tendermint/node"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	core_grpc "github.com/tendermint/tendermint/rpc/grpc"
+	coregrpc "github.com/tendermint/tendermint/rpc/grpc"
 	rpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
 )
 
@@ -45,7 +45,7 @@ func waitForRPC(ctx context.Context, conf *config.Config) {
 func waitForGRPC(ctx context.Context, conf *config.Config) {
 	client := GetGRPCClient(conf)
 	for {
-		_, err := client.Ping(ctx, &core_grpc.RequestPing{})
+		_, err := client.Ping(ctx, &coregrpc.RequestPing{})
 		if err == nil {
 			return
 		}
@@ -78,9 +78,9 @@ func CreateConfig(testName string) *config.Config {
 	return c
 }
 
-func GetGRPCClient(conf *config.Config) core_grpc.BroadcastAPIClient {
+func GetGRPCClient(conf *config.Config) coregrpc.BroadcastAPIClient {
 	grpcAddr := conf.RPC.GRPCListenAddress
-	return core_grpc.StartGRPCClient(grpcAddr)
+	return coregrpc.StartGRPCClient(grpcAddr)
 }
 
 type ServiceCloser func(context.Context) error

--- a/scripts/json2wal/main.go
+++ b/scripts/json2wal/main.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strings"
 
-	cs "github.com/tendermint/tendermint/internal/consensus"
+	"github.com/tendermint/tendermint/internal/consensus"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/types"
 )
@@ -41,7 +41,7 @@ func main() {
 	// because of the byte array in BlockPart
 	// leading to unmarshal error: unexpected end of JSON input
 	br := bufio.NewReaderSize(f, int(2*types.BlockPartSizeBytes))
-	dec := cs.NewWALEncoder(walFile)
+	dec := consensus.NewWALEncoder(walFile)
 
 	for {
 		msgJSON, _, err := br.ReadLine()
@@ -55,7 +55,7 @@ func main() {
 			continue
 		}
 
-		var msg cs.TimedWALMessage
+		var msg consensus.TimedWALMessage
 		err = tmjson.Unmarshal(msgJSON, &msg)
 		if err != nil {
 			panic(fmt.Errorf("failed to unmarshal json: %v", err))

--- a/scripts/wal2json/main.go
+++ b/scripts/wal2json/main.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"os"
 
-	cs "github.com/tendermint/tendermint/internal/consensus"
+	"github.com/tendermint/tendermint/internal/consensus"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 )
 
@@ -28,7 +28,7 @@ func main() {
 	}
 	defer f.Close()
 
-	dec := cs.NewWALDecoder(f)
+	dec := consensus.NewWALDecoder(f)
 	for {
 		msg, err := dec.Decode()
 		if err == io.EOF {
@@ -48,7 +48,7 @@ func main() {
 		}
 
 		if err == nil {
-			if endMsg, ok := msg.Msg.(cs.EndHeightMessage); ok {
+			if endMsg, ok := msg.Msg.(consensus.EndHeightMessage); ok {
 				_, err = os.Stdout.Write([]byte(fmt.Sprintf("ENDHEIGHT %d\n", endMsg.Height)))
 			}
 		}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	dbm "github.com/tendermint/tm-db"
 
-	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	sm "github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/internal/state/test/factory"
@@ -46,13 +46,13 @@ func makeTestCommit(height int64, timestamp time.Time) *types.Commit {
 }
 
 func makeStateAndBlockStore(logger log.Logger) (sm.State, *BlockStore, cleanupFunc) {
-	config := cfg.ResetTestRoot("blockchain_reactor_test")
+	cfg := config.ResetTestRoot("blockchain_reactor_test")
 	blockDB := dbm.NewMemDB()
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	state, err := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
 	if err != nil {
 		panic(fmt.Errorf("error constructing state from genesis file: %w", err))
 	}
-	return state, NewBlockStore(blockDB), func() { os.RemoveAll(config.RootDir) }
+	return state, NewBlockStore(blockDB), func() { os.RemoveAll(cfg.RootDir) }
 }
 
 func freshBlockStore() (*BlockStore, dbm.DB) {
@@ -292,9 +292,9 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 }
 
 func TestLoadBaseMeta(t *testing.T) {
-	config := cfg.ResetTestRoot("blockchain_reactor_test")
-	defer os.RemoveAll(config.RootDir)
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	cfg := config.ResetTestRoot("blockchain_reactor_test")
+	defer os.RemoveAll(cfg.RootDir)
+	state, err := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
 	require.NoError(t, err)
 	bs := NewBlockStore(dbm.NewMemDB())
 
@@ -348,9 +348,9 @@ func TestLoadBlockPart(t *testing.T) {
 }
 
 func TestPruneBlocks(t *testing.T) {
-	config := cfg.ResetTestRoot("blockchain_reactor_test")
-	defer os.RemoveAll(config.RootDir)
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	cfg := config.ResetTestRoot("blockchain_reactor_test")
+	defer os.RemoveAll(cfg.RootDir)
+	state, err := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
 	require.NoError(t, err)
 	db := dbm.NewMemDB()
 	bs := NewBlockStore(db)

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	abci "github.com/tendermint/tendermint/abci/types"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 )
 
 //-------------------------------------------------------
@@ -22,7 +22,7 @@ func (tm2pb) Validator(val *Validator) abci.Validator {
 
 // XXX: panics on unknown pubkey type
 func (tm2pb) ValidatorUpdate(val *Validator) abci.ValidatorUpdate {
-	pk, err := cryptoenc.PubKeyToProto(val.PubKey)
+	pk, err := encoding.PubKeyToProto(val.PubKey)
 	if err != nil {
 		panic(err)
 	}
@@ -52,7 +52,7 @@ type pb2tm struct{}
 func (pb2tm) ValidatorUpdates(vals []abci.ValidatorUpdate) ([]*Validator, error) {
 	tmVals := make([]*Validator, len(vals))
 	for i, v := range vals {
-		pub, err := cryptoenc.PubKeyFromProto(v.PubKey)
+		pub, err := encoding.PubKeyFromProto(v.PubKey)
 		if err != nil {
 			return nil, err
 		}

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -9,7 +9,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 )
 
 func TestABCIPubKey(t *testing.T) {
@@ -19,9 +19,9 @@ func TestABCIPubKey(t *testing.T) {
 }
 
 func testABCIPubKey(t *testing.T, pk crypto.PubKey, typeStr string) error {
-	abciPubKey, err := cryptoenc.PubKeyToProto(pk)
+	abciPubKey, err := encoding.PubKeyToProto(pk)
 	require.NoError(t, err)
-	pk2, err := cryptoenc.PubKeyFromProto(abciPubKey)
+	pk2, err := encoding.PubKeyFromProto(abciPubKey)
 	require.NoError(t, err)
 	require.Equal(t, pk, pk2)
 	return nil

--- a/types/validator.go
+++ b/types/validator.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/tendermint/tendermint/crypto"
-	ce "github.com/tendermint/tendermint/crypto/encoding"
+	"github.com/tendermint/tendermint/crypto/encoding"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
@@ -114,7 +114,7 @@ func ValidatorListString(vals []*Validator) string {
 // as its redundant with the pubkey. This also excludes ProposerPriority
 // which changes every round.
 func (v *Validator) Bytes() []byte {
-	pk, err := ce.PubKeyToProto(v.PubKey)
+	pk, err := encoding.PubKeyToProto(v.PubKey)
 	if err != nil {
 		panic(err)
 	}
@@ -137,7 +137,7 @@ func (v *Validator) ToProto() (*tmproto.Validator, error) {
 		return nil, errors.New("nil validator")
 	}
 
-	pk, err := ce.PubKeyToProto(v.PubKey)
+	pk, err := encoding.PubKeyToProto(v.PubKey)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func ValidatorFromProto(vp *tmproto.Validator) (*Validator, error) {
 		return nil, errors.New("nil validator")
 	}
 
-	pk, err := ce.PubKeyFromProto(vp.PubKey)
+	pk, err := encoding.PubKeyFromProto(vp.PubKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Note to reviewers:** While this is a large diff, it is a completely trivial change, and mostly mechanically generated.

The code in the Tendermint repository makes heavy use of import aliasing. This is made necessary by our extensive reuse of common base package names, and by repetition of similar names across different subdirectories.

Unfortunately we have not been very consistent about which packages we alias in various circumstances, and the aliases we use vary. In the spirit of the advice in the style guide and https://github.com/golang/go/wiki/CodeReviewComments#imports, this change makes an effort to clean up and normalize import aliasing.

This change makes no API or behavioral changes. It is a pure cleanup intended to help make the code more readable to developers (including myself) trying to understand what is being imported where.

Only unexported names have been modified, and the changes were generated and applied mechanically with gofmt -r and comby, respecting the lexical and syntactic rules of Go.  Even so, I did not fix every inconsistency. Where the changes would be too disruptive, I left it alone.

The principles I followed in this cleanup are:

- Remove aliases that restate the package name.
- Remove aliases where the base package name is unambiguous.
- Move overly-terse abbreviations from the import to the usage site.
- Fix lexical issues (remove underscores, remove capitalization).
- Fix import groupings to more closely match the style guide.
- Group blank (side-effecting) imports and ensure they are commented.
- Add aliases to multiple imports with the same base package name.
