### PR TITLE
Fix metric cardinality left over from backport.

### DIFF
--- a/internal/p2p/peer.go
+++ b/internal/p2p/peer.go
@@ -261,6 +261,7 @@ func (p *peer) Send(chID byte, msgBytes []byte) bool {
 		labels := []string{
 			"peer_id", string(p.ID()),
 			"chID", fmt.Sprintf("%#x", chID),
+			"message_type", "bytes",
 		}
 		p.metrics.PeerSendBytesTotal.With(labels...).Add(float64(len(msgBytes)))
 	}


### PR DESCRIPTION
One of the patched uses in #7161 missed the message type field,
triggering panic failures from Prometheus.
