### PR TITLE
Update tm-db from v0.6.4 to v0.6.5.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -91,7 +91,7 @@ jobs:
           GOTAGS:
         run: |
           cat pkgs.txt.part.${{ matrix.part }} | \
-            xargs go test -tags memdb,goleveldb -mod=readonly \
+            xargs go test -tags memdb,goleveldb,badgerdb -mod=readonly \
                   -timeout 8m -race -coverprofile=${{ matrix.part }}profile.out
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -87,8 +87,12 @@ jobs:
         with:
           go-version: "1.17"
       - name: test & coverage report creation
+        env:
+          GOTAGS:
         run: |
-          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 8m -race -coverprofile=${{ matrix.part }}profile.out
+          cat pkgs.txt.part.${{ matrix.part }} | \
+            xargs go test -tags memdb,goleveldb -mod=readonly \
+                  -timeout 8m -race -coverprofile=${{ matrix.part }}profile.out
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
             go.mod
             go.sum
       - name: install
-        run: make install install_abci
+        run: make TENDERMINT_BUILD_OPTIONS=memdb,goleveldb,badgerdb install install_abci
         if: "env.GIT_DIFF != ''"
       - uses: actions/cache@v2.1.6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
             go.mod
             go.sum
       - name: install
-        run: make TENDERMINT_BUILD_OPTIONS=memdb,goleveldb,badgerdb install install_abci
+        run: make TENDERMINT_BUILD_OPTIONS=memdb,badgerdb install install_abci
         if: "env.GIT_DIFF != ''"
       - uses: actions/cache@v2.1.6
         with:

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ ifeq (cleveldb,$(findstring cleveldb,$(TENDERMINT_BUILD_OPTIONS)))
   BUILD_TAGS += cleveldb
 endif
 
+# handle goleveldb
+ifeq (goleveldb,$(findstring goleveldb,$(TENDERMINT_BUILD_OPTIONS)))
+  BUILD_TAGS += goleveldb
+endif
+
 # handle badgerdb
 ifeq (badgerdb,$(findstring badgerdb,$(TENDERMINT_BUILD_OPTIONS)))
   BUILD_TAGS += badgerdb

--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/abci/example/code"
 	"github.com/tendermint/tendermint/abci/types"
@@ -71,7 +72,7 @@ type Application struct {
 }
 
 func NewApplication() *Application {
-	state := loadState(dbm.NewMemDB())
+	state := loadState(memdb.NewDB())
 	return &Application{state: state}
 }
 

--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/goleveldb"
 
 	"github.com/tendermint/tendermint/abci/example/code"
 	"github.com/tendermint/tendermint/abci/types"
