### PR TITLE
pubsub: Report a non-nil error when shutting down.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,7 +10,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - CLI/RPC/Config
 
-  - [config] \#7230 rpc: Add experimental config params to allow for subscription buffer size control (@thanethomson).
+  - [config] [\#7230](https://github.com/tendermint/tendermint/issues/7230) rpc: Add experimental config params to allow for subscription buffer size control (@thanethomson).
 
 - Apps
 
@@ -26,5 +26,6 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### BUG FIXES
 
+- [\#7309](https://github.com/tendermint/tendermint/issues/7309) pubsub: Report a non-nil error when shutting down (fixes #7306).
 - [\#7057](https://github.com/tendermint/tendermint/pull/7057) Import Postgres driver support for the psql indexer (@creachadair).
 - [\#7106](https://github.com/tendermint/tendermint/pull/7106) Revert mutex change to ABCI Clients (@tychoish).

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -194,7 +194,7 @@ func (s *Server) subscribe(ctx context.Context, clientID string, query Query, ou
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-s.Quit():
-		return nil, nil
+		return nil, errors.New("service is shutting down")
 	}
 }
 


### PR DESCRIPTION
If a subscriber arrives while the pubsub service is shutting down, the existing
code will return a nil subscription without error. With unlucky timing, this
may lead to a nil indirection panic in the RPC service.

To avoid that problem, make sure that when a subscription fails for this
reason, we report a non-nil error so that the client will detect it and give up
gracefully.

Fixes #7306.