### PR TITLE
consensus: remove stale WAL benchmark

### DIFF
--- a/internal/consensus/wal_test.go
+++ b/internal/consensus/wal_test.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"bytes"
-	"crypto/rand"
 	"path/filepath"
 
 	// "sync"
@@ -207,70 +206,4 @@ func TestWALPeriodicSync(t *testing.T) {
 	if gr != nil {
 		gr.Close()
 	}
-}
-
-/*
-var initOnce sync.Once
-
-func registerInterfacesOnce() {
-	initOnce.Do(func() {
-		var _ = wire.RegisterInterface(
-			struct{ WALMessage }{},
-			wire.ConcreteType{[]byte{}, 0x10},
-		)
-	})
-}
-*/
-
-func nBytes(n int) []byte {
-	buf := make([]byte, n)
-	n, _ = rand.Read(buf)
-	return buf[:n]
-}
-
-func benchmarkWalDecode(b *testing.B, n int) {
-	// registerInterfacesOnce()
-	buf := new(bytes.Buffer)
-	enc := NewWALEncoder(buf)
-
-	data := nBytes(n)
-	if err := enc.Encode(&TimedWALMessage{Msg: data, Time: time.Now().Round(time.Second).UTC()}); err != nil {
-		b.Error(err)
-	}
-
-	encoded := buf.Bytes()
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		buf.Reset()
-		buf.Write(encoded)
-		dec := NewWALDecoder(buf)
-		if _, err := dec.Decode(); err != nil {
-			b.Fatal(err)
-		}
-	}
-	b.ReportAllocs()
-}
-
-func BenchmarkWalDecode512B(b *testing.B) {
-	benchmarkWalDecode(b, 512)
-}
-
-func BenchmarkWalDecode10KB(b *testing.B) {
-	benchmarkWalDecode(b, 10*1024)
-}
-func BenchmarkWalDecode100KB(b *testing.B) {
-	benchmarkWalDecode(b, 100*1024)
-}
-func BenchmarkWalDecode1MB(b *testing.B) {
-	benchmarkWalDecode(b, 1024*1024)
-}
-func BenchmarkWalDecode10MB(b *testing.B) {
-	benchmarkWalDecode(b, 10*1024*1024)
-}
-func BenchmarkWalDecode100MB(b *testing.B) {
-	benchmarkWalDecode(b, 100*1024*1024)
-}
-func BenchmarkWalDecode1GB(b *testing.B) {
-	benchmarkWalDecode(b, 1024*1024*1024)
 }


### PR DESCRIPTION
Closes: #7172

I recognize that this is not a satisfying resolution to this issue,
but I think it makes sense because, these tests have likely not passed
in quite a while. It's also the case that these benchmarks are asking
the question "does encoding performance change for messages of
arbitrary sizes." This isn't a super interesting question (the answer
is yes, because message serialization runtime is always a function of
input size) particularly since our own message encoding is just a thin
wrapper around protocol buffers. I imagine this might have been more
interesting in the past before we switched to using protobufs here,
but the type safety of the generated pb code makes it difficult to
produce a valid message of arbitrary size.