### PR TITLE
e2e: improve chances of statesyncing success

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -327,8 +327,7 @@ func generateNode(
 	if startAt > 0 {
 		node.StateSync = nodeStateSyncs.Choose(r)
 		if manifest.InitialHeight-startAt <= 5 && node.StateSync == e2e.StateSyncDisabled {
-			// avoid needint to blocsync more than five
-			// total blocks.
+			// avoid needing to blocsync more than five total blocks.
 			node.StateSync = uniformSetChoice([]string{
 				e2e.StateSyncP2P,
 				e2e.StateSyncRPC,


### PR DESCRIPTION
This reduces this situation where a node will get stuck block syncing,
which seemed to happen a lot in last nights run.