### PR TITLE
ci: fix p2p configuration for e2e tests

### DIFF
--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        p2p: ['legacy', 'new', 'hybrid']
         group: ['00', '01', '02', '03']
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -35,11 +34,11 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 4 -d networks/nightly/${{ matrix.p2p }} -p ${{ matrix.p2p }}
+        run: ./build/generator -g 4 -d networks/nightly/
 
-      - name: Run ${{ matrix.p2p }} p2p testnets in group ${{ matrix.group }}
+      - name: Run ${{ matrix.p2p }} p2p testnets
         working-directory: test/e2e
-        run: ./run-multiple.sh networks/nightly/${{ matrix.p2p }}/*-group${{ matrix.group }}-*.toml
+        run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
 
   e2e-nightly-fail-2:
     needs: e2e-nightly-test-2


### PR DESCRIPTION
My earlier p2p cleanup code removed support for the p2p tests from the
e2e generator and runner, but missed removing the CI
configuration. This patch remedies that.