### PR TITLE
tools: clone proto files from spec

### DIFF
--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -196,10 +196,6 @@ message ResponseCheckTx {
   string         codespace  = 8;
   string         sender     = 9;
   int64          priority   = 10;
-
-  // mempool_error is set by Tendermint.
-  // ABCI applictions creating a ResponseCheckTX should not set mempool_error.
-  string mempool_error = 11;
 }
 
 message ResponseDeliverTx {

--- a/proto/tendermint/statesync/types.proto
+++ b/proto/tendermint/statesync/types.proto
@@ -1,9 +1,7 @@
 syntax = "proto3";
 package tendermint.statesync;
 
-import "gogoproto/gogo.proto";
 import "tendermint/types/types.proto";
-import "tendermint/types/params.proto";
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/statesync";
 
@@ -57,6 +55,6 @@ message ParamsRequest {
 }
 
 message ParamsResponse {
-  uint64                           height           = 1;
-  tendermint.types.ConsensusParams consensus_params = 2 [(gogoproto.nullable) = false];
+  uint64 height = 1;
+  tendermint.types.ConsensusParams consensus_params = 2;
 }

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -2,8 +2,28 @@
 
 set -eo pipefail
 
+git clone https://github.com/tendermint/spec.git
+
+cp -vr ./spec/proto/tendermint/** ./proto/tendermint
+
 buf generate --path proto/tendermint
 
 mv ./proto/tendermint/abci/types.pb.go ./abci/types
 
 mv ./proto/tendermint/rpc/grpc/types.pb.go ./rpc/grpc
+
+rm -rf ./proto/tendermint/abci/types.proto
+rm -rf ./proto/tendermint/blocksync/types.proto
+rm -rf ./proto/tendermint/consensus/types.proto
+rm -rf ./proto/tendermint/mempool/types.proto
+rm -rf ./proto/tendermint/p2p/types.proto
+rm -rf ./proto/tendermint/p2p/conn.proto
+rm -rf ./proto/tendermint/p2p/pex.proto
+rm -rf ./proto/tendermint/types/block.proto
+rm -rf ./proto/tendermint/types/evidence.proto
+rm -rf ./proto/tendermint/types/params.proto
+rm -rf ./proto/tendermint/types/types.proto
+rm -rf ./proto/tendermint/types/validator.proto
+rm -rf ./proto/tendermint/version/version.proto
+
+rm -rf ./spec


### PR DESCRIPTION
## Description

clone proto files from spec in order to have them in a single location

