### PR TITLE
e2e: app hash test cleanup 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
     - govet
     - ineffassign
     # - interfacer
-    - lll
+    # - lll
     # - maligned
     - misspell
     - nakedret
@@ -46,9 +46,6 @@ issues:
     - path: _test\.go
       linters:
         - gosec
-    - linters:
-        - lll
-      source: "https://"
   max-same-issues: 50
 
 linters-settings:

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -97,6 +97,9 @@ func NewApplication(cfg *Config) (*Application, error) {
 
 // Info implements ABCI.
 func (app *Application) Info(req abci.RequestInfo) abci.ResponseInfo {
+	app.state.RLock()
+	defer app.state.RUnlock()
+
 	return abci.ResponseInfo{
 		Version:          version.ABCIVersion,
 		AppVersion:       1,

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -46,6 +46,7 @@ func TestApp_Hash(t *testing.T) {
 
 		status, err := client.Status(ctx)
 		require.NoError(t, err)
+		require.NotZero(t, status.SyncInfo.LatestBlockHeight)
 
 		block, err := client.Block(ctx, &info.Response.LastBlockHeight)
 		require.NoError(t, err)
@@ -54,6 +55,29 @@ func TestApp_Hash(t *testing.T) {
 			require.EqualValues(t, info.Response.LastBlockAppHash, block.Block.AppHash.Bytes(),
 				"app hash does not match last block's app hash")
 		}
+
+		require.True(t, status.SyncInfo.LatestBlockHeight >= info.Response.LastBlockHeight,
+			"status out of sync with application")
+	})
+}
+
+// Tests that the app and blockstore have and report the same height.
+func TestApp_Height(t *testing.T) {
+	testNode(t, func(t *testing.T, node e2e.Node) {
+		client, err := node.Client()
+		require.NoError(t, err)
+		info, err := client.ABCIInfo(ctx)
+		require.NoError(t, err)
+		require.NotZero(t, info.Response.LastBlockHeight)
+
+		status, err := client.Status(ctx)
+		require.NoError(t, err)
+		require.NotZero(t, status.SyncInfo.LatestBlockHeight)
+
+		block, err := client.Block(ctx, &info.Response.LastBlockHeight)
+		require.NoError(t, err)
+
+		require.Equal(t, info.Response.LastBlockHeight, block.Block.Height)
 
 		require.True(t, status.SyncInfo.LatestBlockHeight >= info.Response.LastBlockHeight,
 			"status out of sync with application")


### PR DESCRIPTION
This is a manual (but clean!) backport of a few e2e test stabilization from master.