### PR TITLE
.github: remove tessr and bez from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # global owners are only requested if there isn't a more specific
 # codeowner specified below. For this reason, the global codeowners
 # are often repeated in package-level definitions.
-*       @alexanderbez @ebuchman @cmwaters @tessr @tychoish @williambanfield @creachadair
+*      @ebuchman @cmwaters @tychoish @williambanfield @creachadair


### PR DESCRIPTION
with @alexanderbez's blessing, of course.

