### PR TITLE
e2e: load should be proportional to network

### DIFF
--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -22,6 +22,9 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 	// This also limits the number of TCP connections, since each worker has
 	// a connection to all nodes.
 	concurrency := len(testnet.Nodes) * 8
+	if concurrency > 64 {
+		concurrency = 64
+	}
 
 	chTx := make(chan types.Tx)
 	chSuccess := make(chan int) // success counts per iteration

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -21,10 +21,7 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 	// CPU. This gives high-throughput small networks and low-throughput large ones.
 	// This also limits the number of TCP connections, since each worker has
 	// a connection to all nodes.
-	concurrency := 64 / len(testnet.Nodes)
-	if concurrency == 0 {
-		concurrency = 1
-	}
+	concurrency := len(testnet.Nodes) * 8
 
 	chTx := make(chan types.Tx)
 	chSuccess := make(chan int) // success counts per iteration
@@ -32,7 +29,11 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 	defer cancel()
 
 	// Spawn job generator and processors.
-	logger.Info(fmt.Sprintf("Starting transaction load (%v workers)...", concurrency))
+	logger.Info("starting transaction load",
+		"workers", concurrency,
+		"nodes", len(testnet.Nodes),
+		"tx", testnet.TxSize)
+
 	started := time.Now()
 
 	go loadGenerate(ctx, chTx, testnet.TxSize)
@@ -78,8 +79,8 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 			logger.Info("ending transaction load",
 				"dur_secs", time.Since(started).Seconds(),
 				"txns", success,
-				"rate", rate,
-				"slow", rate < 1)
+				"workers", concurrency,
+				"rate", rate)
 
 			return nil
 		}
@@ -129,8 +130,8 @@ func loadGenerate(ctx context.Context, chTx chan<- types.Tx, size int64) {
 
 func loadGenerateWaitTime(size int64) time.Duration {
 	const (
-		min = int64(100 * time.Millisecond)
-		max = int64(time.Second)
+		min = int64(10 * time.Millisecond)
+		max = int64(100 * time.Millisecond)
 	)
 
 	var (


### PR DESCRIPTION
Historically, the workload in the e2e test suite, was inversely
proportional to the number of nodes in the network (more threads for
smaller networks,) but the generator also has a lot of sleep/rests to
ensure that the workload doesn't overwhlem the network. 

This is all somewhat complicated because the e2e tests all run on a
single system, so no only does the workload have to avoid overwhelming
the capability of a node, but it also has to avoid overwhelming the
capability of the system it's running on, which can be an issue on the
CI infrastrucure.

Also, while the e2e tests need some woarkload to validate that the
network works, the main goal of these tests is to make sure the system
_works_: proving that it's possible generate a workload that can
overwhlem the system is not particularly interesting. As a result,
we've spent a lot of time finding a workload that fits in the context
of our tests. If the workload is too active then the nodes can get
overwhelmed and the network doesn't succeed, and if the worklod is too
small and no transactions land successfully, then the network can fail
as wll.

*Therefore,* this change, attempts to make the workload more
consistent, and have a more rational/predictable model for workload:

- the size of the workload should be proportional to the number of
  nodes in the network

- in general the workload geneator should mostly sleep for jitter
  purposes, and not as a means of controling the size of the workload.