### PR TITLE
light: Update links in package docs.

### DIFF
--- a/light/doc.go
+++ b/light/doc.go
@@ -94,7 +94,7 @@ Check out other examples in example_test.go
 ## 2. Pure functions to verify a new header (see verifier.go)
 
 Verify function verifies a new header against some trusted header. See
-https://github.com/tendermint/spec/blob/master/spec/consensus/light-client/verification.md
+https://github.com/tendermint/spec/blob/master/spec/light-client/verification/README.md
 for details.
 
 There are two methods of verification: sequential and bisection
@@ -118,10 +118,7 @@ as a wrapper, which verifies all the headers, using a light client connected to
 some other node.
 
 See
-https://docs.tendermint.com/master/tendermint-core/light-client-protocol.html
-for usage example.
-Or see
-https://github.com/tendermint/spec/tree/master/spec/consensus/light-client
-for the full spec
+https://github.com/tendermint/spec/tree/master/spec/light-client
+for the light client specification.
 */
 package light


### PR DESCRIPTION
Fixes #7098. The light client documentation moved to the spec repository.

I was not able to figure out what happened to light-client-protocol.md, it was removed in #5252 but no corresponding file exists in the spec repository. Since the spec also discusses the protocol, this change simply links to the spec and removes the non-functional reference.

Alternatively we could link to the top-level [light client doc](https://docs.tendermint.com/master/tendermint-core/light-client.html) if you think that's better.