### PR TITLE
e2e: do not inject evidence through light proxy

### DIFF
--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -35,7 +35,7 @@ func InjectEvidence(ctx context.Context, testnet *e2e.Testnet, amount int) error
 	for _, idx := range rand.Perm(len(testnet.Nodes)) {
 		targetNode = testnet.Nodes[idx]
 
-		if targetNode.Mode == e2e.ModeSeed {
+		if targetNode.Mode == e2e.ModeSeed || targetNode.Mode == e2e.ModeLight {
 			targetNode = nil
 			continue
 		}


### PR DESCRIPTION
In the last run, there were two problems at the RPC layer returned
from light nodes' RPC end points. I think exercising the light client
proxy RPC system is something that can/should be done via unit
testing, and that likely these errors are (in production) transient
and (in CI) very likely to fail for test environment issues.