### PR TITLE
cli: allow node operator to rollback last state

### DIFF
--- a/cmd/tendermint/commands/reindex_event.go
+++ b/cmd/tendermint/commands/reindex_event.go
@@ -29,11 +29,12 @@ var ReIndexEventCmd = &cobra.Command{
 	Use:   "reindex-event",
 	Short: "reindex events to the event store backends",
 	Long: `
-	reindex-event is an offline tooling to re-index block and tx events to the eventsinks,
-	you can run this command when the event store backend dropped/disconnected or you want to replace the backend.
-	The default start-height is 0, meaning the tooling will start reindex from the base block height(inclusive); and the
-	default end-height is 0, meaning the tooling will reindex until the latest block height(inclusive). User can omits
-	either or both arguments.
+reindex-event is an offline tooling to re-index block and tx events to the eventsinks,
+you can run this command when the event store backend dropped/disconnected or you want to 
+replace the backend. The default start-height is 0, meaning the tooling will start 
+reindex from the base block height(inclusive); and the default end-height is 0, meaning 
+the tooling will reindex until the latest block height(inclusive). User can omit
+either or both arguments.
 	`,
 	Example: `
 	tendermint reindex-event

--- a/cmd/tendermint/commands/rollback.go
+++ b/cmd/tendermint/commands/rollback.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tendermint/tendermint/internal/state"
+	"github.com/tendermint/tendermint/version"
+)
+
+var RollbackStateCmd = &cobra.Command{
+	Use:   "rollback",
+	Short: "rollback tendermint state by one height",
+	Long: `
+rollbacking state should be performed in the event of a non-deterministic app hash where 
+Tendermint has persisted an incorrect app hash and is thus stuck and unable to make 
+progress. By default this will rollback the very last height. Note: this does not remove 
+any blocks from the blockstore, rather alter the state store such that Tendermint can 
+replay blocks from the new starting point.
+`,
+	Example: `
+tendermint rollback
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// use the parsed config to load the block and state store
+		bs, ss, err := loadStateAndBlockStore(config)
+		if err != nil {
+			return err
+		}
+
+		// rollback the last state
+		return rollbackState(bs, ss)
+	},
+}
+
+// rollbackState takes a state at height n and overwrites it with the state
+// at height n - 1. Note state here refers to tendermint state not application state.
+func rollbackState(bs state.BlockStore, ss state.Store) error {
+	invalidState, err := ss.Load()
+	if err != nil {
+		return err
+	}
+
+	rollbackHeight := invalidState.LastBlockHeight
+	rollbackBlock := bs.LoadBlockMeta(rollbackHeight)
+	if rollbackBlock == nil {
+		return fmt.Errorf("block at height %d not found", rollbackHeight)
+	}
+
+	previousValidatorSet, err := ss.LoadValidators(rollbackHeight - 1)
+	if err != nil {
+		return err
+	}
+
+	previousParams, err := ss.LoadConsensusParams(rollbackHeight)
+	if err != nil {
+		return err
+	}
+
+	valChangeHeight := invalidState.LastHeightValidatorsChanged
+	// this can only happen if the validator set changed since the last block
+	if valChangeHeight > rollbackHeight {
+		valChangeHeight = rollbackHeight
+	}
+
+	paramsChangeHeight := invalidState.LastHeightConsensusParamsChanged
+	// this can only happen if params changed from the last block
+	if paramsChangeHeight > rollbackHeight {
+		paramsChangeHeight = rollbackHeight
+	}
+
+	// build the new state from the old state and the prior block
+	newState := state.State{
+		Version: state.Version{
+			Consensus: version.Consensus{
+				Block: version.BlockProtocol,
+				App:   previousParams.Version.AppVersion,
+			},
+			Software: version.TMVersion,
+		},
+		// immutable fields
+		ChainID:       invalidState.ChainID,
+		InitialHeight: invalidState.InitialHeight,
+
+		LastBlockHeight: invalidState.LastBlockHeight - 1,
+		LastBlockID:     rollbackBlock.Header.LastBlockID,
+		LastBlockTime:   rollbackBlock.Header.Time,
+
+		NextValidators:              invalidState.Validators,
+		Validators:                  invalidState.LastValidators,
+		LastValidators:              previousValidatorSet,
+		LastHeightValidatorsChanged: valChangeHeight,
+
+		ConsensusParams:                  previousParams,
+		LastHeightConsensusParamsChanged: paramsChangeHeight,
+
+		LastResultsHash: rollbackBlock.Header.LastResultsHash,
+		AppHash:         rollbackBlock.Header.AppHash,
+	}
+
+	// persist the new state. This overrides the invalid one. NOTE: this will also
+	// persist the validator set and consensus params over the existing structures,
+	// but both should be the same
+	if err := ss.Save(newState); err != nil {
+		return err
+	}
+
+	fmt.Printf("Rolled back state to height %d and hash %v", rollbackHeight, rollbackBlock.Header.AppHash)
+	return nil
+}

