### PR TITLE
Make doc site index default to the latest release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,6 +249,7 @@ The author of the original pull request is responsible for solving the conflicts
 merging the pull request.
 
 #### Creating a backport branch
+
 If this is the first release candidate for a major release, you get to have the honor of creating
 the backport branch!
 
@@ -334,6 +335,14 @@ If there were no release candidates, begin by creating a backport branch, as des
    - `git tag -a v0.35.0 -m 'Release v0.35.0'`
    - `git push origin v0.35.0`
 7. Make sure that `master` is updated with the latest `CHANGELOG.md`, `CHANGELOG_PENDING.md`, and `UPGRADING.md`.
+8. Add the release to the documentation site generator config (see
+   [DOCS_README.md](./docs/DOCS_README.md) for more details. In summary:
+   - Start on branch `master`.
+   - Add a new line at the bottom of [`docs/versions`](./docs/versions) to
+     ensure the newest release is the default for the landing page.
+   - Add a new entry to `themeConfig.versions` in
+     [`docs/.vuepress/config.js`](./docs/.vuepress/config.js) to include the
+	 release in the dropdown versions menu.
 
 #### Minor release (point releases)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,7 +336,7 @@ If there were no release candidates, begin by creating a backport branch, as des
    - `git push origin v0.35.0`
 7. Make sure that `master` is updated with the latest `CHANGELOG.md`, `CHANGELOG_PENDING.md`, and `UPGRADING.md`.
 8. Add the release to the documentation site generator config (see
-   [DOCS_README.md](./docs/DOCS_README.md) for more details. In summary:
+   [DOCS_README.md](./docs/DOCS_README.md) for more details). In summary:
    - Start on branch `master`.
    - Add a new line at the bottom of [`docs/versions`](./docs/versions) to
      ensure the newest release is the default for the landing page.

--- a/Makefile
+++ b/Makefile
@@ -131,11 +131,11 @@ generate_test_cert:
 	# generate server cerificate
 	@certstrap request-cert -cn server -ip 127.0.0.1
 	# self-sign server cerificate with rootCA
-	@certstrap sign server --CA "root CA" 
+	@certstrap sign server --CA "root CA"
 	# generate client cerificate
 	@certstrap request-cert -cn client -ip 127.0.0.1
 	# self-sign client cerificate with rootCA
-	@certstrap sign client --CA "root CA" 
+	@certstrap sign client --CA "root CA"
 .PHONY: generate_test_cert
 
 ###############################################################################
@@ -214,7 +214,7 @@ DESTINATION = ./index.html.md
 build-docs:
 	@cd docs && \
 	while read -r branch path_prefix; do \
-		(git checkout $${branch} && npm install && VUEPRESS_BASE="/$${path_prefix}/" npm run build) ; \
+		(git checkout $${branch} && npm ci && VUEPRESS_BASE="/$${path_prefix}/" npm run build) ; \
 		mkdir -p ~/output/$${path_prefix} ; \
 		cp -r .vuepress/dist/* ~/output/$${path_prefix}/ ; \
 		cp ~/output/$${path_prefix}/index.html ~/output ; \

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -2,10 +2,10 @@
 
 The documentation for Tendermint Core is hosted at:
 
-- <https://docs.tendermint.com/master/>
+- <https://docs.tendermint.com/>
 
-built from the files in this (`/docs`) directory for
-[master](https://github.com/tendermint/tendermint/tree/master/docs) respectively.
+built from the files in this [`docs` directory for `master`](https://github.com/tendermint/tendermint/tree/master/docs)
+and other supported release branches.
 
 ## How It Works
 

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -11,7 +11,7 @@ and other supported release branches.
 
 There is a [GitHub Actions workflow](https://github.com/tendermint/docs/actions/workflows/deployment.yml)
 in the `tendermint/docs` repository that clones and builds the documentation
-site from the contents of this `/docs` directory, for `master` and each
+site from the contents of this `docs` directory, for `master` and for each
 supported release branch. Under the hood, this workflow runs `make build-docs`
 from the [Makefile](../Makefile#L214).
 

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -9,10 +9,20 @@ built from the files in this (`/docs`) directory for
 
 ## How It Works
 
-There is a CircleCI job listening for changes in the `/docs` directory, on both
-the `master` branch. Any updates to files in this directory
-on those branches will automatically trigger a website deployment. Under the hood,
-the private website repository has a `make build-docs` target consumed by a CircleCI job in that repo.
+There is a [GitHub Actions workflow](https://github.com/tendermint/docs/actions/workflows/deployment.yml)
+in the `tendermint/docs` repository that clones and builds the documentation
+site from the contents of this `/docs` directory, for `master` and each
+supported release branch. Under the hood, this workflow runs `make build-docs`
+from the [Makefile](../Makefile).
+
+The list of spuported versions are defined in [`config.js`](./.vuepress/config.js),
+which defines the UI menu on the documentation site, and also in
+[`docs/versions`](./versions), which determines which branches are built.
+
+The last entry in the `docs/versions` file determines which version is linked
+by default from the generated `index.html`. This should generally be the most
+recent release, rather than `master`, so that new users are not confused by
+documentation for unreleased features.
 
 ## README
 

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -15,7 +15,7 @@ site from the contents of this `/docs` directory, for `master` and each
 supported release branch. Under the hood, this workflow runs `make build-docs`
 from the [Makefile](../Makefile).
 
-The list of spuported versions are defined in [`config.js`](./.vuepress/config.js),
+The list of supported versions are defined in [`config.js`](./.vuepress/config.js),
 which defines the UI menu on the documentation site, and also in
 [`docs/versions`](./versions), which determines which branches are built.
 

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -13,7 +13,7 @@ There is a [GitHub Actions workflow](https://github.com/tendermint/docs/actions/
 in the `tendermint/docs` repository that clones and builds the documentation
 site from the contents of this `/docs` directory, for `master` and each
 supported release branch. Under the hood, this workflow runs `make build-docs`
-from the [Makefile](../Makefile).
+from the [Makefile](../Makefile#L214).
 
 The list of supported versions are defined in [`config.js`](./.vuepress/config.js),
 which defines the UI menu on the documentation site, and also in

--- a/docs/versions
+++ b/docs/versions
@@ -1,4 +1,4 @@
+master                  master
 v0.32.x                 v0.32
 v0.33.x                 v0.33
 v0.34.x                 v0.34
-master                  master


### PR DESCRIPTION
Fixes #7017. The essence of the fix is to change the order of lines in `docs/versions`.
In addition:

- Update `docs/DOCS_README.md` to reflect the current state of how we publish the site.
- Fix the `build-docs` target in Makefile to not perturb the package-lock.json during the build.

Despite what the workflow configuration says, the docs repository has not been regularly
publishing updates to the site since the end of July. I will investigate fixing that up separately.