### PR TITLE
Add basic metrics to the indexer package.

### DIFF
--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -47,8 +47,11 @@ func New(cfg *config.RPCConfig, bs state.BlockStore, ss state.Store, es []indexe
 	routes := rpc.Routes(*cfg, ss, bs, es, logger)
 	eb := eventbus.NewDefault()
 	eb.SetLogger(logger.With("module", "events"))
-	is := indexer.NewIndexerService(es, eb)
-	is.SetLogger(logger.With("module", "txindex"))
+	is := indexer.NewService(indexer.ServiceArgs{
+		EventSinks: es,
+		EventBus:   eb,
+		Logger:     logger.With("module", "txindex"),
+	})
 	return &Inspector{
 		routes:         routes,
 		config:         cfg,

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -48,9 +48,9 @@ func New(cfg *config.RPCConfig, bs state.BlockStore, ss state.Store, es []indexe
 	eb := eventbus.NewDefault()
 	eb.SetLogger(logger.With("module", "events"))
 	is := indexer.NewService(indexer.ServiceArgs{
-		EventSinks: es,
-		EventBus:   eb,
-		Logger:     logger.With("module", "txindex"),
+		Sinks:    es,
+		EventBus: eb,
+		Logger:   logger.With("module", "txindex"),
 	})
 	return &Inspector{
 		routes:         routes,

--- a/internal/state/indexer/indexer_service.go
+++ b/internal/state/indexer/indexer_service.go
@@ -16,6 +16,7 @@ type Service struct {
 
 	eventSinks []EventSink
 	eventBus   *eventbus.EventBus
+	metrics *Metrics
 
 	currentBlock struct {
 		header types.EventDataNewBlockHeader

--- a/internal/state/indexer/metrics.go
+++ b/internal/state/indexer/metrics.go
@@ -1,0 +1,73 @@
+package indexer
+
+import (
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/discard"
+
+	prometheus "github.com/go-kit/kit/metrics/prometheus"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+)
+
+// MetricsSubsystem is a the subsystem label for the indexer package.
+const MetricsSubsystem = "indexer"
+
+// Metrics contains metrics exposed by this package.
+type Metrics struct {
+	// Latency for indexing block events.
+	BlockEventsSeconds metrics.Histogram
+
+	// Latency for indexing transaction events.
+	TxEventsSeconds metrics.Histogram
+
+	// Number of complete blocks indexed.
+	BlocksIndexed metrics.Counter
+
+	// Number of transactions indexed.
+	TransactionsIndexed metrics.Counter
+}
+
+// PrometheusMetrics returns Metrics build using Prometheus client library.
+// Optionally, labels can be provided along with their values ("foo",
+// "fooValue").
+func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
+	labels := []string{}
+	for i := 0; i < len(labelsAndValues); i += 2 {
+		labels = append(labels, labelsAndValues[i])
+	}
+	return &Metrics{
+		BlockEventsSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "block_events_seconds",
+			Help:      "Latency for indexing block events.",
+		}, labels).With(labelsAndValues...),
+		TxEventsSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "tx_events_seconds",
+			Help:      "Latency for indexing transaction events.",
+		}, labels).With(labelsAndValues...),
+		BlocksIndexed: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "blocks_indexed",
+			Help:      "Number of complete blocks indexed.",
+		}, labels).With(labelsAndValues...),
+		TransactionsIndexed: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "transactions_indexed",
+			Help:      "Number of transactions indexed.",
+		}, labels).With(labelsAndValues...),
+	}
+}
+
+// NopMetrics returns no-op Metrics.
+func NopMetrics() *Metrics {
+	return &Metrics{
+		BlockEventsSeconds:  discard.NewHistogram(),
+		TxEventsSeconds:     discard.NewHistogram(),
+		BlocksIndexed:       discard.NewCounter(),
+		TransactionsIndexed: discard.NewCounter(),
+	}
+}

--- a/internal/state/indexer/metrics.go
+++ b/internal/state/indexer/metrics.go
@@ -62,8 +62,8 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 	}
 }
 
