### PR TITLE
rpc: implement header and header_by_hash queries

### DIFF
--- a/internal/rpc/core/blocks.go
+++ b/internal/rpc/core/blocks.go
@@ -51,7 +51,8 @@ func (env *Environment) BlockchainInfo(
 
 	return &coretypes.ResultBlockchainInfo{
 		LastHeight: env.BlockStore.Height(),
-		BlockMetas: blockMetas}, nil
+		BlockMetas: blockMetas,
+	}, nil
 }
 
 // error if either min or max are negative or min > max
@@ -120,6 +121,38 @@ func (env *Environment) BlockByHash(ctx *rpctypes.Context, hash bytes.HexBytes) 
 	// If block is not nil, then blockMeta can't be nil.
 	blockMeta := env.BlockStore.LoadBlockMeta(block.Height)
 	return &coretypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block}, nil
+}
+
+// Header gets block header at a given height.
+// If no height is provided, it will fetch the latest header.
+// More: https://docs.tendermint.com/master/rpc/#/Info/header
+func (env *Environment) Header(ctx *rpctypes.Context, heightPtr *int64) (*coretypes.ResultHeader, error) {
+	height, err := env.getHeight(env.BlockStore.Height(), heightPtr)
+	if err != nil {
+		return nil, err
+	}
+
+	block := env.BlockStore.LoadBlock(height)
+	if block == nil {
+		return &coretypes.ResultHeader{}, nil
+	}
+
+	return &coretypes.ResultHeader{Header: &block.Header}, nil
+}
+
+// HeaderByHash gets header by hash.
+// More: https://docs.tendermint.com/master/rpc/#/Info/header_by_hash
+func (env *Environment) HeaderByHash(ctx *rpctypes.Context, hash bytes.HexBytes) (*coretypes.ResultHeader, error) {
+	// N.B. The hash parameter is HexBytes so that the reflective parameter
+	// decoding logic in the HTTP service will correctly translate from JSON.
+	// See https://github.com/tendermint/tendermint/issues/6802 for context.
+
+	block := env.BlockStore.LoadBlockByHash(hash)
+	if block == nil {
+		return &coretypes.ResultHeader{}, nil
+	}
+
+	return &coretypes.ResultHeader{Header: &block.Header}, nil
 }
 
 // Commit gets block commit at a given height.

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -92,9 +92,11 @@ type baseRPCClient struct {
 	caller jsonrpcclient.Caller
 }
 
-var _ rpcClient = (*HTTP)(nil)
-var _ rpcClient = (*BatchHTTP)(nil)
-var _ rpcClient = (*baseRPCClient)(nil)
+var (
+	_ rpcClient = (*HTTP)(nil)
+	_ rpcClient = (*BatchHTTP)(nil)
+	_ rpcClient = (*baseRPCClient)(nil)
+)
 
 //-----------------------------------------------------------------------------
 // HTTP
@@ -444,6 +446,31 @@ func (c *baseRPCClient) BlockResults(
 		params["height"] = height
 	}
 	_, err := c.caller.Call(ctx, "block_results", params, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *baseRPCClient) Header(ctx context.Context, height *int64) (*coretypes.ResultHeader, error) {
+	result := new(coretypes.ResultHeader)
+	params := make(map[string]interface{})
+	if height != nil {
+		params["height"] = height
+	}
+	_, err := c.caller.Call(ctx, "header", params, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *baseRPCClient) HeaderByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultHeader, error) {
+	result := new(coretypes.ResultHeader)
+	params := map[string]interface{}{
+		"hash": hash,
+	}
+	_, err := c.caller.Call(ctx, "header_by_hash", params, result)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -78,6 +78,8 @@ type SignClient interface {
 	Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error)
 	BlockByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error)
 	BlockResults(ctx context.Context, height *int64) (*coretypes.ResultBlockResults, error)
+	Header(ctx context.Context, height *int64) (*coretypes.ResultHeader, error)
+	HeaderByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultHeader, error)
 	Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error)
 	Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error)
 	Tx(ctx context.Context, hash bytes.HexBytes, prove bool) (*coretypes.ResultTx, error)

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -165,6 +165,14 @@ func (c *Local) BlockResults(ctx context.Context, height *int64) (*coretypes.Res
 	return c.env.BlockResults(c.ctx, height)
 }
 
+func (c *Local) Header(ctx context.Context, height *int64) (*coretypes.ResultHeader, error) {
+	return c.env.Header(c.ctx, height)
+}
+
+func (c *Local) HeaderByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultHeader, error) {
+	return c.env.HeaderByHash(c.ctx, hash)
+}
+
 func (c *Local) Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
 	return c.env.Commit(c.ctx, height)
 }

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -359,6 +359,15 @@ func TestClientMethodCalls(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, block, blockByHash)
 
