### PR TITLE
e2e: add limit and sort to generator

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -165,7 +165,7 @@ func generateTestnet(r *rand.Rand, opt map[string]interface{}) (e2e.Manifest, er
 		case LegacyP2PMode:
 			node.UseLegacyP2P = true
 		case HybridP2PMode:
-			node.UseLegacyP2P = r.Intn(2) == 1
+			node.UseLegacyP2P = r.Intn(5) < 2
 		}
 
 		manifest.Nodes[fmt.Sprintf("seed%02d", i)] = node
@@ -190,7 +190,7 @@ func generateTestnet(r *rand.Rand, opt map[string]interface{}) (e2e.Manifest, er
 		case LegacyP2PMode:
 			node.UseLegacyP2P = true
 		case HybridP2PMode:
-			node.UseLegacyP2P = r.Intn(2) == 1
+			node.UseLegacyP2P = r.Intn(5) < 2
 		}
 
 		manifest.Nodes[name] = node
@@ -227,7 +227,7 @@ func generateTestnet(r *rand.Rand, opt map[string]interface{}) (e2e.Manifest, er
 		case LegacyP2PMode:
 			node.UseLegacyP2P = true
 		case HybridP2PMode:
-			node.UseLegacyP2P = r.Intn(2) == 1
+			node.UseLegacyP2P = r.Intn(5) < 2
 		}
 
 		manifest.Nodes[fmt.Sprintf("full%02d", i)] = node

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -90,6 +90,10 @@ func Generate(r *rand.Rand, opts Options) ([]e2e.Manifest, error) {
 			}
 		}
 
+		if opts.MaxNetworkSize > 0 && len(manifest.Nodes) > opts.MaxNetworkSize {
+			continue
+		}
+
 		manifests = append(manifests, manifest)
 	}
 
@@ -98,9 +102,11 @@ func Generate(r *rand.Rand, opts Options) ([]e2e.Manifest, error) {
 
 type Options struct {
 	MinNetworkSize int
+	MaxNetworkSize int
 	NumGroups      int
 	Directory      string
 	P2P            P2PMode
+	Reverse        bool
 }
 
 type P2PMode string

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -90,7 +90,7 @@ func Generate(r *rand.Rand, opts Options) ([]e2e.Manifest, error) {
 			}
 		}
 
