### PR TITLE
e2e: limit legacyp2p and statesyncp2p

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -113,11 +113,9 @@ func Generate(r *rand.Rand, opts Options) ([]e2e.Manifest, error) {
 				}
 			}
 			if numLegacy == len(manifest.Nodes) {
-				fmt.Println("omit")
 				continue
 			}
 			if numLegacy == 0 {
-				fmt.Println("omit", "omit")
 				continue
 			}
 		}

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -402,14 +402,10 @@ func generateNode(
 		node.StateSync = nodeStateSyncs.Choose(r)
 		if manifest.InitialHeight-startAt <= 5 && node.StateSync == e2e.StateSyncDisabled {
 			// avoid needing to blocsync more than five total blocks.
-			if node.UseLegacyP2P {
-				node.StateSync = e2e.StateSyncRPC
-			} else {
-				node.StateSync = uniformSetChoice([]string{
-					e2e.StateSyncP2P,
-					e2e.StateSyncRPC,
-				}).Choose(r)[0]
-			}
+			node.StateSync = uniformSetChoice([]string{
+				e2e.StateSyncP2P,
+				e2e.StateSyncRPC,
+			}).Choose(r)[0]
 		}
 	}
 


### PR DESCRIPTION
This is a little bit of a shot in the dark, but it seems odd that there'd be a usecase for v0.35 users who would be using the legacy P2P stack and also statesync using the new p2p state provider. This is a configuration that is not available in 0.34 *nor* in versions of tendermint after 0.35. 

In the end this affects about 7 nodes total across all hybrid cases.

I think this really gets to the heart of "what's the legacy p2p stack for" in v0.35, given that the new stack is deeply compatible with the legacy stack for most cases. In my estimation keeping the legacy stack around is good as a migration strategy and as a fallback for existing operators if there's a problem (that we haven't yet seen) with the new system, we have an easy operational strategy and workaround already in the bag. I don't expect that people will be doing statesyncs (in hybrid situations, with the p2p provider on legacy nodes, and even from hybrid networks,) so testing this doesn't provide much value. 

I might be wrong about these assumptions though, and I'm not committed to making this change. 
