### PR TITLE
e2e: use smaller transactions

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -63,7 +63,7 @@ var (
 		"restart":    0.1,
 	}
 	evidence = uniformChoice{0, 1, 10}
-	txSize   = uniformChoice{1024, 10240} // either 1kb or 10kb
+	txSize   = uniformChoice{1024, 4096} // either 1kb or 4kb
 	ipv6     = uniformChoice{false, true}
 	keyType  = uniformChoice{types.ABCIPubKeyTypeEd25519, types.ABCIPubKeyTypeSecp256k1}
 )


### PR DESCRIPTION
75% of the failures in the last run all ran with the 10kb
transactions. I'd like to dial it back and see if things improve more.