### PR TITLE
rpc: Add experimental config params to allow for subscription buffer size control (tm v0.34.x)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,13 +2,15 @@
 
 ## v0.34.15
 
-Special thanks to external contributors on this release:
+Special thanks to external contributors on this release: @thanethomson
 
 Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermint).
 
 ### BREAKING CHANGES
 
 - CLI/RPC/Config
+
+  - [config] \#7230 rpc: Add experimental config params to allow for subscription buffer size control (@thanethomson).
 
 - Apps
 

--- a/config/config.go
+++ b/config/config.go
@@ -358,6 +358,15 @@ type RPCConfig struct {
 	// connections may be dropped unnecessarily.
 	WebSocketWriteBufferSize int `mapstructure:"experimental_websocket_write_buffer_size"`
 
+	// If a WebSocket client cannot read fast enough, at present we may
+	// silently drop events instead of generating an error or disconnecting the
+	// client.
+	//
+	// Enabling this parameter will cause the WebSocket connection to be closed
+	// instead if it cannot read fast enough, allowing for greater
+	// predictability in subscription behaviour.
+	CloseOnSlowClient bool `mapstructure:"experimental_close_on_slow_client"`
+
 	// How long to wait for a tx to be committed during /broadcast_tx_commit
 	// WARNING: Using a value larger than 10s will result in increasing the
 	// global HTTP write timeout, which applies to all connections and endpoints.

--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,8 @@ var (
 	defaultNodeKeyPath  = filepath.Join(defaultConfigDir, defaultNodeKeyName)
 	defaultAddrBookPath = filepath.Join(defaultConfigDir, defaultAddrBookName)
 
-	minSubscriptionBufferSize = 100
+	minSubscriptionBufferSize     = 100
+	defaultSubscriptionBufferSize = 1000
 )
 
 // Config defines the top level configuration for a Tendermint node
@@ -416,9 +417,9 @@ func DefaultRPCConfig() *RPCConfig {
 
 		MaxSubscriptionClients:    100,
 		MaxSubscriptionsPerClient: 5,
-		SubscriptionBufferSize:    minSubscriptionBufferSize,
+		SubscriptionBufferSize:    defaultSubscriptionBufferSize,
 		TimeoutBroadcastTxCommit:  10 * time.Second,
-		WebSocketWriteBufferSize:  minSubscriptionBufferSize,
+		WebSocketWriteBufferSize:  defaultSubscriptionBufferSize,
 
 		MaxBodyBytes:   int64(1000000), // 1MB
 		MaxHeaderBytes: 1 << 20,        // same as the net/http default

--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,7 @@ var (
 	defaultAddrBookPath = filepath.Join(defaultConfigDir, defaultAddrBookName)
 
 	minSubscriptionBufferSize     = 100
-	defaultSubscriptionBufferSize = 1000
+	defaultSubscriptionBufferSize = 200
 )
 
 // Config defines the top level configuration for a Tendermint node

--- a/config/config.go
+++ b/config/config.go
@@ -444,10 +444,16 @@ func (cfg *RPCConfig) ValidateBasic() error {
 		return errors.New("max_subscriptions_per_client can't be negative")
 	}
 	if cfg.SubscriptionBufferSize < minSubscriptionBufferSize {
-		return fmt.Errorf("experimental_subscription_buffer_size must be at least %d", minSubscriptionBufferSize)
+		return fmt.Errorf(
+			"experimental_subscription_buffer_size must be >= %d",
+			minSubscriptionBufferSize,
+		)
 	}
 	if cfg.WebSocketWriteBufferSize < cfg.SubscriptionBufferSize {
-		return fmt.Errorf("experimental_websocket_write_buffer_size must be at least the same as experimental_subscription_buffer_size (%d)", cfg.SubscriptionBufferSize)
+		return fmt.Errorf(
+			"experimental_websocket_write_buffer_size must be >= experimental_subscription_buffer_size (%d)",
+			cfg.SubscriptionBufferSize,
+		)
 	}
 	if cfg.TimeoutBroadcastTxCommit < 0 {
 		return errors.New("timeout_broadcast_tx_commit can't be negative")

--- a/config/toml.go
+++ b/config/toml.go
@@ -224,6 +224,15 @@ experimental_subscription_buffer_size = {{ .RPC.SubscriptionBufferSize }}
 # accommodate non-subscription-related RPC responses.
 experimental_websocket_write_buffer_size = {{ .RPC.WebSocketWriteBufferSize }}
 
+# If a WebSocket client cannot read fast enough, at present we may
+# silently drop events instead of generating an error or disconnecting the
+# client.
+#
+# Enabling this experimental parameter will cause the WebSocket connection to
+# be closed instead if it cannot read fast enough, allowing for greater
+# predictability in subscription behaviour.
+experimental_close_on_slow_client = {{ .RPC.CloseOnSlowClient }}
+
 # How long to wait for a tx to be committed during /broadcast_tx_commit.
 # WARNING: Using a value larger than 10s will result in increasing the
 # global HTTP write timeout, which applies to all connections and endpoints.

--- a/config/toml.go
+++ b/config/toml.go
@@ -206,6 +206,12 @@ max_subscription_clients = {{ .RPC.MaxSubscriptionClients }}
 # the estimated # maximum number of broadcast_tx_commit calls per block.
 max_subscriptions_per_client = {{ .RPC.MaxSubscriptionsPerClient }}
 
+# Experimental parameter to specify the maximum number of events a node will
+# buffer, per subscription, before returning an error and closing the
+# subscription. Must be set to at least 100, but higher values will accommodate
+# higher event throughput rates (and will use more memory).
+experimental_subscription_buffer_size = {{ .RPC.SubscriptionBufferSize }}
+
 # How long to wait for a tx to be committed during /broadcast_tx_commit.
 # WARNING: Using a value larger than 10s will result in increasing the
 # global HTTP write timeout, which applies to all connections and endpoints.

--- a/config/toml.go
+++ b/config/toml.go
@@ -212,6 +212,18 @@ max_subscriptions_per_client = {{ .RPC.MaxSubscriptionsPerClient }}
 # higher event throughput rates (and will use more memory).
 experimental_subscription_buffer_size = {{ .RPC.SubscriptionBufferSize }}
 
+# Experimental parameter to specify the maximum number of RPC responses that
+# can be buffered per WebSocket client. If clients cannot read from the
+# WebSocket endpoint fast enough, they will be disconnected, so increasing this
+# parameter may reduce the chances of them being disconnected (but will cause
+# the node to use more memory).
+#
+# Must be at least the same as "experimental_subscription_buffer_size",
+# otherwise connections could be dropped unnecessarily. This value should
+# ideally be somewhat higher than "experimental_subscription_buffer_size" to
+# accommodate non-subscription-related RPC responses.
+experimental_websocket_write_buffer_size = {{ .RPC.WebSocketWriteBufferSize }}
+
 # How long to wait for a tx to be committed during /broadcast_tx_commit.
 # WARNING: Using a value larger than 10s will result in increasing the
 # global HTTP write timeout, which applies to all connections and endpoints.

--- a/evidence/mocks/block_store.go
+++ b/evidence/mocks/block_store.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
+
 	types "github.com/tendermint/tendermint/types"
 )
 

--- a/libs/pubsub/subscription.go
+++ b/libs/pubsub/subscription.go
@@ -12,7 +12,7 @@ var (
 
 	// ErrOutOfCapacity is returned by Err when a client is not pulling messages
 	// fast enough. Note the client's subscription will be terminated.
-	ErrOutOfCapacity = errors.New("client is not pulling messages fast enough")
+	ErrOutOfCapacity = errors.New("internal subscription event buffer is out of capacity")
 )
 
 // A Subscription represents a client subscription for a particular query and

--- a/node/node.go
+++ b/node/node.go
@@ -1090,6 +1090,7 @@ func (n *Node) startRPC() ([]net.Listener, error) {
 				}
 			}),
 			rpcserver.ReadLimit(config.MaxBodyBytes),
