### PR TITLE
service: remove stop method and use contexts

### DIFF
--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -63,7 +63,7 @@ func dialerFunc(ctx context.Context, addr string) (net.Conn, error) {
 	return tmnet.Connect(addr)
 }
 
-func (cli *grpcClient) OnStart() error {
+func (cli *grpcClient) OnStart(ctx context.Context) error {
 	// This processes asynchronous request/response messages and dispatches
 	// them to callbacks.
 	go func() {

--- a/abci/client/mocks/client.go
+++ b/abci/client/mocks/client.go
@@ -7,8 +7,6 @@ import (
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
 
-	log "github.com/tendermint/tendermint/libs/log"
-
 	mock "github.com/stretchr/testify/mock"
 
 	types "github.com/tendermint/tendermint/abci/types"
@@ -636,39 +634,6 @@ func (_m *Client) OfferSnapshotSync(_a0 context.Context, _a1 types.RequestOfferS
 	return r0, r1
 }
 
-// OnReset provides a mock function with given fields:
-func (_m *Client) OnReset() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// OnStart provides a mock function with given fields:
-func (_m *Client) OnStart() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// OnStop provides a mock function with given fields:
-func (_m *Client) OnStop() {
-	_m.Called()
-}
-
 // QueryAsync provides a mock function with given fields: _a0, _a1
 func (_m *Client) QueryAsync(_a0 context.Context, _a1 types.RequestQuery) (*abciclient.ReqRes, error) {
 	ret := _m.Called(_a0, _a1)
@@ -745,37 +710,18 @@ func (_m *Client) Reset() error {
 	return r0
 }
 
-// SetLogger provides a mock function with given fields: _a0
-func (_m *Client) SetLogger(_a0 log.Logger) {
-	_m.Called(_a0)
-}
-
 // SetResponseCallback provides a mock function with given fields: _a0
 func (_m *Client) SetResponseCallback(_a0 abciclient.Callback) {
 	_m.Called(_a0)
 }
 
-// Start provides a mock function with given fields:
-func (_m *Client) Start() error {
-	ret := _m.Called()
+// Start provides a mock function with given fields: _a0
+func (_m *Client) Start(_a0 context.Context) error {
+	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// Stop provides a mock function with given fields:
-func (_m *Client) Stop() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -66,7 +66,7 @@ func NewSocketClient(logger log.Logger, addr string, mustConnect bool) Client {
 
 // OnStart implements Service by connecting to the server and spawning reading
 // and writing goroutines.
-func (cli *socketClient) OnStart() error {
+func (cli *socketClient) OnStart(ctx context.Context) error {
 	var (
 		err  error
 		conn net.Conn

--- a/abci/example/example_test.go
+++ b/abci/example/example_test.go
@@ -29,21 +29,29 @@ func init() {
 }
 
 func TestKVStore(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	fmt.Println("### Testing KVStore")
-	testStream(t, kvstore.NewApplication())
+	testStream(ctx, t, kvstore.NewApplication())
 }
 
 func TestBaseApp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	fmt.Println("### Testing BaseApp")
-	testStream(t, types.NewBaseApplication())
+	testStream(ctx, t, types.NewBaseApplication())
 }
 
 func TestGRPC(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	fmt.Println("### Testing GRPC")
-	testGRPCSync(t, types.NewGRPCApplication(types.NewBaseApplication()))
+	testGRPCSync(ctx, t, types.NewGRPCApplication(types.NewBaseApplication()))
 }
 
-func testStream(t *testing.T, app types.Application) {
+func testStream(ctx context.Context, t *testing.T, app types.Application) {
 	t.Helper()
 
 	const numDeliverTxs = 20000
@@ -53,25 +61,16 @@ func testStream(t *testing.T, app types.Application) {
 	logger := log.TestingLogger()
 	// Start the listener
 	server := abciserver.NewSocketServer(logger.With("module", "abci-server"), socket, app)
-
-	err := server.Start()
+	t.Cleanup(func() { server.Wait() })
+	err := server.Start(ctx)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := server.Stop(); err != nil {
-			t.Error(err)
-		}
-	})
 
 	// Connect to the socket
 	client := abciclient.NewSocketClient(log.TestingLogger().With("module", "abci-client"), socket, false)
+	t.Cleanup(func() { client.Wait() })
 
-	err = client.Start()
+	err = client.Start(ctx)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := client.Stop(); err != nil {
-			t.Error(err)
-		}
-	})
 
 	done := make(chan struct{})
 	counter := 0
@@ -100,8 +99,6 @@ func testStream(t *testing.T, app types.Application) {
 		}
 	})
 
-	ctx := context.Background()
-
 	// Write requests
 	for counter := 0; counter < numDeliverTxs; counter++ {
 		// Send request
@@ -129,7 +126,7 @@ func dialerFunc(ctx context.Context, addr string) (net.Conn, error) {
 	return tmnet.Connect(addr)
 }
 
-func testGRPCSync(t *testing.T, app types.ABCIApplicationServer) {
+func testGRPCSync(ctx context.Context, t *testing.T, app types.ABCIApplicationServer) {
 	numDeliverTxs := 2000
 	socketFile := fmt.Sprintf("/tmp/test-%08x.sock", rand.Int31n(1<<30))
 	defer os.Remove(socketFile)
@@ -138,15 +135,11 @@ func testGRPCSync(t *testing.T, app types.ABCIApplicationServer) {
 	// Start the listener
 	server := abciserver.NewGRPCServer(logger.With("module", "abci-server"), socket, app)
 
-	if err := server.Start(); err != nil {
+	if err := server.Start(ctx); err != nil {
 		t.Fatalf("Error starting GRPC server: %v", err.Error())
 	}
 
-	t.Cleanup(func() {
-		if err := server.Stop(); err != nil {
-			t.Error(err)
-		}
-	})
+	t.Cleanup(func() { server.Wait() })
 
 	// Connect to the socket
 	conn, err := grpc.Dial(socket, grpc.WithInsecure(), grpc.WithContextDialer(dialerFunc))

--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -24,8 +24,6 @@ const (
 	testValue = "def"
 )
 
-var ctx = context.Background()
-
 func testKVStore(t *testing.T, app types.Application, tx []byte, key, value string) {
 	req := types.RequestDeliverTx{Tx: tx}
 	ar := app.DeliverTx(req)
@@ -229,101 +227,105 @@ func valsEqual(t *testing.T, vals1, vals2 []types.ValidatorUpdate) {
 	}
 }
 
-func makeSocketClientServer(app types.Application, name string) (abciclient.Client, service.Service, error) {
+func makeSocketClientServer(
+	ctx context.Context,
+	logger log.Logger,
+	t *testing.T,
+	app types.Application,
+	name string,
+) (abciclient.Client, service.Service, error) {
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	t.Cleanup(func() { cancel() })
+
 	// Start the listener
 	socket := fmt.Sprintf("unix://%s.sock", name)
-	logger := log.TestingLogger()
 
 	server := abciserver.NewSocketServer(logger.With("module", "abci-server"), socket, app)
-	if err := server.Start(); err != nil {
+	if err := server.Start(ctx); err != nil {
+		cancel()
 		return nil, nil, err
 	}
 
 	// Connect to the socket
 	client := abciclient.NewSocketClient(logger.With("module", "abci-client"), socket, false)
-	if err := client.Start(); err != nil {
-		if err = server.Stop(); err != nil {
-			return nil, nil, err
-		}
+	if err := client.Start(ctx); err != nil {
+		cancel()
 		return nil, nil, err
 	}
 
 	return client, server, nil
 }
 
-func makeGRPCClientServer(app types.Application, name string) (abciclient.Client, service.Service, error) {
+func makeGRPCClientServer(
+	ctx context.Context,
+	t *testing.T,
+	logger log.Logger,
+	app types.Application,
+	name string,
+) (abciclient.Client, service.Service, error) {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	t.Cleanup(func() { cancel() })
 	// Start the listener
 	socket := fmt.Sprintf("unix://%s.sock", name)
-	logger := log.TestingLogger()
 
 	gapp := types.NewGRPCApplication(app)
 	server := abciserver.NewGRPCServer(logger.With("module", "abci-server"), socket, gapp)
 
-	if err := server.Start(); err != nil {
+	if err := server.Start(ctx); err != nil {
+		cancel()
 		return nil, nil, err
 	}
 
 	client := abciclient.NewGRPCClient(logger.With("module", "abci-client"), socket, true)
 
-	if err := client.Start(); err != nil {
-		if err := server.Stop(); err != nil {
-			return nil, nil, err
-		}
+	if err := client.Start(ctx); err != nil {
+		cancel()
 		return nil, nil, err
 	}
 	return client, server, nil
 }
 
 func TestClientServer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := log.TestingLogger()
+
 	// set up socket app
 	kvstore := NewApplication()
-	client, server, err := makeSocketClientServer(kvstore, "kvstore-socket")
+	client, server, err := makeSocketClientServer(ctx, logger, t, kvstore, "kvstore-socket")
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := server.Stop(); err != nil {
-			t.Error(err)
-		}
-	})
-	t.Cleanup(func() {
-		if err := client.Stop(); err != nil {
-			t.Error(err)
-		}
-	})
+	t.Cleanup(func() { cancel(); server.Wait() })
+	t.Cleanup(func() { cancel(); client.Wait() })
 
-	runClientTests(t, client)
+	runClientTests(ctx, t, client)
 
 	// set up grpc app
 	kvstore = NewApplication()
-	gclient, gserver, err := makeGRPCClientServer(kvstore, "/tmp/kvstore-grpc")
+	gclient, gserver, err := makeGRPCClientServer(ctx, t, logger, kvstore, "/tmp/kvstore-grpc")
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		if err := gserver.Stop(); err != nil {
-			t.Error(err)
-		}
-	})
-	t.Cleanup(func() {
-		if err := gclient.Stop(); err != nil {
-			t.Error(err)
-		}
-	})
+	t.Cleanup(func() { cancel(); gserver.Wait() })
+	t.Cleanup(func() { cancel(); gclient.Wait() })
 
-	runClientTests(t, gclient)
+	runClientTests(ctx, t, gclient)
 }
 
-func runClientTests(t *testing.T, client abciclient.Client) {
+func runClientTests(ctx context.Context, t *testing.T, client abciclient.Client) {
 	// run some tests....
 	key := testKey
 	value := key
 	tx := []byte(key)
-	testClient(t, client, tx, key, value)
+	testClient(ctx, t, client, tx, key, value)
 
 	value = testValue
 	tx = []byte(key + "=" + value)
-	testClient(t, client, tx, key, value)
+	testClient(ctx, t, client, tx, key, value)
 }
 
-func testClient(t *testing.T, app abciclient.Client, tx []byte, key, value string) {
+func testClient(ctx context.Context, t *testing.T, app abciclient.Client, tx []byte, key, value string) {
 	ar, err := app.DeliverTxSync(ctx, types.RequestDeliverTx{Tx: tx})
 	require.NoError(t, err)
 	require.False(t, ar.IsErr(), ar)

--- a/abci/server/grpc_server.go
+++ b/abci/server/grpc_server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net"
 
 	"google.golang.org/grpc"
@@ -36,7 +37,7 @@ func NewGRPCServer(logger log.Logger, protoAddr string, app types.ABCIApplicatio
 }
 
 // OnStart starts the gRPC service.
-func (s *GRPCServer) OnStart() error {
+func (s *GRPCServer) OnStart(ctx context.Context) error {
 
 	ln, err := net.Listen(s.proto, s.addr)
 	if err != nil {

--- a/abci/server/socket_server.go
+++ b/abci/server/socket_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -44,7 +45,7 @@ func NewSocketServer(logger tmlog.Logger, protoAddr string, app types.Applicatio
 	return s
 }
 
-func (s *SocketServer) OnStart() error {
+func (s *SocketServer) OnStart(ctx context.Context) error {
 	ln, err := net.Listen(s.proto, s.addr)
 	if err != nil {
 		return err

--- a/abci/tests/client_server_test.go
+++ b/abci/tests/client_server_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,19 +13,23 @@ import (
 )
 
 func TestClientServerNoAddrPrefix(t *testing.T) {
-	addr := "localhost:26658"
-	transport := "socket"
-	app := kvstore.NewApplication()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
+	const (
+		addr      = "localhost:26658"
+		transport = "socket"
+	)
+	app := kvstore.NewApplication()
 	logger := log.TestingLogger()
 
 	server, err := abciserver.NewServer(logger, addr, transport, app)
 	assert.NoError(t, err, "expected no error on NewServer")
-	err = server.Start()
+	err = server.Start(ctx)
 	assert.NoError(t, err, "expected no error on server.Start")
 
 	client, err := abciclientent.NewClient(logger, addr, transport, true)
 	assert.NoError(t, err, "expected no error on NewClient")
-	err = client.Start()
+	err = client.Start(ctx)
 	assert.NoError(t, err, "expected no error on client.Start")
 }

--- a/abci/tests/server/client.go
+++ b/abci/tests/server/client.go
@@ -12,9 +12,7 @@ import (
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 )
 
-var ctx = context.Background()
-
-func InitChain(client abciclient.Client) error {
+func InitChain(ctx context.Context, client abciclient.Client) error {
 	total := 10
 	vals := make([]types.ValidatorUpdate, total)
 	for i := 0; i < total; i++ {
@@ -34,7 +32,7 @@ func InitChain(client abciclient.Client) error {
 	return nil
 }
 
-func Commit(client abciclient.Client, hashExp []byte) error {
+func Commit(ctx context.Context, client abciclient.Client, hashExp []byte) error {
 	res, err := client.CommitSync(ctx)
 	data := res.Data
 	if err != nil {
@@ -51,7 +49,7 @@ func Commit(client abciclient.Client, hashExp []byte) error {
 	return nil
 }
 
-func DeliverTx(client abciclient.Client, txBytes []byte, codeExp uint32, dataExp []byte) error {
+func DeliverTx(ctx context.Context, client abciclient.Client, txBytes []byte, codeExp uint32, dataExp []byte) error {
 	res, _ := client.DeliverTxSync(ctx, types.RequestDeliverTx{Tx: txBytes})
 	code, data, log := res.Code, res.Data, res.Log
 	if code != codeExp {
@@ -70,7 +68,7 @@ func DeliverTx(client abciclient.Client, txBytes []byte, codeExp uint32, dataExp
 	return nil
 }
 
-func CheckTx(client abciclient.Client, txBytes []byte, codeExp uint32, dataExp []byte) error {
+func CheckTx(ctx context.Context, client abciclient.Client, txBytes []byte, codeExp uint32, dataExp []byte) error {
 	res, _ := client.CheckTxSync(ctx, types.RequestCheckTx{Tx: txBytes})
 	code, data, log := res.Code, res.Data, res.Log
 	if code != codeExp {

--- a/cmd/tendermint/commands/light.go
+++ b/cmd/tendermint/commands/light.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -191,8 +193,12 @@ func runProxy(cmd *cobra.Command, args []string) error {
 		p.Listener.Close()
 	})
 
+	// this might be redundant to the above, eventually.
+	ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGTERM)
+	defer cancel()
+
 	logger.Info("Starting proxy...", "laddr", listenAddr)
-	if err := p.ListenAndServe(); err != http.ErrServerClosed {
+	if err := p.ListenAndServe(ctx); err != http.ErrServerClosed {
 		// Error starting or closing listener:
 		logger.Error("proxy ListenAndServe", "err", err)
 	}

--- a/cmd/tendermint/commands/replay.go
+++ b/cmd/tendermint/commands/replay.go
@@ -10,8 +10,7 @@ var ReplayCmd = &cobra.Command{
 	Use:   "replay",
 	Short: "Replay messages from WAL",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return consensus.RunReplayFile(logger, config.BaseConfig, config.Consensus, false)
-
+		return consensus.RunReplayFile(cmd.Context(), logger, config.BaseConfig, config.Consensus, false)
 	},
 }
 
@@ -21,6 +20,6 @@ var ReplayConsoleCmd = &cobra.Command{
 	Use:   "replay-console",
 	Short: "Replay messages from WAL in a console",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return consensus.RunReplayFile(logger, config.BaseConfig, config.Consensus, true)
+		return consensus.RunReplayFile(cmd.Context(), logger, config.BaseConfig, config.Consensus, true)
 	},
 }

--- a/config/db.go
+++ b/config/db.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"context"
+
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/libs/log"
@@ -8,7 +10,7 @@ import (
 )
 
 // ServiceProvider takes a config and a logger and returns a ready to go Node.
-type ServiceProvider func(*Config, log.Logger) (service.Service, error)
+type ServiceProvider func(context.Context, *Config, log.Logger) (service.Service, error)
 
 // DBContext specifies config information for loading a new DB.
 type DBContext struct {

--- a/docs/architecture/adr-006-trust-metric.md
+++ b/docs/architecture/adr-006-trust-metric.md
@@ -178,7 +178,7 @@ type TrustMetricStore struct {
 }
 
 // OnStart implements Service
-func (tms *TrustMetricStore) OnStart() error {}
+func (tms *TrustMetricStore) OnStart(ctx context.Context) error {}
 
 // OnStop implements Service
 func (tms *TrustMetricStore) OnStop() {}

--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -1,6 +1,7 @@
 package blocksync
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -116,15 +117,15 @@ func NewBlockPool(
 
 // OnStart implements service.Service by spawning requesters routine and recording
 // pool's start time.
-func (pool *BlockPool) OnStart() error {
+func (pool *BlockPool) OnStart(ctx context.Context) error {
 	pool.lastAdvance = time.Now()
 	pool.lastHundredBlockTimeStamp = pool.lastAdvance
-	go pool.makeRequestersRoutine()
+	go pool.makeRequestersRoutine(ctx)
 	return nil
 }
 
 // spawns requesters as needed
-func (pool *BlockPool) makeRequestersRoutine() {
+func (pool *BlockPool) makeRequestersRoutine(ctx context.Context) {
 	for {
 		if !pool.IsRunning() {
 			break
@@ -144,7 +145,7 @@ func (pool *BlockPool) makeRequestersRoutine() {
 			pool.removeTimedoutPeers()
 		default:
 			// request for more blocks.
-			pool.makeNextRequester()
+			pool.makeNextRequester(ctx)
 		}
 	}
 }
@@ -397,7 +398,7 @@ func (pool *BlockPool) pickIncrAvailablePeer(height int64) *bpPeer {
 	return nil
 }
 
-func (pool *BlockPool) makeNextRequester() {
+func (pool *BlockPool) makeNextRequester(ctx context.Context) {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 
@@ -411,7 +412,7 @@ func (pool *BlockPool) makeNextRequester() {
 	pool.requesters[nextHeight] = request
 	atomic.AddInt32(&pool.numPending, 1)
 
-	err := request.Start()
+	err := request.Start(ctx)
 	if err != nil {
 		request.Logger.Error("Error starting request", "err", err)
 	}
@@ -570,7 +571,7 @@ func newBPRequester(pool *BlockPool, height int64) *bpRequester {
 	return bpr
 }
 
-func (bpr *bpRequester) OnStart() error {
+func (bpr *bpRequester) OnStart(ctx context.Context) error {
 	go bpr.requestRoutine()
 	return nil
 }

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -1,6 +1,7 @@
 package blocksync
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -49,7 +50,7 @@ func GetChannelDescriptor() *p2p.ChannelDescriptor {
 type consensusReactor interface {
 	// For when we switch from block sync reactor to the consensus
 	// machine.
-	SwitchToConsensus(state sm.State, skipWAL bool)
+	SwitchToConsensus(ctx context.Context, state sm.State, skipWAL bool)
 }
 
 type peerError struct {
@@ -151,9 +152,9 @@ func NewReactor(
 //
 // If blockSync is enabled, we also start the pool and the pool processing
 // goroutine. If the pool fails to start, an error is returned.
-func (r *Reactor) OnStart() error {
+func (r *Reactor) OnStart(ctx context.Context) error {
 	if r.blockSync.IsSet() {
-		if err := r.pool.Start(); err != nil {
+		if err := r.pool.Start(ctx); err != nil {
 			return err
 		}
 		r.poolWG.Add(1)
@@ -362,12 +363,12 @@ func (r *Reactor) processPeerUpdates() {
 
 // SwitchToBlockSync is called by the state sync reactor when switching to fast
 // sync.
-func (r *Reactor) SwitchToBlockSync(state sm.State) error {
+func (r *Reactor) SwitchToBlockSync(ctx context.Context, state sm.State) error {
 	r.blockSync.Set()
 	r.initialState = state
 	r.pool.height = state.LastBlockHeight + 1
 
-	if err := r.pool.Start(); err != nil {
+	if err := r.pool.Start(ctx); err != nil {
 		return err
 	}
 
@@ -423,6 +424,17 @@ func (r *Reactor) requestRoutine() {
 	}
 }
 
+func (r *Reactor) stopCtx() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		<-r.closeCh
+		cancel()
+	}()
+
+	return ctx
+}
+
 // poolRoutine handles messages from the poolReactor telling the reactor what to
 // do.
 //
@@ -441,6 +453,7 @@ func (r *Reactor) poolRoutine(stateSynced bool) {
 		lastRate    = 0.0
 
 		didProcessCh = make(chan struct{}, 1)
+		ctx          = r.stopCtx()
 	)
 
 	defer trySyncTicker.Stop()
@@ -488,7 +501,7 @@ FOR_LOOP:
 			r.blockSync.UnSet()
 
 			if r.consReactor != nil {
-				r.consReactor.SwitchToConsensus(state, blocksSynced > 0 || stateSynced)
+				r.consReactor.SwitchToConsensus(ctx, state, blocksSynced > 0 || stateSynced)
 			}
 
 			break FOR_LOOP

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 	"time"
@@ -174,7 +175,7 @@ func NewReactor(
 // envelopes on each. In addition, it also listens for peer updates and handles
 // messages on that p2p channel accordingly. The caller must be sure to execute
 // OnStop to ensure the outbound p2p Channels are closed.
-func (r *Reactor) OnStart() error {
+func (r *Reactor) OnStart(ctx context.Context) error {
 	r.Logger.Debug("consensus wait sync", "wait_sync", r.WaitSync())
 
 	// start routine that computes peer statistics for evaluating peer quality
@@ -186,7 +187,7 @@ func (r *Reactor) OnStart() error {
 	r.subscribeToBroadcastEvents()
 
 	if !r.WaitSync() {
-		if err := r.state.Start(); err != nil {
+		if err := r.state.Start(ctx); err != nil {
 			return err
 		}
 	}
@@ -264,7 +265,7 @@ func ReactorMetrics(metrics *Metrics) ReactorOption {
 
 // SwitchToConsensus switches from block-sync mode to consensus mode. It resets
 // the state, turns off block-sync, and starts the consensus state-machine.
-func (r *Reactor) SwitchToConsensus(state sm.State, skipWAL bool) {
+func (r *Reactor) SwitchToConsensus(ctx context.Context, state sm.State, skipWAL bool) {
 	r.Logger.Info("switching to consensus")
 
 	// we have no votes, so reconstruct LastCommit from SeenCommit
@@ -287,7 +288,7 @@ func (r *Reactor) SwitchToConsensus(state sm.State, skipWAL bool) {
 		r.state.doWALCatchup = false
 	}
 
-	if err := r.state.Start(); err != nil {
+	if err := r.state.Start(ctx); err != nil {
 		panic(fmt.Sprintf(`failed to start consensus state: %v
 
 conS:

--- a/internal/consensus/replay.go
+++ b/internal/consensus/replay.go
@@ -237,7 +237,7 @@ func (h *Handshaker) NBlocks() int {
 }
 
 // TODO: retry the handshake/replay if it fails ?
-func (h *Handshaker) Handshake(proxyApp proxy.AppConns) error {
+func (h *Handshaker) Handshake(ctx context.Context, proxyApp proxy.AppConns) error {
 
 	// Handshake is done via ABCI Info on the query conn.
 	res, err := proxyApp.Query().InfoSync(context.Background(), proxy.RequestInfo)
@@ -264,7 +264,7 @@ func (h *Handshaker) Handshake(proxyApp proxy.AppConns) error {
 	}
 
 	// Replay blocks up to the latest in the blockstore.
-	_, err = h.ReplayBlocks(h.initialState, appHash, blockHeight, proxyApp)
+	_, err = h.ReplayBlocks(ctx, h.initialState, appHash, blockHeight, proxyApp)
 	if err != nil {
 		return fmt.Errorf("error on replay: %v", err)
 	}
@@ -281,6 +281,7 @@ func (h *Handshaker) Handshake(proxyApp proxy.AppConns) error {
 // matches the current state.
 // Returns the final AppHash or an error.
 func (h *Handshaker) ReplayBlocks(
+	ctx context.Context,
 	state sm.State,
 	appHash []byte,
 	appBlockHeight int64,
@@ -421,7 +422,7 @@ func (h *Handshaker) ReplayBlocks(
 			if err != nil {
 				return nil, err
 			}
-			mockApp := newMockProxyApp(h.logger, appHash, abciResponses)
+			mockApp := newMockProxyApp(ctx, h.logger, appHash, abciResponses)
 			h.logger.Info("Replay last block using mock app")
 			state, err = h.replayBlock(state, storeBlockHeight, mockApp)
 			return state.AppHash, err

--- a/internal/consensus/replay_stubs.go
+++ b/internal/consensus/replay_stubs.go
@@ -55,13 +55,18 @@ func (emptyMempool) CloseWAL()      {}
 // Useful because we don't want to call Commit() twice for the same block on
 // the real app.
 
-func newMockProxyApp(logger log.Logger, appHash []byte, abciResponses *tmstate.ABCIResponses) proxy.AppConnConsensus {
+func newMockProxyApp(
+	ctx context.Context,
+	logger log.Logger,
+	appHash []byte,
+	abciResponses *tmstate.ABCIResponses,
+) proxy.AppConnConsensus {
 	clientCreator := abciclient.NewLocalCreator(&mockProxyApp{
 		appHash:       appHash,
 		abciResponses: abciResponses,
 	})
 	cli, _ := clientCreator(logger)
-	err := cli.Start()
+	err := cli.Start(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -329,11 +329,11 @@ func (cs *State) LoadCommit(height int64) *types.Commit {
 
 // OnStart loads the latest state via the WAL, and starts the timeout and
 // receive routines.
-func (cs *State) OnStart() error {
+func (cs *State) OnStart(ctx context.Context) error {
 	// We may set the WAL in testing before calling Start, so only OpenWAL if its
 	// still the nilWAL.
 	if _, ok := cs.wal.(nilWAL); ok {
-		if err := cs.loadWalFile(); err != nil {
+		if err := cs.loadWalFile(ctx); err != nil {
 			return err
 		}
 	}
@@ -384,13 +384,13 @@ func (cs *State) OnStart() error {
 			cs.Logger.Info("successful WAL repair")
 
 			// reload WAL file
-			if err := cs.loadWalFile(); err != nil {
+			if err := cs.loadWalFile(ctx); err != nil {
 				return err
 			}
 		}
 	}
 
-	if err := cs.evsw.Start(); err != nil {
+	if err := cs.evsw.Start(ctx); err != nil {
 		return err
 	}
 
@@ -399,7 +399,7 @@ func (cs *State) OnStart() error {
 	// NOTE: we will get a build up of garbage go routines
 	// firing on the tockChan until the receiveRoutine is started
 	// to deal with them (by that point, at most one will be valid)
-	if err := cs.timeoutTicker.Start(); err != nil {
+	if err := cs.timeoutTicker.Start(ctx); err != nil {
 		return err
 	}
 
@@ -420,8 +420,8 @@ func (cs *State) OnStart() error {
 
 // timeoutRoutine: receive requests for timeouts on tickChan and fire timeouts on tockChan
 // receiveRoutine: serializes processing of proposoals, block parts, votes; coordinates state transitions
-func (cs *State) startRoutines(maxSteps int) {
-	err := cs.timeoutTicker.Start()
+func (cs *State) startRoutines(ctx context.Context, maxSteps int) {
+	err := cs.timeoutTicker.Start(ctx)
 	if err != nil {
 		cs.Logger.Error("failed to start timeout ticker", "err", err)
 		return
@@ -431,8 +431,8 @@ func (cs *State) startRoutines(maxSteps int) {
 }
 
 // loadWalFile loads WAL data from file. It overwrites cs.wal.
-func (cs *State) loadWalFile() error {
-	wal, err := cs.OpenWAL(cs.config.WalFile())
+func (cs *State) loadWalFile(ctx context.Context) error {
+	wal, err := cs.OpenWAL(ctx, cs.config.WalFile())
 	if err != nil {
 		cs.Logger.Error("failed to load state WAL", "err", err)
 		return err
@@ -475,14 +475,14 @@ func (cs *State) Wait() {
 
 // OpenWAL opens a file to log all consensus messages and timeouts for
 // deterministic accountability.
-func (cs *State) OpenWAL(walFile string) (WAL, error) {
+func (cs *State) OpenWAL(ctx context.Context, walFile string) (WAL, error) {
 	wal, err := NewWAL(cs.Logger.With("wal", walFile), walFile)
 	if err != nil {
 		cs.Logger.Error("failed to open WAL", "file", walFile, "err", err)
 		return nil, err
 	}
 
-	if err := wal.Start(); err != nil {
+	if err := wal.Start(ctx); err != nil {
 		cs.Logger.Error("failed to start WAL", "err", err)
 		return nil, err
 	}

--- a/internal/consensus/ticker.go
+++ b/internal/consensus/ticker.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"context"
 	"time"
 
 	"github.com/tendermint/tendermint/libs/log"
@@ -15,7 +16,7 @@ var (
 // conditional on the height/round/step in the timeoutInfo.
 // The timeoutInfo.Duration may be non-positive.
 type TimeoutTicker interface {
-	Start() error
+	Start(context.Context) error
 	Stop() error
 	Chan() <-chan timeoutInfo       // on which to receive a timeout
 	ScheduleTimeout(ti timeoutInfo) // reset the timer
@@ -47,8 +48,7 @@ func NewTimeoutTicker(logger log.Logger) TimeoutTicker {
 }
 
 // OnStart implements service.Service. It starts the timeout routine.
-func (t *timeoutTicker) OnStart() error {
-
+func (t *timeoutTicker) OnStart(gctx context.Context) error {
 	go t.timeoutRoutine()
 
 	return nil

--- a/internal/consensus/wal.go
+++ b/internal/consensus/wal.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -63,7 +64,7 @@ type WAL interface {
 	SearchForEndHeight(height int64, options *WALSearchOptions) (rd io.ReadCloser, found bool, err error)
 
 	// service methods
-	Start() error
+	Start(context.Context) error
 	Stop() error
 	Wait()
 }
@@ -116,7 +117,7 @@ func (wal *BaseWAL) Group() *auto.Group {
 	return wal.group
 }
 
-func (wal *BaseWAL) OnStart() error {
+func (wal *BaseWAL) OnStart(ctx context.Context) error {
 	size, err := wal.group.Head.Size()
 	if err != nil {
 		return err
@@ -125,7 +126,7 @@ func (wal *BaseWAL) OnStart() error {
 			return err
 		}
 	}
-	err = wal.group.Start()
+	err = wal.group.Start(ctx)
 	if err != nil {
 		return err
 	}
@@ -423,6 +424,6 @@ func (nilWAL) FlushAndSync() error          { return nil }
 func (nilWAL) SearchForEndHeight(height int64, options *WALSearchOptions) (rd io.ReadCloser, found bool, err error) {
 	return nil, false, nil
 }
-func (nilWAL) Start() error { return nil }
-func (nilWAL) Stop() error  { return nil }
-func (nilWAL) Wait()        {}
+func (nilWAL) Start(context.Context) error { return nil }
+func (nilWAL) Stop() error                 { return nil }
+func (nilWAL) Wait()                       {}

--- a/internal/consensus/wal_generator.go
+++ b/internal/consensus/wal_generator.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	mrand "math/rand"
@@ -30,7 +31,7 @@ import (
 // persistent kvstore application and special consensus wal instance
 // (byteBufferWAL) and waits until numBlocks are created.
 // If the node fails to produce given numBlocks, it returns an error.
-func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
+func WALGenerateNBlocks(ctx context.Context, t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	cfg := getConfig(t)
 
 	app := kvstore.NewPersistentKVStoreApplication(filepath.Join(cfg.DBDir(), "wal_generator"))
@@ -67,17 +68,17 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	blockStore := store.NewBlockStore(blockStoreDB)
 
 	proxyApp := proxy.NewAppConns(abciclient.NewLocalCreator(app), logger.With("module", "proxy"), proxy.NopMetrics())
-	if err := proxyApp.Start(); err != nil {
+	if err := proxyApp.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start proxy app connections: %w", err)
 	}
 	t.Cleanup(func() {
-		if err := proxyApp.Stop(); err != nil {
+		if err := proxyApp.(interface{ Stop() error }).Stop(); err != nil {
 			t.Error(err)
 		}
 	})
 
 	eventBus := eventbus.NewDefault(logger.With("module", "events"))
-	if err := eventBus.Start(); err != nil {
+	if err := eventBus.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start event bus: %w", err)
 	}
 	t.Cleanup(func() {
@@ -105,7 +106,7 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 
 	consensusState.wal = wal
 
-	if err := consensusState.Start(); err != nil {
+	if err := consensusState.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start consensus state: %w", err)
 	}
 
@@ -124,11 +125,11 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 }
 
 // WALWithNBlocks returns a WAL content with numBlocks.
-func WALWithNBlocks(t *testing.T, numBlocks int) (data []byte, err error) {
+func WALWithNBlocks(ctx context.Context, t *testing.T, numBlocks int) (data []byte, err error) {
 	var b bytes.Buffer
 	wr := bufio.NewWriter(&b)
 
-	if err := WALGenerateNBlocks(t, wr, numBlocks); err != nil {
+	if err := WALGenerateNBlocks(ctx, t, wr, numBlocks); err != nil {
 		return []byte{}, err
 	}
 
@@ -227,6 +228,6 @@ func (w *byteBufferWAL) SearchForEndHeight(
 	return nil, false, nil
 }
 
-func (w *byteBufferWAL) Start() error { return nil }
-func (w *byteBufferWAL) Stop() error  { return nil }
-func (w *byteBufferWAL) Wait()        {}
+func (w *byteBufferWAL) Start(context.Context) error { return nil }
+func (w *byteBufferWAL) Stop() error                 { return nil }
+func (w *byteBufferWAL) Wait()                       {}

--- a/internal/consensus/wal_test.go
+++ b/internal/consensus/wal_test.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"bytes"
+	"context"
 	"path/filepath"
 
 	"testing"
@@ -18,14 +19,15 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
-const (
-	walTestFlushInterval = time.Duration(100) * time.Millisecond
-)
+const walTestFlushInterval = 100 * time.Millisecond
 
 func TestWALTruncate(t *testing.T) {
 	walDir := t.TempDir()
 	walFile := filepath.Join(walDir, "wal")
 	logger := log.TestingLogger()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// this magic number 4K can truncate the content when RotateFile.
 	// defaultHeadSizeLimit(10M) is hard to simulate.
@@ -36,7 +38,7 @@ func TestWALTruncate(t *testing.T) {
 		autofile.GroupCheckDuration(1*time.Millisecond),
 	)
 	require.NoError(t, err)
-	err = wal.Start()
+	err = wal.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := wal.Stop(); err != nil {
@@ -50,7 +52,7 @@ func TestWALTruncate(t *testing.T) {
 	// 60 block's size nearly 70K, greater than group's headBuf size(4096 * 10),
 	// when headBuf is full, truncate content will Flush to the file. at this
 	// time, RotateFile is called, truncate content exist in each file.
-	err = WALGenerateNBlocks(t, wal.Group(), 60)
+	err = WALGenerateNBlocks(ctx, t, wal.Group(), 60)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Millisecond) // wait groupCheckDuration, make sure RotateFile run
@@ -105,9 +107,12 @@ func TestWALWrite(t *testing.T) {
 	walDir := t.TempDir()
 	walFile := filepath.Join(walDir, "wal")
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	wal, err := NewWAL(log.TestingLogger(), walFile)
 	require.NoError(t, err)
-	err = wal.Start()
+	err = wal.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := wal.Stop(); err != nil {
@@ -142,7 +147,10 @@ func TestWALWrite(t *testing.T) {
 }
 
 func TestWALSearchForEndHeight(t *testing.T) {
-	walBody, err := WALWithNBlocks(t, 6)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	walBody, err := WALWithNBlocks(ctx, t, 6)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,18 +179,21 @@ func TestWALPeriodicSync(t *testing.T) {
 	walFile := filepath.Join(walDir, "wal")
 	wal, err := NewWAL(log.TestingLogger(), walFile, autofile.GroupCheckDuration(1*time.Millisecond))
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	require.NoError(t, err)
 
 	wal.SetFlushInterval(walTestFlushInterval)
 
 	// Generate some data
-	err = WALGenerateNBlocks(t, wal.Group(), 5)
+	err = WALGenerateNBlocks(ctx, t, wal.Group(), 5)
 	require.NoError(t, err)
 
 	// We should have data in the buffer now
 	assert.NotZero(t, wal.Group().Buffered())
 
-	require.NoError(t, wal.Start())
+	require.NoError(t, wal.Start(ctx))
 	t.Cleanup(func() {
 		if err := wal.Stop(); err != nil {
 			t.Error(err)

--- a/internal/eventbus/event_bus.go
+++ b/internal/eventbus/event_bus.go
@@ -38,8 +38,8 @@ func NewDefault(l log.Logger) *EventBus {
 	return b
 }
 
-func (b *EventBus) OnStart() error {
-	return b.pubsub.Start()
+func (b *EventBus) OnStart(ctx context.Context) error {
+	return b.pubsub.Start(ctx)
 }
 
 func (b *EventBus) OnStop() {

--- a/internal/eventbus/event_bus_test.go
+++ b/internal/eventbus/event_bus_test.go
@@ -19,8 +19,11 @@ import (
 )
 
 func TestEventBusPublishEventTx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	eventBus := eventbus.NewDefault(log.TestingLogger())
-	err := eventBus.Start()
+	err := eventBus.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := eventBus.Stop(); err != nil {
@@ -37,7 +40,6 @@ func TestEventBusPublishEventTx(t *testing.T) {
 	}
 
 	// PublishEventTx adds 3 composite keys, so the query below should work
-	ctx := context.Background()
 	query := fmt.Sprintf("tm.event='Tx' AND tx.height=1 AND tx.hash='%X' AND testType.baz=1", tx.Hash())
 	txsSub, err := eventBus.SubscribeWithArgs(ctx, tmpubsub.SubscribeArgs{
 		ClientID: "test",
@@ -76,8 +78,10 @@ func TestEventBusPublishEventTx(t *testing.T) {
 }
 
 func TestEventBusPublishEventNewBlock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	eventBus := eventbus.NewDefault(log.TestingLogger())
-	err := eventBus.Start()
+	err := eventBus.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := eventBus.Stop(); err != nil {
@@ -99,7 +103,6 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 	}
 
 	// PublishEventNewBlock adds the tm.event compositeKey, so the query below should work
-	ctx := context.Background()
 	query := "tm.event='NewBlock' AND testType.baz=1 AND testType.foz=2"
 	blocksSub, err := eventBus.SubscribeWithArgs(ctx, tmpubsub.SubscribeArgs{
 		ClientID: "test",
@@ -136,8 +139,10 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 }
 
 func TestEventBusPublishEventTxDuplicateKeys(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	eventBus := eventbus.NewDefault(log.TestingLogger())
-	err := eventBus.Start()
+	err := eventBus.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := eventBus.Stop(); err != nil {
@@ -243,8 +248,11 @@ func TestEventBusPublishEventTxDuplicateKeys(t *testing.T) {
 }
 
 func TestEventBusPublishEventNewBlockHeader(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	eventBus := eventbus.NewDefault(log.TestingLogger())
-	err := eventBus.Start()
+	err := eventBus.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := eventBus.Stop(); err != nil {
@@ -265,7 +273,6 @@ func TestEventBusPublishEventNewBlockHeader(t *testing.T) {
 	}
 
 	// PublishEventNewBlockHeader adds the tm.event compositeKey, so the query below should work
-	ctx := context.Background()
 	query := "tm.event='NewBlockHeader' AND testType.baz=1 AND testType.foz=2"
 	headersSub, err := eventBus.SubscribeWithArgs(ctx, tmpubsub.SubscribeArgs{
 		ClientID: "test",
@@ -300,8 +307,11 @@ func TestEventBusPublishEventNewBlockHeader(t *testing.T) {
 }
 
 func TestEventBusPublishEventNewEvidence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	eventBus := eventbus.NewDefault(log.TestingLogger())
-	err := eventBus.Start()
+	err := eventBus.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := eventBus.Stop(); err != nil {
@@ -311,7 +321,6 @@ func TestEventBusPublishEventNewEvidence(t *testing.T) {
 
 	ev := types.NewMockDuplicateVoteEvidence(1, time.Now(), "test-chain-id")
 
-	ctx := context.Background()
 	const query = `tm.event='NewEvidence'`
 	evSub, err := eventBus.SubscribeWithArgs(ctx, tmpubsub.SubscribeArgs{
 		ClientID: "test",
@@ -344,8 +353,11 @@ func TestEventBusPublishEventNewEvidence(t *testing.T) {
 }
 
 func TestEventBusPublish(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	eventBus := eventbus.NewDefault(log.TestingLogger())
-	err := eventBus.Start()
+	err := eventBus.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := eventBus.Stop(); err != nil {
@@ -355,7 +367,6 @@ func TestEventBusPublish(t *testing.T) {
 
 	const numEventsExpected = 14
 
-	ctx := context.Background()
 	sub, err := eventBus.SubscribeWithArgs(ctx, tmpubsub.SubscribeArgs{
 		ClientID: "test",
 		Query:    tmquery.Empty{},
@@ -434,8 +445,11 @@ func benchmarkEventBus(numClients int, randQueries bool, randEvents bool, b *tes
 	// for random* functions
 	mrand.Seed(time.Now().Unix())
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	eventBus := eventbus.NewDefault(log.TestingLogger()) // set buffer capacity to 0 so we are not testing cache
-	err := eventBus.Start()
+	err := eventBus.Start(ctx)
 	if err != nil {
 		b.Error(err)
 	}
@@ -445,7 +459,6 @@ func benchmarkEventBus(numClients int, randQueries bool, randEvents bool, b *tes
 		}
 	})
 
-	ctx := context.Background()
 	q := types.EventQueryNewBlock
 
 	for i := 0; i < numClients; i++ {

--- a/internal/evidence/reactor.go
+++ b/internal/evidence/reactor.go
@@ -1,6 +1,7 @@
 package evidence
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -81,7 +82,7 @@ func NewReactor(
 // envelopes on each. In addition, it also listens for peer updates and handles
 // messages on that p2p channel accordingly. The caller must be sure to execute
 // OnStop to ensure the outbound p2p Channels are closed. No error is returned.
-func (r *Reactor) OnStart() error {
+func (r *Reactor) OnStart(ctx context.Context) error {
 	go r.processEvidenceCh()
 	go r.processPeerUpdates()
 

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -85,7 +85,7 @@ func NewFromConfig(logger log.Logger, cfg *config.Config) (*Inspector, error) {
 // Run starts the Inspector servers and blocks until the servers shut down. The passed
 // in context is used to control the lifecycle of the servers.
 func (ins *Inspector) Run(ctx context.Context) error {
-	err := ins.eventBus.Start()
+	err := ins.eventBus.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("error starting event bus: %s", err)
 	}
@@ -95,7 +95,7 @@ func (ins *Inspector) Run(ctx context.Context) error {
 			ins.logger.Error("event bus stopped with error", "err", err)
 		}
 	}()
-	err = ins.indexerService.Start()
+	err = ins.indexerService.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("error starting indexer service: %s", err)
 	}

--- a/internal/libs/autofile/group.go
+++ b/internal/libs/autofile/group.go
@@ -2,6 +2,7 @@ package autofile
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -135,7 +136,7 @@ func GroupTotalSizeLimit(limit int64) func(*Group) {
 
 // OnStart implements service.Service by starting the goroutine that checks file
 // and group limits.
-func (g *Group) OnStart() error {
+func (g *Group) OnStart(ctx context.Context) error {
 	g.ticker = time.NewTicker(g.groupCheckDuration)
 	go g.processTicks()
 	return nil

--- a/internal/mempool/mempool_bench_test.go
+++ b/internal/mempool/mempool_bench_test.go
@@ -11,7 +11,10 @@ import (
 )
 
 func BenchmarkTxMempool_CheckTx(b *testing.B) {
-	txmp := setup(b, 10000)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	txmp := setup(ctx, b, 10000)
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	b.ResetTimer()

--- a/internal/mempool/reactor.go
+++ b/internal/mempool/reactor.go
@@ -112,7 +112,7 @@ func GetChannelDescriptor(cfg *config.MempoolConfig) *p2p.ChannelDescriptor {
 // envelopes on each. In addition, it also listens for peer updates and handles
 // messages on that p2p channel accordingly. The caller must be sure to execute
 // OnStop to ensure the outbound p2p Channels are closed.
-func (r *Reactor) OnStart() error {
+func (r *Reactor) OnStart(ctx context.Context) error {
 	if !r.cfg.Broadcast {
 		r.Logger.Info("tx broadcasting is disabled")
 	}

--- a/internal/mempool/reactor_test.go
+++ b/internal/mempool/reactor_test.go
@@ -36,7 +36,7 @@ type reactorTestSuite struct {
 	nodes []types.NodeID
 }
 
-func setupReactors(t *testing.T, numNodes int, chBuf uint) *reactorTestSuite {
+func setupReactors(ctx context.Context, t *testing.T, numNodes int, chBuf uint) *reactorTestSuite {
 	t.Helper()
 
 	cfg, err := config.ResetTestRoot(strings.ReplaceAll(t.Name(), "/", "|"))
@@ -45,7 +45,7 @@ func setupReactors(t *testing.T, numNodes int, chBuf uint) *reactorTestSuite {
 
 	rts := &reactorTestSuite{
 		logger:          log.TestingLogger().With("testCase", t.Name()),
-		network:         p2ptest.MakeNetwork(t, p2ptest.NetworkOptions{NumNodes: numNodes}),
+		network:         p2ptest.MakeNetwork(ctx, t, p2ptest.NetworkOptions{NumNodes: numNodes}),
 		reactors:        make(map[types.NodeID]*Reactor, numNodes),
 		mempoolChannels: make(map[types.NodeID]*p2p.Channel, numNodes),
 		mempools:        make(map[types.NodeID]*TxMempool, numNodes),
@@ -60,7 +60,7 @@ func setupReactors(t *testing.T, numNodes int, chBuf uint) *reactorTestSuite {
 	for nodeID := range rts.network.Nodes {
 		rts.kvstores[nodeID] = kvstore.NewApplication()
 
-		mempool := setup(t, 0)
+		mempool := setup(ctx, t, 0)
 		rts.mempools[nodeID] = mempool
 
 		rts.peerChans[nodeID] = make(chan p2p.PeerUpdate)
@@ -78,7 +78,7 @@ func setupReactors(t *testing.T, numNodes int, chBuf uint) *reactorTestSuite {
 
 		rts.nodes = append(rts.nodes, nodeID)
 
-		require.NoError(t, rts.reactors[nodeID].Start())
+		require.NoError(t, rts.reactors[nodeID].Start(ctx))
 		require.True(t, rts.reactors[nodeID].IsRunning())
 	}
 
@@ -147,8 +147,11 @@ func (rts *reactorTestSuite) waitForTxns(t *testing.T, txs []types.Tx, ids ...ty
 }
 
 func TestReactorBroadcastDoesNotPanic(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	numNodes := 2
-	rts := setupReactors(t, numNodes, 0)
+	rts := setupReactors(ctx, t, numNodes, 0)
 
 	observePanic := func(r interface{}) {
 		t.Fatal("panic detected in reactor")
@@ -192,8 +195,10 @@ func TestReactorBroadcastDoesNotPanic(t *testing.T) {
 func TestReactorBroadcastTxs(t *testing.T) {
 	numTxs := 1000
 	numNodes := 10
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	rts := setupReactors(t, numNodes, 0)
+	rts := setupReactors(ctx, t, numNodes, 0)
 
 	primary := rts.nodes[0]
 	secondaries := rts.nodes[1:]
@@ -215,7 +220,10 @@ func TestReactorConcurrency(t *testing.T) {
 	numTxs := 5
 	numNodes := 2
 
-	rts := setupReactors(t, numNodes, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rts := setupReactors(ctx, t, numNodes, 0)
 
 	primary := rts.nodes[0]
 	secondary := rts.nodes[1]
@@ -273,7 +281,10 @@ func TestReactorNoBroadcastToSender(t *testing.T) {
 	numTxs := 1000
 	numNodes := 2
 
-	rts := setupReactors(t, numNodes, uint(numTxs))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rts := setupReactors(ctx, t, numNodes, uint(numTxs))
 
 	primary := rts.nodes[0]
 	secondary := rts.nodes[1]
@@ -296,7 +307,10 @@ func TestReactor_MaxTxBytes(t *testing.T) {
 	numNodes := 2
 	cfg := config.TestConfig()
 
-	rts := setupReactors(t, numNodes, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rts := setupReactors(ctx, t, numNodes, 0)
 
 	primary := rts.nodes[0]
 	secondary := rts.nodes[1]
@@ -330,7 +344,11 @@ func TestReactor_MaxTxBytes(t *testing.T) {
 func TestDontExhaustMaxActiveIDs(t *testing.T) {
 	// we're creating a single node network, but not starting the
 	// network.
-	rts := setupReactors(t, 1, MaxActiveIDs+1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rts := setupReactors(ctx, t, 1, MaxActiveIDs+1)
 
 	nodeID := rts.nodes[0]
 
@@ -395,7 +413,10 @@ func TestBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	rts := setupReactors(t, 2, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rts := setupReactors(ctx, t, 2, 0)
 
 	primary := rts.nodes[0]
 	secondary := rts.nodes[1]

--- a/internal/p2p/address_test.go
+++ b/internal/p2p/address_test.go
@@ -1,6 +1,7 @@
 package p2p_test
 
 import (
+	"context"
 	"net"
 	"strings"
 	"testing"
@@ -204,6 +205,9 @@ func TestParseNodeAddress(t *testing.T) {
 func TestNodeAddress_Resolve(t *testing.T) {
 	id := types.NodeID("00112233445566778899aabbccddeeff00112233")
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	testcases := []struct {
 		address p2p.NodeAddress
 		expect  p2p.Endpoint
@@ -275,6 +279,9 @@ func TestNodeAddress_Resolve(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.address.String(), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
 			endpoints, err := tc.address.Resolve(ctx)
 			if !tc.ok {
 				require.Error(t, err)

--- a/internal/p2p/conn/connection.go
+++ b/internal/p2p/conn/connection.go
@@ -2,6 +2,7 @@ package conn
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -209,8 +210,8 @@ func NewMConnectionWithConfig(
 }
 
 // OnStart implements BaseService
-func (c *MConnection) OnStart() error {
-	if err := c.BaseService.OnStart(); err != nil {
+func (c *MConnection) OnStart(ctx context.Context) error {
+	if err := c.BaseService.OnStart(ctx); err != nil {
 		return err
 	}
 	c.flushTimer = timer.NewThrottleTimer("flush", c.config.FlushThrottle)

--- a/internal/p2p/conn/connection_test.go
+++ b/internal/p2p/conn/connection_test.go
@@ -1,6 +1,7 @@
 package conn
 
 import (
+	"context"
 	"encoding/hex"
 	"net"
 	"testing"
@@ -47,8 +48,11 @@ func TestMConnectionSendFlushStop(t *testing.T) {
 	server, client := NetPipe()
 	t.Cleanup(closeAll(t, client, server))
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	clientConn := createTestMConnection(log.TestingLogger(), client)
-	err := clientConn.Start()
+	err := clientConn.Start(ctx)
 	require.Nil(t, err)
 	t.Cleanup(stopAll(t, clientConn))
 
@@ -81,8 +85,11 @@ func TestMConnectionSend(t *testing.T) {
 	server, client := NetPipe()
 	t.Cleanup(closeAll(t, client, server))
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	mconn := createTestMConnection(log.TestingLogger(), client)
-	err := mconn.Start()
+	err := mconn.Start(ctx)
 	require.Nil(t, err)
 	t.Cleanup(stopAll(t, mconn))
 
@@ -118,13 +125,17 @@ func TestMConnectionReceive(t *testing.T) {
 		errorsCh <- r
 	}
 	logger := log.TestingLogger()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	mconn1 := createMConnectionWithCallbacks(logger, client, onReceive, onError)
-	err := mconn1.Start()
+	err := mconn1.Start(ctx)
 	require.Nil(t, err)
 	t.Cleanup(stopAll(t, mconn1))
 
 	mconn2 := createTestMConnection(logger, server)
-	err = mconn2.Start()
+	err = mconn2.Start(ctx)
 	require.Nil(t, err)
 	t.Cleanup(stopAll(t, mconn2))
 
@@ -153,8 +164,12 @@ func TestMConnectionPongTimeoutResultsInError(t *testing.T) {
 	onError := func(r interface{}) {
 		errorsCh <- r
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	mconn := createMConnectionWithCallbacks(log.TestingLogger(), client, onReceive, onError)
-	err := mconn.Start()
+	err := mconn.Start(ctx)
 	require.Nil(t, err)
 	t.Cleanup(stopAll(t, mconn))
 
@@ -191,8 +206,11 @@ func TestMConnectionMultiplePongsInTheBeginning(t *testing.T) {
 	onError := func(r interface{}) {
 		errorsCh <- r
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	mconn := createMConnectionWithCallbacks(log.TestingLogger(), client, onReceive, onError)
-	err := mconn.Start()
+	err := mconn.Start(ctx)
 	require.Nil(t, err)
 	t.Cleanup(stopAll(t, mconn))
 
@@ -245,8 +263,11 @@ func TestMConnectionMultiplePings(t *testing.T) {
 	onError := func(r interface{}) {
 		errorsCh <- r
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	mconn := createMConnectionWithCallbacks(log.TestingLogger(), client, onReceive, onError)
-	err := mconn.Start()
+	err := mconn.Start(ctx)
 	require.Nil(t, err)
 	t.Cleanup(stopAll(t, mconn))
 
@@ -292,8 +313,12 @@ func TestMConnectionPingPongs(t *testing.T) {
 	onError := func(r interface{}) {
 		errorsCh <- r
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	mconn := createMConnectionWithCallbacks(log.TestingLogger(), client, onReceive, onError)
-	err := mconn.Start()
+	err := mconn.Start(ctx)
 	require.Nil(t, err)
 	t.Cleanup(stopAll(t, mconn))
 
@@ -349,8 +374,11 @@ func TestMConnectionStopsAndReturnsError(t *testing.T) {
 	onError := func(r interface{}) {
 		errorsCh <- r
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	mconn := createMConnectionWithCallbacks(log.TestingLogger(), client, onReceive, onError)
-	err := mconn.Start()
+	err := mconn.Start(ctx)
 	require.Nil(t, err)
 	t.Cleanup(stopAll(t, mconn))
 
@@ -369,7 +397,11 @@ func TestMConnectionStopsAndReturnsError(t *testing.T) {
 	}
 }
 
-func newClientAndServerConnsForReadErrors(t *testing.T, chOnErr chan struct{}) (*MConnection, *MConnection) {
+func newClientAndServerConnsForReadErrors(
+	ctx context.Context,
+	t *testing.T,
+	chOnErr chan struct{},
+) (*MConnection, *MConnection) {
 	server, client := NetPipe()
 
 	onReceive := func(chID ChannelID, msgBytes []byte) {}
@@ -381,8 +413,9 @@ func newClientAndServerConnsForReadErrors(t *testing.T, chOnErr chan struct{}) (
 		{ID: 0x02, Priority: 1, SendQueueCapacity: 1},
 	}
 	logger := log.TestingLogger()
+
 	mconnClient := NewMConnection(logger.With("module", "client"), client, chDescs, onReceive, onError)
-	err := mconnClient.Start()
+	err := mconnClient.Start(ctx)
 	require.Nil(t, err)
 
 	// create server conn with 1 channel
@@ -391,8 +424,9 @@ func newClientAndServerConnsForReadErrors(t *testing.T, chOnErr chan struct{}) (
 	onError = func(r interface{}) {
 		chOnErr <- struct{}{}
 	}
+
 	mconnServer := createMConnectionWithCallbacks(serverLogger, server, onReceive, onError)
-	err = mconnServer.Start()
+	err = mconnServer.Start(ctx)
 	require.Nil(t, err)
 	return mconnClient, mconnServer
 }
@@ -408,8 +442,11 @@ func expectSend(ch chan struct{}) bool {
 }
 
 func TestMConnectionReadErrorBadEncoding(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	chOnErr := make(chan struct{})
-	mconnClient, mconnServer := newClientAndServerConnsForReadErrors(t, chOnErr)
+	mconnClient, mconnServer := newClientAndServerConnsForReadErrors(ctx, t, chOnErr)
 
 	client := mconnClient.conn
 
@@ -421,8 +458,11 @@ func TestMConnectionReadErrorBadEncoding(t *testing.T) {
 }
 
 func TestMConnectionReadErrorUnknownChannel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	chOnErr := make(chan struct{})
-	mconnClient, mconnServer := newClientAndServerConnsForReadErrors(t, chOnErr)
+	mconnClient, mconnServer := newClientAndServerConnsForReadErrors(ctx, t, chOnErr)
 
 	msg := []byte("Ant-Man")
 
@@ -440,7 +480,10 @@ func TestMConnectionReadErrorLongMessage(t *testing.T) {
 	chOnErr := make(chan struct{})
 	chOnRcv := make(chan struct{})
 
-	mconnClient, mconnServer := newClientAndServerConnsForReadErrors(t, chOnErr)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mconnClient, mconnServer := newClientAndServerConnsForReadErrors(ctx, t, chOnErr)
 	t.Cleanup(stopAll(t, mconnClient, mconnServer))
 
 	mconnServer.onReceive = func(chID ChannelID, msgBytes []byte) {
@@ -474,8 +517,11 @@ func TestMConnectionReadErrorLongMessage(t *testing.T) {
 }
 
 func TestMConnectionReadErrorUnknownMsgType(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	chOnErr := make(chan struct{})
-	mconnClient, mconnServer := newClientAndServerConnsForReadErrors(t, chOnErr)
+	mconnClient, mconnServer := newClientAndServerConnsForReadErrors(ctx, t, chOnErr)
 	t.Cleanup(stopAll(t, mconnClient, mconnServer))
 
 	// send msg with unknown msg type
@@ -487,9 +533,11 @@ func TestMConnectionReadErrorUnknownMsgType(t *testing.T) {
 func TestMConnectionTrySend(t *testing.T) {
 	server, client := NetPipe()
 	t.Cleanup(closeAll(t, client, server))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	mconn := createTestMConnection(log.TestingLogger(), client)
-	err := mconn.Start()
+	err := mconn.Start(ctx)
 	require.Nil(t, err)
 	t.Cleanup(stopAll(t, mconn))
 
@@ -535,7 +583,10 @@ func TestMConnectionChannelOverflow(t *testing.T) {
 	chOnErr := make(chan struct{})
 	chOnRcv := make(chan struct{})
 
-	mconnClient, mconnServer := newClientAndServerConnsForReadErrors(t, chOnErr)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mconnClient, mconnServer := newClientAndServerConnsForReadErrors(ctx, t, chOnErr)
 	t.Cleanup(stopAll(t, mconnClient, mconnServer))
 
 	mconnServer.onReceive = func(chID ChannelID, msgBytes []byte) {

--- a/internal/p2p/p2p_test.go
+++ b/internal/p2p/p2p_test.go
@@ -1,8 +1,6 @@
 package p2p_test
 
 import (
-	"context"
-
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/internal/p2p"
@@ -13,7 +11,6 @@ import (
 // Common setup for P2P tests.
 
 var (
-	ctx    = context.Background()
 	chID   = p2p.ChannelID(1)
 	chDesc = &p2p.ChannelDescriptor{
 		ID:                  chID,

--- a/internal/p2p/p2ptest/network.go
+++ b/internal/p2p/p2ptest/network.go
@@ -47,7 +47,7 @@ func (opts *NetworkOptions) setDefaults() {
 
 // MakeNetwork creates a test network with the given number of nodes and
 // connects them to each other.
-func MakeNetwork(t *testing.T, opts NetworkOptions) *Network {
+func MakeNetwork(ctx context.Context, t *testing.T, opts NetworkOptions) *Network {
 	opts.setDefaults()
 	logger := log.TestingLogger()
 	network := &Network{
@@ -57,7 +57,7 @@ func MakeNetwork(t *testing.T, opts NetworkOptions) *Network {
 	}
 
 	for i := 0; i < opts.NumNodes; i++ {
-		node := network.MakeNode(t, opts.NodeOpts)
+		node := network.MakeNode(ctx, t, opts.NodeOpts)
 		network.Nodes[node.NodeID] = node
 	}
 
@@ -221,7 +221,7 @@ type Node struct {
 // MakeNode creates a new Node configured for the network with a
 // running peer manager, but does not add it to the existing
 // network. Callers are responsible for updating peering relationships.
-func (n *Network) MakeNode(t *testing.T, opts NodeOptions) *Node {
+func (n *Network) MakeNode(ctx context.Context, t *testing.T, opts NodeOptions) *Node {
 	privKey := ed25519.GenPrivKey()
 	nodeID := types.NodeIDFromPubKey(privKey.PubKey())
 	nodeInfo := types.NodeInfo{
@@ -252,8 +252,9 @@ func (n *Network) MakeNode(t *testing.T, opts NodeOptions) *Node {
 		transport.Endpoints(),
 		p2p.RouterOptions{DialSleep: func(_ context.Context) {}},
 	)
+
 	require.NoError(t, err)
-	require.NoError(t, router.Start())
+	require.NoError(t, router.Start(ctx))
 
 	t.Cleanup(func() {
 		if router.IsRunning() {

--- a/internal/p2p/peermanager_test.go
+++ b/internal/p2p/peermanager_test.go
@@ -273,6 +273,9 @@ func TestPeerManager_Add(t *testing.T) {
 }
 
 func TestPeerManager_DialNext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
 	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
@@ -296,6 +299,9 @@ func TestPeerManager_DialNext(t *testing.T) {
 }
 
 func TestPeerManager_DialNext_Retry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
 	options := p2p.PeerManagerOptions{
@@ -311,7 +317,7 @@ func TestPeerManager_DialNext_Retry(t *testing.T) {
 
 	// Do five dial retries (six dials total). The retry time should double for
 	// each failure. At the forth retry, MaxRetryTime should kick in.
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	for i := 0; i <= 5; i++ {
@@ -342,6 +348,9 @@ func TestPeerManager_DialNext_Retry(t *testing.T) {
 }
 
 func TestPeerManager_DialNext_WakeOnAdd(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
 	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
@@ -356,7 +365,7 @@ func TestPeerManager_DialNext_WakeOnAdd(t *testing.T) {
 	}()
 
 	// This will block until peer is added above.
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	dial, err := peerManager.DialNext(ctx)
 	require.NoError(t, err)
@@ -364,6 +373,9 @@ func TestPeerManager_DialNext_WakeOnAdd(t *testing.T) {
 }
 
 func TestPeerManager_DialNext_WakeOnDialFailed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
 		MaxConnected: 1,
 	})
@@ -395,7 +407,7 @@ func TestPeerManager_DialNext_WakeOnDialFailed(t *testing.T) {
 	}()
 
 	// This should make b available for dialing (not a, retries are disabled).
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	dial, err = peerManager.DialNext(ctx)
 	require.NoError(t, err)
@@ -403,6 +415,9 @@ func TestPeerManager_DialNext_WakeOnDialFailed(t *testing.T) {
 }
 
 func TestPeerManager_DialNext_WakeOnDialFailedRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	options := p2p.PeerManagerOptions{MinRetryTime: 200 * time.Millisecond}
 	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), options)
 	require.NoError(t, err)
@@ -421,7 +436,7 @@ func TestPeerManager_DialNext_WakeOnDialFailedRetry(t *testing.T) {
 
 	// The retry timer should unblock DialNext and make a available again after
 	// the retry time passes.
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	dial, err = peerManager.DialNext(ctx)
 	require.NoError(t, err)
@@ -430,6 +445,9 @@ func TestPeerManager_DialNext_WakeOnDialFailedRetry(t *testing.T) {
 }
 
 func TestPeerManager_DialNext_WakeOnDisconnected(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
 	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
@@ -450,7 +468,7 @@ func TestPeerManager_DialNext_WakeOnDisconnected(t *testing.T) {
 		peerManager.Disconnected(a.NodeID)
 	}()
 
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	dial, err = peerManager.DialNext(ctx)
 	require.NoError(t, err)
@@ -1289,6 +1307,9 @@ func TestPeerManager_Ready(t *testing.T) {
 
 // See TryEvictNext for most tests, this just tests blocking behavior.
 func TestPeerManager_EvictNext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
 	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
@@ -1322,6 +1343,9 @@ func TestPeerManager_EvictNext(t *testing.T) {
 }
 
 func TestPeerManager_EvictNext_WakeOnError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
 	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
@@ -1340,7 +1364,7 @@ func TestPeerManager_EvictNext_WakeOnError(t *testing.T) {
 	}()
 
 	// This will block until peer errors above.
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	evict, err := peerManager.EvictNext(ctx)
 	require.NoError(t, err)
@@ -1348,6 +1372,9 @@ func TestPeerManager_EvictNext_WakeOnError(t *testing.T) {
 }
 
 func TestPeerManager_EvictNext_WakeOnUpgradeDialed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 
@@ -1378,7 +1405,7 @@ func TestPeerManager_EvictNext_WakeOnUpgradeDialed(t *testing.T) {
 	}()
 
 	// This will block until peer is upgraded above.
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	evict, err := peerManager.EvictNext(ctx)
 	require.NoError(t, err)
@@ -1386,6 +1413,9 @@ func TestPeerManager_EvictNext_WakeOnUpgradeDialed(t *testing.T) {
 }
 
 func TestPeerManager_EvictNext_WakeOnUpgradeAccepted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 	b := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("b", 40))}
 
@@ -1410,7 +1440,7 @@ func TestPeerManager_EvictNext_WakeOnUpgradeAccepted(t *testing.T) {
 	}()
 
 	// This will block until peer is upgraded above.
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	evict, err := peerManager.EvictNext(ctx)
 	require.NoError(t, err)

--- a/internal/p2p/pex/reactor.go
+++ b/internal/p2p/pex/reactor.go
@@ -1,6 +1,7 @@
 package pex
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -139,7 +140,7 @@ func NewReactor(
 // envelopes on each. In addition, it also listens for peer updates and handles
 // messages on that p2p channel accordingly. The caller must be sure to execute
 // OnStop to ensure the outbound p2p Channels are closed.
-func (r *Reactor) OnStart() error {
+func (r *Reactor) OnStart(ctx context.Context) error {
 	go r.processPexCh()
 	go r.processPeerUpdates()
 	return nil

--- a/internal/p2p/pex/reactor_test.go
+++ b/internal/p2p/pex/reactor_test.go
@@ -1,6 +1,7 @@
 package pex_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -29,13 +30,15 @@ const (
 )
 
 func TestReactorBasic(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	// start a network with one mock reactor and one "real" reactor
-	testNet := setupNetwork(t, testOptions{
+	testNet := setupNetwork(ctx, t, testOptions{
 		MockNodes:  1,
 		TotalNodes: 2,
 	})
 	testNet.connectAll(t)
-	testNet.start(t)
+	testNet.start(ctx, t)
 
 	// assert that the mock node receives a request from the real node
 	testNet.listenForRequest(t, secondNode, firstNode, shortWait)
@@ -47,14 +50,17 @@ func TestReactorBasic(t *testing.T) {
 }
 
 func TestReactorConnectFullNetwork(t *testing.T) {
-	testNet := setupNetwork(t, testOptions{
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testNet := setupNetwork(ctx, t, testOptions{
 		TotalNodes: 4,
 	})
 
 	// make every node be only connected with one other node (it actually ends up
 	// being two because of two way connections but oh well)
 	testNet.connectN(t, 1)
-	testNet.start(t)
+	testNet.start(ctx, t)
 
 	// assert that all nodes add each other in the network
 	for idx := 0; idx < len(testNet.nodes); idx++ {
@@ -63,7 +69,10 @@ func TestReactorConnectFullNetwork(t *testing.T) {
 }
 
 func TestReactorSendsRequestsTooOften(t *testing.T) {
-	r := setupSingle(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := setupSingle(ctx, t)
 
 	badNode := newNodeID(t, "b")
 
@@ -90,12 +99,15 @@ func TestReactorSendsRequestsTooOften(t *testing.T) {
 }
 
 func TestReactorSendsResponseWithoutRequest(t *testing.T) {
-	testNet := setupNetwork(t, testOptions{
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testNet := setupNetwork(ctx, t, testOptions{
 		MockNodes:  1,
 		TotalNodes: 3,
 	})
 	testNet.connectAll(t)
-	testNet.start(t)
+	testNet.start(ctx, t)
 
 	// firstNode sends the secondNode an unrequested response
 	// NOTE: secondNode will send a request by default during startup so we send
@@ -108,14 +120,17 @@ func TestReactorSendsResponseWithoutRequest(t *testing.T) {
 }
 
 func TestReactorNeverSendsTooManyPeers(t *testing.T) {
-	testNet := setupNetwork(t, testOptions{
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testNet := setupNetwork(ctx, t, testOptions{
 		MockNodes:  1,
 		TotalNodes: 2,
 	})
 	testNet.connectAll(t)
-	testNet.start(t)
+	testNet.start(ctx, t)
 
-	testNet.addNodes(t, 110)
+	testNet.addNodes(ctx, t, 110)
 	nodes := make([]int, 110)
 	for i := 0; i < len(nodes); i++ {
 		nodes[i] = i + 2
@@ -128,7 +143,10 @@ func TestReactorNeverSendsTooManyPeers(t *testing.T) {
 }
 
 func TestReactorErrorsOnReceivingTooManyPeers(t *testing.T) {
-	r := setupSingle(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := setupSingle(ctx, t)
 	peer := p2p.NodeAddress{Protocol: p2p.MemoryProtocol, NodeID: randomNodeID(t)}
 	added, err := r.manager.Add(peer)
 	require.NoError(t, err)
@@ -172,14 +190,17 @@ func TestReactorErrorsOnReceivingTooManyPeers(t *testing.T) {
 }
 
 func TestReactorSmallPeerStoreInALargeNetwork(t *testing.T) {
-	testNet := setupNetwork(t, testOptions{
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testNet := setupNetwork(ctx, t, testOptions{
 		TotalNodes:   8,
 		MaxPeers:     4,
 		MaxConnected: 3,
 		BufferSize:   8,
 	})
 	testNet.connectN(t, 1)
-	testNet.start(t)
+	testNet.start(ctx, t)
 
 	// test that all nodes reach full capacity
 	for _, nodeID := range testNet.nodes {
@@ -191,14 +212,17 @@ func TestReactorSmallPeerStoreInALargeNetwork(t *testing.T) {
 }
 
 func TestReactorLargePeerStoreInASmallNetwork(t *testing.T) {
-	testNet := setupNetwork(t, testOptions{
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testNet := setupNetwork(ctx, t, testOptions{
 		TotalNodes:   3,
 		MaxPeers:     25,
 		MaxConnected: 25,
 		BufferSize:   5,
 	})
 	testNet.connectN(t, 1)
-	testNet.start(t)
+	testNet.start(ctx, t)
 
 	// assert that all nodes add each other in the network
 	for idx := 0; idx < len(testNet.nodes); idx++ {
@@ -207,12 +231,15 @@ func TestReactorLargePeerStoreInASmallNetwork(t *testing.T) {
 }
 
 func TestReactorWithNetworkGrowth(t *testing.T) {
-	testNet := setupNetwork(t, testOptions{
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testNet := setupNetwork(ctx, t, testOptions{
 		TotalNodes: 5,
 		BufferSize: 5,
 	})
 	testNet.connectAll(t)
-	testNet.start(t)
+	testNet.start(ctx, t)
 
 	// assert that all nodes add each other in the network
 	for idx := 0; idx < len(testNet.nodes); idx++ {
@@ -220,10 +247,10 @@ func TestReactorWithNetworkGrowth(t *testing.T) {
 	}
 
 	// now we inject 10 more nodes
-	testNet.addNodes(t, 10)
+	testNet.addNodes(ctx, t, 10)
 	for i := 5; i < testNet.total; i++ {
 		node := testNet.nodes[i]
-		require.NoError(t, testNet.reactors[node].Start())
+		require.NoError(t, testNet.reactors[node].Start(ctx))
 		require.True(t, testNet.reactors[node].IsRunning())
 		// we connect all new nodes to a single entry point and check that the
 		// node can distribute the addresses to all the others
@@ -247,7 +274,7 @@ type singleTestReactor struct {
 	manager  *p2p.PeerManager
 }
 
-func setupSingle(t *testing.T) *singleTestReactor {
+func setupSingle(ctx context.Context, t *testing.T) *singleTestReactor {
 	t.Helper()
 	nodeID := newNodeID(t, "a")
 	chBuf := 2
@@ -268,7 +295,7 @@ func setupSingle(t *testing.T) *singleTestReactor {
 	require.NoError(t, err)
 
 	reactor := pex.NewReactor(log.TestingLogger(), peerManager, pexCh, peerUpdates)
-	require.NoError(t, reactor.Start())
+	require.NoError(t, reactor.Start(ctx))
 	t.Cleanup(func() {
 		err := reactor.Stop()
 		if err != nil {
@@ -315,7 +342,7 @@ type testOptions struct {
 
 // setup setups a test suite with a network of nodes. Mocknodes represent the
 // hollow nodes that the test can listen and send on
-func setupNetwork(t *testing.T, opts testOptions) *reactorTestSuite {
+func setupNetwork(ctx context.Context, t *testing.T, opts testOptions) *reactorTestSuite {
 	t.Helper()
 
 	require.Greater(t, opts.TotalNodes, opts.MockNodes)
@@ -335,7 +362,7 @@ func setupNetwork(t *testing.T, opts testOptions) *reactorTestSuite {
 
 	rts := &reactorTestSuite{
 		logger:      log.TestingLogger().With("testCase", t.Name()),
-		network:     p2ptest.MakeNetwork(t, networkOpts),
+		network:     p2ptest.MakeNetwork(ctx, t, networkOpts),
 		reactors:    make(map[types.NodeID]*pex.Reactor, realNodes),
 		pexChannels: make(map[types.NodeID]*p2p.Channel, opts.TotalNodes),
 		peerChans:   make(map[types.NodeID]chan p2p.PeerUpdate, opts.TotalNodes),
@@ -391,20 +418,20 @@ func setupNetwork(t *testing.T, opts testOptions) *reactorTestSuite {
 }
 
 // starts up the pex reactors for each node
-func (r *reactorTestSuite) start(t *testing.T) {
+func (r *reactorTestSuite) start(ctx context.Context, t *testing.T) {
 	t.Helper()
 
 	for _, reactor := range r.reactors {
-		require.NoError(t, reactor.Start())
+		require.NoError(t, reactor.Start(ctx))
 		require.True(t, reactor.IsRunning())
 	}
 }
 
-func (r *reactorTestSuite) addNodes(t *testing.T, nodes int) {
+func (r *reactorTestSuite) addNodes(ctx context.Context, t *testing.T, nodes int) {
 	t.Helper()
 
 	for i := 0; i < nodes; i++ {
-		node := r.network.MakeNode(t, p2ptest.NodeOptions{
+		node := r.network.MakeNode(ctx, t, p2ptest.NodeOptions{
 			MaxPeers:     r.opts.MaxPeers,
 			MaxConnected: r.opts.MaxConnected,
 		})

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -1023,7 +1023,7 @@ func (r *Router) NodeInfo() types.NodeInfo {
 }
 
 // OnStart implements service.Service.
-func (r *Router) OnStart() error {
+func (r *Router) OnStart(ctx context.Context) error {
 	for _, transport := range r.transports {
 		for _, endpoint := range r.endpoints {
 			if err := transport.Listen(endpoint); err != nil {

--- a/internal/p2p/router_test.go
+++ b/internal/p2p/router_test.go
@@ -44,10 +44,13 @@ func echoReactor(channel *p2p.Channel) {
 }
 
 func TestRouter_Network(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	t.Cleanup(leaktest.Check(t))
 
 	// Create a test network and open a channel where all peers run echoReactor.
-	network := p2ptest.MakeNetwork(t, p2ptest.NetworkOptions{NumNodes: 8})
+	network := p2ptest.MakeNetwork(ctx, t, p2ptest.NetworkOptions{NumNodes: 8})
 	local := network.RandomNode()
 	peers := network.Peers(local.NodeID)
 	channels := network.MakeChannels(t, chDesc)
@@ -114,7 +117,10 @@ func TestRouter_Channel_Basic(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, router.Start())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, router.Start(ctx))
 	t.Cleanup(func() {
 		require.NoError(t, router.Stop())
 	})
@@ -158,10 +164,13 @@ func TestRouter_Channel_Basic(t *testing.T) {
 
 // Channel tests are hairy to mock, so we use an in-memory network instead.
 func TestRouter_Channel_SendReceive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	t.Cleanup(leaktest.Check(t))
 
 	// Create a test network and open a channel on all nodes.
-	network := p2ptest.MakeNetwork(t, p2ptest.NetworkOptions{NumNodes: 3})
+	network := p2ptest.MakeNetwork(ctx, t, p2ptest.NetworkOptions{NumNodes: 3})
 
 	ids := network.NodeIDs()
 	aID, bID, cID := ids[0], ids[1], ids[2]
@@ -219,8 +228,11 @@ func TestRouter_Channel_SendReceive(t *testing.T) {
 func TestRouter_Channel_Broadcast(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Create a test network and open a channel on all nodes.
-	network := p2ptest.MakeNetwork(t, p2ptest.NetworkOptions{NumNodes: 4})
+	network := p2ptest.MakeNetwork(ctx, t, p2ptest.NetworkOptions{NumNodes: 4})
 
 	ids := network.NodeIDs()
 	aID, bID, cID, dID := ids[0], ids[1], ids[2], ids[3]
@@ -247,8 +259,11 @@ func TestRouter_Channel_Broadcast(t *testing.T) {
 func TestRouter_Channel_Wrapper(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Create a test network and open a channel on all nodes.
-	network := p2ptest.MakeNetwork(t, p2ptest.NetworkOptions{NumNodes: 2})
+	network := p2ptest.MakeNetwork(ctx, t, p2ptest.NetworkOptions{NumNodes: 2})
 
 	ids := network.NodeIDs()
 	aID, bID := ids[0], ids[1]
@@ -314,8 +329,11 @@ func (w *wrapperMessage) Unwrap() (proto.Message, error) {
 func TestRouter_Channel_Error(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Create a test network and open a channel on all nodes.
-	network := p2ptest.MakeNetwork(t, p2ptest.NetworkOptions{NumNodes: 3})
+	network := p2ptest.MakeNetwork(ctx, t, p2ptest.NetworkOptions{NumNodes: 3})
 	network.Start(t)
 
 	ids := network.NodeIDs()
@@ -353,9 +371,16 @@ func TestRouter_AcceptPeers(t *testing.T) {
 			false,
 		},
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for name, tc := range testcases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			ctx, cancel = context.WithCancel(ctx)
+			defer cancel()
+
 			t.Cleanup(leaktest.Check(t))
 
 			// Set up a mock transport that handshakes.
@@ -398,7 +423,7 @@ func TestRouter_AcceptPeers(t *testing.T) {
 				p2p.RouterOptions{},
 			)
 			require.NoError(t, err)
-			require.NoError(t, router.Start())
+			require.NoError(t, router.Start(ctx))
 
 			if tc.ok {
 				p2ptest.RequireUpdate(t, sub, p2p.PeerUpdate{
@@ -427,6 +452,9 @@ func TestRouter_AcceptPeers(t *testing.T) {
 func TestRouter_AcceptPeers_Error(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Set up a mock transport that returns an error, which should prevent
 	// the router from calling Accept again.
 	mockTransport := &mocks.Transport{}
@@ -452,7 +480,7 @@ func TestRouter_AcceptPeers_Error(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, router.Start())
+	require.NoError(t, router.Start(ctx))
 	time.Sleep(time.Second)
 	require.NoError(t, router.Stop())
 
@@ -487,7 +515,10 @@ func TestRouter_AcceptPeers_ErrorEOF(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, router.Start())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, router.Start(ctx))
 	time.Sleep(time.Second)
 	require.NoError(t, router.Stop())
 
@@ -496,6 +527,9 @@ func TestRouter_AcceptPeers_ErrorEOF(t *testing.T) {
 
 func TestRouter_AcceptPeers_HeadOfLineBlocking(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Set up a mock transport that returns a connection that blocks during the
 	// handshake. It should be able to accept several of these in parallel, i.e.
@@ -535,7 +569,7 @@ func TestRouter_AcceptPeers_HeadOfLineBlocking(t *testing.T) {
 		p2p.RouterOptions{},
 	)
 	require.NoError(t, err)
-	require.NoError(t, router.Start())
+	require.NoError(t, router.Start(ctx))
 
 	require.Eventually(t, func() bool {
 		return len(acceptCh) == 3
@@ -574,10 +608,16 @@ func TestRouter_DialPeers(t *testing.T) {
 			false,
 		},
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for name, tc := range testcases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Cleanup(leaktest.Check(t))
+			ctx, cancel = context.WithCancel(ctx)
+			defer cancel()
 
 			address := p2p.NodeAddress{Protocol: "mock", NodeID: tc.dialID}
 			endpoint := p2p.Endpoint{Protocol: "mock", Path: string(tc.dialID)}
@@ -635,7 +675,7 @@ func TestRouter_DialPeers(t *testing.T) {
 				p2p.RouterOptions{},
 			)
 			require.NoError(t, err)
-			require.NoError(t, router.Start())
+			require.NoError(t, router.Start(ctx))
 
 			if tc.ok {
 				p2ptest.RequireUpdate(t, sub, p2p.PeerUpdate{
@@ -663,6 +703,9 @@ func TestRouter_DialPeers(t *testing.T) {
 
 func TestRouter_DialPeers_Parallel(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	a := p2p.NodeAddress{Protocol: "mock", NodeID: types.NodeID(strings.Repeat("a", 40))}
 	b := p2p.NodeAddress{Protocol: "mock", NodeID: types.NodeID(strings.Repeat("b", 40))}
@@ -729,7 +772,7 @@ func TestRouter_DialPeers_Parallel(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	require.NoError(t, router.Start())
+	require.NoError(t, router.Start(ctx))
 
 	require.Eventually(t,
 		func() bool {
@@ -749,6 +792,9 @@ func TestRouter_DialPeers_Parallel(t *testing.T) {
 
 func TestRouter_EvictPeers(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Set up a mock transport that we can evict.
 	closeCh := make(chan time.Time)
@@ -792,7 +838,7 @@ func TestRouter_EvictPeers(t *testing.T) {
 		p2p.RouterOptions{},
 	)
 	require.NoError(t, err)
-	require.NoError(t, router.Start())
+	require.NoError(t, router.Start(ctx))
 
 	// Wait for the mock peer to connect, then evict it by reporting an error.
 	p2ptest.RequireUpdate(t, sub, p2p.PeerUpdate{
@@ -815,6 +861,8 @@ func TestRouter_EvictPeers(t *testing.T) {
 
 func TestRouter_ChannelCompatability(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	incompatiblePeer := types.NodeInfo{
 		NodeID:     peerID,
@@ -854,7 +902,7 @@ func TestRouter_ChannelCompatability(t *testing.T) {
 		p2p.RouterOptions{},
 	)
 	require.NoError(t, err)
-	require.NoError(t, router.Start())
+	require.NoError(t, router.Start(ctx))
 	time.Sleep(1 * time.Second)
 	require.NoError(t, router.Stop())
 	require.Empty(t, peerManager.Peers())
@@ -865,6 +913,8 @@ func TestRouter_ChannelCompatability(t *testing.T) {
 
 func TestRouter_DontSendOnInvalidChannel(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	peer := types.NodeInfo{
 		NodeID:     peerID,
@@ -909,7 +959,7 @@ func TestRouter_DontSendOnInvalidChannel(t *testing.T) {
 		p2p.RouterOptions{},
 	)
 	require.NoError(t, err)
-	require.NoError(t, router.Start())
+	require.NoError(t, router.Start(ctx))
 
 	p2ptest.RequireUpdate(t, sub, p2p.PeerUpdate{
 		NodeID: peerInfo.NodeID,

--- a/internal/p2p/transport_mconn.go
+++ b/internal/p2p/transport_mconn.go
@@ -291,7 +291,7 @@ func (c *mConnConnection) Handshake(
 		}
 		c.mconn = mconn
 		c.logger = mconn.Logger
-		if err = c.mconn.Start(); err != nil {
+		if err = c.mconn.Start(ctx); err != nil {
 			return types.NodeInfo{}, nil, err
 		}
 		return peerInfo, peerKey, nil

--- a/internal/p2p/transport_mconn_test.go
+++ b/internal/p2p/transport_mconn_test.go
@@ -1,6 +1,7 @@
 package p2p_test
 
 import (
+	"context"
 	"io"
 	"net"
 	"testing"
@@ -58,6 +59,9 @@ func TestMConnTransport_AcceptBeforeListen(t *testing.T) {
 }
 
 func TestMConnTransport_AcceptMaxAcceptedConnections(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	transport := p2p.NewMConnTransport(
 		log.TestingLogger(),
 		conn.DefaultMConnConfig(),
@@ -124,6 +128,9 @@ func TestMConnTransport_AcceptMaxAcceptedConnections(t *testing.T) {
 }
 
 func TestMConnTransport_Listen(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	testcases := []struct {
 		endpoint p2p.Endpoint
 		ok       bool
@@ -144,6 +151,9 @@ func TestMConnTransport_Listen(t *testing.T) {
 		tc := tc
 		t.Run(tc.endpoint.String(), func(t *testing.T) {
 			t.Cleanup(leaktest.Check(t))
+
+			ctx, cancel = context.WithCancel(ctx)
+			defer cancel()
 
 			transport := p2p.NewMConnTransport(
 				log.TestingLogger(),

--- a/internal/p2p/trust/metric.go
+++ b/internal/p2p/trust/metric.go
@@ -4,6 +4,7 @@
 package trust
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -109,8 +110,8 @@ func NewMetricWithConfig(tmc MetricConfig) *Metric {
 }
 
 // OnStart implements Service
-func (tm *Metric) OnStart() error {
-	if err := tm.BaseService.OnStart(); err != nil {
+func (tm *Metric) OnStart(ctx context.Context) error {
+	if err := tm.BaseService.OnStart(ctx); err != nil {
 		return err
 	}
 	go tm.processRequests()

--- a/internal/p2p/trust/metric_test.go
+++ b/internal/p2p/trust/metric_test.go
@@ -1,6 +1,7 @@
 package trust
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,8 +10,11 @@ import (
 )
 
 func TestTrustMetricScores(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	tm := NewMetric()
-	err := tm.Start()
+	err := tm.Start(ctx)
 	require.NoError(t, err)
 
 	// Perfect score
@@ -27,6 +31,9 @@ func TestTrustMetricScores(t *testing.T) {
 }
 
 func TestTrustMetricConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// 7 days
 	window := time.Minute * 60 * 24 * 7
 	config := MetricConfig{
@@ -35,7 +42,7 @@ func TestTrustMetricConfig(t *testing.T) {
 	}
 
 	tm := NewMetricWithConfig(config)
-	err := tm.Start()
+	err := tm.Start(ctx)
 	require.NoError(t, err)
 
 	// The max time intervals should be the TrackingWindow / IntervalLen
@@ -52,7 +59,7 @@ func TestTrustMetricConfig(t *testing.T) {
 	config.ProportionalWeight = 0.3
 	config.IntegralWeight = 0.7
 	tm = NewMetricWithConfig(config)
-	err = tm.Start()
+	err = tm.Start(ctx)
 	require.NoError(t, err)
 
 	// These weights should be equal to our custom values
@@ -74,12 +81,15 @@ func TestTrustMetricCopyNilPointer(t *testing.T) {
 // XXX: This test fails non-deterministically
 //nolint:unused,deadcode
 func _TestTrustMetricStopPause(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// The TestTicker will provide manual control over
 	// the passing of time within the metric
 	tt := NewTestTicker()
 	tm := NewMetric()
 	tm.SetTicker(tt)
-	err := tm.Start()
+	err := tm.Start(ctx)
 	require.NoError(t, err)
 	// Allow some time intervals to pass and pause
 	tt.NextTick()

--- a/internal/proxy/app_conn_test.go
+++ b/internal/proxy/app_conn_test.go
@@ -51,16 +51,15 @@ func TestEcho(t *testing.T) {
 	logger := log.TestingLogger()
 	clientCreator := abciclient.NewRemoteCreator(logger, sockPath, SOCKET, true)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Start server
 	s := server.NewSocketServer(logger.With("module", "abci-server"), sockPath, kvstore.NewApplication())
-	if err := s.Start(); err != nil {
+	if err := s.Start(ctx); err != nil {
 		t.Fatalf("Error starting socket server: %v", err.Error())
 	}
-	t.Cleanup(func() {
-		if err := s.Stop(); err != nil {
-			t.Error(err)
-		}
-	})
+	t.Cleanup(func() { cancel(); s.Wait() })
 
 	// Start client
 	cli, err := clientCreator(logger.With("module", "abci-client"))
@@ -68,14 +67,13 @@ func TestEcho(t *testing.T) {
 		t.Fatalf("Error creating ABCI client: %v", err.Error())
 	}
 
-	if err := cli.Start(); err != nil {
+	if err := cli.Start(ctx); err != nil {
 		t.Fatalf("Error starting ABCI client: %v", err.Error())
 	}
 
 	proxy := newAppConnTest(cli)
 	t.Log("Connected")
 
-	ctx := context.Background()
 	for i := 0; i < 1000; i++ {
 		_, err = proxy.EchoAsync(ctx, fmt.Sprintf("echo-%v", i))
 		if err != nil {
@@ -99,16 +97,15 @@ func BenchmarkEcho(b *testing.B) {
 	logger := log.TestingLogger()
 	clientCreator := abciclient.NewRemoteCreator(logger, sockPath, SOCKET, true)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Start server
 	s := server.NewSocketServer(logger.With("module", "abci-server"), sockPath, kvstore.NewApplication())
-	if err := s.Start(); err != nil {
+	if err := s.Start(ctx); err != nil {
 		b.Fatalf("Error starting socket server: %v", err.Error())
 	}
-	b.Cleanup(func() {
-		if err := s.Stop(); err != nil {
-			b.Error(err)
-		}
-	})
+	b.Cleanup(func() { cancel(); s.Wait() })
 
 	// Start client
 	cli, err := clientCreator(logger.With("module", "abci-client"))
@@ -116,7 +113,7 @@ func BenchmarkEcho(b *testing.B) {
 		b.Fatalf("Error creating ABCI client: %v", err.Error())
 	}
 
-	if err := cli.Start(); err != nil {
+	if err := cli.Start(ctx); err != nil {
 		b.Fatalf("Error starting ABCI client: %v", err.Error())
 	}
 
@@ -125,7 +122,6 @@ func BenchmarkEcho(b *testing.B) {
 	echoString := strings.Repeat(" ", 200)
 	b.StartTimer() // Start benchmarking tests
 
-	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		_, err = proxy.EchoAsync(ctx, echoString)
 		if err != nil {
@@ -152,16 +148,15 @@ func TestInfo(t *testing.T) {
 	logger := log.TestingLogger()
 	clientCreator := abciclient.NewRemoteCreator(logger, sockPath, SOCKET, true)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Start server
 	s := server.NewSocketServer(logger.With("module", "abci-server"), sockPath, kvstore.NewApplication())
-	if err := s.Start(); err != nil {
+	if err := s.Start(ctx); err != nil {
 		t.Fatalf("Error starting socket server: %v", err.Error())
 	}
-	t.Cleanup(func() {
-		if err := s.Stop(); err != nil {
-			t.Error(err)
-		}
-	})
+	t.Cleanup(func() { cancel(); s.Wait() })
 
 	// Start client
 	cli, err := clientCreator(logger.With("module", "abci-client"))
@@ -169,7 +164,7 @@ func TestInfo(t *testing.T) {
 		t.Fatalf("Error creating ABCI client: %v", err.Error())
 	}
 
-	if err := cli.Start(); err != nil {
+	if err := cli.Start(ctx); err != nil {
 		t.Fatalf("Error starting ABCI client: %v", err.Error())
 	}
 

--- a/internal/state/execution_test.go
+++ b/internal/state/execution_test.go
@@ -40,9 +40,12 @@ func TestApplyBlock(t *testing.T) {
 	cc := abciclient.NewLocalCreator(app)
 	logger := log.TestingLogger()
 	proxyApp := proxy.NewAppConns(cc, logger, proxy.NopMetrics())
-	err := proxyApp.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := proxyApp.Start(ctx)
 	require.Nil(t, err)
-	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
 
 	state, stateDB, _ := makeState(1, 1)
 	stateStore := sm.NewStore(stateDB)
@@ -62,12 +65,15 @@ func TestApplyBlock(t *testing.T) {
 
 // TestBeginBlockValidators ensures we send absent validators list.
 func TestBeginBlockValidators(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	app := &testApp{}
 	cc := abciclient.NewLocalCreator(app)
 	proxyApp := proxy.NewAppConns(cc, log.TestingLogger(), proxy.NopMetrics())
-	err := proxyApp.Start()
+
+	err := proxyApp.Start(ctx)
 	require.Nil(t, err)
-	defer proxyApp.Stop() //nolint:errcheck // no need to check error again
 
 	state, stateDB, _ := makeState(2, 2)
 	stateStore := sm.NewStore(stateDB)
@@ -125,12 +131,14 @@ func TestBeginBlockValidators(t *testing.T) {
 
 // TestBeginBlockByzantineValidators ensures we send byzantine validators list.
 func TestBeginBlockByzantineValidators(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	app := &testApp{}
 	cc := abciclient.NewLocalCreator(app)
 	proxyApp := proxy.NewAppConns(cc, log.TestingLogger(), proxy.NopMetrics())
-	err := proxyApp.Start()
+	err := proxyApp.Start(ctx)
 	require.Nil(t, err)
-	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
 
 	state, stateDB, privVals := makeState(1, 1)
 	stateStore := sm.NewStore(stateDB)
@@ -350,13 +358,15 @@ func TestUpdateValidators(t *testing.T) {
 
 // TestEndBlockValidatorUpdates ensures we update validator set and send an event.
 func TestEndBlockValidatorUpdates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	app := &testApp{}
 	cc := abciclient.NewLocalCreator(app)
 	logger := log.TestingLogger()
 	proxyApp := proxy.NewAppConns(cc, logger, proxy.NopMetrics())
-	err := proxyApp.Start()
+	err := proxyApp.Start(ctx)
 	require.Nil(t, err)
-	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
 
 	state, stateDB, _ := makeState(1, 1)
 	stateStore := sm.NewStore(stateDB)
@@ -372,7 +382,7 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 	)
 
 	eventBus := eventbus.NewDefault(logger)
-	err = eventBus.Start()
+	err = eventBus.Start(ctx)
 	require.NoError(t, err)
 	defer eventBus.Stop() //nolint:errcheck // ignore for tests
 
@@ -405,7 +415,7 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 	}
 
 	// test we threw an event
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 	msg, err := updatesSub.Next(ctx)
 	require.NoError(t, err)
@@ -420,13 +430,15 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 // TestEndBlockValidatorUpdatesResultingInEmptySet checks that processing validator updates that
 // would result in empty set causes no panic, an error is raised and NextValidators is not updated
 func TestEndBlockValidatorUpdatesResultingInEmptySet(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	app := &testApp{}
 	cc := abciclient.NewLocalCreator(app)
 	logger := log.TestingLogger()
 	proxyApp := proxy.NewAppConns(cc, logger, proxy.NopMetrics())
-	err := proxyApp.Start()
+	err := proxyApp.Start(ctx)
 	require.Nil(t, err)
-	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
 
 	state, stateDB, _ := makeState(1, 1)
 	stateStore := sm.NewStore(stateDB)

--- a/internal/state/indexer/indexer_service.go
+++ b/internal/state/indexer/indexer_service.go
@@ -116,7 +116,7 @@ func (is *Service) publish(msg pubsub.Message) error {
 // indexer if the underlying event sinks support indexing.
 //
 // TODO(creachadair): Can we get rid of the "enabled" check?
-func (is *Service) OnStart() error {
+func (is *Service) OnStart(ctx context.Context) error {
 	// If the event sinks support indexing, register an observer to capture
 	// block header data for the indexer.
 	if IndexingEnabled(is.eventSinks) {

--- a/internal/state/indexer/indexer_service_test.go
+++ b/internal/state/indexer/indexer_service_test.go
@@ -1,6 +1,7 @@
 package indexer_test
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
@@ -47,10 +48,13 @@ func NewIndexerService(es []indexer.EventSink, eventBus *eventbus.EventBus) *ind
 }
 
 func TestIndexerServiceIndexesBlocks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	logger := tmlog.TestingLogger()
 	// event bus
 	eventBus := eventbus.NewDefault(logger)
-	err := eventBus.Start()
+	err := eventBus.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := eventBus.Stop(); err != nil {
@@ -71,7 +75,7 @@ func TestIndexerServiceIndexesBlocks(t *testing.T) {
 	assert.True(t, indexer.IndexingEnabled(eventSinks))
 
 	service := NewIndexerService(eventSinks, eventBus)
-	err = service.Start()
+	err = service.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := service.Stop(); err != nil {

--- a/internal/state/validation_test.go
+++ b/internal/state/validation_test.go
@@ -28,9 +28,11 @@ import (
 const validationTestsStopHeight int64 = 10
 
 func TestValidateBlockHeader(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	proxyApp := newTestApp()
-	require.NoError(t, proxyApp.Start())
-	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
+	require.NoError(t, proxyApp.Start(ctx))
 
 	state, stateDB, privVals := makeState(3, 1)
 	stateStore := sm.NewStore(stateDB)
@@ -115,9 +117,11 @@ func TestValidateBlockHeader(t *testing.T) {
 }
 
 func TestValidateBlockCommit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	proxyApp := newTestApp()
-	require.NoError(t, proxyApp.Start())
-	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
+	require.NoError(t, proxyApp.Start(ctx))
 
 	state, stateDB, privVals := makeState(1, 1)
 	stateStore := sm.NewStore(stateDB)
@@ -236,9 +240,11 @@ func TestValidateBlockCommit(t *testing.T) {
 }
 
 func TestValidateBlockEvidence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	proxyApp := newTestApp()
-	require.NoError(t, proxyApp.Start())
-	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
+	require.NoError(t, proxyApp.Start(ctx))
 
 	state, stateDB, privVals := makeState(4, 1)
 	stateStore := sm.NewStore(stateDB)

--- a/internal/statesync/dispatcher_test.go
+++ b/internal/statesync/dispatcher_test.go
@@ -114,6 +114,10 @@ func TestDispatcherProviders(t *testing.T) {
 
 func TestPeerListBasic(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	peerList := newPeerList()
 	assert.Zero(t, peerList.Len())
 	numPeers := 10
@@ -199,6 +203,9 @@ func TestEmptyPeerListReturnsWhenContextCanceled(t *testing.T) {
 
 func TestPeerListConcurrent(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	peerList := newPeerList()
 	numPeers := 10
 
@@ -229,7 +236,6 @@ func TestPeerListConcurrent(t *testing.T) {
 
 	// we use a context with cancel and a separate go routine to wait for all
 	// the other goroutines to close.
-	ctx, cancel := context.WithCancel(context.Background())
 	go func() { wg.Wait(); cancel() }()
 
 	select {

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -210,7 +210,7 @@ func NewReactor(
 // handle individual envelopes as to not have to deal with bounding workers or pools.
 // The caller must be sure to execute OnStop to ensure the outbound p2p Channels are
 // closed. No error is returned.
-func (r *Reactor) OnStart() error {
+func (r *Reactor) OnStart(ctx context.Context) error {
 	go r.processSnapshotCh()
 
 	go r.processChunkCh()

--- a/libs/events/event_cache_test.go
+++ b/libs/events/event_cache_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,8 +9,11 @@ import (
 )
 
 func TestEventCache_Flush(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	evsw := NewEventSwitch()
-	err := evsw.Start()
+	err := evsw.Start(ctx)
 	require.NoError(t, err)
 
 	err = evsw.AddListenerForEvent("nothingness", "", func(data EventData) {

--- a/libs/events/events.go
+++ b/libs/events/events.go
@@ -2,6 +2,7 @@
 package events
 
 import (
+	"context"
 	"fmt"
 
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
@@ -45,10 +46,15 @@ type Fireable interface {
 type EventSwitch interface {
 	service.Service
 	Fireable
+	stoppable
 
 	AddListenerForEvent(listenerID, eventValue string, cb EventCallback) error
 	RemoveListenerForEvent(event string, listenerID string)
 	RemoveListener(listenerID string)
+}
+
+type stoppable interface {
+	Stop() error
 }
 
 type eventSwitch struct {
@@ -68,7 +74,7 @@ func NewEventSwitch() EventSwitch {
 	return evsw
 }
 
-func (evsw *eventSwitch) OnStart() error {
+func (evsw *eventSwitch) OnStart(ctx context.Context) error {
 	return nil
 }
 

--- a/libs/events/events_test.go
+++ b/libs/events/events_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -14,8 +15,11 @@ import (
 // TestAddListenerForEventFireOnce sets up an EventSwitch, subscribes a single
 // listener to an event, and sends a string "data".
 func TestAddListenerForEventFireOnce(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	evsw := NewEventSwitch()
-	err := evsw.Start()
+	err := evsw.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := evsw.Stop(); err != nil {
@@ -41,8 +45,11 @@ func TestAddListenerForEventFireOnce(t *testing.T) {
 // TestAddListenerForEventFireMany sets up an EventSwitch, subscribes a single
 // listener to an event, and sends a thousand integers.
 func TestAddListenerForEventFireMany(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	evsw := NewEventSwitch()
-	err := evsw.Start()
+	err := evsw.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := evsw.Stop(); err != nil {
@@ -75,8 +82,11 @@ func TestAddListenerForEventFireMany(t *testing.T) {
 // listener to three different events and sends a thousand integers for each
 // of the three events.
 func TestAddListenerForDifferentEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	evsw := NewEventSwitch()
-	err := evsw.Start()
+	err := evsw.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := evsw.Stop(); err != nil {
@@ -127,8 +137,11 @@ func TestAddListenerForDifferentEvents(t *testing.T) {
 // listener to two of those three events, and then sends a thousand integers
 // for each of the three events.
 func TestAddDifferentListenerForDifferentEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	evsw := NewEventSwitch()
-	err := evsw.Start()
+	err := evsw.Start(ctx)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -199,8 +212,11 @@ func TestAddAndRemoveListenerConcurrency(t *testing.T) {
 		roundCount     = 2000
 	)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	evsw := NewEventSwitch()
-	err := evsw.Start()
+	err := evsw.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := evsw.Stop(); err != nil {
@@ -249,8 +265,11 @@ func TestAddAndRemoveListenerConcurrency(t *testing.T) {
 // two events, fires a thousand integers for the first event, then unsubscribes
 // the listener and fires a thousand integers for the second event.
 func TestAddAndRemoveListener(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	evsw := NewEventSwitch()
-	err := evsw.Start()
+	err := evsw.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := evsw.Stop(); err != nil {
@@ -300,8 +319,10 @@ func TestAddAndRemoveListener(t *testing.T) {
 
 // TestRemoveListener does basic tests on adding and removing
 func TestRemoveListener(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	evsw := NewEventSwitch()
-	err := evsw.Start()
+	err := evsw.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := evsw.Stop(); err != nil {
@@ -361,8 +382,10 @@ func TestRemoveListener(t *testing.T) {
 // NOTE: it is important to run this test with race conditions tracking on,
 // `go test -race`, to examine for possible race conditions.
 func TestRemoveListenersAsync(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	evsw := NewEventSwitch()
-	err := evsw.Start()
+	err := evsw.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := evsw.Stop(); err != nil {

--- a/libs/pubsub/example_test.go
+++ b/libs/pubsub/example_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 func TestExample(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := newTestServer(ctx, t)
 
 	sub := newTestSub(t).must(s.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
 		ClientID: "example-client",

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -341,7 +341,7 @@ func (s *Server) OnStop() { s.stop() }
 func (s *Server) Wait() { <-s.exited; s.BaseService.Wait() }
 
 // OnStart implements Service.OnStart by starting the server.
-func (s *Server) OnStart() error { s.run(); return nil }
+func (s *Server) OnStart(ctx context.Context) error { s.run(); return nil }
 
 // OnReset implements Service.OnReset. It has no effect for this service.
 func (s *Server) OnReset() error { return nil }

--- a/libs/pubsub/pubsub_test.go
+++ b/libs/pubsub/pubsub_test.go
@@ -20,8 +20,10 @@ const (
 )
 
 func TestSubscribeWithArgs(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	t.Run("DefaultLimit", func(t *testing.T) {
 		sub := newTestSub(t).must(s.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
@@ -47,8 +49,10 @@ func TestSubscribeWithArgs(t *testing.T) {
 }
 
 func TestObserver(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	done := make(chan struct{})
 	var got interface{}
@@ -65,8 +69,10 @@ func TestObserver(t *testing.T) {
 }
 
 func TestObserverErrors(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	require.Error(t, s.Observe(ctx, nil, query.Empty{}))
 	require.NoError(t, s.Observe(ctx, func(pubsub.Message) error { return nil }))
@@ -74,8 +80,10 @@ func TestObserverErrors(t *testing.T) {
 }
 
 func TestPublishDoesNotBlock(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	sub := newTestSub(t).must(s.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
 		ClientID: clientID,
@@ -100,8 +108,10 @@ func TestPublishDoesNotBlock(t *testing.T) {
 }
 
 func TestSubscribeErrors(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	t.Run("EmptyQueryErr", func(t *testing.T) {
 		_, err := s.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{ClientID: clientID})
@@ -118,8 +128,10 @@ func TestSubscribeErrors(t *testing.T) {
 }
 
 func TestSlowSubscriber(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	sub := newTestSub(t).must(s.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
 		ClientID: clientID,
@@ -137,8 +149,10 @@ func TestSlowSubscriber(t *testing.T) {
 }
 
 func TestDifferentClients(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	sub1 := newTestSub(t).must(s.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
 		ClientID: "client-1",
@@ -188,8 +202,10 @@ func TestDifferentClients(t *testing.T) {
 }
 
 func TestSubscribeDuplicateKeys(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	testCases := []struct {
 		query    string
@@ -241,8 +257,10 @@ func TestSubscribeDuplicateKeys(t *testing.T) {
 }
 
 func TestClientSubscribesTwice(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	q := query.MustParse("tm.events.type='NewBlock'")
 	events := []abci.Event{{
@@ -274,8 +292,10 @@ func TestClientSubscribesTwice(t *testing.T) {
 }
 
 func TestUnsubscribe(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	sub := newTestSub(t).must(s.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
 		ClientID: clientID,
@@ -296,8 +316,10 @@ func TestUnsubscribe(t *testing.T) {
 }
 
 func TestClientUnsubscribesTwice(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	newTestSub(t).must(s.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
 		ClientID: clientID,
@@ -315,8 +337,10 @@ func TestClientUnsubscribesTwice(t *testing.T) {
 }
 
 func TestResubscribe(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	args := pubsub.SubscribeArgs{
 		ClientID: clientID,
@@ -336,8 +360,10 @@ func TestResubscribe(t *testing.T) {
 }
 
 func TestUnsubscribeAll(t *testing.T) {
-	s := newTestServer(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := newTestServer(ctx, t)
 
 	sub1 := newTestSub(t).must(s.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
 		ClientID: clientID,
@@ -375,14 +401,14 @@ func TestBufferCapacity(t *testing.T) {
 	require.ErrorIs(t, s.Publish(ctx, "Ironclad"), context.DeadlineExceeded)
 }
 
-func newTestServer(t testing.TB) *pubsub.Server {
+func newTestServer(ctx context.Context, t testing.TB) *pubsub.Server {
 	t.Helper()
 
 	s := pubsub.NewServer(func(s *pubsub.Server) {
 		s.Logger = log.TestingLogger()
 	})
 
-	require.NoError(t, s.Start())
+	require.NoError(t, s.Start(ctx))
 	t.Cleanup(func() {
 		assert.NoError(t, s.Stop())
 	})

--- a/libs/service/service_test.go
+++ b/libs/service/service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -16,9 +17,12 @@ func (testService) OnReset() error {
 }
 
 func TestBaseServiceWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	ts := &testService{}
 	ts.BaseService = *NewBaseService(nil, "TestService", ts)
-	err := ts.Start()
+	err := ts.Start(ctx)
 	require.NoError(t, err)
 
 	waitFinished := make(chan struct{})
@@ -38,9 +42,12 @@ func TestBaseServiceWait(t *testing.T) {
 }
 
 func TestBaseServiceReset(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	ts := &testService{}
 	ts.BaseService = *NewBaseService(nil, "TestService", ts)
-	err := ts.Start()
+	err := ts.Start(ctx)
 	require.NoError(t, err)
 
 	err = ts.Reset()
@@ -52,6 +59,6 @@ func TestBaseServiceReset(t *testing.T) {
 	err = ts.Reset()
 	require.NoError(t, err)
 
-	err = ts.Start()
+	err = ts.Start(ctx)
 	require.NoError(t, err)
 }

--- a/libs/service/service_test.go
+++ b/libs/service/service_test.go
@@ -40,25 +40,3 @@ func TestBaseServiceWait(t *testing.T) {
 		t.Fatal("expected Wait() to finish within 100 ms.")
 	}
 }
-
-func TestBaseServiceReset(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ts := &testService{}
-	ts.BaseService = *NewBaseService(nil, "TestService", ts)
-	err := ts.Start(ctx)
-	require.NoError(t, err)
-
-	err = ts.Reset()
-	require.Error(t, err, "expected cant reset service error")
-
-	err = ts.Stop()
-	require.NoError(t, err)
-
-	err = ts.Reset()
-	require.NoError(t, err)
-
-	err = ts.Start(ctx)
-	require.NoError(t, err)
-}

--- a/light/proxy/proxy.go
+++ b/light/proxy/proxy.go
@@ -49,8 +49,8 @@ func NewProxy(
 // routes to proxy via Client, and starts up an HTTP server on the TCP network
 // address p.Addr.
 // See http#Server#ListenAndServe.
-func (p *Proxy) ListenAndServe() error {
-	listener, mux, err := p.listen()
+func (p *Proxy) ListenAndServe(ctx context.Context) error {
+	listener, mux, err := p.listen(ctx)
 	if err != nil {
 		return err
 	}
@@ -67,8 +67,8 @@ func (p *Proxy) ListenAndServe() error {
 // ListenAndServeTLS acts identically to ListenAndServe, except that it expects
 // HTTPS connections.
 // See http#Server#ListenAndServeTLS.
-func (p *Proxy) ListenAndServeTLS(certFile, keyFile string) error {
-	listener, mux, err := p.listen()
+func (p *Proxy) ListenAndServeTLS(ctx context.Context, certFile, keyFile string) error {
+	listener, mux, err := p.listen(ctx)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (p *Proxy) ListenAndServeTLS(certFile, keyFile string) error {
 	)
 }
 
-func (p *Proxy) listen() (net.Listener, *http.ServeMux, error) {
+func (p *Proxy) listen(ctx context.Context) (net.Listener, *http.ServeMux, error) {
 	mux := http.NewServeMux()
 
 	// 1) Register regular routes.
@@ -107,7 +107,7 @@ func (p *Proxy) listen() (net.Listener, *http.ServeMux, error) {
 
 	// 3) Start a client.
 	if !p.Client.IsRunning() {
-		if err := p.Client.Start(); err != nil {
+		if err := p.Client.Start(ctx); err != nil {
 			return nil, mux, fmt.Errorf("can't start client: %w", err)
 		}
 	}

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -98,9 +98,9 @@ func NewClient(next rpcclient.Client, lc LightClient, opts ...Option) *Client {
 	return c
 }
 
-func (c *Client) OnStart() error {
+func (c *Client) OnStart(ctx context.Context) error {
 	if !c.next.IsRunning() {
-		return c.next.Start()
+		return c.next.Start(ctx)
 	}
 	return nil
 }

--- a/node/public.go
+++ b/node/public.go
@@ -2,6 +2,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 
 	abciclient "github.com/tendermint/tendermint/abci/client"
@@ -16,8 +17,12 @@ import (
 // process that host their own process-local tendermint node. This is
 // equivalent to running tendermint in it's own process communicating
 // to an external ABCI application.
-func NewDefault(conf *config.Config, logger log.Logger) (service.Service, error) {
-	return newDefaultNode(conf, logger)
+func NewDefault(
+	ctx context.Context,
+	conf *config.Config,
+	logger log.Logger,
+) (service.Service, error) {
+	return newDefaultNode(ctx, conf, logger)
 }
 
 // New constructs a tendermint node. The ClientCreator makes it
@@ -26,7 +31,9 @@ func NewDefault(conf *config.Config, logger log.Logger) (service.Service, error)
 // Genesis document: if the value is nil, the genesis document is read
 // from the file specified in the config, and otherwise the node uses
 // value of the final argument.
-func New(conf *config.Config,
+func New(
+	ctx context.Context,
+	conf *config.Config,
 	logger log.Logger,
 	cf abciclient.Creator,
 	gen *types.GenesisDoc,
@@ -51,7 +58,9 @@ func New(conf *config.Config,
 			return nil, err
 		}
 
-		return makeNode(conf,
+		return makeNode(
+			ctx,
+			conf,
 			pval,
 			nodeKey,
 			cf,

--- a/node/setup.go
+++ b/node/setup.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -52,6 +53,13 @@ func makeCloser(cs []closer) closer {
 	}
 }
 
+func convertCancelCloser(cancel context.CancelFunc) closer {
+	return func() error {
+		cancel()
+		return nil
+	}
+}
+
 func combineCloseError(err error, cl closer) error {
 	if err == nil {
 		return cl()
@@ -88,26 +96,31 @@ func initDBs(
 	return blockStore, stateDB, makeCloser(closers), nil
 }
 
-// nolint:lll
-func createAndStartProxyAppConns(clientCreator abciclient.Creator, logger log.Logger, metrics *proxy.Metrics) (proxy.AppConns, error) {
+func createAndStartProxyAppConns(
+	ctx context.Context,
+	clientCreator abciclient.Creator,
+	logger log.Logger,
+	metrics *proxy.Metrics,
+) (proxy.AppConns, error) {
 	proxyApp := proxy.NewAppConns(clientCreator, logger.With("module", "proxy"), metrics)
 
-	if err := proxyApp.Start(); err != nil {
+	if err := proxyApp.Start(ctx); err != nil {
 		return nil, fmt.Errorf("error starting proxy app connections: %v", err)
 	}
 
 	return proxyApp, nil
 }
 
-func createAndStartEventBus(logger log.Logger) (*eventbus.EventBus, error) {
+func createAndStartEventBus(ctx context.Context, logger log.Logger) (*eventbus.EventBus, error) {
 	eventBus := eventbus.NewDefault(logger.With("module", "events"))
-	if err := eventBus.Start(); err != nil {
+	if err := eventBus.Start(ctx); err != nil {
 		return nil, err
 	}
 	return eventBus, nil
 }
 
 func createAndStartIndexerService(
+	ctx context.Context,
 	cfg *config.Config,
 	dbProvider config.DBProvider,
 	eventBus *eventbus.EventBus,
@@ -127,7 +140,7 @@ func createAndStartIndexerService(
 		Metrics:  metrics,
 	})
 
-	if err := indexerService.Start(); err != nil {
+	if err := indexerService.Start(ctx); err != nil {
 		return nil, nil, err
 	}
 

--- a/privval/signer_client.go
+++ b/privval/signer_client.go
@@ -23,9 +23,9 @@ var _ types.PrivValidator = (*SignerClient)(nil)
 
 // NewSignerClient returns an instance of SignerClient.
 // it will start the endpoint (if not already started)
-func NewSignerClient(endpoint *SignerListenerEndpoint, chainID string) (*SignerClient, error) {
+func NewSignerClient(ctx context.Context, endpoint *SignerListenerEndpoint, chainID string) (*SignerClient, error) {
 	if !endpoint.IsRunning() {
-		if err := endpoint.Start(); err != nil {
+		if err := endpoint.Start(ctx); err != nil {
 			return nil, fmt.Errorf("failed to start listener endpoint: %w", err)
 		}
 	}

--- a/privval/signer_listener_endpoint.go
+++ b/privval/signer_listener_endpoint.go
@@ -1,6 +1,7 @@
 package privval
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -63,7 +64,7 @@ func NewSignerListenerEndpoint(
 }
 
 // OnStart implements service.Service.
-func (sl *SignerListenerEndpoint) OnStart() error {
+func (sl *SignerListenerEndpoint) OnStart(ctx context.Context) error {
 	sl.connectRequestCh = make(chan struct{})
 	sl.connectionAvailableCh = make(chan net.Conn)
 

--- a/privval/signer_listener_endpoint_test.go
+++ b/privval/signer_listener_endpoint_test.go
@@ -1,6 +1,7 @@
 package privval
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -38,6 +39,9 @@ func TestSignerRemoteRetryTCPOnly(t *testing.T) {
 		retries   = 10
 	)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
@@ -71,7 +75,7 @@ func TestSignerRemoteRetryTCPOnly(t *testing.T) {
 	mockPV := types.NewMockPV()
 	signerServer := NewSignerServer(dialerEndpoint, chainID, mockPV)
 
-	err = signerServer.Start()
+	err = signerServer.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := signerServer.Stop(); err != nil {
@@ -88,6 +92,9 @@ func TestSignerRemoteRetryTCPOnly(t *testing.T) {
 }
 
 func TestRetryConnToRemoteSigner(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for _, tc := range getDialerTestCases(t) {
 		var (
 			logger           = log.TestingLogger()
@@ -107,14 +114,14 @@ func TestRetryConnToRemoteSigner(t *testing.T) {
 
 		signerServer := NewSignerServer(dialerEndpoint, chainID, mockPV)
 
-		startListenerEndpointAsync(t, listenerEndpoint, endpointIsOpenCh)
+		startListenerEndpointAsync(ctx, t, listenerEndpoint, endpointIsOpenCh)
 		t.Cleanup(func() {
 			if err := listenerEndpoint.Stop(); err != nil {
 				t.Error(err)
 			}
 		})
 
-		require.NoError(t, signerServer.Start())
+		require.NoError(t, signerServer.Start(ctx))
 		assert.True(t, signerServer.IsRunning())
 		<-endpointIsOpenCh
 		if err := signerServer.Stop(); err != nil {
@@ -128,7 +135,7 @@ func TestRetryConnToRemoteSigner(t *testing.T) {
 		signerServer2 := NewSignerServer(dialerEndpoint2, chainID, mockPV)
 
 		// let some pings pass
-		require.NoError(t, signerServer2.Start())
+		require.NoError(t, signerServer2.Start(ctx))
 		assert.True(t, signerServer2.IsRunning())
 		t.Cleanup(func() {
 			if err := signerServer2.Stop(); err != nil {
@@ -175,9 +182,16 @@ func newSignerListenerEndpoint(logger log.Logger, addr string, timeoutReadWrite 
 	)
 }
 
-func startListenerEndpointAsync(t *testing.T, sle *SignerListenerEndpoint, endpointIsOpenCh chan struct{}) {
+func startListenerEndpointAsync(
+	ctx context.Context,
+	t *testing.T,
+	sle *SignerListenerEndpoint,
+	endpointIsOpenCh chan struct{},
+) {
+	t.Helper()
+
 	go func(sle *SignerListenerEndpoint) {
-		require.NoError(t, sle.Start())
+		require.NoError(t, sle.Start(ctx))
 		assert.True(t, sle.IsRunning())
 		close(endpointIsOpenCh)
 	}(sle)
@@ -201,12 +215,15 @@ func getMockEndpoints(
 		listenerEndpoint = newSignerListenerEndpoint(logger, addr, testTimeoutReadWrite)
 	)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	SignerDialerEndpointTimeoutReadWrite(testTimeoutReadWrite)(dialerEndpoint)
 	SignerDialerEndpointConnRetries(1e6)(dialerEndpoint)
 
-	startListenerEndpointAsync(t, listenerEndpoint, endpointIsOpenCh)
+	startListenerEndpointAsync(ctx, t, listenerEndpoint, endpointIsOpenCh)
 
-	require.NoError(t, dialerEndpoint.Start())
+	require.NoError(t, dialerEndpoint.Start(ctx))
 	assert.True(t, dialerEndpoint.IsRunning())
 
 	<-endpointIsOpenCh

--- a/privval/signer_server.go
+++ b/privval/signer_server.go
@@ -42,7 +42,7 @@ func NewSignerServer(endpoint *SignerDialerEndpoint, chainID string, privVal typ
 }
 
 // OnStart implements service.Service.
-func (ss *SignerServer) OnStart() error {
+func (ss *SignerServer) OnStart(ctx context.Context) error {
 	go ss.serviceLoop()
 	return nil
 }

--- a/rpc/client/http/ws.go
+++ b/rpc/client/http/ws.go
@@ -92,7 +92,7 @@ func newWsEvents(remote string, wso WSOptions) (*wsEvents, error) {
 }
 
 // Start starts the websocket client and the event loop.
-func (w *wsEvents) Start() error {
+func (w *wsEvents) Start(ctx context.Context) error {
 	if err := w.ws.Start(); err != nil {
 		return err
 	}

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -35,7 +35,7 @@ type Client interface {
 	// These methods define the operational structure of the client.
 
 	// Start the client. Start must report an error if the client is running.
-	Start() error
+	Start(context.Context) error
 
 	// Stop the client. Stop must report an error if the client is not running.
 	Stop() error

--- a/rpc/client/main_test.go
+++ b/rpc/client/main_test.go
@@ -32,7 +32,6 @@ func NodeSuite(t *testing.T) (service.Service, *config.Config) {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		cancel()
-		assert.NoError(t, node.Stop())
 		assert.NoError(t, closer(ctx))
 		assert.NoError(t, app.Close())
 		node.Wait()

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -463,7 +463,7 @@ func TestClientMethodCalls(t *testing.T) {
 				// start for this test it if it wasn't already running
 				if !c.IsRunning() {
 					// if so, then we start it, listen, and stop it.
-					err := c.Start()
+					err := c.Start(ctx)
 					require.Nil(t, err)
 					t.Cleanup(func() {
 						if err := c.Stop(); err != nil {

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -73,10 +73,14 @@ func CreateConfig(testName string) (*config.Config, error) {
 
 type ServiceCloser func(context.Context) error
 
-func StartTendermint(ctx context.Context,
+func StartTendermint(
+	ctx context.Context,
 	conf *config.Config,
 	app abci.Application,
-	opts ...func(*Options)) (service.Service, ServiceCloser, error) {
+	opts ...func(*Options),
+) (service.Service, ServiceCloser, error) {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
 
 	nodeOpts := &Options{}
 	for _, opt := range opts {
@@ -89,14 +93,14 @@ func StartTendermint(ctx context.Context,
 		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
 	}
 	papp := abciclient.NewLocalCreator(app)
-	tmNode, err := node.New(conf, logger, papp, nil)
+	tmNode, err := node.New(ctx, conf, logger, papp, nil)
 	if err != nil {
-		return nil, func(_ context.Context) error { return nil }, err
+		return nil, func(_ context.Context) error { cancel(); return nil }, err
 	}
 
-	err = tmNode.Start()
+	err = tmNode.Start(ctx)
 	if err != nil {
-		return nil, func(_ context.Context) error { return nil }, err
+		return nil, func(_ context.Context) error { cancel(); return nil }, err
 	}
 
 	waitForRPC(ctx, conf)
@@ -106,9 +110,7 @@ func StartTendermint(ctx context.Context,
 	}
 
 	return tmNode, func(ctx context.Context) error {
-		if err := tmNode.Stop(); err != nil {
-			logger.Error("Error when trying to stop node", "err", err)
-		}
+		cancel()
 		tmNode.Wait()
 		os.RemoveAll(conf.RootDir)
 		return nil

--- a/test/fuzz/mempool/checktx.go
+++ b/test/fuzz/mempool/checktx.go
@@ -17,7 +17,7 @@ func init() {
 	app := kvstore.NewApplication()
 	cc := abciclient.NewLocalCreator(app)
 	appConnMem, _ := cc(log.NewNopLogger())
-	err := appConnMem.Start()
+	err := appConnMem.Start(context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/tools/tm-signer-harness/internal/test_harness.go
+++ b/tools/tm-signer-harness/internal/test_harness.go
@@ -89,7 +89,7 @@ type timeoutError interface {
 // NewTestHarness will load Tendermint data from the given files (including
 // validator public/private keypairs and chain details) and create a new
 // harness.
-func NewTestHarness(logger log.Logger, cfg TestHarnessConfig) (*TestHarness, error) {
+func NewTestHarness(ctx context.Context, logger log.Logger, cfg TestHarnessConfig) (*TestHarness, error) {
 	keyFile := ExpandPath(cfg.KeyFile)
 	stateFile := ExpandPath(cfg.StateFile)
 	logger.Info("Loading private validator configuration", "keyFile", keyFile, "stateFile", stateFile)
@@ -113,7 +113,7 @@ func NewTestHarness(logger log.Logger, cfg TestHarnessConfig) (*TestHarness, err
 		return nil, newTestHarnessError(ErrFailedToCreateListener, err, "")
 	}
 
-	signerClient, err := privval.NewSignerClient(spv, st.ChainID)
+	signerClient, err := privval.NewSignerClient(ctx, spv, st.ChainID)
 	if err != nil {
 		return nil, newTestHarnessError(ErrFailedToCreateListener, err, "")
 	}


### PR DESCRIPTION
This is just a big refactor of the service interface (and the
resultant plumbing and wiring around that) so that you can use
contexts rather than needing to explicitly call stop.

This also removes the unused "Reset" method.