### PR TITLE
consensus: add calculation for proposal step waits from pbts 

### DIFF
--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -1,0 +1,115 @@
+package consensus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tmtimemocks "github.com/tendermint/tendermint/libs/time/mocks"
+	"github.com/tendermint/tendermint/types"
+)
+
+func TestProposerWaitTime(t *testing.T) {
+	genesisTime, err := time.Parse(time.RFC3339, "2019-03-13T23:00:00Z")
+	require.NoError(t, err)
+	testCases := []struct {
+		name         string
+		blockTime    time.Time
+		localTime    time.Time
+		expectedWait time.Duration
+	}{
+		{
+			name:         "block time greater than local time",
+			blockTime:    genesisTime.Add(5 * time.Nanosecond),
+			localTime:    genesisTime.Add(1 * time.Nanosecond),
+			expectedWait: 4 * time.Nanosecond,
+		},
+		{
+			name:         "local time greater than block time",
+			blockTime:    genesisTime.Add(1 * time.Nanosecond),
+			localTime:    genesisTime.Add(5 * time.Nanosecond),
+			expectedWait: 0,
+		},
+		{
+			name:         "both times equal",
+			blockTime:    genesisTime.Add(5 * time.Nanosecond),
+			localTime:    genesisTime.Add(5 * time.Nanosecond),
+			expectedWait: 0,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			b := types.Block{
+				Header: types.Header{
+					Time: testCase.blockTime,
+				},
+			}
+
+			mockSource := new(tmtimemocks.Source)
+			mockSource.On("Now").Return(testCase.localTime)
+
+			ti := proposerWaitTime(mockSource, b.Header)
+			assert.Equal(t, testCase.expectedWait, ti)
+		})
+	}
+}
+
+func TestProposalTimeout(t *testing.T) {
+	genesisTime, err := time.Parse(time.RFC3339, "2019-03-13T23:00:00Z")
+	require.NoError(t, err)
+	testCases := []struct {
+		name              string
+		localTime         time.Time
+		previousBlockTime time.Time
+		precision         time.Duration
+		msgDelay          time.Duration
+		expectedDuration  time.Duration
+	}{
+		{
+			name:              "MsgDelay + Precision has not quite elapsed",
+			localTime:         genesisTime.Add(525 * time.Millisecond),
+			previousBlockTime: genesisTime.Add(6 * time.Millisecond),
+			precision:         time.Millisecond * 20,
+			msgDelay:          time.Millisecond * 500,
+			expectedDuration:  1 * time.Millisecond,
+		},
+		{
+			name:              "MsgDelay + Precision equals current time",
+			localTime:         genesisTime.Add(525 * time.Millisecond),
+			previousBlockTime: genesisTime.Add(5 * time.Millisecond),
+			precision:         time.Millisecond * 20,
+			msgDelay:          time.Millisecond * 500,
+			expectedDuration:  0,
+		},
+		{
+			name:              "MsgDelay + Precision has elapsed",
+			localTime:         genesisTime.Add(725 * time.Millisecond),
+			previousBlockTime: genesisTime.Add(5 * time.Millisecond),
+			precision:         time.Millisecond * 20,
+			msgDelay:          time.Millisecond * 500,
+			expectedDuration:  0,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			b := types.Block{
+				Header: types.Header{
+					Time: testCase.previousBlockTime,
+				},
+			}
+
+			mockSource := new(tmtimemocks.Source)
+			mockSource.On("Now").Return(testCase.localTime)
+
+			tp := types.TimestampParams{
+				Precision: testCase.precision,
+				MsgDelay:  testCase.msgDelay,
+			}
+
+			ti := proposalStepWaitingTime(mockSource, b.Header, tp)
+			assert.Equal(t, testCase.expectedDuration, ti)
+		})
+	}
+}

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2427,8 +2427,8 @@ func proposerWaitTime(lt tmtime.Source, h types.Header) time.Duration {
 
 // proposalStepWaitingTime determines how long a validator should wait for a block
 // to be sent from a proposer. This duration is determined as a result of the
-// previous block's time as well as by the Accuracy and MsgDelay timestamp parameter.
-// The validator and the proposer's clock should differ from eachother by at most
+// previous block's time as well as by the Accuracy and MsgDelay timestamp parameters.
+// The validator's and the proposer's clocks should differ from eachother by at most
 // 2 * Accuracy and the proposal should take at most MsgDelay to arrive at the validator.
 // The validator must therefore wait at least 2 * Accuracy + MsgDelay for the proposal
 // to arrive.

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2412,3 +2412,15 @@ func repairWalFile(src, dst string) error {
 
 	return nil
 }
+
+// proposerWaitUntil determines when the proposer should propose its next block
+// Block times must be monotonically increasing, so if the block time of the previous
+// block is larger than the proposer's current time, then the proposer will sleep
+// until its local clock exceeds the previous block time.
+func proposerWaitUntil(lt tmtime.Source, h types.Header) time.Time {
+	t := lt.Now()
+	if t.After(h.Time) {
+		return t
+	}
+	return h.Time
+}

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2413,14 +2413,14 @@ func repairWalFile(src, dst string) error {
 	return nil
 }
 
-// proposerWaitUntil determines when the proposer should propose its next block
+// proposerWaitTime determines how long the proposer should wait to propose its next block.
 // Block times must be monotonically increasing, so if the block time of the previous
 // block is larger than the proposer's current time, then the proposer will sleep
 // until its local clock exceeds the previous block time.
-func proposerWaitUntil(lt tmtime.Source, h types.Header) time.Time {
+func proposerWaitTime(lt tmtime.Source, h types.Header) time.Duration {
 	t := lt.Now()
 	if t.After(h.Time) {
-		return t
+		return 0
 	}
-	return h.Time
+	return h.Time.Sub(t)
 }

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2414,6 +2414,8 @@ func repairWalFile(src, dst string) error {
 }
 
 // proposerWaitTime determines how long the proposer should wait to propose its next block.
+// If the result is zero, a block can be proposed immediately.
+//
 // Block times must be monotonically increasing, so if the block time of the previous
 // block is larger than the proposer's current time, then the proposer will sleep
 // until its local clock exceeds the previous block time.

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2424,3 +2424,19 @@ func proposerWaitTime(lt tmtime.Source, h types.Header) time.Duration {
 	}
 	return h.Time.Sub(t)
 }
+
+// proposalStepWaitingTime determines how long a validator should wait for a block
+// to be sent from a proposer. This duration is determined as a result of the
+// previous block's time as well as by the Accuracy and MsgDelay timestamp parameter.
+// The validator and the proposer's clock should differ from eachother by at most
+// 2 * Accuracy and the proposal should take at most MsgDelay to arrive at the validator.
+// The validator must therefore wait at least 2 * Accuracy + MsgDelay for the proposal
+// to arrive.
+func proposalStepWaitingTime(lt tmtime.Source, h types.Header, tp types.TimestampParams) time.Duration {
+	t := lt.Now()
+	wt := h.Time.Add(2 * tp.Accuracy).Add(tp.MsgDelay)
+	if t.After(wt) {
+		return 0
+	}
+	return wt.Sub(t)
+}

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
-	tmtimemocks "github.com/tendermint/tendermint/libs/time/mocks"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -2439,109 +2438,6 @@ func TestSignSameVoteTwice(t *testing.T) {
 	)
 
 	require.Equal(t, vote, vote2)
-}
-
-func TestProposerWaitTime(t *testing.T) {
-	genesisTime, err := time.Parse(time.RFC3339, "2019-03-13T23:00:00Z")
-	require.NoError(t, err)
-	testCases := []struct {
-		name         string
-		blockTime    time.Time
-		localTime    time.Time
-		expectedWait time.Duration
-	}{
-		{
-			name:         "block time greater than local time",
-			blockTime:    genesisTime.Add(5 * time.Nanosecond),
-			localTime:    genesisTime.Add(1 * time.Nanosecond),
-			expectedWait: 4 * time.Nanosecond,
-		},
-		{
-			name:         "local time greater than block time",
-			blockTime:    genesisTime.Add(1 * time.Nanosecond),
-			localTime:    genesisTime.Add(5 * time.Nanosecond),
-			expectedWait: 0,
-		},
-		{
-			name:         "both times equal",
-			blockTime:    genesisTime.Add(5 * time.Nanosecond),
-			localTime:    genesisTime.Add(5 * time.Nanosecond),
-			expectedWait: 0,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			b := types.Block{
-				Header: types.Header{
-					Time: testCase.blockTime,
-				},
-			}
-
-			mockSource := new(tmtimemocks.Source)
-			mockSource.On("Now").Return(testCase.localTime)
-
-			ti := proposerWaitTime(mockSource, b.Header)
-			assert.Equal(t, testCase.expectedWait, ti)
-		})
-	}
-}
-
-func TestProposalTimeout(t *testing.T) {
-	genesisTime, err := time.Parse(time.RFC3339, "2019-03-13T23:00:00Z")
-	require.NoError(t, err)
-	testCases := []struct {
-		name              string
-		localTime         time.Time
-		previousBlockTime time.Time
-		precision         time.Duration
-		msgDelay          time.Duration
-		expectedDuration  time.Duration
-	}{
-		{
-			name:              "MsgDelay + Precision has not quite elapsed",
-			localTime:         genesisTime.Add(525 * time.Millisecond),
-			previousBlockTime: genesisTime.Add(6 * time.Millisecond),
-			precision:         time.Millisecond * 20,
-			msgDelay:          time.Millisecond * 500,
-			expectedDuration:  1 * time.Millisecond,
-		},
-		{
-			name:              "MsgDelay + Precision equals current time",
-			localTime:         genesisTime.Add(525 * time.Millisecond),
-			previousBlockTime: genesisTime.Add(5 * time.Millisecond),
-			precision:         time.Millisecond * 20,
-			msgDelay:          time.Millisecond * 500,
-			expectedDuration:  0,
-		},
-		{
-			name:              "MsgDelay + Precision has elapsed",
-			localTime:         genesisTime.Add(725 * time.Millisecond),
-			previousBlockTime: genesisTime.Add(5 * time.Millisecond),
-			precision:         time.Millisecond * 20,
-			msgDelay:          time.Millisecond * 500,
-			expectedDuration:  0,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			b := types.Block{
-				Header: types.Header{
-					Time: testCase.previousBlockTime,
-				},
-			}
-
-			mockSource := new(tmtimemocks.Source)
-			mockSource.On("Now").Return(testCase.localTime)
-
-			tp := types.TimestampParams{
-				Precision: testCase.precision,
-				MsgDelay:  testCase.msgDelay,
-			}
-
-			ti := proposalStepWaitingTime(mockSource, b.Header, tp)
-			assert.Equal(t, testCase.expectedDuration, ti)
-		})
-	}
 }
 
 // subscribe subscribes test client to the given query and returns a channel with cap = 1.

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmtimemocks "github.com/tendermint/tendermint/libs/time/mocks"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -2438,6 +2439,51 @@ func TestSignSameVoteTwice(t *testing.T) {
 	)
 
 	require.Equal(t, vote, vote2)
