### PR TITLE
consensus: refactor the fake validator to take a clock source

### DIFF
--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -350,8 +350,8 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	ensureNewProposal(t, proposalCh, height, round)
 	rs := css[0].GetRoundState()
 
-	signAddVotes(sim.Config, css[0], tmproto.PrecommitType,
-		rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(),
+	signAddVotes(css[0], tmproto.PrecommitType, sim.Config.ChainID(),
+		types.BlockID{Hash: rs.ProposalBlock.Hash(), PartSetHeader: rs.ProposalBlockParts.Header()},
 		vss[1:nVals]...)
 
 	ensureNewRound(t, newRoundCh, height+1, 0)
@@ -383,8 +383,8 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	}
 	ensureNewProposal(t, proposalCh, height, round)
 	rs = css[0].GetRoundState()
-	signAddVotes(sim.Config, css[0], tmproto.PrecommitType,
-		rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(),
+	signAddVotes(css[0], tmproto.PrecommitType, sim.Config.ChainID(),
+		types.BlockID{Hash: rs.ProposalBlock.Hash(), PartSetHeader: rs.ProposalBlockParts.Header()},
 		vss[1:nVals]...)
 	ensureNewRound(t, newRoundCh, height+1, 0)
 
@@ -415,8 +415,8 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 	}
 	ensureNewProposal(t, proposalCh, height, round)
 	rs = css[0].GetRoundState()
-	signAddVotes(sim.Config, css[0], tmproto.PrecommitType,
-		rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(),
+	signAddVotes(css[0], tmproto.PrecommitType, sim.Config.ChainID(),
+		types.BlockID{Hash: rs.ProposalBlock.Hash(), PartSetHeader: rs.ProposalBlockParts.Header()},
 		vss[1:nVals]...)
 	ensureNewRound(t, newRoundCh, height+1, 0)
 
@@ -483,9 +483,10 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 		if i == selfIndex {
 			continue
 		}
-		signAddVotes(sim.Config, css[0],
-			tmproto.PrecommitType, rs.ProposalBlock.Hash(),
-			rs.ProposalBlockParts.Header(), newVss[i])
+		signAddVotes(css[0],
+			tmproto.PrecommitType, sim.Config.ChainID(),
+			types.BlockID{Hash: rs.ProposalBlock.Hash(), PartSetHeader: rs.ProposalBlockParts.Header()},
+			newVss[i])
 	}
 
 	ensureNewRound(t, newRoundCh, height+1, 0)
@@ -504,9 +505,10 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 		if i == selfIndex {
 			continue
 		}
-		signAddVotes(sim.Config, css[0],
-			tmproto.PrecommitType, rs.ProposalBlock.Hash(),
-			rs.ProposalBlockParts.Header(), newVss[i])
+		signAddVotes(css[0],
+			tmproto.PrecommitType, sim.Config.ChainID(),
+			types.BlockID{Hash: rs.ProposalBlock.Hash(), PartSetHeader: rs.ProposalBlockParts.Header()},
+			newVss[i])
 	}
 	ensureNewRound(t, newRoundCh, height+1, 0)
 
