### PR TITLE
Align atomic struct field for compatibility in 32-bit ABIs.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -25,5 +25,3 @@ Special thanks to external contributors on this release:
 ### IMPROVEMENTS
 
 ### BUG FIXES
-
-- [config] #7036 Update default config template to match mapstructure keys (@creachadair)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -25,3 +25,5 @@ Special thanks to external contributors on this release:
 ### IMPROVEMENTS
 
 ### BUG FIXES
+
+- [config] #7036 Update default config template to match mapstructure keys (@creachadair)

--- a/internal/p2p/conn/connection.go
+++ b/internal/p2p/conn/connection.go
@@ -755,7 +755,7 @@ type Channel struct {
 	// This field must be read atomically.
 	// It is first in the struct to ensure correct alignment.
 	// See https://github.com/tendermint/tendermint/issues/7000.
-	recentlySent  int64
+	recentlySent int64
 
 	conn          *MConnection
 	desc          ChannelDescriptor

--- a/internal/p2p/conn/connection.go
+++ b/internal/p2p/conn/connection.go
@@ -751,13 +751,18 @@ func (chDesc ChannelDescriptor) FillDefaults() (filled ChannelDescriptor) {
 // TODO: lowercase.
 // NOTE: not goroutine-safe.
 type Channel struct {
+	// Exponential moving average.
+	// This field must be read atomically.
+	// It is first in the struct to ensure correct alignment.
+	// See https://github.com/tendermint/tendermint/issues/7000.
+	recentlySent  int64
+
 	conn          *MConnection
 	desc          ChannelDescriptor
 	sendQueue     chan []byte
 	sendQueueSize int32 // atomic.
 	recving       []byte
 	sending       []byte
-	recentlySent  int64 // exponential moving average
 
 	maxPacketMsgPayloadSize int
 

--- a/internal/p2p/conn/connection.go
+++ b/internal/p2p/conn/connection.go
@@ -752,7 +752,7 @@ func (chDesc ChannelDescriptor) FillDefaults() (filled ChannelDescriptor) {
 // NOTE: not goroutine-safe.
 type Channel struct {
 	// Exponential moving average.
-	// This field must be read atomically.
+	// This field must be accessed atomically.
 	// It is first in the struct to ensure correct alignment.
 	// See https://github.com/tendermint/tendermint/issues/7000.
 	recentlySent int64


### PR DESCRIPTION
The layout of struct fields means that interior fields may not be properly
aligned for 64-bit access.

Fixes #7000.

This change seems harmless and doesn't break any APIs.