### PR TITLE
indexer: fix missing tx/block indexing

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,5 +26,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [\#7057](https://github.com/tendermint/tendermint/pull/7057) Import Postgres driver support for the psql indexer (@creachadair).
 - [\#7106](https://github.com/tendermint/tendermint/pull/7106) Revert mutex change to ABCI Clients (@tychoish).
-
 - [\#7323](https://github.com/tendermint/tendermint/pull/7323) Fix missing tx/block indexing when shutdown the node (@jayt106).

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,3 +26,5 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 - [\#7057](https://github.com/tendermint/tendermint/pull/7057) Import Postgres driver support for the psql indexer (@creachadair).
 - [\#7106](https://github.com/tendermint/tendermint/pull/7106) Revert mutex change to ABCI Clients (@tychoish).
+
+- [\#7323](https://github.com/tendermint/tendermint/pull/7323) Fix missing tx/block indexing when shutdown the node (@jayt106).

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -468,7 +468,16 @@ func (h *Handshaker) replayBlocks(
 			assertAppHashEqualsOneFromBlock(appHash, block)
 		}
 
-		appHash, err = sm.ExecCommitBlock(proxyApp.Consensus(), block, h.logger, h.stateStore, h.genDoc.InitialHeight)
+		appHash, err = sm.ExecCommitBlock(
+			proxyApp.Consensus(),
+			block,
+			h.logger,
+			h.stateStore,
+			h.genDoc.InitialHeight,
+			i == finalBlock,
+			h.eventBus,
+			&state.ConsensusParams.Validator,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -476,7 +476,7 @@ func (h *Handshaker) replayBlocks(
 			InitialHeight:    h.genDoc.InitialHeight,
 			EventBus:         h.eventBus,
 			FinalReplayBlock: i == finalBlock,
-			Validator:        &state.ConsensusParams.Validator,
+			Validator:        state.ConsensusParams.Validator,
 		}
 
 		appHash, err = sm.ExecCommitBlock(params)

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -468,16 +468,18 @@ func (h *Handshaker) replayBlocks(
 			assertAppHashEqualsOneFromBlock(appHash, block)
 		}
 
-		appHash, err = sm.ExecCommitBlock(
-			proxyApp.Consensus(),
-			block,
-			h.logger,
-			h.stateStore,
-			h.genDoc.InitialHeight,
-			i == finalBlock,
-			h.eventBus,
-			&state.ConsensusParams.Validator,
-		)
+		params := sm.BlockCommitExecParams{
+			AppConnConsensus: proxyApp.Consensus(),
+			Block:            block,
+			Logger:           h.logger,
+			Store:            h.stateStore,
+			InitialHeight:    h.genDoc.InitialHeight,
+			EventBus:         h.eventBus,
+			FinalReplayBlock: i == finalBlock,
+			Validator:        &state.ConsensusParams.Validator,
+		}
+
+		appHash, err = sm.ExecCommitBlock(params)
 		if err != nil {
 			return nil, err
 		}

--- a/state/execution.go
+++ b/state/execution.go
@@ -50,7 +50,7 @@ func BlockExecutorWithMetrics(metrics *Metrics) BlockExecutorOption {
 	}
 }
 
-// BlockCommitExecParams provides context for excuting the block commit.
+// BlockCommitExecParams provides context for executing the block commit.
 type BlockCommitExecParams struct {
 	AppConnConsensus proxy.AppConnConsensus
 	Block            *types.Block

--- a/state/execution.go
+++ b/state/execution.go
@@ -59,7 +59,7 @@ type BlockCommitExecParams struct {
 	EventBus         types.BlockEventPublisher
 	InitialHeight    int64
 	FinalReplayBlock bool
-	Validator        *tmproto.ValidatorParams
+	Validator        tmproto.ValidatorParams
 }
 
 // NewBlockExecutor returns a new BlockExecutor with a NopEventBus.
@@ -169,7 +169,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 
 	validatorUpdates, err := validateAndConvertValidatorUpdates(
 		abciResponses.EndBlock.ValidatorUpdates,
-		&state.ConsensusParams.Validator,
+		state.ConsensusParams.Validator,
 	)
 	if err != nil {
 		return state, 0, err
@@ -574,9 +574,9 @@ func ExecCommitBlock(params BlockCommitExecParams) ([]byte, error) {
 // validateAndConvertValidatorUpdates validate the validator updates and convert to tendermint types.
 func validateAndConvertValidatorUpdates(
 	validatorUpdates []abci.ValidatorUpdate,
-	validator *tmproto.ValidatorParams,
+	validator tmproto.ValidatorParams,
 ) ([]*types.Validator, error) {
-	if err := validateValidatorUpdates(validatorUpdates, *validator); err != nil {
+	if err := validateValidatorUpdates(validatorUpdates, validator); err != nil {
 		return nil, fmt.Errorf("error in validator updates: %v", err)
 	}
 

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -102,7 +102,15 @@ func TestBeginBlockValidators(t *testing.T) {
 		// block for height 2
 		block, _ := state.MakeBlock(2, makeTxs(2), lastCommit, nil, state.Validators.GetProposer().Address)
 
-		_, err = sm.ExecCommitBlock(proxyApp.Consensus(), block, log.TestingLogger(), stateStore, 1, false, nil, nil)
+		params := sm.BlockCommitExecParams{
+			AppConnConsensus: proxyApp.Consensus(),
+			Block:            block,
+			Logger:           log.TestingLogger(),
+			Store:            stateStore,
+			InitialHeight:    1,
+		}
+
+		_, err = sm.ExecCommitBlock(params)
 		require.Nil(t, err, tc.desc)
 
 		// -> app receives a list of validators with a bool indicating if they signed

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -102,7 +102,7 @@ func TestBeginBlockValidators(t *testing.T) {
 		// block for height 2
 		block, _ := state.MakeBlock(2, makeTxs(2), lastCommit, nil, state.Validators.GetProposer().Address)
 
-		_, err = sm.ExecCommitBlock(proxyApp.Consensus(), block, log.TestingLogger(), stateStore, 1)
+		_, err = sm.ExecCommitBlock(proxyApp.Consensus(), block, log.TestingLogger(), stateStore, 1, false, nil, nil)
 		require.Nil(t, err, tc.desc)
 
 		// -> app receives a list of validators with a bool indicating if they signed

--- a/state/txindex/indexer_service.go
+++ b/state/txindex/indexer_service.go
@@ -2,6 +2,7 @@ package txindex
 
 import (
 	"context"
+	"sync"
 
 	"github.com/tendermint/tendermint/libs/service"
 	"github.com/tendermint/tendermint/state/indexer"
@@ -22,6 +23,7 @@ type IndexerService struct {
 	txIdxr    TxIndexer
 	blockIdxr indexer.BlockIndexer
 	eventBus  *types.EventBus
+	wg        *sync.WaitGroup
 }
 
 // NewIndexerService returns a new service instance.
@@ -55,37 +57,45 @@ func (is *IndexerService) OnStart() error {
 		return err
 	}
 
+	is.wg = &sync.WaitGroup{}
+	is.wg.Add(1)
+
 	go func() {
 		for {
-			msg := <-blockHeadersSub.Out()
-			eventDataHeader := msg.Data().(types.EventDataNewBlockHeader)
-			height := eventDataHeader.Header.Height
-			batch := NewBatch(eventDataHeader.NumTxs)
+			select {
+			case <-blockHeadersSub.Cancelled():
+				is.wg.Done()
+				return
+			case msg := <-blockHeadersSub.Out():
+				eventDataHeader := msg.Data().(types.EventDataNewBlockHeader)
+				height := eventDataHeader.Header.Height
+				batch := NewBatch(eventDataHeader.NumTxs)
 
-			for i := int64(0); i < eventDataHeader.NumTxs; i++ {
-				msg2 := <-txsSub.Out()
-				txResult := msg2.Data().(types.EventDataTx).TxResult
+				for i := int64(0); i < eventDataHeader.NumTxs; i++ {
+					msg2 := <-txsSub.Out()
+					txResult := msg2.Data().(types.EventDataTx).TxResult
 
-				if err = batch.Add(&txResult); err != nil {
-					is.Logger.Error(
-						"failed to add tx to batch",
-						"height", height,
-						"index", txResult.Index,
-						"err", err,
-					)
+					if err = batch.Add(&txResult); err != nil {
+						is.Logger.Error(
+							"failed to add tx to batch",
+							"height", height,
+							"index", txResult.Index,
+							"err", err,
+						)
+					}
 				}
-			}
 
-			if err := is.blockIdxr.Index(eventDataHeader); err != nil {
-				is.Logger.Error("failed to index block", "height", height, "err", err)
-			} else {
-				is.Logger.Info("indexed block", "height", height)
-			}
+				if err := is.blockIdxr.Index(eventDataHeader); err != nil {
+					is.Logger.Error("failed to index block", "height", height, "err", err)
+				} else {
+					is.Logger.Info("indexed block", "height", height)
+				}
 
-			if err = is.txIdxr.AddBatch(batch); err != nil {
-				is.Logger.Error("failed to index block txs", "height", height, "err", err)
-			} else {
-				is.Logger.Debug("indexed block txs", "height", height, "num_txs", eventDataHeader.NumTxs)
+				if err = is.txIdxr.AddBatch(batch); err != nil {
+					is.Logger.Error("failed to index block txs", "height", height, "err", err)
+				} else {
+					is.Logger.Debug("indexed block txs", "height", height, "num_txs", eventDataHeader.NumTxs)
+				}
 			}
 		}
 	}()
@@ -97,4 +107,6 @@ func (is *IndexerService) OnStop() {
 	if is.eventBus.IsRunning() {
 		_ = is.eventBus.UnsubscribeAll(context.Background(), subscriber)
 	}
+
+	is.wg.Wait()
 }

--- a/test/maverick/consensus/replay.go
+++ b/test/maverick/consensus/replay.go
@@ -477,7 +477,7 @@ func (h *Handshaker) replayBlocks(
 			InitialHeight:    h.genDoc.InitialHeight,
 			EventBus:         h.eventBus,
 			FinalReplayBlock: i == finalBlock,
-			Validator:        &state.ConsensusParams.Validator,
+			Validator:        state.ConsensusParams.Validator,
 		}
 
 		appHash, err = sm.ExecCommitBlock(params)

--- a/test/maverick/consensus/replay.go
+++ b/test/maverick/consensus/replay.go
@@ -469,16 +469,18 @@ func (h *Handshaker) replayBlocks(
 			assertAppHashEqualsOneFromBlock(appHash, block)
 		}
 
-		appHash, err = sm.ExecCommitBlock(
-			proxyApp.Consensus(),
-			block,
-			h.logger,
-			h.stateStore,
-			h.genDoc.InitialHeight,
-			i == finalBlock,
-			h.eventBus,
-			&state.ConsensusParams.Validator,
-		)
+		params := sm.BlockCommitExecParams{
+			AppConnConsensus: proxyApp.Consensus(),
+			Block:            block,
+			Logger:           h.logger,
+			Store:            h.stateStore,
+			InitialHeight:    h.genDoc.InitialHeight,
+			EventBus:         h.eventBus,
+			FinalReplayBlock: i == finalBlock,
+			Validator:        &state.ConsensusParams.Validator,
+		}
+
+		appHash, err = sm.ExecCommitBlock(params)
 		if err != nil {
 			return nil, err
 		}

--- a/test/maverick/consensus/replay.go
+++ b/test/maverick/consensus/replay.go
@@ -469,7 +469,16 @@ func (h *Handshaker) replayBlocks(
 			assertAppHashEqualsOneFromBlock(appHash, block)
 		}
 
-		appHash, err = sm.ExecCommitBlock(proxyApp.Consensus(), block, h.logger, h.stateStore, h.genDoc.InitialHeight)
+		appHash, err = sm.ExecCommitBlock(
+			proxyApp.Consensus(),
+			block,
+			h.logger,
+			h.stateStore,
+			h.genDoc.InitialHeight,
+			i == finalBlock,
+			h.eventBus,
+			&state.ConsensusParams.Validator,
+		)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The indexer might not finish the indexing when terminating the node.
1. Handle blockHeadersSub.Cancelled event in the goroutine of the indexer service.
2. Re-index the block/tx events when replaying the final block. 

Closes #7312