### PR TITLE
logger: limit the logger element output length

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -41,7 +41,9 @@ Special thanks to external contributors on this release:
 - [mempool, rpc] \#7041  Add removeTx operation to the RPC layer. (@tychoish)
 
 ### IMPROVEMENTS
+
 - [logger/config](https://github.com/tendermint/tendermint/pull/7258) Limit the logger element output length.(@Jayt106)
+
 ### BUG FIXES
 
 - fix: assignment copies lock value in `BitArray.UnmarshalJSON()` (@lklimek)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -41,7 +41,7 @@ Special thanks to external contributors on this release:
 - [mempool, rpc] \#7041  Add removeTx operation to the RPC layer. (@tychoish)
 
 ### IMPROVEMENTS
-
+- [logger/config](https://github.com/tendermint/tendermint/pull/7258) Limit the logger element output length.(@Jayt106)
 ### BUG FIXES
 
 - fix: assignment copies lock value in `BitArray.UnmarshalJSON()` (@lklimek)

--- a/abci/cmd/abci-cli/abci-cli.go
+++ b/abci/cmd/abci-cli/abci-cli.go
@@ -62,7 +62,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		if logger == nil {
-			logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+			logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 		}
 
 		if client == nil {
@@ -574,7 +574,7 @@ func cmdQuery(cmd *cobra.Command, args []string) error {
 }
 
 func cmdKVStore(cmd *cobra.Command, args []string) error {
-	logger := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	logger := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 
 	// Create the application - in memory or persisted to disk
 	var app types.Application

--- a/cmd/priv_val_server/main.go
+++ b/cmd/priv_val_server/main.go
@@ -45,7 +45,7 @@ func main() {
 		rootCA           = flag.String("rootcafile", "", "absolute path to root CA")
 		prometheusAddr   = flag.String("prometheus-addr", "", "address for prometheus endpoint (host:port)")
 
-		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false).
+		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0).
 			With("module", "priv_val")
 	)
 	flag.Parse()

--- a/cmd/tendermint/commands/debug/debug.go
+++ b/cmd/tendermint/commands/debug/debug.go
@@ -15,7 +15,7 @@ var (
 	flagProfAddr    = "pprof-laddr"
 	flagFrequency   = "frequency"
 
-	logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 )
 
 // DebugCmd defines the root command containing subcommands that assist in

--- a/cmd/tendermint/commands/light.go
+++ b/cmd/tendermint/commands/light.go
@@ -65,8 +65,9 @@ var (
 	trustedHash    []byte
 	trustLevelStr  string
 
-	logLevel  string
-	logFormat string
+	logLevel         string
+	logFormat        string
+	logElementLength int64
 
 	primaryKey   = []byte("primary")
 	witnessesKey = []byte("witnesses")
@@ -98,10 +99,14 @@ func init() {
 	LightCmd.Flags().BoolVar(&sequential, "sequential", false,
 		"sequential verification. Verify all headers sequentially as opposed to using skipping verification",
 	)
+	LightCmd.Flags().Int64Var(&logElementLength, "log-element-length", 0, "The log element length limit")
 }
 
 func runProxy(cmd *cobra.Command, args []string) error {
-	logger, err := log.NewDefaultLogger(logFormat, logLevel, false)
+	if logElementLength < 0 || logElementLength > log.MaxLogElementLength {
+		return fmt.Errorf("invalid element length, the value should be 0 ~ %v", log.MaxLogElementLength)
+	}
+	logger, err := log.NewDefaultLogger(logFormat, logLevel, false, int(logElementLength))
 	if err != nil {
 		return err
 	}

--- a/cmd/tendermint/commands/root.go
+++ b/cmd/tendermint/commands/root.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	config     = cfg.DefaultConfig()
-	logger     = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	logger     = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 	ctxTimeout = 4 * time.Second
 )
 
@@ -55,7 +55,7 @@ var RootCmd = &cobra.Command{
 			return err
 		}
 
-		logger, err = log.NewDefaultLogger(config.LogFormat, config.LogLevel, false)
+		logger, err = log.NewDefaultLogger(config.LogFormat, config.LogLevel, false, int(config.LogElementLength))
 		if err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -206,8 +206,9 @@ type BaseConfig struct { //nolint: maligned
 	// Output format: 'plain' (colored text) or 'json'
 	LogFormat string `mapstructure:"log-format"`
 
-	// The max length of the log message and the log field value:
-	// `0` is the default value (no length limit)
+	// The max length of format string output in each `message`, `field value`, and
+	// `error field value` element in log.
+	// `0` is the default value (no length limit), maximum allowed length for each element is 1e6.
 	LogElementLength int64 `mapstructure:"log-element-length"`
 
 	// Path to the JSON file containing the initial validator set and other meta data

--- a/config/config.go
+++ b/config/config.go
@@ -206,6 +206,10 @@ type BaseConfig struct { //nolint: maligned
 	// Output format: 'plain' (colored text) or 'json'
 	LogFormat string `mapstructure:"log-format"`
 
+	// The max length of the log message and the log field value:
+	// `0` is the default value (no length limit)
+	LogElementLength int64 `mapstructure:"log-element-length"`
+
 	// Path to the JSON file containing the initial validator set and other meta data
 	Genesis string `mapstructure:"genesis-file"`
 
@@ -225,17 +229,18 @@ type BaseConfig struct { //nolint: maligned
 // DefaultBaseConfig returns a default base configuration for a Tendermint node
 func DefaultBaseConfig() BaseConfig {
 	return BaseConfig{
-		Genesis:     defaultGenesisJSONPath,
-		NodeKey:     defaultNodeKeyPath,
-		Mode:        defaultMode,
-		Moniker:     defaultMoniker,
-		ProxyApp:    "tcp://127.0.0.1:26658",
-		ABCI:        "socket",
-		LogLevel:    DefaultLogLevel,
-		LogFormat:   log.LogFormatPlain,
-		FilterPeers: false,
-		DBBackend:   "goleveldb",
-		DBPath:      "data",
+		Genesis:          defaultGenesisJSONPath,
+		NodeKey:          defaultNodeKeyPath,
+		Mode:             defaultMode,
+		Moniker:          defaultMoniker,
+		ProxyApp:         "tcp://127.0.0.1:26658",
+		ABCI:             "socket",
+		LogLevel:         DefaultLogLevel,
+		LogFormat:        log.LogFormatPlain,
+		LogElementLength: 0,
+		FilterPeers:      false,
+		DBBackend:        "goleveldb",
+		DBPath:           "data",
 	}
 }
 
@@ -319,6 +324,10 @@ func (cfg BaseConfig) ValidateBasic() error {
 
 	default:
 		return fmt.Errorf("unknown mode: %v", cfg.Mode)
+	}
+
+	if cfg.LogElementLength < 0 || cfg.LogElementLength > log.MaxLogElementLength {
+		return fmt.Errorf("invalid log size, the value should be 0 ~ %v", log.MaxLogElementLength)
 	}
 
 	return nil

--- a/config/toml.go
+++ b/config/toml.go
@@ -132,6 +132,10 @@ log-level = "{{ .BaseConfig.LogLevel }}"
 # Output format: 'plain' (colored text) or 'json'
 log-format = "{{ .BaseConfig.LogFormat }}"
 
+# The length limit of the message/fieldValue in the log, it will be truncated when the log elements over the limit.
+# The default length is 0 (no truncation) and the maximum length is 1 million.
+log-element-length = {{ .BaseConfig.LogElementLength }}
+
 ##### additional base config options #####
 
 # Path to the JSON file containing the initial validator set and other meta data

--- a/config/toml.go
+++ b/config/toml.go
@@ -132,7 +132,8 @@ log-level = "{{ .BaseConfig.LogLevel }}"
 # Output format: 'plain' (colored text) or 'json'
 log-format = "{{ .BaseConfig.LogFormat }}"
 
-# The length limit of the message/fieldValue in the log, it will be truncated when the log elements over the limit.
+# The length limit of format string output in each message/fieldValue/errFieldValue in the log.
+# It will be truncated when the log elements over the limit.
 # The default length is 0 (no truncation) and the maximum length is 1 million.
 log-element-length = {{ .BaseConfig.LogElementLength }}
 

--- a/libs/log/default.go
+++ b/libs/log/default.go
@@ -35,6 +35,21 @@ func NewDefaultLogger(format, level string, trace bool, elementLength int) (Logg
 		return nil, fmt.Errorf("unsupported log element length: %d", elementLength)
 	}
 
+	var formatter func(interface{}) string
+	if elementLength > 0 {
+		formatter = func(v interface{}) string {
+			s := fmt.Sprint(v)
+			if len(s) > elementLength {
+				return s[:elementLength]
+			}
+			return s
+		}
+	} else {
+		formatter = func(v interface{}) string {
+			return fmt.Sprint(v)
+		}
+	}
+
 	var logWriter io.Writer
 	switch strings.ToLower(format) {
 	case LogFormatPlain, LogFormatText:
@@ -48,28 +63,9 @@ func NewDefaultLogger(format, level string, trace bool, elementLength int) (Logg
 				}
 				return "FormatLevel cannot be cast to string"
 			},
-			FormatFieldValue: func(i interface{}) string {
-				s := fmt.Sprintf("%v", i)
-				if elementLength > 0 && len(s) > elementLength {
-					return s[:elementLength]
-				}
-
-				return s
-			},
-			FormatMessage: func(i interface{}) string {
-				s := fmt.Sprintf("%v", i)
-				if elementLength > 0 && len(s) > elementLength {
-					return s[:elementLength]
-				}
-				return s
-			},
-			FormatErrFieldValue: func(i interface{}) string {
-				s := fmt.Sprintf("%v", i)
-				if elementLength > 0 && len(s) > elementLength {
-					return s[:elementLength]
-				}
-				return s
-			},
+			FormatFieldValue:    formatter,
+			FormatMessage:       formatter,
+			FormatErrFieldValue: formatter,
 		}
 
 	case LogFormatJSON:

--- a/libs/log/default.go
+++ b/libs/log/default.go
@@ -32,7 +32,7 @@ const (
 // pair tuples, where the key must be a string.
 func NewDefaultLogger(format, level string, trace bool, elementLength int) (Logger, error) {
 	if elementLength < 0 || elementLength > MaxLogElementLength {
-		return nil, fmt.Errorf("unsupported log size: %d", elementLength)
+		return nil, fmt.Errorf("unsupported log element length: %d", elementLength)
 	}
 
 	var logWriter io.Writer

--- a/libs/log/default_test.go
+++ b/libs/log/default_test.go
@@ -11,22 +11,38 @@ func TestNewDefaultLogger(t *testing.T) {
 	testCases := map[string]struct {
 		format    string
 		level     string
+		size      int64
 		expectErr bool
 	}{
 		"invalid format": {
 			format:    "foo",
 			level:     log.LogLevelInfo,
+			size:      0,
 			expectErr: true,
 		},
 		"invalid level": {
 			format:    log.LogFormatJSON,
 			level:     "foo",
+			size:      0,
 			expectErr: true,
 		},
 		"valid format and level": {
 			format:    log.LogFormatJSON,
 			level:     log.LogLevelInfo,
+			size:      0,
 			expectErr: false,
+		},
+		"invalid log element length": {
+			format:    log.LogFormatJSON,
+			level:     log.LogLevelInfo,
+			size:      -1,
+			expectErr: true,
+		},
+		"invalid log element length, exceed limit": {
+			format:    log.LogFormatJSON,
+			level:     log.LogLevelInfo,
+			size:      log.MaxLogElementLength + 1,
+			expectErr: true,
 		},
 	}
 
@@ -34,11 +50,11 @@ func TestNewDefaultLogger(t *testing.T) {
 		tc := tc
 
 		t.Run(name, func(t *testing.T) {
-			_, err := log.NewDefaultLogger(tc.format, tc.level, false)
+			_, err := log.NewDefaultLogger(tc.format, tc.level, false, int(tc.size))
 			if tc.expectErr {
 				require.Error(t, err)
 				require.Panics(t, func() {
-					_ = log.MustNewDefaultLogger(tc.format, tc.level, false)
+					_ = log.MustNewDefaultLogger(tc.format, tc.level, false, int(tc.size))
 				})
 			} else {
 				require.NoError(t, err)

--- a/libs/log/default_test.go
+++ b/libs/log/default_test.go
@@ -32,6 +32,12 @@ func TestNewDefaultLogger(t *testing.T) {
 			size:      0,
 			expectErr: false,
 		},
+		"valid log element max length": {
+			format:    log.LogFormatJSON,
+			level:     log.LogLevelInfo,
+			size:      log.MaxLogElementLength,
+			expectErr: false,
+		},
 		"invalid log element length": {
 			format:    log.LogFormatJSON,
 			level:     log.LogLevelInfo,

--- a/libs/log/testing.go
+++ b/libs/log/testing.go
@@ -32,7 +32,7 @@ func TestingLoggerWithOutput(w io.Writer) Logger {
 	}
 
 	if testing.Verbose() {
-		testingLogger = MustNewDefaultLogger(LogFormatText, LogLevelDebug, true)
+		testingLogger = MustNewDefaultLogger(LogFormatText, LogLevelDebug, true, 0)
 	} else {
 		testingLogger = NewNopLogger()
 	}

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -92,7 +92,7 @@ func TestMain(m *testing.M) {
 
 // launch unix and tcp servers
 func setup() {
-	logger := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	logger := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 
 	cmd := exec.Command("rm", "-f", unixSocket)
 	err := cmd.Start()

--- a/rpc/jsonrpc/test/main.go
+++ b/rpc/jsonrpc/test/main.go
@@ -25,7 +25,7 @@ type Result struct {
 func main() {
 	var (
 		mux    = http.NewServeMux()
-		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 	)
 
 	// Stop upon receiving SIGTERM or CTRL-C.

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -86,7 +86,7 @@ func StartTendermint(ctx context.Context,
 	if nodeOpts.suppressStdout {
 		logger = log.NewNopLogger()
 	} else {
-		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 	}
 	papp := abciclient.NewLocalCreator(app)
 	tmNode, err := node.New(conf, logger, papp, nil)

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -88,7 +88,7 @@ func NewApplication(cfg *Config) (*Application, error) {
 		return nil, err
 	}
 	return &Application{
-		logger:    log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false),
+		logger:    log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0),
 		state:     state,
 		snapshots: snapshots,
 		cfg:       cfg,

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -17,7 +17,7 @@ const (
 	randomSeed int64 = 4827085738
 )
 
-var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 
 func main() {
 	NewCLI().Run()

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -34,7 +34,7 @@ import (
 	e2e "github.com/tendermint/tendermint/test/e2e/pkg"
 )
 
-var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 
 // main is the binary entrypoint.
 func main() {
@@ -287,7 +287,7 @@ func setupNode() (*config.Config, log.Logger, error) {
 		return nil, nil, fmt.Errorf("error in config file: %w", err)
 	}
 
-	nodeLogger, err := log.NewDefaultLogger(tmcfg.LogFormat, tmcfg.LogLevel, false)
+	nodeLogger, err := log.NewDefaultLogger(tmcfg.LogFormat, tmcfg.LogLevel, false, int(tmcfg.LogElementLength))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -16,7 +16,7 @@ import (
 
 const randomSeed = 2308084734268
 
-var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 
 func main() {
 	NewCLI().Run()

--- a/test/fuzz/rpc/jsonrpc/server/handler.go
+++ b/test/fuzz/rpc/jsonrpc/server/handler.go
@@ -19,7 +19,7 @@ var mux *http.ServeMux
 
 func init() {
 	mux = http.NewServeMux()
-	lgr := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	lgr := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 	rs.RegisterRPCFuncs(mux, rpcFuncMap, lgr)
 }
 

--- a/tools/tm-signer-harness/main.go
+++ b/tools/tm-signer-harness/main.go
@@ -24,7 +24,7 @@ const (
 
 var defaultTMHome string
 
-var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false, 0)
 
 // Command line flags
 var (


### PR DESCRIPTION
Add a new config to limit the log element output length. The default is `0` (no limit)  

ref #6922
