### PR TITLE
Partial backport of protobuf generation changes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ LD_FLAGS = -X github.com/tendermint/tendermint/version.TMVersion=$(VERSION)
 BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
 HTTPS_GIT := https://github.com/tendermint/tendermint.git
 BUILD_IMAGE := ghcr.io/tendermint/docker-build-proto
+BASE_BRANCH := v0.35.x
 DOCKER_PROTO := docker run -v $(shell pwd):/workspace --workdir /workspace $(BUILD_IMAGE)
 CGO_ENABLED ?= 0
 
@@ -100,12 +101,12 @@ proto-format:
 
 proto-check-breaking:
 	@echo "Checking for breaking changes in .proto files"
-	@$(DOCKER_PROTO) buf breaking --against .git#branch=v0.35.x
+	@$(DOCKER_PROTO) buf breaking --against .git#branch=$(BASE_BRANCH)
 .PHONY: proto-check-breaking
 
 proto-check-breaking-ci:
 	@echo "Checking for breaking changes in .proto files"
-	@$(DOCKER_PROTO) buf breaking --against $(HTTPS_GIT)#branch=v0.35.x
+	@$(DOCKER_PROTO) buf breaking --against $(HTTPS_GIT)#branch=$(BASE_BRANCH)
 .PHONY: proto-check-breaking-ci
 
 ###############################################################################


### PR DESCRIPTION
This is a manual backport of the changes to how we build and run the protobuf
toolchain images in Docker. The main effect here is to point to the new image
from ghcr.io/tendermint/docker-proto-builder, but to make that work it is also
necessary to update some of the branch pointers.

This change does NOT include the changes from #7269 and #7291 to point to the
proto files in the spec repo. To do that, we will need to create a branch or
tag on the spec that has the released version, which does not exist in the spec
history as it currently stands.

Updates #7272.