### PR TITLE
Make ABCI semantic versions match the TM version.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,7 +2,7 @@
 
 Friendly reminder: We have a [bug bounty program](https://hackerone.com/cosmos).
 
-## vX.X
+## vX.Y
 
 Month, DD, YYYY
 
@@ -11,6 +11,7 @@ Special thanks to external contributors on this release:
 ### BREAKING CHANGES
 
 - CLI/RPC/Config
+  - [config] [\#7054] Make ABCI semantic versions match the TM version (@creachadair)
 
   - [rpc] Remove the deprecated gRPC interface to the RPC service. (@creachadair)
   - [blocksync] \#7159 Remove support for disabling blocksync in any circumstance. (@tychoish)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_TAGS?=tendermint
 
 # If building a release, please checkout the version tag to get the correct version setting
 ifneq ($(shell git symbolic-ref -q --short HEAD),)
-VERSION := unreleased-$(shell git symbolic-ref -q --short HEAD)-$(shell git rev-parse HEAD)
+VERSION := v0.0.0-unreleased-$(shell git symbolic-ref -q --short HEAD)-$(shell git rev-parse HEAD)
 else
 VERSION := $(shell git describe)
 endif

--- a/abci/version/version.go
+++ b/abci/version/version.go
@@ -6,4 +6,4 @@ import (
 
 // TODO: eliminate this after some version refactor
 
-const Version = version.ABCIVersion
+var Version = version.ABCIVersion

--- a/version/version.go
+++ b/version/version.go
@@ -3,21 +3,13 @@ package version
 import tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
 
 var (
+	// TMVersion is the semantic version of Tendermint Core.
 	TMVersion = TMVersionDefault
-)
 
-const (
+	// ABCISemVer and ABCIVersion give the semantic version of the ABCI library.
+	ABCISemVer  = TMVersion
+	ABCIVersion = TMVersion
 
-	// TMVersionDefault is the used as the fallback version of Tendermint Core
-	// when not using git describe. It is formatted with semantic versioning.
-	TMVersionDefault = "0.35.0-unreleased"
-	// ABCISemVer is the semantic version of the ABCI library
-	ABCISemVer = "0.17.0"
-
-	ABCIVersion = ABCISemVer
-)
-
-var (
 	// P2PProtocol versions all p2p behavior and msgs.
 	// This includes proposer selection.
 	P2PProtocol uint64 = 8
@@ -26,6 +18,10 @@ var (
 	// This includes validity of blocks and state updates.
 	BlockProtocol uint64 = 11
 )
+
+// TMVersionDefault is the used as the fallback version of Tendermint Core
+// when not using git describe. It is formatted with semantic versioning.
+const TMVersionDefault = "0.34.11"
 
 type Consensus struct {
 	Block uint64 `json:"block"`

--- a/version/version.go
+++ b/version/version.go
@@ -44,11 +44,11 @@ func (c Consensus) ToProto() tmversion.Consensus {
 // version on its major and minor revisions, and does not have a patch version.
 //
 // For example TM "v0.35.11" corresponds to ABCI "v0.35".
-// This function will panic if tmVersion does not have a sensible format.
+// If tmVersion does not have a sensible format, a placeholder is returned.
 func tmToABCIVersion(tmVersion string) string {
 	parts := strings.SplitN(tmVersion, ".", 3)
 	if len(parts) < 2 {
-		panic("invalid semantic version string: " + tmVersion)
+		return tmVersion + "-unknown-abci"
 	}
 	return strings.Join(parts[:2], ".")
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,14 +1,18 @@
 package version
 
-import tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
+import (
+	"strings"
+
+	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
+)
 
 var (
 	// TMVersion is the semantic version of Tendermint Core.
 	TMVersion = TMVersionDefault
 
 	// ABCISemVer and ABCIVersion give the semantic version of the ABCI library.
-	ABCISemVer  = TMVersion
-	ABCIVersion = TMVersion
+	ABCISemVer  = tmToABCIVersion(TMVersion)
+	ABCIVersion = tmToABCIVersion(TMVersion)
 
 	// P2PProtocol versions all p2p behavior and msgs.
 	// This includes proposer selection.
@@ -33,4 +37,18 @@ func (c Consensus) ToProto() tmversion.Consensus {
 		Block: c.Block,
 		App:   c.App,
 	}
+}
+
+// tmToABCIVersion converts a Tendermint semantic version into the
+// corresponding ABCI semantic version. The ABCI version matches the Tendermint
+// version on its major and minor revisions, and does not have a patch version.
+//
+// For example TM "v0.35.11" corresponds to ABCI "v0.35".
+// This function will panic if tmVersion does not have a sensible format.
+func tmToABCIVersion(tmVersion string) string {
+	parts := strings.SplitN(tmVersion, ".", 3)
+	if len(parts) < 2 {
+		panic("invalid semantic version string: " + tmVersion)
+	}
+	return strings.Join(parts[:2], ".")
 }

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 
 // TMVersionDefault is the used as the fallback version of Tendermint Core
 // when not using git describe. It is formatted with semantic versioning.
-const TMVersionDefault = "0.34.11"
+const TMVersionDefault = "v0.35.0-unreleased"
 
 type Consensus struct {
 	Block uint64 `json:"block"`


### PR DESCRIPTION
Since ABCI and Tendermint are built from the same repository, it is no longer
necessary to version them independently. Move the ABCI version constants to be
variables and copy them from the linker-assigned TM version.

Note that the package initialization rules ensure these assignments are
evaluated coherently, https://golang.org/ref/spec#Package_initialization.

Addresses #7053.
