### PR TITLE
ci: 0.35.x nightly should run from master and checkout the release branch

### DIFF
--- a/.github/workflows/e2e-nightly-35x.yml
+++ b/.github/workflows/e2e-nightly-35x.yml
@@ -26,6 +26,8 @@ jobs:
           go-version: '1.17'
 
       - uses: actions/checkout@v2.3.4
+        with:
+          ref: 'v0.35.x'
 
       - name: Build
         working-directory: test/e2e


### PR DESCRIPTION
Nightly branches run CI from master branch, and the configuration misses checking out the correct ref.