### PR TITLE
e2e: tighten timing for load generation

### DIFF
--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         p2p: ['legacy', 'new', 'hybrid']
-        group: ['00', '01']
+        group: ['00', '01', '02', '03']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -35,7 +35,7 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 2 -d networks/nightly/${{ matrix.p2p }} -p ${{ matrix.p2p }}
+        run: ./build/generator -g 4 -d networks/nightly/${{ matrix.p2p }} -p ${{ matrix.p2p }}
 
       - name: Run ${{ matrix.p2p }} p2p testnets in group ${{ matrix.group }}
         working-directory: test/e2e

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -59,7 +59,7 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 		case <-ctx.Done():
 			if success == 0 {
 				return fmt.Errorf("failed to submit transactions in %s by %d workers",
-					concurrency, time.Since(started))
+					time.Since(started), concurrency)
 			}
 
 			// TODO perhaps allow test networks to

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -3,7 +3,6 @@ package main
 import (
 	"container/ring"
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
 	"time"
@@ -58,19 +57,9 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 		case numSeen := <-chSuccess:
 			success += numSeen
 		case <-ctx.Done():
-			// if we couldn't submit any transactions,
-			// that's probably a problem and the test
-			// should error; however, for very short tests
-			// we shouldn't abort.
-			//
-			// The 5s cut off, is a rough guess based on
-			// the expected value of loadGenerateWaitTime
-			// and typical throughput of the load
-			// generation. If these implementations
-			// changes, then this might also need to
-			// change without more refactoring.
-			if success == 0 && time.Since(started) > 5*time.Second {
-				return errors.New("failed to submit any transactions")
+			if success == 0 {
+				return fmt.Errorf("failed to submit transactions in %s by %d workers",
+					concurrency, time.Since(started))
 			}
 
 			// TODO perhaps allow test networks to

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -112,8 +112,8 @@ func NewCLI() *CLI {
 			// TODO allow the load generator to report
 			// successful transactions to avoid needing
 			// this sleep.
-			if time.Since(startAt) < 15*time.Second {
-				time.Sleep(15*time.Second - time.Since(startAt))
+			if rest := time.Since(startAt); rest < 15*time.Second {
+				time.Sleep(15*time.Second - rest)
 			}
 
 			loadCancel()

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -75,7 +76,7 @@ func NewCLI() *CLI {
 			go func() {
 				chLoadResult <- Load(lctx, cli.testnet)
 			}()
-
+			startAt := time.Now()
 			if err = Start(ctx, cli.testnet); err != nil {
 				return err
 			}
@@ -100,6 +101,19 @@ func NewCLI() *CLI {
 				if err = Wait(ctx, cli.testnet, 5); err != nil { // ensure chain progress
 					return err
 				}
+			}
+
+			// to help make sure that we don't run into
+			// situations where 0 transactions have
+			// happened on quick cases, we make sure that
+			// it's been at least 10s before canceling the
+			// load generator.
+			//
+			// TODO allow the load generator to report
+			// successful transactions to avoid needing
+			// this sleep.
+			if time.Since(startAt) < 15*time.Second {
+				time.Sleep(15*time.Second - time.Since(startAt))
 			}
 
 			loadCancel()


### PR DESCRIPTION
This change: 

- halves the amount of sleep between transactions for single node test
  networks. 

- increases the amount of time allowable for very short test runs (so
  that, e.g. if a network runs for less than 5 seconds, up from 2s,
  not landing transactions isn't an error). 
  
- increases the amount of parallelism in the suite as run in CI.