### PR TITLE
internal/libs/autofile: continuously .Sync instead of opening and closing every second

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -46,6 +46,7 @@ Special thanks to external contributors on this release:
 ### IMPROVEMENTS
 
 - [pubsub] \#7319 Performance improvements for the event query API (@creachadair)
+- [internal/autofile] \#7333 autofile conservatively open its destination file and no longer opens a file every second. Only if the prior file doesn't exist does it create a fresh one. It however invokes .Sync every 1 second. This improves performance and reduces on file resources consumed. (@odeke-em)
 
 ### BUG FIXES
 


### PR DESCRIPTION
This change modifies autofile to no longer close and open the same file
every 1 second but instead to open a single file and then continuously
invoke .Sync, and if for example the file no longer exists, it'll open
again. The premise for this change is that the prior requirements
were built to allow for easy log rotation, but also durability thus
wrote the same file to disk, closed it then reopened it every 1 second,
but unfortunately that consumes a whole lot of file descriptors which
on many systems aren't recycled fast enough.
The prior assumption was also fallacious and unrealistic because most
log rotation happens periodically say 1 hour, or when a file/directory
has reached a threshold of which that would take time and not in 1 second durations.

This conservative approach shows good results with the number of
files opened and closed in my custom instrumented Go build, where I
track and count open vs closed files every 2 seconds.

Once we combine this change with https://github.com/tendermint/tendermint/pull/7327,
it ensures that there is only .Sync on a need to basis and avoids
burning unnecessary resources.

Thanks to Tharsis who paid attention to their customers' reports
and then commissioned me to help resolve these problems.

Fixes #7332