### PR TITLE
e2e: control access to state in Info calls

### DIFF
--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -97,6 +97,9 @@ func NewApplication(cfg *Config) (*Application, error) {
 
 // Info implements ABCI.
 func (app *Application) Info(req abci.RequestInfo) abci.ResponseInfo {
+	app.state.RLock()
+	defer app.state.RUnlock()
+
 	return abci.ResponseInfo{
 		Version:          version.ABCIVersion,
 		AppVersion:       1,


### PR DESCRIPTION
This is probably belt and suspenders, but might help the apphash clarity.