+				// check that the header matches the block hash
+				header, err := c.Header(ctx, &apph)
+				require.NoError(t, err)
+				require.Equal(t, block.Block.Header, *header.Header)
+
+				headerByHash, err := c.HeaderByHash(ctx, block.BlockID.Hash)
+				require.NoError(t, err)
+				require.Equal(t, header, headerByHash)
+
 				// now check the results
 				blockResults, err := c.BlockResults(ctx, &txh)
 				require.NoError(t, err, "%d: %+v", i, err)
@@ -551,7 +560,6 @@ func TestClientMethodCalls(t *testing.T) {
 						_, err := c.BroadcastEvidence(ctx, fake)
 						require.Error(t, err, "BroadcastEvidence(%s) succeeded, but the evidence was fake", fake)
 					}
-
 				})
 				t.Run("BroadcastEmpty", func(t *testing.T) {
 					_, err := c.BroadcastEvidence(ctx, nil)
@@ -732,7 +740,6 @@ func TestClientMethodCallsAdvanced(t *testing.T) {
 
 		for _, c := range GetClients(t, n, conf) {
 			t.Run(fmt.Sprintf("%T", c), func(t *testing.T) {
-
 				// now we query for the tx.
 				result, err := c.TxSearch(ctx, fmt.Sprintf("tx.hash='%v'", find.Hash), true, nil, nil, "asc")
 				require.Nil(t, err)

--- a/rpc/coretypes/responses.go
+++ b/rpc/coretypes/responses.go
@@ -51,6 +51,11 @@ type ResultBlock struct {
 	Block   *types.Block  `json:"block"`
 }
 
+// ResultHeader represents the response for a Header RPC Client query
+type ResultHeader struct {
+	Header *types.Header `json:"header"`
+}
+
 // Commit and Header
 type ResultCommit struct {
 	types.SignedHeader `json:"signed_header"`

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -525,7 +525,7 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
   /net_info:
     get:
-      summary: Network informations
+      summary: Network information
       operationId: net_info
       tags:
         - Info
@@ -711,7 +711,7 @@ paths:
         Get Block.
       responses:
         "200":
-          description: Block informations.
+          description: Block information.
           content:
             application/json:
               schema:
@@ -740,7 +740,7 @@ paths:
         Get Block By Hash.
       responses:
         "200":
-          description: Block informations.
+          description: Block information.
           content:
             application/json:
               schema:
@@ -758,7 +758,7 @@ paths:
       parameters:
         - in: query
           name: height
-          description: height to return. If no height is provided, it will fetch informations regarding the latest block.
+          description: height to return. If no height is provided, it will fetch information regarding the latest block.
           schema:
             type: integer
             default: 0
@@ -780,6 +780,64 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /header:
+    get:
+      summary: Get Header at a specified height
+      operationId: header
+      parameters:
+        - in: query
+          name: height
+          schema:
+            type: integer
+            default: 0
+            example: 1
+          description: height to return. If no height is provided, it will fetch the latest block header.
+      tags:
+        - Info
+      description: |
+        Get block header.
+      responses:
+        "200":
+          description: Block header information.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HeaderResponse"
+        "500":
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /header_by_hash:
+    get:
+      summary: Get block header by hash
+      operationId: header_by_hash
+      parameters:
+        - in: query
+          name: hash
+          description: block hash
+          required: true
+          schema:
+            type: string
+            example: "0xD70952032620CC4E2737EB8AC379806359D8E0B17B0488F627997A0B043ABDED"
+      tags:
+        - Info
+      description: |
+        Get Block Header By Hash.
+      responses:
+        "200":
+          description: Block header information.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HeaderResponse"
+        "500":
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /commit:
     get:
       summary: Get commit results at a specified height
@@ -787,7 +845,7 @@ paths:
       parameters:
         - in: query
           name: height
-          description: height to return. If no height is provided, it will fetch commit informations regarding the latest block.
+          description: height to return. If no height is provided, it will fetch commit information regarding the latest block.
           schema:
             type: integer
             default: 0
@@ -968,7 +1026,7 @@ paths:
       parameters:
         - in: query
           name: height
-          description: height to return. If no height is provided, it will fetch commit informations regarding the latest block.
+          description: height to return. If no height is provided, it will fetch commit information regarding the latest block.
           schema:
             type: integer
             default: 0
@@ -1703,13 +1761,21 @@ components:
         block:
           $ref: "#/components/schemas/Block"
     BlockResponse:
-      description: Blockc info
+      description: Block info
       allOf:
         - $ref: "#/components/schemas/JSONRPC"
         - type: object
           properties:
             result:
               $ref: "#/components/schemas/BlockComplete"
+    HeaderResponse:
+      description: Block Header info
+      allOf:
+        - $ref: "#/components/schemas/JSONRPC"
+        - type: object
+          properties:
+            result:
+              $ref: "#/components/schemas/BlockHeader"
 
     ################## FROM NOW ON NEEDS REFACTOR ##################
     BlockResultsResponse:


### PR DESCRIPTION
Introduces `header` and `header_by_hash` queries to the RPC client


