### PR TITLE
codeowners: backport master code owners to 0.34.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # global owners are only requested if there isn't a more specific
 # codeowner specified below. For this reason, the global codeowners
 # are often repeated in package-level definitions.
-*       @alexanderbez @cmwaters @ebuchman @marbar3778 @tessr @tychoish
+*      @ebuchman @cmwaters @tychoish @williambanfield @creachadair


### PR DESCRIPTION
Hopefully this will keep things cleaner for the maintenance branches. 
