### PR TITLE
pubsub: Report a non-nil error when shutting down.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,13 +12,13 @@ Special thanks to external contributors on this release:
 
 - CLI/RPC/Config
 
-  - [config] \#7276 rpc: Add experimental config params to allow for subscription buffer size control (@thanethomson).
+  - [config] [\#7276](https://github.com/tendermint/tendermint/pull/7276) rpc: Add experimental config params to allow for subscription buffer size control (@thanethomson).
 
 - Apps
 
 - P2P Protocol
 
-  - [p2p] \#7265 Peer manager reduces peer score for each failed dial attempts for peers that have not successfully dialed. (@tychoish)
+  - [p2p] [\#7265](https://github.com/tendermint/tendermint/pull/7265) Peer manager reduces peer score for each failed dial attempts for peers that have not successfully dialed. (@tychoish)
 
 - Go API
 
@@ -29,3 +29,5 @@ Special thanks to external contributors on this release:
 ### IMPROVEMENTS
 
 ### BUG FIXES
+
+- [\#7310](https://github.com/tendermint/tendermint/issues/7310) pubsub: Report a non-nil error when shutting down (fixes #7306).

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -219,7 +219,7 @@ func (s *Server) subscribe(ctx context.Context, clientID string, query Query, ou
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-s.Quit():
-		return nil, nil
+		return nil, errors.New("service is shutting down")
 	}
 }
 


### PR DESCRIPTION
If a subscriber arrives while the pubsub service is shutting down, the existing
code will return a nil subscription without error. With unlucky timing, this
may lead to a nil indirection panic in the RPC service.

To avoid that problem, make sure that when a subscription fails for this
reason, we report a non-nil error so that the client will detect it and give up
gracefully.

A side-port of the fix for #7306.