### PR TITLE
build: Fix build-docker to include the full context.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,13 +227,13 @@ build-docs:
 
 build-docker: build-linux
 	cp $(BUILDDIR)/tendermint DOCKER/tendermint
-	docker build --label=tendermint --tag="tendermint/tendermint" DOCKER
+	docker build --label=tendermint --tag="tendermint/tendermint" -f DOCKER/Dockerfile .
 	rm -rf DOCKER/tendermint
 .PHONY: build-docker
 
 
 ###############################################################################
-###                       Mocks 											###
+###                                Mocks                                    ###
 ###############################################################################
 
 mockery:


### PR DESCRIPTION
Fixes #7068. The build-docker rule relies on being able to run make
build-linux, but did not pull the Makefile into the build context.
There are various ways to fix this, but this was probably the smallest.