-		if opts.MaxNetworkSize > 0 && len(manifest.Nodes) > opts.MaxNetworkSize {
+		if opts.MaxNetworkSize > 0 && len(manifest.Nodes) >= opts.MaxNetworkSize {
 			continue
 		}
 

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -64,7 +64,7 @@ func NewCLI() *CLI {
 	cli.root.PersistentFlags().StringP("p2p", "p", string(MixedP2PMode),
 		"P2P typology to be generated [\"new\", \"legacy\", \"hybrid\" or \"mixed\" ]")
 	cli.root.PersistentFlags().IntVarP(&cli.opts.MinNetworkSize, "min-size", "", 1, "Minimum Network Size")
-	cli.root.PersistentFlags().IntVarP(&cli.opts.MaxNetworkSize, "max-size", "", 0, "Maxmum Network Size, default is 0 and unlimited")
+	cli.root.PersistentFlags().IntVarP(&cli.opts.MaxNetworkSize, "max-size", "", 0, "Maxmum Network Size, 0 is unlimited")
 
 	return cli
 }

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -63,8 +63,10 @@ func NewCLI() *CLI {
 	cli.root.PersistentFlags().IntVarP(&cli.opts.NumGroups, "groups", "g", 0, "Number of groups")
 	cli.root.PersistentFlags().StringP("p2p", "p", string(MixedP2PMode),
 		"P2P typology to be generated [\"new\", \"legacy\", \"hybrid\" or \"mixed\" ]")
-	cli.root.PersistentFlags().IntVarP(&cli.opts.MinNetworkSize, "min-size", "", 1, "Minimum network size (nodes)")
-	cli.root.PersistentFlags().IntVarP(&cli.opts.MaxNetworkSize, "max-size", "", 0, "Maxmum network size (nodes), 0 is unlimited")
+	cli.root.PersistentFlags().IntVarP(&cli.opts.MinNetworkSize, "min-size", "", 1, 
+					   "Minimum network size (nodes)")
+	cli.root.PersistentFlags().IntVarP(&cli.opts.MaxNetworkSize, "max-size", "", 0, 
+					   "Maxmum network size (nodes), 0 is unlimited")
 
 	return cli
 }

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -63,8 +63,8 @@ func NewCLI() *CLI {
 	cli.root.PersistentFlags().IntVarP(&cli.opts.NumGroups, "groups", "g", 0, "Number of groups")
 	cli.root.PersistentFlags().StringP("p2p", "p", string(MixedP2PMode),
 		"P2P typology to be generated [\"new\", \"legacy\", \"hybrid\" or \"mixed\" ]")
-	cli.root.PersistentFlags().IntVarP(&cli.opts.MinNetworkSize, "min-size", "min", 1, "Minimum Network Size")
-	cli.root.PersistentFlags().IntVarP(&cli.opts.MaxNetworkSize, "max-size", "max", 0, "Maxmum Network Size, default is 0 and unlimited")
+	cli.root.PersistentFlags().IntVarP(&cli.opts.MinNetworkSize, "min-size", "", 1, "Minimum Network Size")
+	cli.root.PersistentFlags().IntVarP(&cli.opts.MaxNetworkSize, "max-size", "", 0, "Maxmum Network Size, default is 0 and unlimited")
 
 	return cli
 }

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -63,8 +63,8 @@ func NewCLI() *CLI {
 	cli.root.PersistentFlags().IntVarP(&cli.opts.NumGroups, "groups", "g", 0, "Number of groups")
 	cli.root.PersistentFlags().StringP("p2p", "p", string(MixedP2PMode),
 		"P2P typology to be generated [\"new\", \"legacy\", \"hybrid\" or \"mixed\" ]")
-	cli.root.PersistentFlags().IntVarP(&cli.opts.MinNetworkSize, "min-size", "", 1, "Minimum Network Size")
-	cli.root.PersistentFlags().IntVarP(&cli.opts.MaxNetworkSize, "max-size", "", 0, "Maxmum Network Size, 0 is unlimited")
+	cli.root.PersistentFlags().IntVarP(&cli.opts.MinNetworkSize, "min-size", "", 1, "Minimum network size (nodes)")
+	cli.root.PersistentFlags().IntVarP(&cli.opts.MaxNetworkSize, "max-size", "", 0, "Maxmum network size (nodes), 0 is unlimited")
 
 	return cli
 }

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -63,10 +63,10 @@ func NewCLI() *CLI {
 	cli.root.PersistentFlags().IntVarP(&cli.opts.NumGroups, "groups", "g", 0, "Number of groups")
 	cli.root.PersistentFlags().StringP("p2p", "p", string(MixedP2PMode),
 		"P2P typology to be generated [\"new\", \"legacy\", \"hybrid\" or \"mixed\" ]")
-	cli.root.PersistentFlags().IntVarP(&cli.opts.MinNetworkSize, "min-size", "", 1, 
-					   "Minimum network size (nodes)")
-	cli.root.PersistentFlags().IntVarP(&cli.opts.MaxNetworkSize, "max-size", "", 0, 
-					   "Maxmum network size (nodes), 0 is unlimited")
+	cli.root.PersistentFlags().IntVarP(&cli.opts.MinNetworkSize, "min-size", "", 1,
+		"Minimum network size (nodes)")
+	cli.root.PersistentFlags().IntVarP(&cli.opts.MaxNetworkSize, "max-size", "", 0,
+		"Maxmum network size (nodes), 0 is unlimited")
 
 	return cli
 }

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -172,8 +172,11 @@ func LoadManifest(file string) (Manifest, error) {
 // SortManifests orders (in-place) a list of manifests such that the
 // manifests will be ordered in terms of complexity (or expected
 // runtime). Complexity is determined first by the number of nodes,
-// and then by the total number of perturbations in the network
-func SortManifests(manifests []Manifest) {
+// and then by the total number of perturbations in the network.
+//
+// If reverse is true, then the manifests are ordered with the most
+// complex networks before the less complex networks.
+func SortManifests(manifests []Manifest, reverse bool) {
 	sort.SliceStable(manifests, func(i, j int) bool {
 		// sort based on a point-based comparison between two
 		// manifests.
@@ -194,22 +197,35 @@ func SortManifests(manifests []Manifest) {
 			leftScore += (len(n.Perturb) * 2)
 
 			if n.StartAt > 0 {
-				leftScore++
+				leftScore += 3
 			}
 		}
 		for _, n := range right.Nodes {
 			rightScore += (len(n.Perturb) * 2)
 			if n.StartAt > 0 {
-				rightScore++
+				rightScore += 3
 			}
 		}
 
 		// add one point if the network has evidence.
 		if left.Evidence > 0 {
+			leftScore += 2
+		}
+
+		if right.Evidence > 0 {
+			rightScore += 2
+		}
+
+		if left.TxSize > right.TxSize {
 			leftScore++
 		}
-		if right.Evidence > 0 {
+
+		if right.TxSize > left.TxSize {
 			rightScore++
+		}
+
+		if reverse {
+			return leftScore >= rightScore
 		}
 
 		return leftScore < rightScore


### PR DESCRIPTION
I observed a couple of problems with the generator in some recent tests: 

- there were a couple of hybrid test cases which did not have any
  legacy nodes (randomness and all.) I change the probability to
  produce more reliable results.

- added options to the generation to be able to add a max (to
  compliment the earlier min) number of nodes for local testing. 

- added an option to support reversing the sort order so "more
  complex" networks were first, as well as tweaked some of the point
  values. 

- this refactored the generators cli parsing to be a bit more clear.