### PR TITLE
ci: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,42 @@ updates:
     labels:
       - T:dependencies
       - S:automerge
+
   - package-ecosystem: npm
     directory: "/docs"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+
+  ###################################
+  ##
+  ## Update All Go Dependencies
+
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: daily
+    target-branch: "master"
+    open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+      - S:automerge
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    target-branch: "v0.34.x"
+    open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+      - S:automerge
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    target-branch: "v0.35.x"
     open-pull-requests-limit: 10
     labels:
       - T:dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,25 +3,21 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
-      time: "11:00"
+      interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+      - S:automerge
   - package-ecosystem: npm
     directory: "/docs"
     schedule:
-      interval: daily
-      time: "11:00"
+      interval: weekly
     open-pull-requests-limit: 10
-    reviewers:
-      - fadeev
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: daily
-      time: "11:00"
     open-pull-requests-limit: 10
-    reviewers:
-      - melekes
-      - tessr
     labels:
       - T:dependencies
+      - S:automerge


### PR DESCRIPTION
I increased the chill of the github actions and NPM/docs dependencies,
and added default automerging of the go dependencies.