### PR TITLE
rpc: backport experimental buffer size control parameters from #7230 (tm v0.35.x)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,8 @@ Special thanks to external contributors on this release:
 
 - CLI/RPC/Config
 
+  - [config] \#7276 rpc: Add experimental config params to allow for subscription buffer size control (@thanethomson).
+
 - Apps
 
 - P2P Protocol

--- a/config/config.go
+++ b/config/config.go
@@ -503,6 +503,16 @@ type RPCConfig struct {
 	// returning `ErrOutOfCapacity`.
 	SubscriptionBufferSize int `mapstructure:"experimental-subscription-buffer-size"`
 
+	// The maximum number of responses that can be buffered per WebSocket
+	// client. If clients cannot read from the WebSocket endpoint fast enough,
+	// they will be disconnected, so increasing this parameter may reduce the
+	// chances of them being disconnected (but will cause the node to use more
+	// memory).
+	//
+	// Must be at least the same as `SubscriptionBufferSize`, otherwise
+	// connections may be dropped unnecessarily.
+	WebSocketWriteBufferSize int `mapstructure:"experimental-websocket-write-buffer-size"`
+
 	// How long to wait for a tx to be committed during /broadcast_tx_commit
 	// WARNING: Using a value larger than 10s will result in increasing the
 	// global HTTP write timeout, which applies to all connections and endpoints.
@@ -554,6 +564,7 @@ func DefaultRPCConfig() *RPCConfig {
 		MaxSubscriptionsPerClient: 5,
 		SubscriptionBufferSize:    defaultSubscriptionBufferSize,
 		TimeoutBroadcastTxCommit:  10 * time.Second,
+		WebSocketWriteBufferSize:  defaultSubscriptionBufferSize,
 
 		MaxBodyBytes:   int64(1000000), // 1MB
 		MaxHeaderBytes: 1 << 20,        // same as the net/http default
@@ -591,6 +602,12 @@ func (cfg *RPCConfig) ValidateBasic() error {
 		return fmt.Errorf(
 			"experimental-subscription-buffer-size must be >= %d",
 			minSubscriptionBufferSize,
+		)
+	}
+	if cfg.WebSocketWriteBufferSize < cfg.SubscriptionBufferSize {
+		return fmt.Errorf(
+			"experimental-websocket-write-buffer-size must be >= experimental-subscription-buffer-size (%d)",
+			cfg.SubscriptionBufferSize,
 		)
 	}
 	if cfg.TimeoutBroadcastTxCommit < 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -513,6 +513,15 @@ type RPCConfig struct {
 	// connections may be dropped unnecessarily.
 	WebSocketWriteBufferSize int `mapstructure:"experimental-websocket-write-buffer-size"`
 
+	// If a WebSocket client cannot read fast enough, at present we may
+	// silently drop events instead of generating an error or disconnecting the
+	// client.
+	//
+	// Enabling this parameter will cause the WebSocket connection to be closed
+	// instead if it cannot read fast enough, allowing for greater
+	// predictability in subscription behavior.
+	CloseOnSlowClient bool `mapstructure:"experimental-close-on-slow-client"`
+
 	// How long to wait for a tx to be committed during /broadcast_tx_commit
 	// WARNING: Using a value larger than 10s will result in increasing the
 	// global HTTP write timeout, which applies to all connections and endpoints.

--- a/config/toml.go
+++ b/config/toml.go
@@ -236,6 +236,12 @@ max-subscription-clients = {{ .RPC.MaxSubscriptionClients }}
 # the estimated # maximum number of broadcast_tx_commit calls per block.
 max-subscriptions-per-client = {{ .RPC.MaxSubscriptionsPerClient }}
 
+# Experimental parameter to specify the maximum number of events a node will
+# buffer, per subscription, before returning an error and closing the
+# subscription. Must be set to at least 100, but higher values will accommodate
+# higher event throughput rates (and will use more memory).
+experimental-subscription-buffer-size = {{ .RPC.SubscriptionBufferSize }}
+
 # How long to wait for a tx to be committed during /broadcast_tx_commit.
 # WARNING: Using a value larger than 10s will result in increasing the
 # global HTTP write timeout, which applies to all connections and endpoints.

--- a/config/toml.go
+++ b/config/toml.go
@@ -254,6 +254,15 @@ experimental-subscription-buffer-size = {{ .RPC.SubscriptionBufferSize }}
 # accommodate non-subscription-related RPC responses.
 experimental-websocket-write-buffer-size = {{ .RPC.WebSocketWriteBufferSize }}
 
+# If a WebSocket client cannot read fast enough, at present we may
+# silently drop events instead of generating an error or disconnecting the
+# client.
+#
+# Enabling this experimental parameter will cause the WebSocket connection to
+# be closed instead if it cannot read fast enough, allowing for greater
+# predictability in subscription behavior.
+experimental-close-on-slow-client = {{ .RPC.CloseOnSlowClient }}
+
 # How long to wait for a tx to be committed during /broadcast_tx_commit.
 # WARNING: Using a value larger than 10s will result in increasing the
 # global HTTP write timeout, which applies to all connections and endpoints.

--- a/config/toml.go
+++ b/config/toml.go
@@ -242,6 +242,18 @@ max-subscriptions-per-client = {{ .RPC.MaxSubscriptionsPerClient }}
 # higher event throughput rates (and will use more memory).
 experimental-subscription-buffer-size = {{ .RPC.SubscriptionBufferSize }}
 
+# Experimental parameter to specify the maximum number of RPC responses that
+# can be buffered per WebSocket client. If clients cannot read from the
+# WebSocket endpoint fast enough, they will be disconnected, so increasing this
+# parameter may reduce the chances of them being disconnected (but will cause
+# the node to use more memory).
+#
+# Must be at least the same as "experimental-subscription-buffer-size",
+# otherwise connections could be dropped unnecessarily. This value should
+# ideally be somewhat higher than "experimental-subscription-buffer-size" to
+# accommodate non-subscription-related RPC responses.
+experimental-websocket-write-buffer-size = {{ .RPC.WebSocketWriteBufferSize }}
+
 # How long to wait for a tx to be committed during /broadcast_tx_commit.
 # WARNING: Using a value larger than 10s will result in increasing the
 # global HTTP write timeout, which applies to all connections and endpoints.

--- a/internal/rpc/core/events.go
+++ b/internal/rpc/core/events.go
@@ -13,9 +13,6 @@ import (
 )
 
 const (
-	// Buffer on the Tendermint (server) side to allow some slowness in clients.
-	subBufferSize = 100
-
 	// maxQueryLength is the maximum length of a query string that will be
 	// accepted. This is just a safety check to avoid outlandish queries.
 	maxQueryLength = 512
@@ -44,7 +41,7 @@ func (env *Environment) Subscribe(ctx *rpctypes.Context, query string) (*coretyp
 	subCtx, cancel := context.WithTimeout(ctx.Context(), SubscribeTimeout)
 	defer cancel()
 
-	sub, err := env.EventBus.Subscribe(subCtx, addr, q, subBufferSize)
+	sub, err := env.EventBus.Subscribe(subCtx, addr, q, env.Config.SubscriptionBufferSize)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/pubsub/subscription.go
+++ b/libs/pubsub/subscription.go
@@ -15,7 +15,7 @@ var (
 
 	// ErrOutOfCapacity is returned by Err when a client is not pulling messages
 	// fast enough. Note the client's subscription will be terminated.
-	ErrOutOfCapacity = errors.New("client is not pulling messages fast enough")
+	ErrOutOfCapacity = errors.New("internal subscription event buffer is out of capacity")
 )
 
 // A Subscription represents a client subscription for a particular query and

--- a/node/node.go
+++ b/node/node.go
@@ -889,6 +889,7 @@ func (n *nodeImpl) startRPC() ([]net.Listener, error) {
 				}
 			}),
 			rpcserver.ReadLimit(cfg.MaxBodyBytes),
+			rpcserver.WriteChanCapacity(n.config.RPC.WebSocketWriteBufferSize),
 		)
 		wm.SetLogger(wmLogger)
 		mux.HandleFunc("/websocket", wm.WebsocketHandler)


### PR DESCRIPTION
As per https://github.com/tendermint/tendermint/pull/7230#issuecomment-963629146, this PR backports the changes from #7230 for Tendermint v0.35.x.

