### PR TITLE
docs: clarify where doc site config settings must land

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -146,6 +146,8 @@ If there were no release candidates, begin by creating a backport branch, as des
    - Add a new entry to `themeConfig.versions` in
      [`docs/.vuepress/config.js`](./docs/.vuepress/config.js) to include the
 	 release in the dropdown versions menu.
+   - Commit these changes to `master` and backport them into the backport
+     branch for this release.
 
 ## Minor release (point releases)
 

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -11,9 +11,9 @@ and other supported release branches.
 
 There is a [GitHub Actions workflow](https://github.com/tendermint/docs/actions/workflows/deployment.yml)
 in the `tendermint/docs` repository that clones and builds the documentation
-site from the contents of this `docs` directory, for `master` and for each
-supported release branch. Under the hood, this workflow runs `make build-docs`
-from the [Makefile](../Makefile#L214).
+site from the contents of this `docs` directory, for `master` and for the
+backport branch of each supported release. Under the hood, this workflow runs
+`make build-docs` from the [Makefile](../Makefile#L214).
 
 The list of supported versions are defined in [`config.js`](./.vuepress/config.js),
 which defines the UI menu on the documentation site, and also in


### PR DESCRIPTION
Since the doc site is built from the backport branches, the config changes for
a new major release also need to be replicated into the backport branch as well
as master. Update the release docs to mention that specifically, since I missed
it during the v0.35 release.
