### PR TITLE
e2e: skip validation of status apphash

### DIFF
--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -44,17 +44,15 @@ func TestApp_Hash(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, info.Response.LastBlockAppHash, "expected app to return app hash")
 
-		status, err := client.Status(ctx)
-		require.NoError(t, err)
-		if info.Response.LastBlockHeight == status.SyncInfo.LatestBlockHeight {
-			require.EqualValues(t, info.Response.LastBlockAppHash, status.SyncInfo.LatestAppHash,
-				"app hash does not match node status")
-		}
-
 		block, err := client.Block(ctx, &info.Response.LastBlockHeight)
 		require.NoError(t, err)
 		require.EqualValues(t, info.Response.LastBlockAppHash, block.Block.AppHash.Bytes(),
 			"app hash does not match last block's app hash")
+
+		status, err := client.Status(ctx)
+		require.NoError(t, err)
+		require.True(t, status.SyncInfo.LatestBlockHeight >= info.Response.LastBlockHeight,
+			"status out of sync with application")
 	})
 }
 


### PR DESCRIPTION
I believe this assertion is likely redundant given that we're checking the block apphash.