@@ -541,9 +543,10 @@ func setupSimulator(t *testing.T) *simulatorTestSuite {
 		if i == selfIndex {
 			continue
 		}
-		signAddVotes(sim.Config, css[0],
-			tmproto.PrecommitType, rs.ProposalBlock.Hash(),
-			rs.ProposalBlockParts.Header(), newVss[i])
+		signAddVotes(css[0],
+			tmproto.PrecommitType, sim.Config.ChainID(),
+			types.BlockID{Hash: rs.ProposalBlock.Hash(), PartSetHeader: rs.ProposalBlockParts.Header()},
+			newVss[i])
 	}
 	ensureNewRound(t, newRoundCh, height+1, 0)
 

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -2266,7 +2266,8 @@ func TestStateSlashing_Prevotes(t *testing.T) {
 	// add one for a different block should cause us to go into prevote wait
 	hash := rs.ProposalBlock.Hash()
 	hash[0] = byte(hash[0]+1) % 255
-	signAddVotes(tmproto.PrevoteType, hash,config.ChainID(), blockID, rs.ProposalBlock.Hash(),config.ChainID(), rs.ProposalBlockParts.Header(), vs2)
+	signAddVotes(tmproto.PrevoteType, hash, config.ChainID(), blockID,
+		rs.ProposalBlock.Hash(), config.ChainID(), rs.ProposalBlockParts.Header(), vs2)
 
 	// XXX: Check for existence of Dupeout info
 }

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -2292,7 +2292,8 @@ func TestStateSlashing_Precommits(t *testing.T) {
 	// add one for a different block should cause us to go into prevote wait
 	hash := rs.ProposalBlock.Hash()
 	hash[0] = byte(hash[0]+1) % 255
-	signAddVotes(tmproto.PrecommitType, hash,config.ChainID(), blockID, rs.ProposalBlock.Hash(),config.ChainID(), rs.ProposalBlockParts.Header(), vs2)
+	signAddVotes(tmproto.PrecommitType, hash, config.ChainID(), blockID,
+		rs.ProposalBlock.Hash(), config.ChainID(), rs.ProposalBlockParts.Header(), vs2)
 
 	// XXX: Check for existence of Dupeout info
 }

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -89,7 +89,10 @@ func TestStateProposerSelection0(t *testing.T) {
 	ensureNewProposal(t, proposalCh, height, round)
 
 	rs := cs1.GetRoundState()
-	signAddVotes(cs1, tmproto.PrecommitType, config.ChainID(), types.BlockID{Hash: rs.ProposalBlock.Hash(), PartSetHeader: rs.ProposalBlockParts.Header()}, vss[1:]...)
+	signAddVotes(cs1, tmproto.PrecommitType, config.ChainID(), types.BlockID{
+		Hash:          rs.ProposalBlock.Hash(),
+		PartSetHeader: rs.ProposalBlockParts.Header(),
+	}, vss[1:]...)
 
 	// Wait for new round so next validator is set.
 	ensureNewRound(t, newRoundCh, height+1, 0)

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -469,7 +469,10 @@ func TestStateLock_NoPOL(t *testing.T) {
 	hash := make([]byte, len(initialBlockID.Hash))
 	copy(hash, initialBlockID.Hash)
 	hash[0] = (hash[0] + 1) % 255
-	signAddVotes(cs1, tmproto.PrecommitType, config.ChainID(), types.BlockID{Hash: hash, PartSetHeader: initialBlockID.PartSetHeader}, vs2)
+	signAddVotes(cs1, tmproto.PrecommitType, config.ChainID(), types.BlockID{
+		Hash:          hash,
+		PartSetHeader: initialBlockID.PartSetHeader,
+	}, vs2)
 	ensurePrecommit(t, voteCh, height, round) // precommit
 
 	// (note we're entering precommit for a second time this round)

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -450,7 +450,10 @@ func TestStateLock_NoPOL(t *testing.T) {
 
 	ensureNewProposal(t, proposalCh, height, round)
 	roundState := cs1.GetRoundState()
-	initialBlockID := types.BlockID{Hash: roundState.ProposalBlock.Hash(), PartSetHeader: roundState.ProposalBlockParts.Header()}
+	initialBlockID := types.BlockID{
+		Hash:          roundState.ProposalBlock.Hash(),
+		PartSetHeader: roundState.ProposalBlockParts.Header(),
+	}
 
 	ensurePrevote(t, voteCh, height, round) // prevote
 


### PR DESCRIPTION
Mild refactor of the state tests. This refactor performs two things:

The `validatorStub` objects now are created with a clock source that they use when signing votes. The goal of this is to be able to control the timestamps that votes are signed with for future testing with proposer based timestamps.

The vote signing helper functions have been altered slightly. They now take a `types.BlockID` instead of the constituent pieces of a `BlockID` this seems a bit cleaner and aids readability. They also no longer take a `Config` object and instead take the one piece of configuration information that they need, the `ChainID`. This helps the test harness I'm working on by making it not need to keep track of so many disparate pieces of state.