### PR TITLE
pubsub: Make the queue unwritable after shutdown.

### DIFF
--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -376,6 +376,7 @@ func (s *Server) run() {
 		s.pubs.Lock()
 		defer s.pubs.Unlock()
 		close(s.queue)
+		s.queue = nil
 	}()
 
 	s.exited = make(chan struct{})

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -382,9 +382,10 @@ func (s *Server) run() {
 	s.exited = make(chan struct{})
 	go func() {
 		defer close(s.exited)
+		queue := s.queue
 
 		// Sender: Service the queue and forward messages to subscribers.
-		for it := range s.queue {
+		for it := range queue {
 			if err := s.send(it.Data, it.Events); err != nil {
 				s.Logger.Error("Error sending event", "err", err)
 			}

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -368,6 +368,7 @@ func (s *Server) run() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.done = ctx.Done()
 	s.stop = cancel
+	queue := s.queue
 
 	// Shutdown monitor: When the context ends, wait for any active publish
 	// calls to exit, then close the queue to signal the sender to exit.
@@ -382,7 +383,6 @@ func (s *Server) run() {
 	s.exited = make(chan struct{})
 	go func() {
 		defer close(s.exited)
-		queue := s.queue
 
 		// Sender: Service the queue and forward messages to subscribers.
 		for it := range queue {

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -341,7 +341,7 @@ func (s *Server) OnStop() { s.stop() }
 func (s *Server) Wait() { <-s.exited; s.BaseService.Wait() }
 
 // OnStart implements Service.OnStart by starting the server.
-func (s *Server) OnStart(ctx context.Context) error { s.run(); return nil }
+func (s *Server) OnStart(ctx context.Context) error { s.run(ctx); return nil }
 
 // OnReset implements Service.OnReset. It has no effect for this service.
 func (s *Server) OnReset() error { return nil }
@@ -363,9 +363,9 @@ func (s *Server) publish(ctx context.Context, data interface{}, events []types.E
 	}
 }
 
-func (s *Server) run() {
+func (s *Server) run(ctx context.Context) {
 	// The server runs until ctx is canceled.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	s.done = ctx.Done()
 	s.stop = cancel
 	queue := s.queue


### PR DESCRIPTION
Prior to this change, shutting down the pubsub server could cause
any laggard publishers to race with the shutdown plumbing.
Fix that race condition, and plumb in the service context to the
runner so that it will respect the external signal directly.
