### PR TITLE
Revert temporary patch to buf.yaml.

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -14,6 +14,3 @@ lint:
 breaking:
   use:
     - FILE
-  ignore:
-    # TODO(#7075): Remove after file deletion is merged.
-    - tendermint/rpc


### PR DESCRIPTION
This patch was needed to pass the buf breakage check for the proto file removed
in #7121, but now that master contains the change we no longer need the patch.