-// NopMetrics returns no-op Metrics.
-func NopMetrics() *Metrics {
+// nopMetrics returns an indexer metrics stub that discards all samples.
+func nopMetrics() *Metrics {
 	return &Metrics{
 		BlockEventsSeconds:  discard.NewHistogram(),
 		TxEventsSeconds:     discard.NewHistogram(),

--- a/internal/state/indexer/metrics.go
+++ b/internal/state/indexer/metrics.go
@@ -62,8 +62,8 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 	}
 }
 
-// nopMetrics returns an indexer metrics stub that discards all samples.
-func nopMetrics() *Metrics {
+// NopMetrics returns an indexer metrics stub that discards all samples.
+func NopMetrics() *Metrics {
 	return &Metrics{
 		BlockEventsSeconds:  discard.NewHistogram(),
 		TxEventsSeconds:     discard.NewHistogram(),

--- a/node/node.go
+++ b/node/node.go
@@ -171,7 +171,8 @@ func makeNode(cfg *config.Config,
 		return nil, combineCloseError(err, makeCloser(closers))
 	}
 
-	indexerService, eventSinks, err := createAndStartIndexerService(cfg, dbProvider, eventBus, logger, genDoc.ChainID)
+	indexerService, eventSinks, err := createAndStartIndexerService(cfg, dbProvider, eventBus,
+		logger, genDoc.ChainID, nodeMetrics.indexer)
 	if err != nil {
 		return nil, combineCloseError(err, makeCloser(closers))
 	}
@@ -900,11 +901,12 @@ func defaultGenesisDocProviderFunc(cfg *config.Config) genesisDocProvider {
 
 type nodeMetrics struct {
 	consensus *consensus.Metrics
-	p2p       *p2p.Metrics
+	indexer   *indexer.Metrics
 	mempool   *mempool.Metrics
+	p2p       *p2p.Metrics
+	proxy     *proxy.Metrics
 	state     *sm.Metrics
 	statesync *statesync.Metrics
-	proxy     *proxy.Metrics
 }
 
 // metricsProvider returns consensus, p2p, mempool, state, statesync Metrics.
@@ -917,20 +919,22 @@ func defaultMetricsProvider(cfg *config.InstrumentationConfig) metricsProvider {
 		if cfg.Prometheus {
 			return &nodeMetrics{
 				consensus.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
-				p2p.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				indexer.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
 				mempool.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				p2p.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				proxy.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
 				sm.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
 				statesync.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
-				proxy.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
 			}
 		}
 		return &nodeMetrics{
 			consensus.NopMetrics(),
-			p2p.NopMetrics(),
+			indexer.NopMetrics(),
 			mempool.NopMetrics(),
+			p2p.NopMetrics(),
+			proxy.NopMetrics(),
 			sm.NopMetrics(),
 			statesync.NopMetrics(),
-			proxy.NopMetrics(),
 		}
 	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -918,23 +918,23 @@ func defaultMetricsProvider(cfg *config.InstrumentationConfig) metricsProvider {
 	return func(chainID string) *nodeMetrics {
 		if cfg.Prometheus {
 			return &nodeMetrics{
-				consensus.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
-				indexer.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
-				mempool.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
-				p2p.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
-				proxy.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
-				sm.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
-				statesync.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				consensus: consensus.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				indexer:   indexer.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				mempool:   mempool.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				p2p:       p2p.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				proxy:     proxy.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				state:     sm.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
+				statesync: statesync.PrometheusMetrics(cfg.Namespace, "chain_id", chainID),
 			}
 		}
 		return &nodeMetrics{
-			consensus.NopMetrics(),
-			indexer.NopMetrics(),
-			mempool.NopMetrics(),
-			p2p.NopMetrics(),
-			proxy.NopMetrics(),
-			sm.NopMetrics(),
-			statesync.NopMetrics(),
+			consensus: consensus.NopMetrics(),
+			indexer:   indexer.NopMetrics(),
+			mempool:   mempool.NopMetrics(),
+			p2p:       p2p.NopMetrics(),
+			proxy:     proxy.NopMetrics(),
+			state:     sm.NopMetrics(),
+			statesync: statesync.NopMetrics(),
 		}
 	}
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -558,7 +558,8 @@ func TestNodeSetEventSink(t *testing.T) {
 		require.NoError(t, err)
 
 		indexService, eventSinks, err := createAndStartIndexerService(cfg,
-			config.DefaultDBProvider, eventBus, logger, genDoc.ChainID)
+			config.DefaultDBProvider, eventBus, logger, genDoc.ChainID,
+			indexer.NopMetrics())
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, indexService.Stop()) })
 		return eventSinks

--- a/node/setup.go
+++ b/node/setup.go
@@ -113,6 +113,7 @@ func createAndStartIndexerService(
 	eventBus *eventbus.EventBus,
 	logger log.Logger,
 	chainID string,
+	metrics *indexer.Metrics,
 ) (*indexer.Service, []indexer.EventSink, error) {
 	eventSinks, err := sink.EventSinksFromConfig(cfg, dbProvider, chainID)
 	if err != nil {
@@ -123,6 +124,7 @@ func createAndStartIndexerService(
 		Sinks:    eventSinks,
 		EventBus: eventBus,
 		Logger:   logger.With("module", "txindex"),
+		Metrics:  metrics,
 	})
 
 	if err := indexerService.Start(); err != nil {

--- a/node/setup.go
+++ b/node/setup.go
@@ -119,8 +119,11 @@ func createAndStartIndexerService(
 		return nil, nil, err
 	}
 
-	indexerService := indexer.NewIndexerService(eventSinks, eventBus)
-	indexerService.SetLogger(logger.With("module", "txindex"))
+	indexerService := indexer.NewService(indexer.ServiceArgs{
+		Sinks:    eventSinks,
+		EventBus: eventBus,
+		Logger:   logger.With("module", "txindex"),
+	})
 
 	if err := indexerService.Start(); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Fixes #7249. Following the general pattern from other packages, add a Metrics type to the indexer package with some basic latencies and counters for indexing activity.

These are intentionally coarse-grained: The transaction latency, for example, is aggregated over the batches committed to storage, since that is the high-order bit of how long the indexing step takes. If later on we change indexing to index in a more granular fashion, these values can be reused with the same semantics.