+}
+
+func TestProposerWaitUntil(t *testing.T) {
+	genesisTime, err := time.Parse(time.RFC3339, "2019-03-13T23:00:00Z")
+	require.NoError(t, err)
+	testCases := []struct {
+		name         string
+		blockTime    time.Time
+		localTime    time.Time
+		expectedTime time.Time
+	}{
+		{
+			name:         "block time greater than local time",
+			blockTime:    genesisTime.Add(5 * time.Nanosecond),
+			localTime:    genesisTime.Add(1 * time.Nanosecond),
+			expectedTime: genesisTime.Add(5 * time.Nanosecond),
+		},
+		{
+			name:         "local time greater than block time",
+			blockTime:    genesisTime.Add(1 * time.Nanosecond),
+			localTime:    genesisTime.Add(5 * time.Nanosecond),
+			expectedTime: genesisTime.Add(5 * time.Nanosecond),
+		},
+		{
+			name:         "both times equal",
+			blockTime:    genesisTime.Add(5 * time.Nanosecond),
+			localTime:    genesisTime.Add(5 * time.Nanosecond),
+			expectedTime: genesisTime.Add(5 * time.Nanosecond),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			b := types.Block{
+				Header: types.Header{
+					Time: testCase.blockTime,
+				},
+			}
+
+			mockSource := new(tmtimemocks.Source)
+			mockSource.On("Now").Return(testCase.localTime)
+
+			ti := proposerWaitUntil(mockSource, b.Header)
+			assert.Equal(t, testCase.expectedTime, ti)
+		})
+	}
 }
 
 // subscribe subscribes test client to the given query and returns a channel with cap = 1.

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -2448,25 +2448,25 @@ func TestProposerWaitUntil(t *testing.T) {
 		name         string
 		blockTime    time.Time
 		localTime    time.Time
-		expectedTime time.Time
+		expectedWait time.Duration
 	}{
 		{
 			name:         "block time greater than local time",
 			blockTime:    genesisTime.Add(5 * time.Nanosecond),
 			localTime:    genesisTime.Add(1 * time.Nanosecond),
-			expectedTime: genesisTime.Add(5 * time.Nanosecond),
+			expectedWait: 4 * time.Nanosecond,
 		},
 		{
 			name:         "local time greater than block time",
 			blockTime:    genesisTime.Add(1 * time.Nanosecond),
 			localTime:    genesisTime.Add(5 * time.Nanosecond),
-			expectedTime: genesisTime.Add(5 * time.Nanosecond),
+			expectedWait: 0,
 		},
 		{
 			name:         "both times equal",
 			blockTime:    genesisTime.Add(5 * time.Nanosecond),
 			localTime:    genesisTime.Add(5 * time.Nanosecond),
-			expectedTime: genesisTime.Add(5 * time.Nanosecond),
+			expectedWait: 0,
 		},
 	}
 	for _, testCase := range testCases {
@@ -2480,8 +2480,8 @@ func TestProposerWaitUntil(t *testing.T) {
 			mockSource := new(tmtimemocks.Source)
 			mockSource.On("Now").Return(testCase.localTime)
 
-			ti := proposerWaitUntil(mockSource, b.Header)
-			assert.Equal(t, testCase.expectedTime, ti)
+			ti := proposerWaitTime(mockSource, b.Header)
+			assert.Equal(t, testCase.expectedWait, ti)
 		})
 	}
 }

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -2493,31 +2493,31 @@ func TestProposalTimeout(t *testing.T) {
 		name              string
 		localTime         time.Time
 		previousBlockTime time.Time
-		accuracy          time.Duration
+		precision         time.Duration
 		msgDelay          time.Duration
 		expectedDuration  time.Duration
 	}{
 		{
-			name:              "MsgDelay + 2 * Accuracy has not quite elapsed",
+			name:              "MsgDelay + Precision has not quite elapsed",
 			localTime:         genesisTime.Add(525 * time.Millisecond),
 			previousBlockTime: genesisTime.Add(6 * time.Millisecond),
-			accuracy:          time.Millisecond * 10,
+			precision:         time.Millisecond * 20,
 			msgDelay:          time.Millisecond * 500,
 			expectedDuration:  1 * time.Millisecond,
 		},
 		{
-			name:              "MsgDelay + 2 * Accuracy equals current time",
+			name:              "MsgDelay + Precision equals current time",
 			localTime:         genesisTime.Add(525 * time.Millisecond),
 			previousBlockTime: genesisTime.Add(5 * time.Millisecond),
-			accuracy:          time.Millisecond * 10,
+			precision:         time.Millisecond * 20,
 			msgDelay:          time.Millisecond * 500,
 			expectedDuration:  0,
 		},
 		{
-			name:              "MsgDelay + 2 * Accuracy has elapsed",
+			name:              "MsgDelay + Precision has elapsed",
 			localTime:         genesisTime.Add(725 * time.Millisecond),
 			previousBlockTime: genesisTime.Add(5 * time.Millisecond),
-			accuracy:          time.Millisecond * 10,
+			precision:         time.Millisecond * 20,
 			msgDelay:          time.Millisecond * 500,
 			expectedDuration:  0,
 		},
@@ -2534,8 +2534,8 @@ func TestProposalTimeout(t *testing.T) {
 			mockSource.On("Now").Return(testCase.localTime)
 
 			tp := types.TimestampParams{
-				Accuracy: testCase.accuracy,
-				MsgDelay: testCase.msgDelay,
+				Precision: testCase.precision,
+				MsgDelay:  testCase.msgDelay,
 			}
 
 			ti := proposalStepWaitingTime(mockSource, b.Header, tp)

--- a/types/proposal.go
+++ b/types/proposal.go
@@ -92,7 +92,7 @@ func (p *Proposal) IsTimely(clock tmtime.Source, tp TimestampParams) bool {
 	lt := clock.Now()
 	lhs := lt.Add(-tp.Precision)
 	rhs := lt.Add(tp.Precision).Add(tp.MsgDelay)
-	if lhs.Before(p.Timestamp) && p.Timestamp.Before(rhs) {
+	if lhs.Before(p.Timestamp) && rhs.After(p.Timestamp) {
 		return true
 	}
 	return false


### PR DESCRIPTION
This pull requests implements helper functions to for calculating sleep durations during the propose phase.

For more information on the inequalities in these functions, please see the proposer-based timestamps ADR. Specifically, this pull requests implements the [proposer waits](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-071-proposer-based-timestamps.md#proposer-waits) and [changes to propose step timeout](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-071-proposer-based-timestamps.md#changes-to-the-propose-step-timeout) calculations.

Related to: #6942 