### PR TITLE
consensus: add some more checks to vote counting

### DIFF
--- a/internal/consensus/peer_state.go
+++ b/internal/consensus/peer_state.go
@@ -358,6 +358,9 @@ func (ps *PeerState) BlockPartsSent() int {
 
 // SetHasVote sets the given vote as known by the peer
 func (ps *PeerState) SetHasVote(vote *types.Vote) {
+	if vote == nil {
+		return
+	}
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
 

--- a/internal/consensus/peer_state.go
+++ b/internal/consensus/peer_state.go
@@ -193,7 +193,10 @@ func (ps *PeerState) PickVoteToSend(votes types.VoteSetReader) (*types.Vote, boo
 	}
 
 	if index, ok := votes.BitArray().Sub(psVotes).PickRandom(); ok {
-		return votes.GetByIndex(int32(index)), true
+		vote := votes.GetByIndex(int32(index))
+		if vote != nil {
+			return vote, true
+		}
 	}
 
 	return nil, false

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -638,7 +638,7 @@ OUTER_LOOP:
 // pickSendVote picks a vote and sends it to the peer. It will return true if
 // there is a vote to send and false otherwise.
 func (r *Reactor) pickSendVote(ps *PeerState, votes types.VoteSetReader) bool {
-	if vote, ok := ps.PickVoteToSend(votes); ok {
+	if vote, ok := ps.PickVoteToSend(votes); ok && vote != nil {
 		r.Logger.Debug("sending vote message", "ps", ps, "vote", vote)
 		r.voteCh.Out <- p2p.Envelope{
 			To: ps.peerID,

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -638,7 +638,7 @@ OUTER_LOOP:
 // pickSendVote picks a vote and sends it to the peer. It will return true if
 // there is a vote to send and false otherwise.
 func (r *Reactor) pickSendVote(ps *PeerState, votes types.VoteSetReader) bool {
-	if vote, ok := ps.PickVoteToSend(votes); ok && vote != nil {
+	if vote, ok := ps.PickVoteToSend(votes); ok {
 		r.Logger.Debug("sending vote message", "ps", ps, "vote", vote)
 		r.voteCh.Out <- p2p.Envelope{
 			To: ps.peerID,

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -372,6 +372,9 @@ func (voteSet *VoteSet) GetByIndex(valIndex int32) *Vote {
 	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
+	if int(valIndex) >= len(voteSet.votes) {
+		return nil
+	}
 	return voteSet.votes[valIndex]
 }
 


### PR DESCRIPTION
This was brought up by a user off-band. They were running nodes in debug mode and were experiencing occasional panics when the returned vote here: 
https://github.com/tendermint/tendermint/blob/c2908ef785bb5ca6e015910368e4b7a32821b9ff/consensus/reactor.go#L1056
 was `nil` and the logger was trying to marshal the nil vote. 

I have added in a few extra "defensive programming" checks to try to avoid accidental nil pointer dereferencing. 



