### PR TITLE
Fix spurious crasher in mempool fuzz test.

### DIFF
--- a/test/fuzz/mempool/checktx.go
+++ b/test/fuzz/mempool/checktx.go
@@ -2,6 +2,7 @@ package mempool
 
 import (
 	"context"
+	"testing"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
@@ -25,6 +26,7 @@ func init() {
 	cfg := config.DefaultMempoolConfig()
 	cfg.Broadcast = false
 
+	testing.Init()
 	getMp = func() mempool.Mempool {
 		if mp == nil {
 			mp = mempool.NewTxMempool(

--- a/test/fuzz/mempool/checktx.go
+++ b/test/fuzz/mempool/checktx.go
@@ -2,7 +2,6 @@ package mempool
 
 import (
 	"context"
-	"testing"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
@@ -26,11 +25,10 @@ func init() {
 	cfg := config.DefaultMempoolConfig()
 	cfg.Broadcast = false
 
-	testing.Init()
 	getMp = func() mempool.Mempool {
 		if mp == nil {
 			mp = mempool.NewTxMempool(
-				log.TestingLogger().With("module", "mempool"),
+				log.NewNopLogger(),
 				cfg,
 				appConnMem,
 				0,


### PR DESCRIPTION
We are creating a TestLogger without testing being initialized.
We could either swap to a non-test logger, or initialize testing.
This PR uses a no-op (non-test) logger.

Fixes #7189.