### PR TITLE
ci: use cheaper codecov data collection

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -89,7 +89,7 @@ jobs:
           go-version: 1.16
       - name: test & coverage report creation
         run: |
-          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 8m -race -coverprofile=${{ matrix.part }}profile.out -covermode=atomic
+          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 8m -race -coverprofile=${{ matrix.part }}profile.out
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -125,7 +125,7 @@ jobs:
           name: "${{ github.sha }}-03-coverage"
         if: env.GIT_DIFF
       - run: |
-          cat ./*profile.out | grep -v "mode: atomic" >> coverage.txt
+          cat ./*profile.out | grep -v "mode: set" >> coverage.txt
         if: env.GIT_DIFF
       - uses: codecov/codecov-action@v2.1.0
         with:

--- a/test/test_cover.sh
+++ b/test/test_cover.sh
@@ -6,7 +6,7 @@ set -e
 
 echo "mode: atomic" > coverage.txt
 for pkg in ${PKGS[@]}; do
-	go test -timeout 5m -race -coverprofile=profile.out -covermode=atomic "$pkg"
+	go test -timeout 5m -race -coverprofile=profile.out "$pkg"
 	if [ -f profile.out ]; then
 		tail -n +2 profile.out >> coverage.txt;
 		rm profile.out


### PR DESCRIPTION
this uses the default "set" method, and avoids the more expensive
atomic counters.