### PR TITLE
ci: use smart merges

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        strict: true
+        strict: smart+fasttrack
         commit_message: title+body
   - name: backport patches to v0.34.x branch
     conditions:


### PR DESCRIPTION
This should make it possible to avoid needing to babysit the merge
queue by hand. [see docs](https://docs.mergify.io/actions/merge/#options). 

At some point we should probably opt into using the new(er?)
[queue](https://docs.mergify.io/actions/queue/#queue-action) feature,
but in the mean time this is a good improvement.