### PR TITLE
rpc: Make outgoing WebSocket response buffer size configurable

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -36,6 +36,10 @@ Special thanks to external contributors on this release:
 
 - [cli] [#7033](https://github.com/tendermint/tendermint/pull/7033) Add a `rollback` command to rollback to the previous tendermint state in the event of non-determinstic app hash or reverting an upgrade.
 - [mempool, rpc] \#7041  Add removeTx operation to the RPC layer. (@tychoish)
+- [rpc] \#7159 Add a `max-response-buffer-size` parameter to the `rpc`
+  configuration section to allow node operators control over how many
+  WebSocket-based responses (e.g. events) the node will buffer per connection
+  (@thanethomson)
 
 ### IMPROVEMENTS
 

--- a/config/config.go
+++ b/config/config.go
@@ -543,7 +543,7 @@ func (cfg *RPCConfig) ValidateBasic() error {
 		return errors.New("max-header-bytes can't be negative")
 	}
 	if cfg.MaxResponseBufferSize < minResponseBufferSize {
-		return errors.New(fmt.Sprintf("max-response-buffer-size must be greater than or equal to %d", minResponseBufferSize))
+		return fmt.Errorf("max-response-buffer-size must be greater than or equal to %d", minResponseBufferSize)
 	}
 	return nil
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -231,6 +231,15 @@ max-body-bytes = {{ .RPC.MaxBodyBytes }}
 # Maximum size of request header, in bytes
 max-header-bytes = {{ .RPC.MaxHeaderBytes }}
 
+# The maximum number of outgoing responses the node can buffer for a single
+# WebSocket connection.
+#
+# The lower this value, the less memory will be used, but the higher the
+# likelihood that clients will be disconnected for not being able to read
+# responses fast enough from the WebSocket endpoint. This therefore needs to be
+# tuned for your particular use case.
+max-response-buffer-size = {{ .RPC.MaxResponseBufferSize }}
+
 # The path to a file containing certificate that is used to create the HTTPS server.
 # Might be either absolute path or path related to Tendermint's config directory.
 # If the certificate is signed by a certificate authority,

--- a/node/node.go
+++ b/node/node.go
@@ -769,6 +769,7 @@ func (n *nodeImpl) startRPC() ([]net.Listener, error) {
 	if cfg.WriteTimeout <= n.config.RPC.TimeoutBroadcastTxCommit {
 		cfg.WriteTimeout = n.config.RPC.TimeoutBroadcastTxCommit + 1*time.Second
 	}
+	cfg.MaxResponseBufferSize = n.config.RPC.MaxResponseBufferSize
 
 	// we may expose the rpc over both a unix and tcp socket
 	listeners := make([]net.Listener, len(listenAddrs))
@@ -784,6 +785,7 @@ func (n *nodeImpl) startRPC() ([]net.Listener, error) {
 				}
 			}),
 			rpcserver.ReadLimit(cfg.MaxBodyBytes),
+			rpcserver.WriteChanCapacity(cfg.MaxResponseBufferSize),
 		)
 		wm.SetLogger(wmLogger)
 		mux.HandleFunc("/websocket", wm.WebsocketHandler)

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -32,16 +32,20 @@ type Config struct {
 	MaxBodyBytes int64
 	// mirrors http.Server#MaxHeaderBytes
 	MaxHeaderBytes int
+	// The maximum number of responses that can be buffered for a single
+	// WebSocket connection.
+	MaxResponseBufferSize int
 }
 
 // DefaultConfig returns a default configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		MaxOpenConnections: 0, // unlimited
-		ReadTimeout:        10 * time.Second,
-		WriteTimeout:       10 * time.Second,
-		MaxBodyBytes:       int64(1000000), // 1MB
-		MaxHeaderBytes:     1 << 20,        // same as the net/http default
+		MaxOpenConnections:    0, // unlimited
+		ReadTimeout:           10 * time.Second,
+		WriteTimeout:          10 * time.Second,
+		MaxBodyBytes:          int64(1000000), // 1MB
+		MaxHeaderBytes:        1 << 20,        // same as the net/http default
+		MaxResponseBufferSize: 100,
 	}
 }
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // This file uses the recommended method for tracking developer tools in a go module.


### PR DESCRIPTION
Potentially closes #6729 - I'll update this comment when I've confirmed that this change actually allows us to solve the issue we're facing with ibc-rs.

This PR implements one possible solution to this problem: to make the `writeChanCapacity` parameter for a `wsConnection` configurable. This should allow for tuning of full nodes' capacities to buffer various quantities of events depending on who or what's pulling events via the WebSocket connection.

My current hypothesis is that, if we had to increase this from the default value of 100 to a value of 500 or 1000, we may no longer encounter this issue.