@@ -37,7 +37,7 @@ type PersistentKVStoreApplication struct {
 
 func NewPersistentKVStoreApplication(dbDir string) *PersistentKVStoreApplication {
 	name := "kvstore"
-	db, err := dbm.NewGoLevelDB(name, dbDir)
+	db, err := goleveldb.NewDB(name, dbDir)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/tendermint/commands/light.go
+++ b/cmd/tendermint/commands/light.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/goleveldb"
 
 	"github.com/tendermint/tendermint/libs/log"
 	tmmath "github.com/tendermint/tendermint/libs/math"
@@ -114,7 +116,7 @@ func runProxy(cmd *cobra.Command, args []string) error {
 		witnessesAddrs = strings.Split(witnessAddrsJoined, ",")
 	}
 
-	lightDB, err := dbm.NewGoLevelDB("light-client-db", dir)
+	lightDB, err := goleveldb.NewDB("light-client-db", dir)
 	if err != nil {
 		return fmt.Errorf("can't create a db: %w", err)
 	}

--- a/cmd/tendermint/commands/reindex_event.go
+++ b/cmd/tendermint/commands/reindex_event.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/metadb"
 
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmcfg "github.com/tendermint/tendermint/config"
@@ -30,9 +31,9 @@ var ReIndexEventCmd = &cobra.Command{
 	Short: "reindex events to the event store backends",
 	Long: `
 reindex-event is an offline tooling to re-index block and tx events to the eventsinks,
-you can run this command when the event store backend dropped/disconnected or you want to 
-replace the backend. The default start-height is 0, meaning the tooling will start 
-reindex from the base block height(inclusive); and the default end-height is 0, meaning 
+you can run this command when the event store backend dropped/disconnected or you want to
+replace the backend. The default start-height is 0, meaning the tooling will start
+reindex from the base block height(inclusive); and the default end-height is 0, meaning
 the tooling will reindex until the latest block height(inclusive). User can omit
 either or both arguments.
 	`,
@@ -130,17 +131,17 @@ func loadEventSinks(cfg *tmcfg.Config) ([]indexer.EventSink, error) {
 }
 
 func loadStateAndBlockStore(cfg *tmcfg.Config) (*store.BlockStore, state.Store, error) {
-	dbType := dbm.BackendType(cfg.DBBackend)
+	dbType := metadb.BackendType(cfg.DBBackend)
 
 	// Get BlockStore
-	blockStoreDB, err := dbm.NewDB("blockstore", dbType, cfg.DBDir())
+	blockStoreDB, err := metadb.NewDB("blockstore", dbType, cfg.DBDir())
 	if err != nil {
 		return nil, nil, err
 	}
 	blockStore := store.NewBlockStore(blockStoreDB)
 
 	// Get StateStore
-	stateDB, err := dbm.NewDB("state", dbType, cfg.DBDir())
+	stateDB, err := metadb.NewDB("state", dbType, cfg.DBDir())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/config/db.go
+++ b/config/db.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/metadb"
 
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/libs/service"
@@ -22,6 +23,6 @@ type DBProvider func(*DBContext) (dbm.DB, error)
 // DefaultDBProvider returns a database using the DBBackend and DBDir
 // specified in the Config.
 func DefaultDBProvider(ctx *DBContext) (dbm.DB, error) {
-	dbType := dbm.BackendType(ctx.Config.DBBackend)
-	return dbm.NewDB(ctx.ID, dbType, ctx.Config.DBDir())
+	dbType := metadb.BackendType(ctx.Config.DBBackend)
+	return metadb.NewDB(ctx.ID, dbType, ctx.Config.DBDir())
 }

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
-	github.com/tendermint/tm-db v0.6.4
+	github.com/tendermint/tm-db v0.6.5
 	github.com/vektra/mockery/v2 v2.9.4
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/net v0.0.0-20211005001312-d4b1ae081e3b

--- a/go.sum
+++ b/go.sum
@@ -62,7 +62,6 @@ github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
@@ -79,7 +78,6 @@ github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXG
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1 h1:VlW4R6jmBIv3/u1JNlawEvJMM4J+dPORPaZasQee8Us=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
@@ -215,12 +213,9 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/denis-tingajkin/go-header v0.4.2 h1:jEeSF4sdv8/3cT/WY8AgDHUoItNSoEZ7qg9dX7pc218=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
-github.com/dgraph-io/badger/v2 v2.2007.2 h1:EjjK0KqwaFMlPin1ajhP943VPENHJdEz1KLIegjaI3k=
-github.com/dgraph-io/badger/v2 v2.2007.2/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
-github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
+github.com/dgraph-io/badger/v2 v2.2007.3/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -228,7 +223,6 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -248,11 +242,8 @@ github.com/esimonov/ifshort v1.0.3 h1:JD6x035opqGec5fZ0TLjXeROD2p5H7oLGn8MKfy9HT
 github.com/esimonov/ifshort v1.0.3/go.mod h1:yZqNJUrNn20K8Q9n2CrjTKYyVEmX209Hgu+M1LBpeZE=
 github.com/ettle/strcase v0.1.1 h1:htFueZyVeE1XNnMEfbqp5r67qAN/4r6ya1ysq8Q+Zcw=
 github.com/ettle/strcase v0.1.1/go.mod h1:hzDLsPC7/lwKyBOywSHEP89nt2pDgdy+No1NBA9o9VY=
-github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 h1:0JZ+dUmQeA8IIVUMzysrX4/AKuQwWhV2dYQuPZdvdSQ=
 github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51/go.mod h1:Yg+htXGokKKdzcwhuNDwVvN+uBxDGXJ7G/VN1d8fa64=
-github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
-github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 h1:E2s37DuLxFhQDg5gKsWoLBOB0n+ZW8s599zru8FJ2/Y=
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
@@ -555,7 +546,6 @@ github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af/go.mod 
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -897,7 +887,6 @@ github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
@@ -950,10 +939,9 @@ github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca h1:Ld/zXl5t4+D6
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b h1:HxLVTlqcHhFAz3nWUcuvpH7WuOMv8LQoCWmruLfFH2U=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
-github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzHWCjJB1zZfXPIAaDpzXIEJ0eS6B5Ok=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
-github.com/tendermint/tm-db v0.6.4 h1:3N2jlnYQkXNQclQwd/eKV/NzlqPlfK21cpRRIx80XXQ=
-github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
+github.com/tendermint/tm-db v0.6.5 h1:vWv/FRqi14AKmW0tbpoPKUv47/LdsZgxdHHIyiO79wA=
+github.com/tendermint/tm-db v0.6.5/go.mod h1:hnkblbtGOQtt6hsFY2zLLgwJ4inOeYbcIeaWDAAP46k=
 github.com/tenntenn/modver v1.0.1 h1:2klLppGhDgzJrScMpkj9Ujy3rXPUspSjAcev9tSEBgA=
 github.com/tenntenn/modver v1.0.1/go.mod h1:bePIyQPb7UeioSRkw3Q0XeMhYZSMx9B8ePqg6SAMGH0=
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpRQGxTSkNYKJ51yaw6ChIqO+Je8UqsTKN/cDag=
@@ -1013,8 +1001,7 @@ github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxt
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
-go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
-go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
+go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd v0.0.0-20200513171258-e048e166ab9c/go.mod h1:xCI7ZzBfRuGgBXyXO6yfWfDmlWd35khcWpUa4L0xI/k=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
@@ -1256,6 +1243,7 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
@@ -78,6 +79,7 @@ github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXG
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1 h1:VlW4R6jmBIv3/u1JNlawEvJMM4J+dPORPaZasQee8Us=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
@@ -213,9 +215,12 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/denis-tingajkin/go-header v0.4.2 h1:jEeSF4sdv8/3cT/WY8AgDHUoItNSoEZ7qg9dX7pc218=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
+github.com/dgraph-io/badger/v2 v2.2007.3 h1:Sl9tQWz92WCbVSe8pj04Tkqlm2boW+KAxd+XSs58SQI=
 github.com/dgraph-io/badger/v2 v2.2007.3/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -223,6 +228,7 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -242,8 +248,11 @@ github.com/esimonov/ifshort v1.0.3 h1:JD6x035opqGec5fZ0TLjXeROD2p5H7oLGn8MKfy9HT
 github.com/esimonov/ifshort v1.0.3/go.mod h1:yZqNJUrNn20K8Q9n2CrjTKYyVEmX209Hgu+M1LBpeZE=
 github.com/ettle/strcase v0.1.1 h1:htFueZyVeE1XNnMEfbqp5r67qAN/4r6ya1ysq8Q+Zcw=
 github.com/ettle/strcase v0.1.1/go.mod h1:hzDLsPC7/lwKyBOywSHEP89nt2pDgdy+No1NBA9o9VY=
+github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 h1:0JZ+dUmQeA8IIVUMzysrX4/AKuQwWhV2dYQuPZdvdSQ=
 github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51/go.mod h1:Yg+htXGokKKdzcwhuNDwVvN+uBxDGXJ7G/VN1d8fa64=
+github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
+github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 h1:E2s37DuLxFhQDg5gKsWoLBOB0n+ZW8s599zru8FJ2/Y=
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
@@ -546,6 +555,7 @@ github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af/go.mod 
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -887,6 +897,7 @@ github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
@@ -939,6 +950,7 @@ github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca h1:Ld/zXl5t4+D6
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b h1:HxLVTlqcHhFAz3nWUcuvpH7WuOMv8LQoCWmruLfFH2U=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
+github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzHWCjJB1zZfXPIAaDpzXIEJ0eS6B5Ok=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
 github.com/tendermint/tm-db v0.6.5 h1:vWv/FRqi14AKmW0tbpoPKUv47/LdsZgxdHHIyiO79wA=
 github.com/tendermint/tm-db v0.6.5/go.mod h1:hnkblbtGOQtt6hsFY2zLLgwJ4inOeYbcIeaWDAAP46k=
@@ -1001,6 +1013,7 @@ github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxt
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
+go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd v0.0.0-20200513171258-e048e166ab9c/go.mod h1:xCI7ZzBfRuGgBXyXO6yfWfDmlWd35khcWpUa4L0xI/k=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=

--- a/internal/blocksync/reactor_test.go
+++ b/internal/blocksync/reactor_test.go
@@ -6,7 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -101,8 +102,8 @@ func (rts *reactorTestSuite) addNode(t *testing.T,
 	rts.app[nodeID] = proxy.NewAppConns(abciclient.NewLocalCreator(&abci.BaseApplication{}), proxy.NopMetrics())
 	require.NoError(t, rts.app[nodeID].Start())
 
-	blockDB := dbm.NewMemDB()
-	stateDB := dbm.NewMemDB()
+	blockDB := memdb.NewDB()
+	stateDB := memdb.NewDB()
 	stateStore := sm.NewStore(stateDB)
 	blockStore := store.NewBlockStore(blockDB)
 

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -10,7 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -44,7 +45,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	for i := 0; i < nValidators; i++ {
 		func() {
 			logger := consensusLogger().With("test", "byzantine", "validator", i)
-			stateDB := dbm.NewMemDB() // each state needs its own db
+			stateDB := memdb.NewDB() // each state needs its own db
 			stateStore := sm.NewStore(stateDB)
 			state, err := sm.MakeGenesisState(genDoc)
 			require.NoError(t, err)
@@ -60,7 +61,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			vals := types.TM2PB.ValidatorUpdates(state.Validators)
 			app.InitChain(abci.RequestInitChain{Validators: vals})
 
-			blockDB := dbm.NewMemDB()
+			blockDB := memdb.NewDB()
 			blockStore := store.NewBlockStore(blockDB)
 
 			// one for mempool, one for consensus
@@ -80,7 +81,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			}
 
 			// Make a full instance of the evidence pool
-			evidenceDB := dbm.NewMemDB()
+			evidenceDB := memdb.NewDB()
 			evpool, err := evidence.NewPool(logger.With("module", "evidence"), evidenceDB, stateStore, blockStore)
 			require.NoError(t, err)
 

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -13,7 +13,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
@@ -403,7 +404,7 @@ func newStateWithConfig(
 	pv types.PrivValidator,
 	app abci.Application,
 ) *State {
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	return newStateWithConfigAndBlockStore(thisConfig, state, pv, app, blockStore)
 }
 
@@ -435,7 +436,7 @@ func newStateWithConfigAndBlockStore(
 	evpool := sm.EmptyEvidencePool{}
 
 	// Make State
-	stateDB := dbm.NewMemDB()
+	stateDB := memdb.NewDB()
 	stateStore := sm.NewStore(stateDB)
 	if err := stateStore.Save(state); err != nil { // for save height 1's validators info
 		panic(err)
@@ -736,7 +737,7 @@ func randConsensusState(
 	configRootDirs := make([]string, 0, nValidators)
 
 	for i := 0; i < nValidators; i++ {
-		blockStore := store.NewBlockStore(dbm.NewMemDB()) // each state needs its own db
+		blockStore := store.NewBlockStore(memdb.NewDB()) // each state needs its own db
 		state, err := sm.MakeGenesisState(genDoc)
 		require.NoError(t, err)
 		thisConfig, err := ResetConfig(fmt.Sprintf("%s_%d", testName, i))

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -10,7 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/abci/example/code"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -126,8 +127,8 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 	config := configSetup(t)
 
 	state, privVals := randGenesisState(config, 1, false, 10)
-	stateStore := sm.NewStore(dbm.NewMemDB())
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	stateStore := sm.NewStore(memdb.NewDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], NewCounterApplication(), blockStore)
 	err := stateStore.Save(state)
 	require.NoError(t, err)
@@ -153,8 +154,8 @@ func TestMempoolRmBadTx(t *testing.T) {
 
 	state, privVals := randGenesisState(config, 1, false, 10)
 	app := NewCounterApplication()
-	stateStore := sm.NewStore(dbm.NewMemDB())
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	stateStore := sm.NewStore(memdb.NewDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], app, blockStore)
 	err := stateStore.Save(state)
 	require.NoError(t, err)

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -12,7 +12,8 @@ import (
 	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
@@ -329,7 +330,7 @@ func TestReactorWithEvidence(t *testing.T) {
 	logger := consensusLogger()
 
 	for i := 0; i < n; i++ {
-		stateDB := dbm.NewMemDB() // each state needs its own db
+		stateDB := memdb.NewDB() // each state needs its own db
 		stateStore := sm.NewStore(stateDB)
 		state, err := sm.MakeGenesisState(genDoc)
 		require.NoError(t, err)
@@ -344,7 +345,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		app.InitChain(abci.RequestInitChain{Validators: vals})
 
 		pv := privVals[i]
-		blockDB := dbm.NewMemDB()
+		blockDB := memdb.NewDB()
 		blockStore := store.NewBlockStore(blockDB)
 
 		// one for mempool, one for consensus

--- a/internal/consensus/replay_file.go
+++ b/internal/consensus/replay_file.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/metadb"
 
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/proxy"
@@ -287,16 +287,16 @@ func (pb *playback) replayConsoleLoop() int {
 
 // convenience for replay mode
 func newConsensusStateForReplay(cfg config.BaseConfig, csConfig *config.ConsensusConfig) *State {
-	dbType := dbm.BackendType(cfg.DBBackend)
+	dbType := metadb.BackendType(cfg.DBBackend)
 	// Get BlockStore
-	blockStoreDB, err := dbm.NewDB("blockstore", dbType, cfg.DBDir())
+	blockStoreDB, err := metadb.NewDB("blockstore", dbType, cfg.DBDir())
 	if err != nil {
 		tmos.Exit(err.Error())
 	}
 	blockStore := store.NewBlockStore(blockStoreDB)
 
 	// Get State
-	stateDB, err := dbm.NewDB("state", dbType, cfg.DBDir())
+	stateDB, err := metadb.NewDB("state", dbType, cfg.DBDir())
 	if err != nil {
 		tmos.Exit(err.Error())
 	}

--- a/internal/consensus/wal_generator.go
+++ b/internal/consensus/wal_generator.go
@@ -11,7 +11,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
@@ -51,7 +52,7 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to read genesis file: %w", err)
 	}
-	blockStoreDB := dbm.NewMemDB()
+	blockStoreDB := memdb.NewDB()
 	stateDB := blockStoreDB
 	stateStore := sm.NewStore(stateDB)
 	state, err := sm.MakeGenesisState(genDoc)

--- a/internal/evidence/pool_test.go
+++ b/internal/evidence/pool_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/internal/evidence"
 	"github.com/tendermint/tendermint/internal/evidence/mocks"
@@ -34,7 +35,7 @@ func TestEvidencePoolBasic(t *testing.T) {
 	var (
 		height     = int64(1)
 		stateStore = &smmocks.Store{}
-		evidenceDB = dbm.NewMemDB()
+		evidenceDB = memdb.NewDB()
 		blockStore = &mocks.BlockStore{}
 	)
 
@@ -92,7 +93,7 @@ func TestAddExpiredEvidence(t *testing.T) {
 		val                 = types.NewMockPV()
 		height              = int64(30)
 		stateStore          = initializeValidatorState(t, val, height)
-		evidenceDB          = dbm.NewMemDB()
+		evidenceDB          = memdb.NewDB()
 		blockStore          = &mocks.BlockStore{}
 		expiredEvidenceTime = time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
 		expiredHeight       = int64(2)
@@ -292,7 +293,7 @@ func TestLightClientAttackEvidenceLifecycle(t *testing.T) {
 	blockStore.On("LoadBlockCommit", height).Return(trusted.Commit)
 	blockStore.On("LoadBlockCommit", commonHeight).Return(common.Commit)
 
-	pool, err := evidence.NewPool(log.TestingLogger(), dbm.NewMemDB(), stateStore, blockStore)
+	pool, err := evidence.NewPool(log.TestingLogger(), memdb.NewDB(), stateStore, blockStore)
 	require.NoError(t, err)
 
 	hash := ev.Hash()
@@ -329,13 +330,13 @@ func TestRecoverPendingEvidence(t *testing.T) {
 	height := int64(10)
 	val := types.NewMockPV()
 	valAddress := val.PrivKey.PubKey().Address()
-	evidenceDB := dbm.NewMemDB()
+	evidenceDB := memdb.NewDB()
 	stateStore := initializeValidatorState(t, val, height)
 
 	state, err := stateStore.Load()
 	require.NoError(t, err)
 
-	blockStore := initializeBlockStore(dbm.NewMemDB(), state, valAddress)
+	blockStore := initializeBlockStore(memdb.NewDB(), state, valAddress)
 
 	// create previous pool and populate it
 	pool, err := evidence.NewPool(log.TestingLogger(), evidenceDB, stateStore, blockStore)
@@ -386,7 +387,7 @@ func TestRecoverPendingEvidence(t *testing.T) {
 }
 
 func initializeStateFromValidatorSet(t *testing.T, valSet *types.ValidatorSet, height int64) sm.Store {
-	stateDB := dbm.NewMemDB()
+	stateDB := memdb.NewDB()
 	stateStore := sm.NewStore(stateDB)
 	state := sm.State{
 		ChainID:                     evidenceChainID,
@@ -466,10 +467,10 @@ func makeCommit(height int64, valAddr []byte) *types.Commit {
 func defaultTestPool(t *testing.T, height int64) (*evidence.Pool, types.MockPV) {
 	val := types.NewMockPV()
 	valAddress := val.PrivKey.PubKey().Address()
-	evidenceDB := dbm.NewMemDB()
+	evidenceDB := memdb.NewDB()
 	stateStore := initializeValidatorState(t, val, height)
 	state, _ := stateStore.Load()
-	blockStore := initializeBlockStore(dbm.NewMemDB(), state, valAddress)
+	blockStore := initializeBlockStore(memdb.NewDB(), state, valAddress)
 
 	pool, err := evidence.NewPool(log.TestingLogger(), evidenceDB, stateStore, blockStore)
 	require.NoError(t, err, "test evidence pool could not be created")

--- a/internal/evidence/reactor_test.go
+++ b/internal/evidence/reactor_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/tmhash"
@@ -70,7 +70,7 @@ func setup(t *testing.T, stateStores []sm.Store, chBuf uint) *reactorTestSuite {
 	evidenceTime := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
 	for nodeID := range rts.network.Nodes {
 		logger := rts.logger.With("validator", idx)
-		evidenceDB := dbm.NewMemDB()
+		evidenceDB := memdb.NewDB()
 		blockStore := &mocks.BlockStore{}
 		state, _ := stateStores[idx].Load()
 		blockStore.On("LoadBlockMeta", mock.AnythingOfType("int64")).Return(func(h int64) *types.BlockMeta {

--- a/internal/evidence/verify_test.go
+++ b/internal/evidence/verify_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/tmhash"
@@ -90,7 +90,7 @@ func TestVerify_LunaticAttackAgainstState(t *testing.T) {
 	blockStore.On("LoadBlockMeta", height).Return(&types.BlockMeta{Header: *trusted.Header})
 	blockStore.On("LoadBlockCommit", commonHeight).Return(common.Commit)
 	blockStore.On("LoadBlockCommit", height).Return(trusted.Commit)
-	pool, err := evidence.NewPool(log.TestingLogger(), dbm.NewMemDB(), stateStore, blockStore)
+	pool, err := evidence.NewPool(log.TestingLogger(), memdb.NewDB(), stateStore, blockStore)
 	require.NoError(t, err)
 
 	evList := types.EvidenceList{ev}
@@ -112,20 +112,20 @@ func TestVerify_LunaticAttackAgainstState(t *testing.T) {
 
 	// duplicate evidence should be rejected
 	evList = types.EvidenceList{ev, ev}
-	pool, err = evidence.NewPool(log.TestingLogger(), dbm.NewMemDB(), stateStore, blockStore)
+	pool, err = evidence.NewPool(log.TestingLogger(), memdb.NewDB(), stateStore, blockStore)
 	require.NoError(t, err)
 	assert.Error(t, pool.CheckEvidence(evList))
 
 	// If evidence is submitted with an altered timestamp it should return an error
 	ev.Timestamp = defaultEvidenceTime.Add(1 * time.Minute)
-	pool, err = evidence.NewPool(log.TestingLogger(), dbm.NewMemDB(), stateStore, blockStore)
+	pool, err = evidence.NewPool(log.TestingLogger(), memdb.NewDB(), stateStore, blockStore)
 	require.NoError(t, err)
 	assert.Error(t, pool.AddEvidence(ev))
 	ev.Timestamp = defaultEvidenceTime
 
 	// Evidence submitted with a different validator power should fail
 	ev.TotalVotingPower = 1
-	pool, err = evidence.NewPool(log.TestingLogger(), dbm.NewMemDB(), stateStore, blockStore)
+	pool, err = evidence.NewPool(log.TestingLogger(), memdb.NewDB(), stateStore, blockStore)
 	require.NoError(t, err)
 	assert.Error(t, pool.AddEvidence(ev))
 	ev.TotalVotingPower = common.ValidatorSet.TotalVotingPower()
@@ -166,7 +166,7 @@ func TestVerify_ForwardLunaticAttack(t *testing.T) {
 	blockStore.On("LoadBlockCommit", commonHeight).Return(common.Commit)
 	blockStore.On("LoadBlockCommit", nodeHeight).Return(trusted.Commit)
 	blockStore.On("Height").Return(nodeHeight)
-	pool, err := evidence.NewPool(log.TestingLogger(), dbm.NewMemDB(), stateStore, blockStore)
+	pool, err := evidence.NewPool(log.TestingLogger(), memdb.NewDB(), stateStore, blockStore)
 	require.NoError(t, err)
 
 	// check that the evidence pool correctly verifies the evidence
@@ -184,7 +184,7 @@ func TestVerify_ForwardLunaticAttack(t *testing.T) {
 	oldBlockStore.On("Height").Return(nodeHeight)
 	require.Equal(t, defaultEvidenceTime, oldBlockStore.LoadBlockMeta(nodeHeight).Header.Time)
 
-	pool, err = evidence.NewPool(log.TestingLogger(), dbm.NewMemDB(), stateStore, oldBlockStore)
+	pool, err = evidence.NewPool(log.TestingLogger(), memdb.NewDB(), stateStore, oldBlockStore)
 	require.NoError(t, err)
 	assert.Error(t, pool.CheckEvidence(types.EvidenceList{ev}))
 }
@@ -272,7 +272,7 @@ func TestVerifyLightClientAttack_Equivocation(t *testing.T) {
 	blockStore.On("LoadBlockMeta", int64(10)).Return(&types.BlockMeta{Header: *trustedHeader})
 	blockStore.On("LoadBlockCommit", int64(10)).Return(trustedCommit)
 
-	pool, err := evidence.NewPool(log.TestingLogger(), dbm.NewMemDB(), stateStore, blockStore)
+	pool, err := evidence.NewPool(log.TestingLogger(), memdb.NewDB(), stateStore, blockStore)
 	require.NoError(t, err)
 
 	evList := types.EvidenceList{ev}
@@ -358,7 +358,7 @@ func TestVerifyLightClientAttack_Amnesia(t *testing.T) {
 	blockStore.On("LoadBlockMeta", int64(10)).Return(&types.BlockMeta{Header: *trustedHeader})
 	blockStore.On("LoadBlockCommit", int64(10)).Return(trustedCommit)
 
-	pool, err := evidence.NewPool(log.TestingLogger(), dbm.NewMemDB(), stateStore, blockStore)
+	pool, err := evidence.NewPool(log.TestingLogger(), memdb.NewDB(), stateStore, blockStore)
 	require.NoError(t, err)
 
 	evList := types.EvidenceList{ev}
@@ -450,7 +450,7 @@ func TestVerifyDuplicateVoteEvidence(t *testing.T) {
 	blockStore := &mocks.BlockStore{}
 	blockStore.On("LoadBlockMeta", int64(10)).Return(&types.BlockMeta{Header: types.Header{Time: defaultEvidenceTime}})
 
-	pool, err := evidence.NewPool(log.TestingLogger(), dbm.NewMemDB(), stateStore, blockStore)
+	pool, err := evidence.NewPool(log.TestingLogger(), memdb.NewDB(), stateStore, blockStore)
 	require.NoError(t, err)
 
 	evList := types.EvidenceList{goodEv}

--- a/internal/p2p/p2ptest/network.go
+++ b/internal/p2p/p2ptest/network.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -233,7 +233,7 @@ func (n *Network) MakeNode(t *testing.T, opts NodeOptions) *Node {
 	transport := n.memoryNetwork.CreateTransport(nodeID)
 	require.Len(t, transport.Endpoints(), 1, "transport not listening on 1 endpoint")
 
-	peerManager, err := p2p.NewPeerManager(nodeID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(nodeID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MinRetryTime:    10 * time.Millisecond,
 		MaxRetryTime:    100 * time.Millisecond,
 		RetryTimeJitter: time.Millisecond,

--- a/internal/p2p/peermanager_scoring_test.go
+++ b/internal/p2p/peermanager_scoring_test.go
@@ -6,7 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/types"
@@ -18,7 +19,7 @@ func TestPeerScoring(t *testing.T) {
 	selfID := types.NodeIDFromPubKey(selfKey.PubKey())
 
 	// create a mock peer manager
-	db := dbm.NewMemDB()
+	db := memdb.NewDB()
 	peerManager, err := NewPeerManager(selfID, db, PeerManagerOptions{})
 	require.NoError(t, err)
 	defer peerManager.Close()

--- a/internal/p2p/peermanager_test.go
+++ b/internal/p2p/peermanager_test.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/internal/p2p"
 	"github.com/tendermint/tendermint/types"
@@ -110,11 +111,11 @@ func TestPeerManagerOptions_Validate(t *testing.T) {
 
 func TestNewPeerManager(t *testing.T) {
 	// Zero options should be valid.
-	_, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	_, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	// Invalid options should error.
-	_, err = p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	_, err = p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		PersistentPeers: []types.NodeID{"foo"},
 	})
 	require.Error(t, err)
@@ -148,7 +149,7 @@ func TestNewPeerManager_Persistence(t *testing.T) {
 	}
 
 	// Create an initial peer manager and add the peers.
-	db := dbm.NewMemDB()
+	db := memdb.NewDB()
 	peerManager, err := p2p.NewPeerManager(selfID, db, p2p.PeerManagerOptions{
 		PersistentPeers: []types.NodeID{aID},
 		PeerScores:      map[types.NodeID]p2p.PeerScore{bID: 1},
@@ -197,7 +198,7 @@ func TestNewPeerManager_SelfIDChange(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 
-	db := dbm.NewMemDB()
+	db := memdb.NewDB()
 	peerManager, err := p2p.NewPeerManager(selfID, db, p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
@@ -222,7 +223,7 @@ func TestPeerManager_Add(t *testing.T) {
 	bID := types.NodeID(strings.Repeat("b", 40))
 	cID := types.NodeID(strings.Repeat("c", 40))
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		PersistentPeers: []types.NodeID{aID, cID},
 		MaxPeers:        2,
 		MaxConnected:    2,
@@ -275,7 +276,7 @@ func TestPeerManager_Add(t *testing.T) {
 func TestPeerManager_DialNext(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	// Add an address. DialNext should return it.
@@ -302,7 +303,7 @@ func TestPeerManager_DialNext_Retry(t *testing.T) {
 		MinRetryTime: 100 * time.Millisecond,
 		MaxRetryTime: 500 * time.Millisecond,
 	}
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), options)
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), options)
 	require.NoError(t, err)
 
 	added, err := peerManager.Add(a)
@@ -344,7 +345,7 @@ func TestPeerManager_DialNext_Retry(t *testing.T) {
 func TestPeerManager_DialNext_WakeOnAdd(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	// Spawn a goroutine to add a peer after a delay.
@@ -364,7 +365,7 @@ func TestPeerManager_DialNext_WakeOnAdd(t *testing.T) {
 }
 
 func TestPeerManager_DialNext_WakeOnDialFailed(t *testing.T) {
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected: 1,
 	})
 	require.NoError(t, err)
@@ -404,7 +405,7 @@ func TestPeerManager_DialNext_WakeOnDialFailed(t *testing.T) {
 
 func TestPeerManager_DialNext_WakeOnDialFailedRetry(t *testing.T) {
 	options := p2p.PeerManagerOptions{MinRetryTime: 200 * time.Millisecond}
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), options)
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), options)
 	require.NoError(t, err)
 
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
@@ -432,7 +433,7 @@ func TestPeerManager_DialNext_WakeOnDialFailedRetry(t *testing.T) {
 func TestPeerManager_DialNext_WakeOnDisconnected(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	added, err := peerManager.Add(a)
@@ -462,7 +463,7 @@ func TestPeerManager_TryDialNext_MaxConnected(t *testing.T) {
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected: 2,
 	})
 	require.NoError(t, err)
@@ -500,7 +501,7 @@ func TestPeerManager_TryDialNext_MaxConnectedUpgrade(t *testing.T) {
 	d := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("d", 40))}
 	e := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("e", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		PeerScores: map[types.NodeID]p2p.PeerScore{
 			a.NodeID: 0,
 			b.NodeID: 1,
@@ -582,7 +583,7 @@ func TestPeerManager_TryDialNext_UpgradeReservesPeer(t *testing.T) {
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		PeerScores:          map[types.NodeID]p2p.PeerScore{b.NodeID: 1, c.NodeID: 1},
 		MaxConnected:        1,
 		MaxConnectedUpgrade: 2,
@@ -624,7 +625,7 @@ func TestPeerManager_TryDialNext_DialingConnected(t *testing.T) {
 	bID := types.NodeID(strings.Repeat("b", 40))
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: bID}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected: 2,
 	})
 	require.NoError(t, err)
@@ -671,7 +672,7 @@ func TestPeerManager_TryDialNext_Multiple(t *testing.T) {
 		{Protocol: "tcp", NodeID: bID, Hostname: "::1"},
 	}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	for _, address := range addresses {
@@ -704,7 +705,7 @@ func TestPeerManager_DialFailed(t *testing.T) {
 	bID := types.NodeID(strings.Repeat("b", 40))
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: bID}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	added, err := peerManager.Add(a)
@@ -739,7 +740,7 @@ func TestPeerManager_DialFailed_UnreservePeer(t *testing.T) {
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		PeerScores:          map[types.NodeID]p2p.PeerScore{b.NodeID: 1, c.NodeID: 1},
 		MaxConnected:        1,
 		MaxConnectedUpgrade: 2,
@@ -784,7 +785,7 @@ func TestPeerManager_Dialed_Connected(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	// Marking a as dialed twice should error.
@@ -811,7 +812,7 @@ func TestPeerManager_Dialed_Connected(t *testing.T) {
 }
 
 func TestPeerManager_Dialed_Self(t *testing.T) {
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	// Dialing self should error.
@@ -823,7 +824,7 @@ func TestPeerManager_Dialed_MaxConnected(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected: 1,
 	})
 	require.NoError(t, err)
@@ -853,7 +854,7 @@ func TestPeerManager_Dialed_MaxConnectedUpgrade(t *testing.T) {
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 	d := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("d", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected:        2,
 		MaxConnectedUpgrade: 1,
 		PeerScores:          map[types.NodeID]p2p.PeerScore{c.NodeID: 1, d.NodeID: 1},
@@ -891,7 +892,7 @@ func TestPeerManager_Dialed_MaxConnectedUpgrade(t *testing.T) {
 func TestPeerManager_Dialed_Unknown(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	// Marking an unknown node as dialed should error.
@@ -903,7 +904,7 @@ func TestPeerManager_Dialed_Upgrade(t *testing.T) {
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected:        1,
 		MaxConnectedUpgrade: 2,
 		PeerScores:          map[types.NodeID]p2p.PeerScore{b.NodeID: 1, c.NodeID: 1},
@@ -946,7 +947,7 @@ func TestPeerManager_Dialed_UpgradeEvenLower(t *testing.T) {
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 	d := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("d", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected:        2,
 		MaxConnectedUpgrade: 1,
 		PeerScores: map[types.NodeID]p2p.PeerScore{
@@ -999,7 +1000,7 @@ func TestPeerManager_Dialed_UpgradeNoEvict(t *testing.T) {
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected:        2,
 		MaxConnectedUpgrade: 1,
 		PeerScores: map[types.NodeID]p2p.PeerScore{
@@ -1047,7 +1048,7 @@ func TestPeerManager_Accepted(t *testing.T) {
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 	d := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("d", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	// Accepting a connection from self should error.
@@ -1093,7 +1094,7 @@ func TestPeerManager_Accepted_MaxConnected(t *testing.T) {
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected: 2,
 	})
 	require.NoError(t, err)
@@ -1122,7 +1123,7 @@ func TestPeerManager_Accepted_MaxConnectedUpgrade(t *testing.T) {
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 	d := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("d", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		PeerScores: map[types.NodeID]p2p.PeerScore{
 			c.NodeID: 1,
 			d.NodeID: 2,
@@ -1167,7 +1168,7 @@ func TestPeerManager_Accepted_Upgrade(t *testing.T) {
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		PeerScores: map[types.NodeID]p2p.PeerScore{
 			b.NodeID: 1,
 			c.NodeID: 1,
@@ -1210,7 +1211,7 @@ func TestPeerManager_Accepted_UpgradeDialing(t *testing.T) {
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 	c := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("c", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		PeerScores: map[types.NodeID]p2p.PeerScore{
 			b.NodeID: 1,
 			c.NodeID: 1,
@@ -1256,7 +1257,7 @@ func TestPeerManager_Ready(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	sub := peerManager.Subscribe()
@@ -1291,7 +1292,7 @@ func TestPeerManager_Ready(t *testing.T) {
 func TestPeerManager_EvictNext(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	added, err := peerManager.Add(a)
@@ -1324,7 +1325,7 @@ func TestPeerManager_EvictNext(t *testing.T) {
 func TestPeerManager_EvictNext_WakeOnError(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	added, err := peerManager.Add(a)
@@ -1351,7 +1352,7 @@ func TestPeerManager_EvictNext_WakeOnUpgradeDialed(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected:        1,
 		MaxConnectedUpgrade: 1,
 		PeerScores:          map[types.NodeID]p2p.PeerScore{b.NodeID: 1},
@@ -1389,7 +1390,7 @@ func TestPeerManager_EvictNext_WakeOnUpgradeAccepted(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MaxConnected:        1,
 		MaxConnectedUpgrade: 1,
 		PeerScores:          map[types.NodeID]p2p.PeerScore{b.NodeID: 1},
@@ -1419,7 +1420,7 @@ func TestPeerManager_EvictNext_WakeOnUpgradeAccepted(t *testing.T) {
 func TestPeerManager_TryEvictNext(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	added, err := peerManager.Add(a)
@@ -1455,7 +1456,7 @@ func TestPeerManager_TryEvictNext(t *testing.T) {
 func TestPeerManager_Disconnected(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	sub := peerManager.Subscribe()
@@ -1509,7 +1510,7 @@ func TestPeerManager_Disconnected(t *testing.T) {
 func TestPeerManager_Errored(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	// Erroring an unknown peer does nothing.
@@ -1545,7 +1546,7 @@ func TestPeerManager_Errored(t *testing.T) {
 func TestPeerManager_Subscribe(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	// This tests all subscription events for full peer lifecycles.
@@ -1606,7 +1607,7 @@ func TestPeerManager_Subscribe(t *testing.T) {
 func TestPeerManager_Subscribe_Close(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	sub := peerManager.Subscribe()
@@ -1633,7 +1634,7 @@ func TestPeerManager_Subscribe_Broadcast(t *testing.T) {
 
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	s1 := peerManager.Subscribe()
@@ -1677,7 +1678,7 @@ func TestPeerManager_Close(t *testing.T) {
 
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		MinRetryTime: 10 * time.Second,
 	})
 	require.NoError(t, err)
@@ -1716,7 +1717,7 @@ func TestPeerManager_Advertise(t *testing.T) {
 	dID := types.NodeID(strings.Repeat("d", 40))
 
 	// Create an initial peer manager and add the peers.
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{
 		PeerScores: map[types.NodeID]p2p.PeerScore{aID: 3, bID: 2, cID: 1},
 	})
 	require.NoError(t, err)
@@ -1764,7 +1765,7 @@ func TestPeerManager_SetHeight_GetHeight(t *testing.T) {
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 
-	db := dbm.NewMemDB()
+	db := memdb.NewDB()
 	peerManager, err := p2p.NewPeerManager(selfID, db, p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 

--- a/internal/p2p/pex/reactor_test.go
+++ b/internal/p2p/pex/reactor_test.go
@@ -6,7 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/internal/p2p"
@@ -264,7 +265,7 @@ func setupSingle(t *testing.T) *singleTestReactor {
 
 	peerCh := make(chan p2p.PeerUpdate, chBuf)
 	peerUpdates := p2p.NewPeerUpdates(peerCh, chBuf)
-	peerManager, err := p2p.NewPeerManager(nodeID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(nodeID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
 	reactor := pex.NewReactor(log.TestingLogger(), peerManager, pexCh, peerUpdates)

--- a/internal/p2p/router_test.go
+++ b/internal/p2p/router_test.go
@@ -16,7 +16,8 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/crypto"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
@@ -98,7 +99,7 @@ func TestRouter_Channel_Basic(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
 
 	// Set up a router with no transports (so no peers).
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 	defer peerManager.Close()
 
@@ -380,7 +381,7 @@ func TestRouter_AcceptPeers(t *testing.T) {
 			mockTransport.On("Accept").Maybe().Return(nil, io.EOF)
 
 			// Set up and start the router.
-			peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+			peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 			require.NoError(t, err)
 			defer peerManager.Close()
 
@@ -436,7 +437,7 @@ func TestRouter_AcceptPeers_Error(t *testing.T) {
 	mockTransport.On("Close").Return(nil)
 
 	// Set up and start the router.
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 	defer peerManager.Close()
 
@@ -471,7 +472,7 @@ func TestRouter_AcceptPeers_ErrorEOF(t *testing.T) {
 	mockTransport.On("Close").Return(nil)
 
 	// Set up and start the router.
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 	defer peerManager.Close()
 
@@ -520,7 +521,7 @@ func TestRouter_AcceptPeers_HeadOfLineBlocking(t *testing.T) {
 	mockTransport.On("Accept").Once().Return(nil, io.EOF)
 
 	// Set up and start the router.
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 	defer peerManager.Close()
 
@@ -614,7 +615,7 @@ func TestRouter_DialPeers(t *testing.T) {
 			}
 
 			// Set up and start the router.
-			peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+			peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 			require.NoError(t, err)
 			defer peerManager.Close()
 
@@ -692,7 +693,7 @@ func TestRouter_DialPeers_Parallel(t *testing.T) {
 	}
 
 	// Set up and start the router.
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 	defer peerManager.Close()
 
@@ -774,7 +775,7 @@ func TestRouter_EvictPeers(t *testing.T) {
 	mockTransport.On("Accept").Maybe().Return(nil, io.EOF)
 
 	// Set up and start the router.
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 	defer peerManager.Close()
 
@@ -839,7 +840,7 @@ func TestRouter_ChannelCompatability(t *testing.T) {
 	mockTransport.On("Accept").Once().Return(nil, io.EOF)
 
 	// Set up and start the router.
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 	defer peerManager.Close()
 
@@ -891,7 +892,7 @@ func TestRouter_DontSendOnInvalidChannel(t *testing.T) {
 	mockTransport.On("Accept").Maybe().Return(nil, io.EOF)
 
 	// Set up and start the router.
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	peerManager, err := p2p.NewPeerManager(selfID, memdb.NewDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 	defer peerManager.Close()
 

--- a/internal/p2p/trust/store_test.go
+++ b/internal/p2p/trust/store_test.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/metadb"
 
 	"github.com/tendermint/tendermint/libs/log"
 )
@@ -17,7 +18,7 @@ import (
 func TestTrustMetricStoreSaveLoad(t *testing.T) {
 	dir := t.TempDir()
 
-	historyDB, err := dbm.NewDB("trusthistory", "goleveldb", dir)
+	historyDB, err := metadb.NewDB("trusthistory", "goleveldb", dir)
 	require.NoError(t, err)
 
 	// 0 peers saved
@@ -80,7 +81,7 @@ func TestTrustMetricStoreSaveLoad(t *testing.T) {
 }
 
 func TestTrustMetricStoreConfig(t *testing.T) {
-	historyDB, err := dbm.NewDB("", "memdb", "")
+	historyDB, err := metadb.NewDB("", "memdb", "")
 	require.NoError(t, err)
 
 	config := MetricConfig{
@@ -105,7 +106,7 @@ func TestTrustMetricStoreConfig(t *testing.T) {
 }
 
 func TestTrustMetricStoreLookup(t *testing.T) {
-	historyDB, err := dbm.NewDB("", "memdb", "")
+	historyDB, err := metadb.NewDB("", "memdb", "")
 	require.NoError(t, err)
 
 	store := NewTrustMetricStore(historyDB, DefaultConfig())
@@ -128,7 +129,7 @@ func TestTrustMetricStoreLookup(t *testing.T) {
 }
 
 func TestTrustMetricStorePeerScore(t *testing.T) {
-	historyDB, err := dbm.NewDB("", "memdb", "")
+	historyDB, err := metadb.NewDB("", "memdb", "")
 	require.NoError(t, err)
 
 	store := NewTrustMetricStore(historyDB, DefaultConfig())

--- a/internal/rpc/core/blocks_test.go
+++ b/internal/rpc/core/blocks_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	sm "github.com/tendermint/tendermint/internal/state"
@@ -81,7 +81,7 @@ func TestBlockResults(t *testing.T) {
 	}
 
 	env := &Environment{}
-	env.StateStore = sm.NewStore(dbm.NewMemDB())
+	env.StateStore = sm.NewStore(memdb.NewDB())
 	err := env.StateStore.SaveABCIResponses(100, results)
 	require.NoError(t, err)
 	env.BlockStore = mockBlockStore{height: 100}

--- a/internal/state/execution_test.go
+++ b/internal/state/execution_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -43,7 +44,7 @@ func TestApplyBlock(t *testing.T) {
 
 	state, stateDB, _ := makeState(1, 1)
 	stateStore := sm.NewStore(stateDB)
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),
 		mmock.Mempool{}, sm.EmptyEvidencePool{}, blockStore)
 
@@ -198,7 +199,7 @@ func TestBeginBlockByzantineValidators(t *testing.T) {
 	evpool.On("Update", mock.AnythingOfType("state.State"), mock.AnythingOfType("types.EvidenceList")).Return()
 	evpool.On("CheckEvidence", mock.AnythingOfType("types.EvidenceList")).Return(nil)
 
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),
 		mmock.Mempool{}, evpool, blockStore)
@@ -356,7 +357,7 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 
 	state, stateDB, _ := makeState(1, 1)
 	stateStore := sm.NewStore(stateDB)
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 
 	blockExec := sm.NewBlockExecutor(
 		stateStore,
@@ -429,7 +430,7 @@ func TestEndBlockValidatorUpdatesResultingInEmptySet(t *testing.T) {
 
 	state, stateDB, _ := makeState(1, 1)
 	stateStore := sm.NewStore(stateDB)
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	blockExec := sm.NewBlockExecutor(
 		stateStore,
 		log.TestingLogger(),

--- a/internal/state/helpers_test.go
+++ b/internal/state/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -110,7 +111,7 @@ func makeState(nVals, height int) (sm.State, dbm.DB, map[string]types.PrivValida
 		AppHash:    nil,
 	})
 
-	stateDB := dbm.NewMemDB()
+	stateDB := memdb.NewDB()
 	stateStore := sm.NewStore(stateDB)
 	if err := stateStore.Save(s); err != nil {
 		panic(err)

--- a/internal/state/indexer/block/kv/kv_test.go
+++ b/internal/state/indexer/block/kv/kv_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	blockidxkv "github.com/tendermint/tendermint/internal/state/indexer/block/kv"
@@ -15,7 +17,7 @@ import (
 )
 
 func TestBlockIndexer(t *testing.T) {
-	store := dbm.NewPrefixDB(dbm.NewMemDB(), []byte("block_events"))
+	store := dbm.NewPrefixDB(memdb.NewDB(), []byte("block_events"))
 	indexer := blockidxkv.New(store)
 
 	require.NoError(t, indexer.Index(types.EventDataNewBlockHeader{

--- a/internal/state/indexer/indexer_service_test.go
+++ b/internal/state/indexer/indexer_service_test.go
@@ -12,7 +12,8 @@ import (
 	"github.com/ory/dockertest/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/internal/state/indexer"
@@ -56,7 +57,7 @@ func TestIndexerServiceIndexesBlocks(t *testing.T) {
 	pool, err := setupDB(t)
 	assert.Nil(t, err)
 
-	store := dbm.NewMemDB()
+	store := memdb.NewDB()
 	eventSinks := []indexer.EventSink{kv.NewEventSink(store), pSink}
 	assert.True(t, indexer.KVSinkEnabled(eventSinks))
 	assert.True(t, indexer.IndexingEnabled(eventSinks))

--- a/internal/state/indexer/sink/kv/kv_test.go
+++ b/internal/state/indexer/sink/kv/kv_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -18,17 +19,17 @@ import (
 )
 
 func TestType(t *testing.T) {
-	kvSink := NewEventSink(dbm.NewMemDB())
+	kvSink := NewEventSink(memdb.NewDB())
 	assert.Equal(t, indexer.KV, kvSink.Type())
 }
 
 func TestStop(t *testing.T) {
-	kvSink := NewEventSink(dbm.NewMemDB())
+	kvSink := NewEventSink(memdb.NewDB())
 	assert.Nil(t, kvSink.Stop())
 }
 
 func TestBlockFuncs(t *testing.T) {
-	store := dbm.NewPrefixDB(dbm.NewMemDB(), []byte("block_events"))
+	store := dbm.NewPrefixDB(memdb.NewDB(), []byte("block_events"))
 	indexer := NewEventSink(store)
 
 	require.NoError(t, indexer.IndexBlockEvents(types.EventDataNewBlockHeader{
@@ -159,7 +160,7 @@ func TestBlockFuncs(t *testing.T) {
 }
 
 func TestTxSearchWithCancelation(t *testing.T) {
-	indexer := NewEventSink(dbm.NewMemDB())
+	indexer := NewEventSink(memdb.NewDB())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
@@ -181,7 +182,7 @@ func TestTxSearchWithCancelation(t *testing.T) {
 }
 
 func TestTxSearchDeprecatedIndexing(t *testing.T) {
-	esdb := dbm.NewMemDB()
+	esdb := memdb.NewDB()
 	indexer := NewEventSink(esdb)
 
 	// index tx using events indexing (composite key)
@@ -261,7 +262,7 @@ func TestTxSearchDeprecatedIndexing(t *testing.T) {
 }
 
 func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
-	indexer := NewEventSink(dbm.NewMemDB())
+	indexer := NewEventSink(memdb.NewDB())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
@@ -283,7 +284,7 @@ func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
 }
 
 func TestTxSearchMultipleTxs(t *testing.T) {
-	indexer := NewEventSink(dbm.NewMemDB())
+	indexer := NewEventSink(memdb.NewDB())
 
 	// indexed first, but bigger height (to test the order of transactions)
 	txResult := txResultWithEvents([]abci.Event{

--- a/internal/state/indexer/tx/kv/kv_bench_test.go
+++ b/internal/state/indexer/tx/kv/kv_bench_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/goleveldb"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/pubsub/query"
@@ -20,7 +20,7 @@ func BenchmarkTxSearch(b *testing.B) {
 		b.Errorf("failed to create temporary directory: %s", err)
 	}
 
-	db, err := dbm.NewGoLevelDB("benchmark_tx_search_test", dbDir)
+	db, err := goleveldb.NewDB("benchmark_tx_search_test", dbDir)
 	if err != nil {
 		b.Errorf("failed to create database: %s", err)
 	}

--- a/internal/state/indexer/tx/kv/kv_test.go
+++ b/internal/state/indexer/tx/kv/kv_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
+	"github.com/tendermint/tm-db/metadb"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/internal/state/indexer"
@@ -19,7 +21,7 @@ import (
 )
 
 func TestTxIndex(t *testing.T) {
-	txIndexer := NewTxIndex(dbm.NewMemDB())
+	txIndexer := NewTxIndex(memdb.NewDB())
 
 	tx := types.Tx("HELLO WORLD")
 	txResult := &abci.TxResult{
@@ -65,7 +67,7 @@ func TestTxIndex(t *testing.T) {
 }
 
 func TestTxSearch(t *testing.T) {
-	indexer := NewTxIndex(dbm.NewMemDB())
+	indexer := NewTxIndex(memdb.NewDB())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
@@ -145,7 +147,7 @@ func TestTxSearch(t *testing.T) {
 }
 
 func TestTxSearchWithCancelation(t *testing.T) {
-	indexer := NewTxIndex(dbm.NewMemDB())
+	indexer := NewTxIndex(memdb.NewDB())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
@@ -163,7 +165,7 @@ func TestTxSearchWithCancelation(t *testing.T) {
 }
 
 func TestTxSearchDeprecatedIndexing(t *testing.T) {
-	indexer := NewTxIndex(dbm.NewMemDB())
+	indexer := NewTxIndex(memdb.NewDB())
 
 	// index tx using events indexing (composite key)
 	txResult1 := txResultWithEvents([]abci.Event{
@@ -242,7 +244,7 @@ func TestTxSearchDeprecatedIndexing(t *testing.T) {
 }
 
 func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
-	indexer := NewTxIndex(dbm.NewMemDB())
+	indexer := NewTxIndex(memdb.NewDB())
 
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: "number", Value: "1", Index: true}}},
@@ -264,7 +266,7 @@ func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
 }
 
 func TestTxSearchMultipleTxs(t *testing.T) {
-	indexer := NewTxIndex(dbm.NewMemDB())
+	indexer := NewTxIndex(memdb.NewDB())
 
 	// indexed first, but bigger height (to test the order of transactions)
 	txResult := txResultWithEvents([]abci.Event{
@@ -337,7 +339,7 @@ func benchmarkTxIndex(txsCount int64, b *testing.B) {
 	require.NoError(b, err)
 	defer os.RemoveAll(dir)
 
-	store, err := dbm.NewDB("tx_index", "goleveldb", dir)
+	store, err := metadb.NewDB("tx_index", "goleveldb", dir)
 	require.NoError(b, err)
 	txIndexer := NewTxIndex(store)
 

--- a/internal/state/rollback_test.go
+++ b/internal/state/rollback_test.go
@@ -4,7 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/internal/state"
 	"github.com/tendermint/tendermint/internal/state/mocks"
@@ -69,7 +70,7 @@ func TestRollback(t *testing.T) {
 }
 
 func TestRollbackNoState(t *testing.T) {
-	stateStore := state.NewStore(dbm.NewMemDB())
+	stateStore := state.NewStore(memdb.NewDB())
 	blockStore := &mocks.BlockStore{}
 
 	_, _, err := state.Rollback(blockStore, stateStore)
@@ -101,7 +102,7 @@ func TestRollbackDifferentStateHeight(t *testing.T) {
 }
 
 func setupStateStore(t *testing.T, height int64) state.Store {
-	stateStore := state.NewStore(dbm.NewMemDB())
+	stateStore := state.NewStore(memdb.NewDB())
 	valSet, _ := factory.RandValidatorSet(5, 10)
 
 	params := types.DefaultConsensusParams()

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/metadb"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/config"
@@ -29,8 +31,8 @@ func setupTestCase(t *testing.T) (func(t *testing.T), dbm.DB, sm.State) {
 	cfg, err := config.ResetTestRoot("state_")
 	require.NoError(t, err)
 
-	dbType := dbm.BackendType(cfg.DBBackend)
-	stateDB, err := dbm.NewDB("state", dbType, cfg.DBDir())
+	dbType := metadb.BackendType(cfg.DBBackend)
+	stateDB, err := metadb.NewDB("state", dbType, cfg.DBDir())
 	require.NoError(t, err)
 	stateStore := sm.NewStore(stateDB)
 	state, err := stateStore.Load()

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
+	"github.com/tendermint/tm-db/metadb"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/config"
@@ -26,7 +28,7 @@ const (
 )
 
 func TestStoreBootstrap(t *testing.T) {
-	stateDB := dbm.NewMemDB()
+	stateDB := memdb.NewDB()
 	stateStore := sm.NewStore(stateDB)
 	val, _ := factory.RandValidator(true, 10)
 	val2, _ := factory.RandValidator(true, 10)
@@ -52,7 +54,7 @@ func TestStoreBootstrap(t *testing.T) {
 }
 
 func TestStoreLoadValidators(t *testing.T) {
-	stateDB := dbm.NewMemDB()
+	stateDB := memdb.NewDB()
 	stateStore := sm.NewStore(stateDB)
 	val, _ := factory.RandValidator(true, 10)
 	val2, _ := factory.RandValidator(true, 10)
@@ -105,8 +107,8 @@ func BenchmarkLoadValidators(b *testing.B) {
 	require.NoError(b, err)
 
 	defer os.RemoveAll(cfg.RootDir)
-	dbType := dbm.BackendType(cfg.DBBackend)
-	stateDB, err := dbm.NewDB("state", dbType, cfg.DBDir())
+	dbType := metadb.BackendType(cfg.DBBackend)
+	stateDB, err := metadb.NewDB("state", dbType, cfg.DBDir())
 	require.NoError(b, err)
 	stateStore := sm.NewStore(stateDB)
 	state, err := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
@@ -141,7 +143,7 @@ func BenchmarkLoadValidators(b *testing.B) {
 }
 
 func TestStoreLoadConsensusParams(t *testing.T) {
-	stateDB := dbm.NewMemDB()
+	stateDB := memdb.NewDB()
 	stateStore := sm.NewStore(stateDB)
 	err := stateStore.Save(makeRandomStateFromConsensusParams(types.DefaultConsensusParams(), 1, 1))
 	require.NoError(t, err)
@@ -183,7 +185,7 @@ func TestPruneStates(t *testing.T) {
 	for name, tc := range testcases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			db := dbm.NewMemDB()
+			db := memdb.NewDB()
 
 			stateStore := sm.NewStore(db)
 			pk := ed25519.GenPrivKey().PubKey()

--- a/internal/state/validation_test.go
+++ b/internal/state/validation_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -34,7 +35,7 @@ func TestValidateBlockHeader(t *testing.T) {
 
 	state, stateDB, privVals := makeState(3, 1)
 	stateStore := sm.NewStore(stateDB)
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	blockExec := sm.NewBlockExecutor(
 		stateStore,
 		log.TestingLogger(),
@@ -121,7 +122,7 @@ func TestValidateBlockCommit(t *testing.T) {
 
 	state, stateDB, privVals := makeState(1, 1)
 	stateStore := sm.NewStore(stateDB)
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	blockExec := sm.NewBlockExecutor(
 		stateStore,
 		log.TestingLogger(),
@@ -242,7 +243,7 @@ func TestValidateBlockEvidence(t *testing.T) {
 
 	state, stateDB, privVals := makeState(4, 1)
 	stateStore := sm.NewStore(stateDB)
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	defaultEvidenceTime := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	evpool := &mocks.EvidencePool{}

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/config"
@@ -141,7 +142,7 @@ func setup(
 	)
 
 	rts.stateStore = &smmocks.Store{}
-	rts.blockStore = store.NewBlockStore(dbm.NewMemDB())
+	rts.blockStore = store.NewBlockStore(memdb.NewDB())
 
 	cfg := config.DefaultStateSyncConfig()
 

--- a/internal/statesync/stateprovider.go
+++ b/internal/statesync/stateprovider.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/internal/p2p"
@@ -74,7 +74,7 @@ func NewRPCStateProvider(
 	}
 
 	lc, err := light.NewClient(ctx, chainID, trustOptions, providers[0], providers[1:],
-		lightdb.New(dbm.NewMemDB()), light.Logger(logger))
+		lightdb.New(memdb.NewDB()), light.Logger(logger))
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func NewP2PStateProvider(
 	}
 
 	lc, err := light.NewClient(ctx, chainID, trustOptions, providers[0], providers[1:],
-		lightdb.New(dbm.NewMemDB()), light.Logger(logger))
+		lightdb.New(memdb.NewDB()), light.Logger(logger))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
@@ -51,7 +53,7 @@ func makeStateAndBlockStore(logger log.Logger) (sm.State, *BlockStore, cleanupFu
 		panic(err)
 	}
 
-	blockDB := dbm.NewMemDB()
+	blockDB := memdb.NewDB()
 	state, err := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
 	if err != nil {
 		panic(fmt.Errorf("error constructing state from genesis file: %w", err))
@@ -60,7 +62,7 @@ func makeStateAndBlockStore(logger log.Logger) (sm.State, *BlockStore, cleanupFu
 }
 
 func freshBlockStore() (*BlockStore, dbm.DB) {
-	db := dbm.NewMemDB()
+	db := memdb.NewDB()
 	return NewBlockStore(db), db
 }
 
@@ -302,7 +304,7 @@ func TestLoadBaseMeta(t *testing.T) {
 	defer os.RemoveAll(cfg.RootDir)
 	state, err := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
 	require.NoError(t, err)
-	bs := NewBlockStore(dbm.NewMemDB())
+	bs := NewBlockStore(memdb.NewDB())
 
 	for h := int64(1); h <= 10; h++ {
 		block := factory.MakeBlock(state, h, new(types.Commit))
@@ -360,7 +362,7 @@ func TestPruneBlocks(t *testing.T) {
 	defer os.RemoveAll(cfg.RootDir)
 	state, err := sm.MakeGenesisStateFromFile(cfg.GenesisFile())
 	require.NoError(t, err)
-	db := dbm.NewMemDB()
+	db := memdb.NewDB()
 	bs := NewBlockStore(db)
 	assert.EqualValues(t, 0, bs.Base())
 	assert.EqualValues(t, 0, bs.Height())

--- a/light/client_benchmark_test.go
+++ b/light/client_benchmark_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/light"
@@ -75,7 +75,7 @@ func BenchmarkSequence(b *testing.B) {
 		},
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 		light.SequentialVerification(),
 	)
@@ -107,7 +107,7 @@ func BenchmarkBisection(b *testing.B) {
 		},
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	if err != nil {
@@ -138,7 +138,7 @@ func BenchmarkBackwards(b *testing.B) {
 		},
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	if err != nil {

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/internal/test/factory"
 	"github.com/tendermint/tendermint/libs/log"
@@ -217,7 +218,7 @@ func TestClient_SequentialVerification(t *testing.T) {
 				trustOptions,
 				mockNode,
 				[]provider.Provider{mockNode},
-				dbs.New(dbm.NewMemDB()),
+				dbs.New(memdb.NewDB()),
 				light.SequentialVerification(),
 				light.Logger(log.TestingLogger()),
 			)
@@ -337,7 +338,7 @@ func TestClient_SkippingVerification(t *testing.T) {
 				trustOptions,
 				mockNode,
 				[]provider.Provider{mockNode},
-				dbs.New(dbm.NewMemDB()),
+				dbs.New(memdb.NewDB()),
 				light.SkippingVerification(light.DefaultTrustLevel),
 				light.Logger(log.TestingLogger()),
 			)
@@ -390,7 +391,7 @@ func TestClientLargeBisectionVerification(t *testing.T) {
 		},
 		mockNode,
 		[]provider.Provider{mockNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.SkippingVerification(light.DefaultTrustLevel),
 	)
 	require.NoError(t, err)
@@ -417,7 +418,7 @@ func TestClientBisectionBetweenTrustedHeaders(t *testing.T) {
 		},
 		mockFullNode,
 		[]provider.Provider{mockFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.SkippingVerification(light.DefaultTrustLevel),
 	)
 	require.NoError(t, err)
@@ -444,7 +445,7 @@ func TestClient_Cleanup(t *testing.T) {
 		trustOptions,
 		mockFullNode,
 		[]provider.Provider{mockFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
@@ -466,7 +467,7 @@ func TestClientRestoresTrustedHeaderAfterStartup(t *testing.T) {
 	// 1. options.Hash == trustedHeader.Hash
 	t.Run("hashes should match", func(t *testing.T) {
 		mockNode := &provider_mocks.Provider{}
-		trustedStore := dbs.New(dbm.NewMemDB())
+		trustedStore := dbs.New(memdb.NewDB())
 		err := trustedStore.SaveLightBlock(l1)
 		require.NoError(t, err)
 
@@ -491,7 +492,7 @@ func TestClientRestoresTrustedHeaderAfterStartup(t *testing.T) {
 
 	// 2. options.Hash != trustedHeader.Hash
 	t.Run("hashes should not match", func(t *testing.T) {
-		trustedStore := dbs.New(dbm.NewMemDB())
+		trustedStore := dbs.New(memdb.NewDB())
 		err := trustedStore.SaveLightBlock(l1)
 		require.NoError(t, err)
 
@@ -537,7 +538,7 @@ func TestClient_Update(t *testing.T) {
 		trustOptions,
 		mockFullNode,
 		[]provider.Provider{mockFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
@@ -562,7 +563,7 @@ func TestClient_Concurrency(t *testing.T) {
 		trustOptions,
 		mockFullNode,
 		[]provider.Provider{mockFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
@@ -608,7 +609,7 @@ func TestClient_AddProviders(t *testing.T) {
 		trustOptions,
 		mockFullNode,
 		[]provider.Provider{mockFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
@@ -644,7 +645,7 @@ func TestClientReplacesPrimaryWithWitnessIfPrimaryIsUnavailable(t *testing.T) {
 		trustOptions,
 		mockDeadNode,
 		[]provider.Provider{mockDeadNode, mockFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 
@@ -674,7 +675,7 @@ func TestClientReplacesPrimaryWithWitnessIfPrimaryDoesntHaveBlock(t *testing.T) 
 		trustOptions,
 		mockDeadNode,
 		[]provider.Provider{mockDeadNode, mockFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
@@ -708,7 +709,7 @@ func TestClient_BackwardsVerification(t *testing.T) {
 			},
 			mockLargeFullNode,
 			[]provider.Provider{mockLargeFullNode},
-			dbs.New(dbm.NewMemDB()),
+			dbs.New(memdb.NewDB()),
 			light.Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
@@ -767,7 +768,7 @@ func TestClient_BackwardsVerification(t *testing.T) {
 			},
 			mockNode,
 			[]provider.Provider{mockNode},
-			dbs.New(dbm.NewMemDB()),
+			dbs.New(memdb.NewDB()),
 			light.Logger(log.TestingLogger()),
 		)
 		require.NoError(t, err)
@@ -780,7 +781,7 @@ func TestClient_BackwardsVerification(t *testing.T) {
 
 func TestClient_NewClientFromTrustedStore(t *testing.T) {
 	// 1) Initiate DB and fill with a "trusted" header
-	db := dbs.New(dbm.NewMemDB())
+	db := dbs.New(memdb.NewDB())
 	err := db.SaveLightBlock(l1)
 	require.NoError(t, err)
 	mockNode := &provider_mocks.Provider{}
@@ -839,7 +840,7 @@ func TestClientRemovesWitnessIfItSendsUsIncorrectHeader(t *testing.T) {
 		trustOptions,
 		mockFullNode,
 		[]provider.Provider{mockBadNode1, mockBadNode2},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	// witness should have behaved properly -> no error
@@ -895,7 +896,7 @@ func TestClient_TrustedValidatorSet(t *testing.T) {
 		trustOptions,
 		mockFullNode,
 		[]provider.Provider{mockBadValSetNode, mockFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
@@ -927,7 +928,7 @@ func TestClientPrunesHeadersAndValidatorSets(t *testing.T) {
 		trustOptions,
 		mockFullNode,
 		[]provider.Provider{mockFullNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 		light.PruningSize(1),
 	)
@@ -1017,7 +1018,7 @@ func TestClientEnsureValidHeadersAndValSets(t *testing.T) {
 				trustOptions,
 				mockBadNode,
 				[]provider.Provider{mockBadNode, mockBadNode},
-				dbs.New(dbm.NewMemDB()),
+				dbs.New(memdb.NewDB()),
 			)
 			require.NoError(t, err)
 
@@ -1055,7 +1056,7 @@ func TestClientHandlesContexts(t *testing.T) {
 		trustOptions,
 		mockNode,
 		[]provider.Provider{mockNode, mockNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 	)
 	require.Error(t, ctxTimeOut.Err())
 	require.Error(t, err)
@@ -1068,7 +1069,7 @@ func TestClientHandlesContexts(t *testing.T) {
 		trustOptions,
 		mockNode,
 		[]provider.Provider{mockNode, mockNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 	)
 	require.NoError(t, err)
 

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/light"
@@ -87,7 +87,7 @@ func TestLightClientAttackEvidence_Lunatic(t *testing.T) {
 		},
 		mockPrimary,
 		[]provider.Provider{mockWitness},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestLightClientAttackEvidence_Equivocation(t *testing.T) {
 				},
 				mockPrimary,
 				[]provider.Provider{mockWitness},
-				dbs.New(dbm.NewMemDB()),
+				dbs.New(memdb.NewDB()),
 				light.Logger(log.TestingLogger()),
 				testCase.lightOption,
 			)
@@ -297,7 +297,7 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 		},
 		mockPrimary,
 		[]provider.Provider{mockWitness, accomplice},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 		light.MaxClockDrift(1*time.Second),
 		light.MaxBlockLag(1*time.Second),
@@ -357,7 +357,7 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 		},
 		mockPrimary,
 		[]provider.Provider{mockLaggingWitness, accomplice},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 		light.MaxClockDrift(1*time.Second),
 		light.MaxBlockLag(1*time.Second),
@@ -391,7 +391,7 @@ func TestClientDivergentTraces1(t *testing.T) {
 		},
 		mockPrimary,
 		[]provider.Provider{mockWitness},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.Error(t, err)
@@ -419,7 +419,7 @@ func TestClientDivergentTraces2(t *testing.T) {
 		},
 		mockPrimaryNode,
 		[]provider.Provider{mockDeadNode, mockDeadNode, mockPrimaryNode},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
@@ -457,7 +457,7 @@ func TestClientDivergentTraces3(t *testing.T) {
 		},
 		mockPrimary,
 		[]provider.Provider{mockWitness},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)
@@ -495,7 +495,7 @@ func TestClientDivergentTraces4(t *testing.T) {
 		},
 		mockPrimary,
 		[]provider.Provider{mockWitness},
-		dbs.New(dbm.NewMemDB()),
+		dbs.New(memdb.NewDB()),
 		light.Logger(log.TestingLogger()),
 	)
 	require.NoError(t, err)

--- a/light/example_test.go
+++ b/light/example_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/goleveldb"
 
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	"github.com/tendermint/tendermint/libs/log"
@@ -58,7 +58,7 @@ func ExampleClient() {
 		stdlog.Fatal(err)
 	}
 
-	db, err := dbm.NewGoLevelDB("light-client-db", dbDir)
+	db, err := goleveldb.NewDB("light-client-db", dbDir)
 	if err != nil {
 		stdlog.Fatal(err)
 	}

--- a/light/light_test.go
+++ b/light/light_test.go
@@ -7,7 +7,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/goleveldb"
 
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	"github.com/tendermint/tendermint/libs/log"
@@ -53,7 +54,7 @@ func TestClientIntegration_Update(t *testing.T) {
 	block, err := waitForBlock(ctx, primary, 2)
 	require.NoError(t, err)
 
-	db, err := dbm.NewGoLevelDB("light-client-db", dbDir)
+	db, err := goleveldb.NewDB("light-client-db", dbDir)
 	require.NoError(t, err)
 
 	c, err := light.NewClient(
@@ -112,7 +113,7 @@ func TestClientIntegration_VerifyLightBlockAtHeight(t *testing.T) {
 	block, err := waitForBlock(ctx, primary, 2)
 	require.NoError(t, err)
 
-	db, err := dbm.NewGoLevelDB("light-client-db", dbDir)
+	db, err := goleveldb.NewDB("light-client-db", dbDir)
 	require.NoError(t, err)
 
 	c, err := light.NewClient(ctx,

--- a/light/store/db/db_test.go
+++ b/light/store/db/db_test.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	dbm "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tm-db/memdb"
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/tmhash"
@@ -18,7 +19,7 @@ import (
 )
 
 func TestLast_FirstLightBlockHeight(t *testing.T) {
-	dbStore := New(dbm.NewMemDB())
+	dbStore := New(memdb.NewDB())
 
 	// Empty store
 	height, err := dbStore.LastLightBlockHeight()
@@ -43,7 +44,7 @@ func TestLast_FirstLightBlockHeight(t *testing.T) {
 }
 
 func Test_SaveLightBlock(t *testing.T) {
-	dbStore := New(dbm.NewMemDB())
+	dbStore := New(memdb.NewDB())
 
 	// Empty store
 	h, err := dbStore.LightBlock(1)
@@ -73,7 +74,7 @@ func Test_SaveLightBlock(t *testing.T) {
 }
 
 func Test_LightBlockBefore(t *testing.T) {
-	dbStore := New(dbm.NewMemDB())
+	dbStore := New(memdb.NewDB())
 
 	assert.Panics(t, func() {
 		_, _ = dbStore.LightBlockBefore(0)
@@ -94,7 +95,7 @@ func Test_LightBlockBefore(t *testing.T) {
 }
 
 func Test_Prune(t *testing.T) {
-	dbStore := New(dbm.NewMemDB())
+	dbStore := New(memdb.NewDB())
 
 	// Empty store
 	assert.EqualValues(t, 0, dbStore.Size())
@@ -131,7 +132,7 @@ func Test_Prune(t *testing.T) {
 }
 
 func Test_Concurrency(t *testing.T) {
-	dbStore := New(dbm.NewMemDB())
+	dbStore := New(memdb.NewDB())
 
 	var wg sync.WaitGroup
 	for i := 1; i <= 100; i++ {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
@@ -272,8 +274,8 @@ func TestCreateProposalBlock(t *testing.T) {
 	)
 
 	// Make EvidencePool
-	evidenceDB := dbm.NewMemDB()
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	evidenceDB := memdb.NewDB()
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	evidencePool, err := evidence.NewPool(logger, evidenceDB, stateStore, blockStore)
 	require.NoError(t, err)
 
@@ -351,7 +353,7 @@ func TestMaxTxsProposalBlockSize(t *testing.T) {
 	const height int64 = 1
 	state, stateDB, _ := state(t, 1, height)
 	stateStore := sm.NewStore(stateDB)
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	const maxBytes int64 = 16384
 	const partSize uint32 = 256
 	state.ConsensusParams.Block.MaxBytes = maxBytes
@@ -414,7 +416,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 
 	state, stateDB, _ := state(t, types.MaxVotesCount, int64(1))
 	stateStore := sm.NewStore(stateDB)
-	blockStore := store.NewBlockStore(dbm.NewMemDB())
+	blockStore := store.NewBlockStore(memdb.NewDB())
 	const maxBytes int64 = 1024 * 1024 * 2
 	state.ConsensusParams.Block.MaxBytes = maxBytes
 	proposerAddr, _ := state.Validators.GetByIndex(0)
@@ -683,7 +685,7 @@ func state(t *testing.T, nVals int, height int64) (sm.State, dbm.DB, []types.Pri
 	})
 
 	// save validators to db for 2 heights
-	stateDB := dbm.NewMemDB()
+	stateDB := memdb.NewDB()
 	t.Cleanup(func() { require.NoError(t, stateDB.Close()) })
 
 	stateStore := sm.NewStore(stateDB)
@@ -704,7 +706,7 @@ func TestLoadStateFromGenesis(t *testing.T) {
 func loadStatefromGenesis(t *testing.T) sm.State {
 	t.Helper()
 
-	stateDB := dbm.NewMemDB()
+	stateDB := memdb.NewDB()
 	stateStore := sm.NewStore(stateDB)
 	cfg, err := config.ResetTestRoot("load_state_from_genesis")
 	require.NoError(t, err)

--- a/scripts/keymigrate/migrate_test.go
+++ b/scripts/keymigrate/migrate_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/google/orderedcode"
 	"github.com/stretchr/testify/require"
+
 	dbm "github.com/tendermint/tm-db"
+	"github.com/tendermint/tm-db/memdb"
 )
 
 func makeKey(t *testing.T, elems ...interface{}) []byte {
@@ -71,7 +73,7 @@ func getNewPrefixKeys(t *testing.T, val int) map[string][]byte {
 }
 
 func getLegacyDatabase(t *testing.T) (int, dbm.DB) {
-	db := dbm.NewMemDB()
+	db := memdb.NewDB()
 	batch := db.NewBatch()
 	ct := 0
 
@@ -166,11 +168,11 @@ func TestMigration(t *testing.T) {
 		})
 		t.Run("Replacement", func(t *testing.T) {
 			t.Run("MissingKey", func(t *testing.T) {
-				db := dbm.NewMemDB()
+				db := memdb.NewDB()
 				require.NoError(t, replaceKey(db, keyID("hi"), nil))
 			})
 			t.Run("ReplacementFails", func(t *testing.T) {
-				db := dbm.NewMemDB()
+				db := memdb.NewDB()
 				key := keyID("hi")
 				require.NoError(t, db.Set(key, []byte("world")))
 				require.Error(t, replaceKey(db, key, func(k keyID) (keyID, error) {
@@ -178,7 +180,7 @@ func TestMigration(t *testing.T) {
 				}))
 			})
 			t.Run("KeyDisapears", func(t *testing.T) {
-				db := dbm.NewMemDB()
+				db := memdb.NewDB()
 				key := keyID("hi")
 				require.NoError(t, db.Set(key, []byte("world")))
 				require.Error(t, replaceKey(db, key, func(k keyID) (keyID, error) {

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -4,7 +4,7 @@ docker:
 	docker build --tag tendermint/e2e-node -f docker/Dockerfile ../..
 
 node:
-	go build -o build/node -tags badgerdb,boltdb,cleveldb,rocksdb ./node
+	go build -o build/node -tags badgerdb,boltdb,cleveldb,goleveldb,rocksdb ./node
 
 generator:
 	go build -o build/generator ./generator

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y libleveldb-dev librocksdb-dev >/dev/null
 
 # Set up build directory /src/tendermint
-ENV TENDERMINT_BUILD_OPTIONS badgerdb,boltdb,cleveldb,rocksdb
+ENV TENDERMINT_BUILD_OPTIONS badgerdb,boltdb,cleveldb,goleveldb,rocksdb
 WORKDIR /src/tendermint
 
 # Fetch dependencies separately (for layer caching)


### PR DESCRIPTION
Although the version appears to be a patch release, it includes a substantial
change to the internal structure of the tm-db module. The functionality does
not appear to have changed, but most imports and usage sites needed to be
updated.