### PR TITLE
factory: simplify validator and genesis factory functions

### DIFF
--- a/internal/blocksync/v0/reactor_test.go
+++ b/internal/blocksync/v0/reactor_test.go
@@ -184,7 +184,8 @@ func TestReactor_AbruptDisconnect(t *testing.T) {
 	config := cfg.ResetTestRoot("block_sync_reactor_test")
 	defer os.RemoveAll(config.RootDir)
 
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	valSet, privVals := factory.ValidatorSet(1, 30)
+	genDoc := factory.GenesisDoc(config, time.Now(), valSet.Validators, nil)
 	maxBlockHeight := int64(64)
 
 	rts := setup(t, genDoc, privVals[0], []int64{maxBlockHeight, 0}, 0)
@@ -219,7 +220,8 @@ func TestReactor_SyncTime(t *testing.T) {
 	config := cfg.ResetTestRoot("block_sync_reactor_test")
 	defer os.RemoveAll(config.RootDir)
 
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	valSet, privVals := factory.ValidatorSet(1, 30)
+	genDoc := factory.GenesisDoc(config, time.Now(), valSet.Validators, nil)
 	maxBlockHeight := int64(101)
 
 	rts := setup(t, genDoc, privVals[0], []int64{maxBlockHeight, 0}, 0)
@@ -242,7 +244,8 @@ func TestReactor_NoBlockResponse(t *testing.T) {
 	config := cfg.ResetTestRoot("block_sync_reactor_test")
 	defer os.RemoveAll(config.RootDir)
 
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	valSet, privVals := factory.ValidatorSet(1, 30)
+	genDoc := factory.GenesisDoc(config, time.Now(), valSet.Validators, nil)
 	maxBlockHeight := int64(65)
 
 	rts := setup(t, genDoc, privVals[0], []int64{maxBlockHeight, 0}, 0)
@@ -290,7 +293,8 @@ func TestReactor_BadBlockStopsPeer(t *testing.T) {
 	defer os.RemoveAll(config.RootDir)
 
 	maxBlockHeight := int64(48)
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	valSet, privVals := factory.ValidatorSet(1, 30)
+	genDoc := factory.GenesisDoc(config, time.Now(), valSet.Validators, nil)
 
 	rts := setup(t, genDoc, privVals[0], []int64{maxBlockHeight, 0, 0, 0, 0}, 1000)
 
@@ -324,7 +328,8 @@ func TestReactor_BadBlockStopsPeer(t *testing.T) {
 	//
 	// XXX: This causes a potential race condition.
 	// See: https://github.com/tendermint/tendermint/issues/6005
-	otherGenDoc, otherPrivVals := factory.RandGenesisDoc(config, 1, false, 30)
+	valSet, otherPrivVals := factory.ValidatorSet(1, 30)
+	otherGenDoc := factory.GenesisDoc(config, time.Now(), valSet.Validators, nil)
 	newNode := rts.network.MakeNode(t, p2ptest.NodeOptions{
 		MaxPeers:     uint16(len(rts.nodes) + 1),
 		MaxConnected: uint16(len(rts.nodes) + 1),

--- a/internal/blocksync/v2/reactor_test.go
+++ b/internal/blocksync/v2/reactor_test.go
@@ -366,7 +366,8 @@ func TestReactorHelperMode(t *testing.T) {
 
 	config := cfg.ResetTestRoot("blockchain_reactor_v2_test")
 	defer os.RemoveAll(config.RootDir)
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	valSet, privVals := factory.ValidatorSet(1, 30)
+	genDoc := factory.GenesisDoc(config, time.Now(), valSet.Validators, nil)
 
 	params := testReactorParams{
 		logger:      log.TestingLogger(),
@@ -456,7 +457,8 @@ func TestReactorHelperMode(t *testing.T) {
 func TestReactorSetSwitchNil(t *testing.T) {
 	config := cfg.ResetTestRoot("blockchain_reactor_v2_test")
 	defer os.RemoveAll(config.RootDir)
-	genDoc, privVals := factory.RandGenesisDoc(config, 1, false, 30)
+	valSet, privVals := factory.ValidatorSet(1, 30)
+	genDoc := factory.GenesisDoc(config, time.Now(), valSet.Validators, nil)
 
 	reactor := newTestReactor(t, testReactorParams{
 		logger:   log.TestingLogger(),

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,7 +38,8 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	tickerFunc := newMockTickerFunc(true)
 	appFunc := newKVStore
 
-	genDoc, privVals := factory.RandGenesisDoc(config, nValidators, false, 30)
+	valSet, privVals := factory.ValidatorSet(nValidators, 30)
+	genDoc := factory.GenesisDoc(config, time.Now(), valSet.Validators, nil)
 	states := make([]*State, nValidators)
 
 	for i := 0; i < nValidators; i++ {

--- a/internal/consensus/invalid_test.go
+++ b/internal/consensus/invalid_test.go
@@ -18,7 +18,7 @@ func TestReactorInvalidPrecommit(t *testing.T) {
 	config := configSetup(t)
 
 	n := 4
-	states, cleanup := randConsensusState(t,
+	states, cleanup := makeConsensusState(t,
 		config, n, "consensus_reactor_test",
 		newMockTickerFunc(true), newKVStore)
 	t.Cleanup(cleanup)

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -33,7 +33,9 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 	t.Cleanup(func() { _ = os.RemoveAll(config.RootDir) })
 
 	config.Consensus.CreateEmptyBlocks = false
-	state, privVals := makeGenesisState(baseConfig, 1, 10, nil)
+	state, privVals := makeGenesisState(baseConfig, genesisStateArgs{
+		Validators: 1,
+		Power:      10})
 	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
@@ -55,7 +57,9 @@ func TestMempoolProgressAfterCreateEmptyBlocksInterval(t *testing.T) {
 	t.Cleanup(func() { _ = os.RemoveAll(config.RootDir) })
 
 	config.Consensus.CreateEmptyBlocksInterval = ensureTimeout
-	state, privVals := makeGenesisState(baseConfig, 1, 10, nil)
+	state, privVals := makeGenesisState(baseConfig, genesisStateArgs{
+		Validators: 1,
+		Power:      10})
 	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
 
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
@@ -75,7 +79,9 @@ func TestMempoolProgressInHigherRound(t *testing.T) {
 	t.Cleanup(func() { _ = os.RemoveAll(config.RootDir) })
 
 	config.Consensus.CreateEmptyBlocks = false
-	state, privVals := makeGenesisState(baseConfig, 1, 10, nil)
+	state, privVals := makeGenesisState(baseConfig, genesisStateArgs{
+		Validators: 1,
+		Power:      10})
 	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
@@ -123,7 +129,9 @@ func deliverTxsRange(cs *State, start, end int) {
 func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 	config := configSetup(t)
 
-	state, privVals := makeGenesisState(config, 1, 10, nil)
+	state, privVals := makeGenesisState(config, genesisStateArgs{
+		Validators: 1,
+		Power:      10})
 	stateStore := sm.NewStore(dbm.NewMemDB())
 	blockStore := store.NewBlockStore(dbm.NewMemDB())
 	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], NewCounterApplication(), blockStore)
@@ -149,7 +157,9 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 func TestMempoolRmBadTx(t *testing.T) {
 	config := configSetup(t)
 
-	state, privVals := makeGenesisState(config, 1, 10, nil)
+	state, privVals := makeGenesisState(config, genesisStateArgs{
+		Validators: 1,
+		Power:      10})
 	app := NewCounterApplication()
 	stateStore := sm.NewStore(dbm.NewMemDB())
 	blockStore := store.NewBlockStore(dbm.NewMemDB())

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -33,7 +33,7 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 	t.Cleanup(func() { _ = os.RemoveAll(config.RootDir) })
 
 	config.Consensus.CreateEmptyBlocks = false
-	state, privVals := randGenesisState(baseConfig, 1, false, 10)
+	state, privVals := makeGenesisState(baseConfig, 1, 10, nil)
 	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
@@ -55,7 +55,7 @@ func TestMempoolProgressAfterCreateEmptyBlocksInterval(t *testing.T) {
 	t.Cleanup(func() { _ = os.RemoveAll(config.RootDir) })
 
 	config.Consensus.CreateEmptyBlocksInterval = ensureTimeout
-	state, privVals := randGenesisState(baseConfig, 1, false, 10)
+	state, privVals := makeGenesisState(baseConfig, 1, 10, nil)
 	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
 
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
@@ -75,7 +75,7 @@ func TestMempoolProgressInHigherRound(t *testing.T) {
 	t.Cleanup(func() { _ = os.RemoveAll(config.RootDir) })
 
 	config.Consensus.CreateEmptyBlocks = false
-	state, privVals := randGenesisState(baseConfig, 1, false, 10)
+	state, privVals := makeGenesisState(baseConfig, 1, 10, nil)
 	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
@@ -123,7 +123,7 @@ func deliverTxsRange(cs *State, start, end int) {
 func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 	config := configSetup(t)
 
-	state, privVals := randGenesisState(config, 1, false, 10)
+	state, privVals := makeGenesisState(config, 1, 10, nil)
 	stateStore := sm.NewStore(dbm.NewMemDB())
 	blockStore := store.NewBlockStore(dbm.NewMemDB())
 	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], NewCounterApplication(), blockStore)
@@ -149,7 +149,7 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 func TestMempoolRmBadTx(t *testing.T) {
 	config := configSetup(t)
 
-	state, privVals := randGenesisState(config, 1, false, 10)
+	state, privVals := makeGenesisState(config, 1, 10, nil)
 	app := NewCounterApplication()
 	stateStore := sm.NewStore(dbm.NewMemDB())
 	blockStore := store.NewBlockStore(dbm.NewMemDB())

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -276,7 +276,7 @@ func TestReactorBasic(t *testing.T) {
 	config := configSetup(t)
 
 	n := 4
-	states, cleanup := randConsensusState(t,
+	states, cleanup := makeConsensusState(t,
 		config, n, "consensus_reactor_test",
 		newMockTickerFunc(true), newKVStore)
 	t.Cleanup(cleanup)
@@ -323,7 +323,8 @@ func TestReactorWithEvidence(t *testing.T) {
 	tickerFunc := newMockTickerFunc(true)
 	appFunc := newKVStore
 
-	genDoc, privVals := factory.RandGenesisDoc(config, n, false, 30)
+	valSet, privVals := factory.ValidatorSet(n, 30)
+	genDoc := factory.GenesisDoc(config, time.Now(), valSet.Validators, nil)
 	states := make([]*State, n)
 	logger := consensusLogger()
 
@@ -415,7 +416,7 @@ func TestReactorCreatesBlockWhenEmptyBlocksFalse(t *testing.T) {
 	config := configSetup(t)
 
 	n := 4
-	states, cleanup := randConsensusState(
+	states, cleanup := makeConsensusState(
 		t,
 		config,
 		n,
@@ -465,7 +466,7 @@ func TestReactorRecordsVotesAndBlockParts(t *testing.T) {
 	config := configSetup(t)
 
 	n := 4
-	states, cleanup := randConsensusState(t,
+	states, cleanup := makeConsensusState(t,
 		config, n, "consensus_reactor_test",
 		newMockTickerFunc(true), newKVStore)
 	t.Cleanup(cleanup)
@@ -524,7 +525,7 @@ func TestReactorVotingPowerChange(t *testing.T) {
 	config := configSetup(t)
 
 	n := 4
-	states, cleanup := randConsensusState(
+	states, cleanup := makeConsensusState(
 		t,
 		config,
 		n,

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -1223,7 +1223,8 @@ func (bs *mockBlockStore) PruneBlocks(height int64) (uint64, error) {
 // Test handshake/init chain
 
 func TestHandshakeUpdatesValidators(t *testing.T) {
-	val, _ := factory.RandValidator(true, 10)
+	votePower := 10 + int64(rand.Uint32())
+	val, _ := factory.Validator(votePower)
 	vals := types.NewValidatorSet([]*types.Validator{val})
 	app := &initChainApp{vals: types.TM2PB.ValidatorUpdates(vals)}
 	clientCreator := proxy.NewLocalClientCreator(app)

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -65,7 +65,7 @@ x * TestHalt1 - if we see +2/3 precommits after timing out into new round, we sh
 func TestStateProposerSelection0(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	height, round := cs1.Height, cs1.Round
 
 	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
@@ -107,7 +107,7 @@ func TestStateProposerSelection0(t *testing.T) {
 func TestStateProposerSelection2(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4) // test needs more work for more than 3 validators
+	cs1, vss := makeState(config, 4) // test needs more work for more than 3 validators
 	height := cs1.Height
 	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
 
@@ -145,7 +145,7 @@ func TestStateProposerSelection2(t *testing.T) {
 func TestStateEnterProposeNoPrivValidator(t *testing.T) {
 	config := configSetup(t)
 
-	cs, _ := randState(config, 1)
+	cs, _ := makeState(config, 1)
 	cs.SetPrivValidator(nil)
 	height, round := cs.Height, cs.Round
 
@@ -166,7 +166,7 @@ func TestStateEnterProposeNoPrivValidator(t *testing.T) {
 func TestStateEnterProposeYesPrivValidator(t *testing.T) {
 	config := configSetup(t)
 
-	cs, _ := randState(config, 1)
+	cs, _ := makeState(config, 1)
 	height, round := cs.Height, cs.Round
 
 	// Listen for propose timeout event
@@ -198,7 +198,7 @@ func TestStateEnterProposeYesPrivValidator(t *testing.T) {
 func TestStateBadProposal(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 2)
+	cs1, vss := makeState(config, 2)
 	height, round := cs1.Height, cs1.Round
 	vs2 := vss[1]
 
@@ -258,7 +258,7 @@ func TestStateBadProposal(t *testing.T) {
 func TestStateOversizedBlock(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 2)
+	cs1, vss := makeState(config, 2)
 	cs1.state.ConsensusParams.Block.MaxBytes = 2000
 	height, round := cs1.Height, cs1.Round
 	vs2 := vss[1]
@@ -322,7 +322,7 @@ func TestStateOversizedBlock(t *testing.T) {
 func TestStateFullRound1(t *testing.T) {
 	config := configSetup(t)
 
-	cs, vss := randState(config, 1)
+	cs, vss := makeState(config, 1)
 	height, round := cs.Height, cs.Round
 
 	// NOTE: buffer capacity of 0 ensures we can validate prevote and last commit
@@ -364,7 +364,7 @@ func TestStateFullRound1(t *testing.T) {
 func TestStateFullRoundNil(t *testing.T) {
 	config := configSetup(t)
 
-	cs, vss := randState(config, 1)
+	cs, vss := makeState(config, 1)
 	height, round := cs.Height, cs.Round
 
 	voteCh := subscribeUnBuffered(cs.eventBus, types.EventQueryVote)
@@ -384,7 +384,7 @@ func TestStateFullRoundNil(t *testing.T) {
 func TestStateFullRound2(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 2)
+	cs1, vss := makeState(config, 2)
 	vs2 := vss[1]
 	height, round := cs1.Height, cs1.Round
 
@@ -426,7 +426,7 @@ func TestStateFullRound2(t *testing.T) {
 func TestStateLock_NoPOL(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 2)
+	cs1, vss := makeState(config, 2)
 	vs2 := vss[1]
 	height, round := cs1.Height, cs1.Round
 
@@ -563,7 +563,7 @@ func TestStateLock_NoPOL(t *testing.T) {
 
 	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
-	cs2, _ := randState(config, 2) // needed so generated block is different than locked block
+	cs2, _ := makeState(config, 2) // needed so generated block is different than locked block
 	// before we time out into new round, set next proposal block
 	prop, propBlock := decideProposal(t, cs2, vs2, vs2.Height, vs2.Round+1)
 	if prop == nil || propBlock == nil {
@@ -617,7 +617,7 @@ func TestStateLock_NoPOL(t *testing.T) {
 func TestStateLock_POLUpdateLock(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -717,7 +717,7 @@ func TestStateLock_POLUpdateLock(t *testing.T) {
 func TestStateLock_POLRelock(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -815,7 +815,7 @@ func TestStateLock_POLRelock(t *testing.T) {
 func TestStateLock_PrevoteNilWhenLockedAndMissProposal(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -899,7 +899,7 @@ func TestStateLock_PrevoteNilWhenLockedAndDifferentProposal(t *testing.T) {
 		state.
 	*/
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -996,7 +996,7 @@ func TestStateLock_POLDoesNotUnlock(t *testing.T) {
 		state.
 	*/
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1127,7 +1127,7 @@ func TestStateLock_POLDoesNotUnlock(t *testing.T) {
 func TestStateLock_MissingProposalWhenPOLSeenDoesNotUpdateLock(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1210,7 +1210,7 @@ func TestStateLock_MissingProposalWhenPOLSeenDoesNotUpdateLock(t *testing.T) {
 func TestStateLock_DoesNotLockOnOldProposal(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1284,7 +1284,7 @@ func TestStateLock_DoesNotLockOnOldProposal(t *testing.T) {
 func TestStateLock_POLSafety1(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1401,7 +1401,7 @@ func TestStateLock_POLSafety1(t *testing.T) {
 func TestStateLock_POLSafety2(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1496,7 +1496,7 @@ func TestStateLock_POLSafety2(t *testing.T) {
 func TestState_PrevotePOLFromPreviousRound(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1634,7 +1634,7 @@ func TestState_PrevotePOLFromPreviousRound(t *testing.T) {
 func TestProposeValidBlock(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1723,7 +1723,7 @@ func TestProposeValidBlock(t *testing.T) {
 func TestSetValidBlockOnDelayedPrevote(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1787,7 +1787,7 @@ func TestSetValidBlockOnDelayedPrevote(t *testing.T) {
 func TestSetValidBlockOnDelayedProposal(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1845,7 +1845,7 @@ func TestSetValidBlockOnDelayedProposal(t *testing.T) {
 func TestWaitingTimeoutOnNilPolka(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1868,7 +1868,7 @@ func TestWaitingTimeoutOnNilPolka(t *testing.T) {
 func TestWaitingTimeoutProposeOnNewRound(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1906,7 +1906,7 @@ func TestWaitingTimeoutProposeOnNewRound(t *testing.T) {
 func TestRoundSkipOnNilPolkaFromHigherRound(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1944,7 +1944,7 @@ func TestRoundSkipOnNilPolkaFromHigherRound(t *testing.T) {
 func TestWaitTimeoutProposeOnNilPolkaForTheCurrentRound(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, int32(1)
 
@@ -1973,7 +1973,7 @@ func TestWaitTimeoutProposeOnNilPolkaForTheCurrentRound(t *testing.T) {
 func TestEmitNewValidBlockEventOnCommitWithoutBlock(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, int32(1)
 
@@ -2009,7 +2009,7 @@ func TestEmitNewValidBlockEventOnCommitWithoutBlock(t *testing.T) {
 func TestCommitFromPreviousRound(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, int32(1)
 
@@ -2065,7 +2065,7 @@ func TestStartNextHeightCorrectlyAfterTimeout(t *testing.T) {
 	config := configSetup(t)
 
 	config.Consensus.SkipTimeoutCommit = false
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	cs1.txNotifier = &fakeTxNotifier{ch: make(chan struct{})}
 
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
@@ -2128,7 +2128,7 @@ func TestResetTimeoutPrecommitUponNewHeight(t *testing.T) {
 	config := configSetup(t)
 
 	config.Consensus.SkipTimeoutCommit = false
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
@@ -2271,7 +2271,7 @@ func TestStateSlashing_Precommits(t *testing.T) {
 func TestStateHalt1(t *testing.T) {
 	config := configSetup(t)
 
-	cs1, vss := randState(config, 4)
+	cs1, vss := makeState(config, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 	partSize := types.BlockPartSizeBytes
@@ -2340,7 +2340,7 @@ func TestStateOutputsBlockPartsStats(t *testing.T) {
 	config := configSetup(t)
 
 	// create dummy peer
-	cs, _ := randState(config, 1)
+	cs, _ := makeState(config, 1)
 	peer := p2pmock.NewPeer(nil)
 
 	// 1) new block part
@@ -2384,7 +2384,7 @@ func TestStateOutputsBlockPartsStats(t *testing.T) {
 func TestStateOutputVoteStats(t *testing.T) {
 	config := configSetup(t)
 
-	cs, vss := randState(config, 2)
+	cs, vss := makeState(config, 2)
 	// create dummy peer
 	peer := p2pmock.NewPeer(nil)
 
@@ -2419,7 +2419,7 @@ func TestStateOutputVoteStats(t *testing.T) {
 func TestSignSameVoteTwice(t *testing.T) {
 	config := configSetup(t)
 
-	_, vss := randState(config, 2)
+	_, vss := makeState(config, 2)
 
 	randBytes := tmrand.Bytes(tmhash.Size)
 

--- a/internal/consensus/types/height_vote_set_test.go
+++ b/internal/consensus/types/height_vote_set_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestPeerCatchupRounds(t *testing.T) {
-	valSet, privVals := factory.RandValidatorSet(10, 1)
+	valSet, privVals := factory.ValidatorSet(10, 1)
 
 	hvs := NewHeightVoteSet(config.ChainID(), 1, valSet)
 

--- a/internal/evidence/pool_test.go
+++ b/internal/evidence/pool_test.go
@@ -38,7 +38,7 @@ func TestEvidencePoolBasic(t *testing.T) {
 		blockStore = &mocks.BlockStore{}
 	)
 
-	valSet, privVals := factory.RandValidatorSet(1, 10)
+	valSet, privVals := factory.ValidatorSet(1, 10)
 
 	blockStore.On("LoadBlockMeta", mock.AnythingOfType("int64")).Return(
 		&types.BlockMeta{Header: types.Header{Time: defaultEvidenceTime}},

--- a/internal/evidence/verify_test.go
+++ b/internal/evidence/verify_test.go
@@ -191,7 +191,7 @@ func TestVerify_ForwardLunaticAttack(t *testing.T) {
 }
 
 func TestVerifyLightClientAttack_Equivocation(t *testing.T) {
-	conflictingVals, conflictingPrivVals := factory.RandValidatorSet(5, 10)
+	conflictingVals, conflictingPrivVals := factory.ValidatorSet(5, 10)
 
 	conflictingHeader, err := factory.MakeHeader(&types.Header{
 		ChainID:        evidenceChainID,
@@ -286,7 +286,7 @@ func TestVerifyLightClientAttack_Equivocation(t *testing.T) {
 
 func TestVerifyLightClientAttack_Amnesia(t *testing.T) {
 	var height int64 = 10
-	conflictingVals, conflictingPrivVals := factory.RandValidatorSet(5, 10)
+	conflictingVals, conflictingPrivVals := factory.ValidatorSet(5, 10)
 
 	conflictingHeader, err := factory.MakeHeader(&types.Header{
 		ChainID:        evidenceChainID,
@@ -475,14 +475,14 @@ func makeLunaticEvidence(
 	totalVals, byzVals, phantomVals int,
 	commonTime, attackTime time.Time,
 ) (ev *types.LightClientAttackEvidence, trusted *types.LightBlock, common *types.LightBlock) {
-	commonValSet, commonPrivVals := factory.RandValidatorSet(totalVals, defaultVotingPower)
+	commonValSet, commonPrivVals := factory.ValidatorSet(totalVals, defaultVotingPower)
 
 	require.Greater(t, totalVals, byzVals)
 
 	// extract out the subset of byzantine validators in the common validator set
 	byzValSet, byzPrivVals := commonValSet.Validators[:byzVals], commonPrivVals[:byzVals]
 
-	phantomValSet, phantomPrivVals := factory.RandValidatorSet(phantomVals, defaultVotingPower)
+	phantomValSet, phantomPrivVals := factory.ValidatorSet(phantomVals, defaultVotingPower)
 
 	conflictingVals := phantomValSet.Copy()
 	require.NoError(t, conflictingVals.UpdateWithChangeSet(byzValSet))
@@ -538,7 +538,7 @@ func makeLunaticEvidence(
 		ValidatorSet: commonValSet,
 	}
 	trustedBlockID := factory.MakeBlockIDWithHash(trustedHeader.Hash())
-	trustedVals, privVals := factory.RandValidatorSet(totalVals, defaultVotingPower)
+	trustedVals, privVals := factory.ValidatorSet(totalVals, defaultVotingPower)
 	trustedVoteSet := types.NewVoteSet(evidenceChainID, height, 1, tmproto.SignedMsgType(2), trustedVals)
 	trustedCommit, err := factory.MakeCommit(trustedBlockID, height, 1, trustedVoteSet, privVals, defaultEvidenceTime)
 	require.NoError(t, err)

--- a/internal/statesync/block_queue_test.go
+++ b/internal/statesync/block_queue_test.go
@@ -274,7 +274,7 @@ loop:
 }
 
 func mockLBResp(t *testing.T, peer types.NodeID, height int64, time time.Time) lightBlockResponse {
-	vals, pv := factory.RandValidatorSet(3, 10)
+	vals, pv := factory.ValidatorSet(3, 10)
 	_, _, lb := mockLB(t, height, time, factory.MakeBlockID(), vals, pv)
 	return lightBlockResponse{
 		block: lb,

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -394,7 +394,7 @@ func TestReactor_LightBlockResponse(t *testing.T) {
 	h := factory.MakeRandomHeader()
 	h.Height = height
 	blockID := factory.MakeBlockIDWithHash(h.Hash())
-	vals, pv := factory.RandValidatorSet(1, 10)
+	vals, pv := factory.ValidatorSet(1, 10)
 	vote, err := factory.MakeVote(pv[0], h.ChainID, 0, h.Height, 0, 2,
 		blockID, factory.DefaultTestTime)
 	require.NoError(t, err)
@@ -649,7 +649,7 @@ func handleLightBlockRequests(t *testing.T,
 				} else {
 					switch errorCount % 3 {
 					case 0: // send a different block
-						vals, pv := factory.RandValidatorSet(3, 10)
+						vals, pv := factory.ValidatorSet(3, 10)
 						_, _, lb := mockLB(t, int64(msg.Height), factory.DefaultTestTime, factory.MakeBlockID(), vals, pv)
 						differntLB, err := lb.ToProto()
 						require.NoError(t, err)
@@ -706,7 +706,7 @@ func buildLightBlockChain(t *testing.T, fromHeight, toHeight int64, startTime ti
 	chain := make(map[int64]*types.LightBlock, toHeight-fromHeight)
 	lastBlockID := factory.MakeBlockID()
 	blockTime := startTime.Add(time.Duration(fromHeight-toHeight) * time.Minute)
-	vals, pv := factory.RandValidatorSet(3, 10)
+	vals, pv := factory.ValidatorSet(3, 10)
 	for height := fromHeight; height < toHeight; height++ {
 		vals, pv, chain[height] = mockLB(t, height, blockTime, lastBlockID, vals, pv)
 		lastBlockID = factory.MakeBlockIDWithHash(chain[height].Header.Hash())
@@ -724,7 +724,7 @@ func mockLB(t *testing.T, height int64, time time.Time, lastBlockID types.BlockI
 		Time:        time,
 	})
 	require.NoError(t, err)
-	nextVals, nextPrivVals := factory.RandValidatorSet(3, 10)
+	nextVals, nextPrivVals := factory.ValidatorSet(3, 10)
 	header.ValidatorsHash = currentVals.Hash()
 	header.NextValidatorsHash = nextVals.Hash()
 	header.ConsensusHash = types.DefaultConsensusParams().HashConsensusParams()

--- a/internal/test/factory/genesis.go
+++ b/internal/test/factory/genesis.go
@@ -1,35 +1,33 @@
 package factory
 
 import (
-	"sort"
+	"time"
 
 	cfg "github.com/tendermint/tendermint/config"
-	tmtime "github.com/tendermint/tendermint/libs/time"
 	"github.com/tendermint/tendermint/types"
 )
 
-func RandGenesisDoc(
+func GenesisDoc(
 	config *cfg.Config,
-	numValidators int,
-	randPower bool,
-	minPower int64) (*types.GenesisDoc, []types.PrivValidator) {
+	time time.Time,
+	validators []*types.Validator,
+	consensusParams *types.ConsensusParams,
+) *types.GenesisDoc {
 
-	validators := make([]types.GenesisValidator, numValidators)
-	privValidators := make([]types.PrivValidator, numValidators)
-	for i := 0; i < numValidators; i++ {
-		val, privVal := RandValidator(randPower, minPower)
-		validators[i] = types.GenesisValidator{
-			PubKey: val.PubKey,
-			Power:  val.VotingPower,
+	genesisValidators := make([]types.GenesisValidator, len(validators))
+
+	for i := range validators {
+		genesisValidators[i] = types.GenesisValidator{
+			Power:  validators[i].VotingPower,
+			PubKey: validators[i].PubKey,
 		}
-		privValidators[i] = privVal
 	}
-	sort.Sort(types.PrivValidatorsByAddress(privValidators))
 
 	return &types.GenesisDoc{
-		GenesisTime:   tmtime.Now(),
-		InitialHeight: 1,
-		ChainID:       config.ChainID(),
-		Validators:    validators,
-	}, privValidators
+		GenesisTime:     time,
+		InitialHeight:   1,
+		ChainID:         config.ChainID(),
+		Validators:      genesisValidators,
+		ConsensusParams: consensusParams,
+	}
 }

--- a/internal/test/factory/validator.go
+++ b/internal/test/factory/validator.go
@@ -3,35 +3,29 @@ package factory
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"sort"
 
 	"github.com/tendermint/tendermint/types"
 )
 
-func RandValidator(randPower bool, minPower int64) (*types.Validator, types.PrivValidator) {
+func Validator(votingPower int64) (*types.Validator, types.PrivValidator) {
 	privVal := types.NewMockPV()
-	votePower := minPower
-	if randPower {
-		// nolint:gosec // G404: Use of weak random number generator
-		votePower += int64(rand.Uint32())
-	}
 	pubKey, err := privVal.GetPubKey(context.Background())
 	if err != nil {
 		panic(fmt.Errorf("could not retrieve pubkey %w", err))
 	}
-	val := types.NewValidator(pubKey, votePower)
+	val := types.NewValidator(pubKey, votingPower)
 	return val, privVal
 }
 
-func RandValidatorSet(numValidators int, votingPower int64) (*types.ValidatorSet, []types.PrivValidator) {
+func ValidatorSet(numValidators int, votingPower int64) (*types.ValidatorSet, []types.PrivValidator) {
 	var (
 		valz           = make([]*types.Validator, numValidators)
 		privValidators = make([]types.PrivValidator, numValidators)
 	)
 
 	for i := 0; i < numValidators; i++ {
-		val, privValidator := RandValidator(false, votingPower)
+		val, privValidator := Validator(votingPower)
 		valz[i] = val
 		privValidators[i] = privValidator
 	}

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -113,7 +113,7 @@ func TestValidateTrustOptions(t *testing.T) {
 func TestClient_SequentialVerification(t *testing.T) {
 	newKeys := genPrivKeys(4)
 	newVals := newKeys.ToValidators(10, 1)
-	differentVals, _ := factory.RandValidatorSet(10, 100)
+	differentVals, _ := factory.ValidatorSet(10, 100)
 
 	testCases := []struct {
 		name         string
@@ -866,7 +866,7 @@ func TestClientRemovesWitnessIfItSendsUsIncorrectHeader(t *testing.T) {
 }
 
 func TestClient_TrustedValidatorSet(t *testing.T) {
-	differentVals, _ := factory.RandValidatorSet(10, 100)
+	differentVals, _ := factory.ValidatorSet(10, 100)
 	mockBadValSetNode := mockNodeFromHeadersAndVals(
 		map[int64]*types.SignedHeader{
 			1: h1,

--- a/light/store/db/db_test.go
+++ b/light/store/db/db_test.go
@@ -184,7 +184,7 @@ func Test_Concurrency(t *testing.T) {
 }
 
 func randLightBlock(height int64) *types.LightBlock {
-	vals, _ := factory.RandValidatorSet(2, 1)
+	vals, _ := factory.ValidatorSet(2, 1)
 	return &types.LightBlock{
 		SignedHeader: &types.SignedHeader{
 			Header: &types.Header{

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -654,7 +654,8 @@ func loadStatefromGenesis(t *testing.T) sm.State {
 	require.NoError(t, err)
 	require.True(t, loadedState.IsEmpty())
 
-	genDoc, _ := factory.RandGenesisDoc(config, 0, false, 10)
+	valSet, _ := factory.ValidatorSet(0, 10)
+	genDoc := factory.GenesisDoc(config, time.Now(), valSet.Validators, nil)
 
 	state, err := loadStateFromDBOrGenesisDocProvider(
 		stateStore,

--- a/state/helpers_test.go
+++ b/state/helpers_test.go
@@ -3,6 +3,7 @@ package state_test
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"time"
 
 	dbm "github.com/tendermint/tm-db"
@@ -244,7 +245,7 @@ func makeRandomStateFromValidatorSet(
 
 func makeRandomStateFromConsensusParams(consensusParams *types.ConsensusParams,
 	height, lastHeightConsensusParamsChanged int64) sm.State {
-	val, _ := factory.RandValidator(true, 10)
+	val, _ := factory.Validator(10 + int64(rand.Uint32()))
 	valSet := types.NewValidatorSet([]*types.Validator{val})
 	return sm.State{
 		LastBlockHeight:                  height - 1,

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -2,6 +2,7 @@ package state_test
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -29,9 +30,9 @@ const (
 func TestStoreBootstrap(t *testing.T) {
 	stateDB := dbm.NewMemDB()
 	stateStore := sm.NewStore(stateDB)
-	val, _ := factory.RandValidator(true, 10)
-	val2, _ := factory.RandValidator(true, 10)
-	val3, _ := factory.RandValidator(true, 10)
+	val, _ := factory.Validator(10 + int64(rand.Uint32()))
+	val2, _ := factory.Validator(10 + int64(rand.Uint32()))
+	val3, _ := factory.Validator(10 + int64(rand.Uint32()))
 	vals := types.NewValidatorSet([]*types.Validator{val, val2, val3})
 	bootstrapState := makeRandomStateFromValidatorSet(vals, 100, 100)
 	err := stateStore.Bootstrap(bootstrapState)
@@ -55,9 +56,9 @@ func TestStoreBootstrap(t *testing.T) {
 func TestStoreLoadValidators(t *testing.T) {
 	stateDB := dbm.NewMemDB()
 	stateStore := sm.NewStore(stateDB)
-	val, _ := factory.RandValidator(true, 10)
-	val2, _ := factory.RandValidator(true, 10)
-	val3, _ := factory.RandValidator(true, 10)
+	val, _ := factory.Validator(10 + int64(rand.Uint32()))
+	val2, _ := factory.Validator(10 + int64(rand.Uint32()))
+	val3, _ := factory.Validator(10 + int64(rand.Uint32()))
 	vals := types.NewValidatorSet([]*types.Validator{val, val2, val3})
 
 	// 1) LoadValidators loads validators using a height where they were last changed

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -291,7 +291,7 @@ func makeBlockID(hash []byte, partSetSize uint32, partSetHash []byte) types.Bloc
 
 func mutateValidatorSet(privVals []types.MockPV, vals *types.ValidatorSet,
 ) ([]types.PrivValidator, *types.ValidatorSet, error) {
-	newVal, newPrivVal := factory.RandValidator(false, 10)
+	newVal, newPrivVal := factory.Validator(10)
 
 	var newVals *types.ValidatorSet
 	if vals.Size() > 2 {


### PR DESCRIPTION
This pull requests makes a few changes that will be helpful for writing the proposer-based timestamps tests. It simplifies a few of the existing test helpers and allows the addition of needed parameters. 

First, the `Validator` constructors in the `test/factory` package took a `bool` parameter that indicated if a random amount of voting power should be added to the passed in `minPower`. This `bool` was set to `true` at very few call sites, but was threaded all the way through the helper functions that used  the `Validator` constructor. This change removes the `bool` parameter and instead updates the few places where a random amount of voting power is required to generate a random number. 

Additionally, the `Genesis` consuctor has been updated to take a `time.Time` to be used as the genesis time. It has also been updated to take a `types.ConsensusParams` instead of just using the default. The helper functions that wrap the constructor have been updated to use `types.DefaultConsensusParams()` so the functionality is identical for most callers.