### PR TITLE
p2p: fix race condition in legacy-p2p connection tracking

### DIFF
--- a/internal/p2p/pex/pex_reactor.go
+++ b/internal/p2p/pex/pex_reactor.go
@@ -349,11 +349,10 @@ func (r *Reactor) receiveRequest(src Peer) error {
 // request out for this peer.
 func (r *Reactor) RequestAddrs(p Peer) {
 	id := string(p.ID())
-	if r.requestsSent.Has(id) {
+	if _, exists := r.requestsSent.GetOrSet(id, struct{}{}); exists {
 		return
 	}
 	r.Logger.Debug("Request addrs", "from", p)
-	r.requestsSent.Set(id, struct{}{})
 	p.Send(PexChannel, mustEncode(&tmp2p.PexRequest{}))
 }
 

--- a/internal/p2p/switch.go
+++ b/internal/p2p/switch.go
@@ -432,10 +432,9 @@ func (sw *Switch) stopAndRemovePeer(peer Peer, reason interface{}) {
 //  - ie. if we're getting ErrDuplicatePeer we can stop
 //  	because the addrbook got us the peer back already
 func (sw *Switch) reconnectToPeer(addr *NetAddress) {
-	if sw.reconnecting.Has(string(addr.ID)) {
+	if _, exists := sw.reconnecting.GetOrSet(string(addr.ID), addr); exists {
 		return
 	}
-	sw.reconnecting.Set(string(addr.ID), addr)
 	defer sw.reconnecting.Delete(string(addr.ID))
 
 	start := time.Now()

--- a/libs/cmap/cmap.go
+++ b/libs/cmap/cmap.go
@@ -22,6 +22,20 @@ func (cm *CMap) Set(key string, value interface{}) {
 	cm.l.Unlock()
 }
 
+// GetOrSet returns the existing value if present. Othewise, it stores `newValue` and returns it.
+func (cm *CMap) GetOrSet(key string, newValue interface{}) (value interface{}, alreadyExists bool) {
+
+	cm.l.Lock()
+	defer cm.l.Unlock()
+
+	if v, ok := cm.m[key]; ok {
+		return v, true
+	}
+
+	cm.m[key] = newValue
+	return newValue, false
+}
+
 func (cm *CMap) Get(key string) interface{} {
 	cm.l.Lock()
 	val := cm.m[key]


### PR DESCRIPTION
Closes #7014

Fix race condition described in #7014 by implementing CMap.GetOrSet() (inspired by  [sync.Map.LoadOrStore()](https://pkg.go.dev/sync#Map.LoadOrStore))