+			rpcserver.WriteChanCapacity(n.config.RPC.WebSocketWriteBufferSize),
 		)
 		wm.SetLogger(wmLogger)
 		mux.HandleFunc("/websocket", wm.WebsocketHandler)

--- a/proxy/mocks/app_conn_consensus.go
+++ b/proxy/mocks/app_conn_consensus.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
+
 	abcicli "github.com/tendermint/tendermint/abci/client"
 
 	types "github.com/tendermint/tendermint/abci/types"

--- a/proxy/mocks/app_conn_mempool.go
+++ b/proxy/mocks/app_conn_mempool.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
+
 	abcicli "github.com/tendermint/tendermint/abci/client"
 
 	types "github.com/tendermint/tendermint/abci/types"

--- a/proxy/mocks/client_creator.go
+++ b/proxy/mocks/client_creator.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
+
 	abcicli "github.com/tendermint/tendermint/abci/client"
 )
 

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -11,11 +11,6 @@ import (
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
-const (
-	// Buffer on the Tendermint (server) side to allow some slowness in clients.
-	subBufferSize = 100
-)
-
 // Subscribe for events via WebSocket.
 // More: https://docs.tendermint.com/master/rpc/#/Websocket/subscribe
 func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, error) {
@@ -37,7 +32,7 @@ func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, er
 	subCtx, cancel := context.WithTimeout(ctx.Context(), SubscribeTimeout)
 	defer cancel()
 
-	sub, err := env.EventBus.Subscribe(subCtx, addr, q, subBufferSize)
+	sub, err := env.EventBus.Subscribe(subCtx, addr, q, env.Config.SubscriptionBufferSize)
 	if err != nil {
 		return nil, err
 	}

--- a/state/indexer/block/kv/kv_test.go
+++ b/state/indexer/block/kv/kv_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	db "github.com/tendermint/tm-db"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	blockidxkv "github.com/tendermint/tendermint/state/indexer/block/kv"
 	"github.com/tendermint/tendermint/types"
-	db "github.com/tendermint/tm-db"
 )
 
 func TestBlockIndexer(t *testing.T) {

--- a/state/indexer/block/kv/util.go
+++ b/state/indexer/block/kv/util.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/google/orderedcode"
+
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
 )

