### PR TITLE
e2e: try disabling IPv6 in testnets

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -68,7 +68,7 @@ var (
 	}
 	evidence = uniformChoice{0, 1, 10}
 	txSize   = uniformChoice{1024, 4096} // either 1kb or 4kb
-	ipv6     = uniformChoice{false, true}
+	ipv6     = uniformChoice{false}      // was: {false, true}
 	keyType  = uniformChoice{types.ABCIPubKeyTypeEd25519, types.ABCIPubKeyTypeSecp256k1}
 )
 


### PR DESCRIPTION
We have been seeing a lot of "no route to host" in the logs for testnets on
master, leading to no usable connections. This is an attempt to see whether
avoiding IPv6 helps reduce e2e stalls.