--- a/cmd/tendermint/commands/rollback_test.go
+++ b/cmd/tendermint/commands/rollback_test.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tendermint/internal/state"
+	"github.com/tendermint/tendermint/internal/state/mocks"
+	"github.com/tendermint/tendermint/internal/test/factory"
+	"github.com/tendermint/tendermint/types"
+	"github.com/tendermint/tendermint/version"
+)
+
+func TestRollback(t *testing.T) {
+	stateStore := state.NewStore(dbm.NewMemDB())
+	blockStore := &mocks.BlockStore{}
+	var (
+		height     int64  = 100
+		appVersion uint64 = 10
+	)
+
+	valSet, _ := factory.RandValidatorSet(5, 10)
+
+	params := types.DefaultConsensusParams()
+	params.Version.AppVersion = appVersion
+	newParams := types.DefaultConsensusParams()
+	newParams.Block.MaxBytes = 10000
+
+	initialState := state.State{
+		Version: state.Version{
+			Consensus: version.Consensus{
+				Block: version.BlockProtocol,
+				App:   10,
+			},
+			Software: version.TMVersion,
+		},
+		ChainID:                          factory.DefaultTestChainID,
+		InitialHeight:                    10,
+		LastBlockID:                      factory.MakeBlockID(),
+		AppHash:                          factory.RandomHash(),
+		LastResultsHash:                  factory.RandomHash(),
+		LastBlockHeight:                  height,
+		LastValidators:                   valSet,
+		Validators:                       valSet.CopyIncrementProposerPriority(1),
+		NextValidators:                   valSet.CopyIncrementProposerPriority(2),
+		LastHeightValidatorsChanged:      height + 1,
+		ConsensusParams:                  *params,
+		LastHeightConsensusParamsChanged: height + 1,
+	}
+	require.NoError(t, stateStore.Bootstrap(initialState))
+
+	height++
+	block := &types.BlockMeta{
+		Header: types.Header{
+			Height:          height,
+			AppHash:         initialState.AppHash,
+			LastBlockID:     initialState.LastBlockID,
+			LastResultsHash: initialState.LastResultsHash,
+		},
+	}
+	blockStore.On("LoadBlockMeta", height).Return(block)
+
+	appVersion++
+	newParams.Version.AppVersion = appVersion
+	nextState := initialState.Copy()
+	nextState.LastBlockHeight = height
+	nextState.Version.Consensus.App = appVersion
+	nextState.LastBlockID = factory.MakeBlockID()
+	nextState.AppHash = factory.RandomHash()
+	nextState.LastValidators = initialState.Validators
+	nextState.Validators = initialState.NextValidators
+	nextState.NextValidators = initialState.NextValidators.CopyIncrementProposerPriority(1)
+	nextState.ConsensusParams = *newParams
+	nextState.LastHeightConsensusParamsChanged = height + 1
+	nextState.LastHeightValidatorsChanged = height + 1
+
+	// update the state
+	require.NoError(t, stateStore.Save(nextState))
+
+	// rollback the state
+	require.NoError(t, rollbackState(blockStore, stateStore))
+
+	// assert that we've recovered the prior state
+	loadedState, err := stateStore.Load()
+	require.NoError(t, err)
+	require.EqualValues(t, initialState, loadedState)
+}

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -29,6 +29,7 @@ func main() {
 		cmd.GenNodeKeyCmd,
 		cmd.VersionCmd,
 		cmd.InspectCmd,
+		cmd.RollbackStateCmd,
 		cmd.MakeKeyMigrateCommand(),
 		debug.DebugCmd,
 		cli.NewCompletionCmd(rootCmd, true),

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -64,6 +64,8 @@ func VersionFromProto(v tmstate.Version) Version {
 // Instead, use state.Copy() or updateState(...).
 // NOTE: not goroutine-safe.
 type State struct {
+	// FIXME: This can be removed as TMVersion is a constant, and version.Consensus should
+	// eventually be replaced by VersionParams in ConsensusParams
 	Version Version
 
 	// immutable

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tendermint/tendermint/abci/example/code"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/version"
 )
 
@@ -116,6 +117,11 @@ func (app *Application) InitChain(req abci.RequestInitChain) abci.ResponseInitCh
 	}
 	resp := abci.ResponseInitChain{
 		AppHash: app.state.Hash,
+		ConsensusParams: &types.ConsensusParams{
+			Version: &types.VersionParams{
+				AppVersion: 1,
+			},
+		},
 	}
 	if resp.Validators, err = app.validatorUpdates(0); err != nil {
 		panic(err)


### PR DESCRIPTION
Closes: #3845

Adds a simple `tendermint rollback` command which takes a tendermint state at height n and rebuilds the tendermint state at height n-1, overriding the latter state. In order to recover from diverging app hashes, applications need to also be able to rollback their last state as well. This does not remove the block at height n. Upon restart Tendermint will reexecute the transactions at height n against the application.

I thought about adding a `--height` flag which would allow operators to rollback tendermint state to a selected height with which to replay all the transactions again but I think hard coding it to the previous height is sufficient