--- a/state/indexer/sink/psql/psql.go
+++ b/state/indexer/sink/psql/psql.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"

--- a/state/indexer/sink/psql/psql_test.go
+++ b/state/indexer/sink/psql/psql_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ory/dockertest/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/types"
 

--- a/state/mocks/evidence_pool.go
+++ b/state/mocks/evidence_pool.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
+
 	state "github.com/tendermint/tendermint/state"
 
 	types "github.com/tendermint/tendermint/types"

--- a/state/mocks/store.go
+++ b/state/mocks/store.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
+
 	state "github.com/tendermint/tendermint/state"
 
 	tendermintstate "github.com/tendermint/tendermint/proto/tendermint/state"

--- a/statesync/mocks/state_provider.go
+++ b/statesync/mocks/state_provider.go
@@ -6,6 +6,7 @@ import (
 	context "context"
 
 	mock "github.com/stretchr/testify/mock"
+
 	state "github.com/tendermint/tendermint/state"
 
 	types "github.com/tendermint/tendermint/types"


### PR DESCRIPTION
Follows from #7188 and related to #6729.

The aim here is to provide a short-term workaround for #6729 in the v0.34.x series of Tendermint that allows for tuning of the internal buffer sizes relating to event subscription. The following configuration parameters are introduced in the `[rpc]` section:

```toml
[rpc]

# Experimental parameter to specify the maximum number of events a node will
# buffer, per subscription, before returning an error and closing the
# subscription. Must be set to at least 100, but higher values will accommodate
# higher event throughput rates (and will use more memory).
experimental_subscription_buffer_size = 1000

# Experimental parameter to specify the maximum number of RPC responses that
# can be buffered per WebSocket client. If clients cannot read from the
# WebSocket endpoint fast enough, they will be disconnected, so increasing this
# parameter may reduce the chances of them being disconnected (but will cause
# the node to use more memory).
#
# Must be at least the same as "experimental_subscription_buffer_size",
# otherwise connections could be dropped unnecessarily. This value should
# ideally be somewhat higher than "experimental_subscription_buffer_size" to
# accommodate non-subscription-related RPC responses.
experimental_websocket_write_buffer_size = 1000

# If a WebSocket client cannot read fast enough, at present we may
# silently drop events instead of generating an error or disconnecting the
# client.
#
# Enabling this experimental parameter will cause the WebSocket connection to
# be closed instead if it cannot read fast enough, allowing for greater
# predictability in subscription behaviour.
experimental_close_on_slow_client = false
```
