### PR TITLE
indexer: kafka sink implementation (WIP)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1095,6 +1095,8 @@ type TxIndexConfig struct {
 	// The PostgreSQL connection configuration, the connection format:
 	// postgresql://<user>:<password>@<host>:<port>/<db>?<opts>
 	PsqlConn string `mapstructure:"psql-conn"`
+
+	KafkaConn string `mapstructure:"kafka-conn"`
 }
 
 // DefaultTxIndexConfig returns a default configuration for the transaction indexer.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.4.1
+	github.com/Shopify/sarama v1.19.0
 	github.com/adlio/schema v1.1.14
 	github.com/btcsuite/btcd v0.22.0-beta
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
@@ -12,6 +13,7 @@ require (
 	github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 // indirect
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/go-kit/kit v0.12.0
+	github.com/go-zookeeper/zk v1.0.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/golangci/golangci-lint v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -83,7 +83,9 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1 h1:VlW4R6jmBIv3/u1JNlawEvJMM4J+dPORPaZasQee8Us=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
+github.com/Shopify/sarama v1.19.0 h1:9oksLxC6uxVPHPVYUmq6xhr1BOF/hHobWH2UzO67z1s=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
+github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
@@ -233,8 +235,11 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/eapache/go-resiliency v1.1.0 h1:1NtRmCAqadE2FN4ZcN6g90TP3uk8cg9rn9eNK2197aU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
+github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
+github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -326,6 +331,7 @@ github.com/go-toolsmith/typep v1.0.2 h1:8xdsa1+FSIH/RhEkgnD1j2CJOy5mNllW1Q9tRiYw
 github.com/go-toolsmith/typep v1.0.2/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
 github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b h1:khEcpUM4yFcxg4/FHQWkvVRmgijNXRfzkIDHh23ggEo=
 github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
+github.com/go-zookeeper/zk v1.0.2 h1:4mx0EYENAdX/B/rbunjlt5+4RTA/a9SMHBRuSKdGxPM=
 github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
@@ -789,6 +795,7 @@ github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d h1:CdDQnGF8Nq9ocOS/xlSptM1N3BbrA6/kmaep5ggwaIA=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
+github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1 h1:VGcrWe3yk6o+t7BdVNy5UDPWa4OZuDWtE1W1ZbS7Kyw=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/state/indexer/eventsink.go
+++ b/internal/state/indexer/eventsink.go
@@ -11,9 +11,10 @@ import (
 type EventSinkType string
 
 const (
-	NULL EventSinkType = "null"
-	KV   EventSinkType = "kv"
-	PSQL EventSinkType = "psql"
+	NULL  EventSinkType = "null"
+	KV    EventSinkType = "kv"
+	PSQL  EventSinkType = "psql"
+	KAFKA EventSinkType = "kafka"
 )
 
 //go:generate ../../../scripts/mockery_generate.sh EventSink

--- a/internal/state/indexer/indexer_service.go
+++ b/internal/state/indexer/indexer_service.go
@@ -160,7 +160,7 @@ func KVSinkEnabled(sinks []EventSink) bool {
 // IndexingEnabled returns the given eventSinks is supporting the indexing services.
 func IndexingEnabled(sinks []EventSink) bool {
 	for _, sink := range sinks {
-		if sink.Type() == KV || sink.Type() == PSQL {
+		if sink.Type() == KV || sink.Type() == PSQL || sink.Type() == KAFKA {
 			return true
 		}
 	}

--- a/internal/state/indexer/sink/kafka/kafka.go
+++ b/internal/state/indexer/sink/kafka/kafka.go
@@ -1,0 +1,221 @@
+// Package kafka implements an event sink backed by a Kafka message producer.
+package kafka
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/orderedcode"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/internal/state/indexer"
+	"github.com/tendermint/tendermint/libs/pubsub/query"
+	"github.com/tendermint/tendermint/types"
+)
+
+// EventSink is an indexer backend providing the tx/block index services.
+// This implementation emit messages using the kafka producer.
+type EventSink struct {
+	chainID  string
+	producer sarama.SyncProducer
+}
+
+// NewEventSink constructs an event sink associated with the kafka producer
+// specified by connStr. Events written to the sink are attributed to
+// the specified chainID.
+func NewEventSink(connStr, chainID string) (*EventSink, error) {
+	p, err := sarama.NewSyncProducer([]string{connStr}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EventSink{
+		chainID:  chainID,
+		producer: p,
+	}, nil
+}
+
+// Connection returns the underlying kafka connection used by the sink.
+// This is exported to support testing.
+func (es *EventSink) Producer() sarama.SyncProducer { return es.producer }
+
+// Type returns the structure type for this sink, which is KAFKA.
+func (es *EventSink) Type() indexer.EventSinkType { return indexer.KAFKA }
+
+// covertEventsToMessages transform the abci events and associate with the block height or the tx hash
+// to the kafka messages.
+func covertEventsToMessages(chainID string, height int64, txhash string, evts []abci.Event) ([]*sarama.ProducerMessage, error) {
+	msgs := make([]*sarama.ProducerMessage, 0)
+
+	for _, evt := range evts {
+		// Skip events with an empty type.
+		if evt.Type == "" {
+			continue
+		}
+
+		// Add any attributes flagged for indexing.
+		for _, attr := range evt.Attributes {
+			if !attr.Index {
+				continue
+			}
+
+			var key []byte
+			var err error
+			// composite the message key with event attribute key, and/or block height, and/or tx hash.
+			if height == -1 {
+				key, err = orderedcode.Append(nil, attr.Key)
+			} else if len(txhash) == 0 {
+				key, err = orderedcode.Append(nil, attr.Key, height)
+			} else {
+				key, err = orderedcode.Append(nil, attr.Key, height, txhash)
+			}
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to create the index key: %w", err)
+			}
+
+			msgs = append(msgs, &sarama.ProducerMessage{
+				Topic: fmt.Sprintf("%s.%s", chainID, evt.Type),
+				Key:   sarama.ByteEncoder(key),
+				Value: sarama.ByteEncoder(attr.Value),
+			})
+		}
+	}
+	return msgs, nil
+}
+
+// makeIndexedEvent constructs an event from the specified composite key and
+// value. If the key has the form "type.name", the event will have a single
+// attribute with that name and the value; otherwise the event will have only
+// a type and no attributes.
+func makeIndexedEvent(compositeKey, value string) abci.Event {
+	i := strings.Index(compositeKey, ".")
+	if i < 0 {
+		return abci.Event{Type: compositeKey}
+	}
+	return abci.Event{Type: compositeKey[:i], Attributes: []abci.EventAttribute{
+		{Key: compositeKey[i+1:], Value: value, Index: true},
+	}}
+}
+
+// IndexBlockEvents indexes the specified block header, part of the
+// indexer.EventSink interface.
+func (es *EventSink) IndexBlockEvents(h types.EventDataNewBlockHeader) error {
+	kmsgs := make([]*sarama.ProducerMessage, 0)
+
+	// Index the block height event and convert it to an kafka message.
+	blockHeightEvent := makeIndexedEvent(types.BlockHeightKey, fmt.Sprint(h.Header.Height))
+	m, err := covertEventsToMessages(es.chainID, -1, "", []abci.Event{blockHeightEvent})
+	if err != nil {
+		return err
+	}
+	kmsgs = append(kmsgs, m...)
+
+	// Convert the begin block events to the kafka messages.
+	m, err = covertEventsToMessages(es.chainID, h.Header.Height, "", h.ResultBeginBlock.Events)
+	if err != nil {
+		return err
+	}
+	kmsgs = append(kmsgs, m...)
+
+	// Convert the end block events to the kafka messages.
+	m, err = covertEventsToMessages(es.chainID, h.Header.Height, "", h.ResultEndBlock.Events)
+	if err != nil {
+		return err
+	}
+	kmsgs = append(kmsgs, m...)
+
+	return es.producer.SendMessages(kmsgs)
+}
+
+// IndexTxEvents indexes the specified transaction results, part of the
+// indexer.EventSink interface.
+func (es *EventSink) IndexTxEvents(txrs []*abci.TxResult) error {
+	kmsgs := make([]*sarama.ProducerMessage, 0)
+
+	txHeightEventIndexed := false
+	for _, txr := range txrs {
+		// Assume the batched tx_result will be the same block height.
+		if !txHeightEventIndexed {
+			txHeightEvent := makeIndexedEvent(types.TxHeightKey, fmt.Sprint(txr.Height))
+			m, err := covertEventsToMessages(es.chainID, -1, "", []abci.Event{txHeightEvent})
+			if err != nil {
+				return err
+			}
+			kmsgs = append(kmsgs, m...)
+			txHeightEventIndexed = true
+		}
+
+		// Index the hash of the underlying transaction as a hex string.
+		txHash := fmt.Sprintf("%X", types.Tx(txr.Tx).Hash())
+
+		// Index the txhash event with the tx height.
+		txHashEvent := makeIndexedEvent(types.TxHashKey, txHash)
+		m, err := covertEventsToMessages(es.chainID, txr.Height, "", []abci.Event{txHashEvent})
+		if err != nil {
+			return err
+		}
+		kmsgs = append(kmsgs, m...)
+
+		// Encode the result message in protobuf wire format for indexing.
+		resultData, err := proto.Marshal(txr)
+		if err != nil {
+			return fmt.Errorf("marshaling tx_result: %w", err)
+		}
+
+		// Index the tx raw data with txHash
+		key, err := orderedcode.Append(
+			nil,
+			"hash",
+			txHash,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create the index key: %w", err)
+		}
+
+		msg := &sarama.ProducerMessage{
+			Topic: fmt.Sprintf("%s.%s", es.chainID, "tx"),
+			Key:   sarama.ByteEncoder(key),
+			Value: sarama.ByteEncoder(resultData),
+		}
+
+		kmsgs = append(kmsgs, msg)
+
+		// Index the tx event data.
+		m, err = covertEventsToMessages(es.chainID, txr.Height, txHash, txr.Result.Events)
+		if err != nil {
+			return err
+		}
+		kmsgs = append(kmsgs, m...)
+	}
+
+	return es.producer.SendMessages(kmsgs)
+}
+
+// SearchBlockEvents is not implemented by this sink, and reports an error for all queries.
+func (es *EventSink) SearchBlockEvents(ctx context.Context, q *query.Query) ([]int64, error) {
+	return nil, errors.New("block search is not supported via the kafka event sink")
+}
+
+// SearchTxEvents is not implemented by this sink, and reports an error for all queries.
+func (es *EventSink) SearchTxEvents(ctx context.Context, q *query.Query) ([]*abci.TxResult, error) {
+	return nil, errors.New("tx search is not supported via the kafka event sink")
+}
+
+// GetTxByHash is not implemented by this sink, and reports an error for all queries.
+func (es *EventSink) GetTxByHash(hash []byte) (*abci.TxResult, error) {
+	return nil, errors.New("getTxByHash is not supported via the kafka event sink")
+}
+
+// HasBlock is not implemented by this sink, and reports an error for all queries.
+func (es *EventSink) HasBlock(h int64) (bool, error) {
+	return false, errors.New("hasBlock is not supported via the kafka event sink")
+}
+
+// Stop closes the underlying kafka producer.
+func (es *EventSink) Stop() error {
+	return es.producer.Close()
+}

--- a/internal/state/indexer/sink/kafka/kafka.go
+++ b/internal/state/indexer/sink/kafka/kafka.go
@@ -64,7 +64,7 @@ func covertEventsToMessages(chainID string, height int64, txhash string, evts []
 
 			var key []byte
 			var err error
-			// composite the message key with event attribute key, and/or block height, and/or tx hash.
+			// Composite the message key with event attribute key, and/or block height, and/or tx hash.
 			if height == -1 {
 				key, err = orderedcode.Append(nil, attr.Key)
 			} else if len(txhash) == 0 {

--- a/internal/state/indexer/sink/kafka/kafka_test.go
+++ b/internal/state/indexer/sink/kafka/kafka_test.go
@@ -234,14 +234,14 @@ func TestIndexing(t *testing.T) {
 			return txr != nil, err
 		})
 
-		// try to insert the duplicate tx events.
+		// Try to insert the duplicate tx events.
 		err := indexer.IndexTxEvents([]*abci.TxResult{txResult})
 		require.NoError(t, err)
 	})
 }
 
 func verifyBlock(t *testing.T, height int64) {
-	consumer, err := sarama.NewConsumer([]string{"localhost:9093"}, nil)
+	consumer, err := sarama.NewConsumer([]string{fmt.Sprintf("%s:%s", ip, kafkaOutPort)}, nil)
 	if err != nil {
 		t.Errorf("No able to create the consumer: %v", err)
 	}
@@ -258,7 +258,7 @@ func verifyBlock(t *testing.T, height int64) {
 	// Check that the blocks table contains an entry for this height.
 	assert.Equal(t, []byte(fmt.Sprint(height)), msg.Value)
 
-	// Verify the first presence of begin_block
+	// Verify the first presence of begin_block.
 	topicBeginEvent := fmt.Sprintf("%s.begin_event", chainID)
 	partitionConsumer, err = consumer.ConsumePartition(topicBeginEvent, 0, 0)
 	if err != nil {
@@ -278,7 +278,7 @@ func verifyBlock(t *testing.T, height int64) {
 		t.Errorf("Not able to create the partitionConsumer-%s: %v", topicThingy, err)
 	}
 
-	// There are two messages for topic thingy, so we need to read twice
+	// There are two messages for topic thingy.
 	msg = <-partitionConsumer.Messages()
 	key, _ = orderedcode.Append(nil, "whatzit", height)
 	assert.Equal(t, key, msg.Key)
@@ -289,7 +289,7 @@ func verifyBlock(t *testing.T, height int64) {
 	assert.Equal(t, key, msg.Key)
 	assert.Equal(t, []byte("-.O"), msg.Value)
 
-	// Verify the first presence of end_block
+	// Verify the first presence of end_block.
 	topicEndEvent := fmt.Sprintf("%s.end_event", chainID)
 	partitionConsumer, err = consumer.ConsumePartition(topicEndEvent, 0, 0)
 	if err != nil {
@@ -304,8 +304,7 @@ func verifyBlock(t *testing.T, height int64) {
 }
 
 func verifyTx(t *testing.T, txResult *abci.TxResult) {
-
-	consumer, err := sarama.NewConsumer([]string{"localhost:9093"}, nil)
+	consumer, err := sarama.NewConsumer([]string{fmt.Sprintf("%s:%s", ip, kafkaOutPort)}, nil)
 	if err != nil {
 		t.Errorf("Not able to create the consumer: %v", err)
 	}

--- a/internal/state/indexer/sink/kafka/kafka_test.go
+++ b/internal/state/indexer/sink/kafka/kafka_test.go
@@ -1,0 +1,401 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/go-zookeeper/zk"
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/orderedcode"
+	"github.com/ory/dockertest"
+	"github.com/ory/dockertest/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/internal/state/indexer"
+	"github.com/tendermint/tendermint/internal/state/indexer/sink/util"
+	"github.com/tendermint/tendermint/types"
+)
+
+var (
+	// Verify that the type satisfies the EventSink interface.
+	_ indexer.EventSink = (*EventSink)(nil)
+
+	// A hook that test cases can call to obtain the shared database instance
+	// used for testing the sink. This is initialized in TestMain (see below).
+	testProducer func() sarama.SyncProducer
+
+	doPauseAtExit = flag.Bool("pause-at-exit", false,
+		"If true, pause the test until interrupted at shutdown, to allow debugging")
+)
+
+const (
+	zkPort       = "2181"
+	kafkaOutPort = "9093"
+	kafkaInPort  = "9092"
+	ip           = "localhost"
+	protocol     = "tcp"
+	chainID      = "test-chainID"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	// Set up docker and start a container running zookeeper and kafka.
+	pool, err := dockertest.NewPool(os.Getenv("DOCKER_URL"))
+	if err != nil {
+		log.Fatalf("Creating docker pool: %v", err)
+	}
+
+	if err = pool.Client.Ping(); err != nil {
+		log.Fatalf(`could not connect to docker: %s`, err)
+	}
+
+	network, err := pool.Client.CreateNetwork(docker.CreateNetworkOptions{Name: "zookeeper_kafka_network"})
+	if err != nil {
+		log.Fatalf("could not create a network to zookeeper and kafka: %s", err)
+	}
+
+	zkResource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Name:         "zookeeper-EventSinkTest",
+		Repository:   "wurstmeister/zookeeper",
+		Tag:          "3.4.6",
+		NetworkID:    network.ID,
+		Hostname:     "zookeeper",
+		ExposedPorts: []string{zkPort},
+	})
+
+	if err != nil {
+		log.Fatalf("Could not start zookeeper: %s", err)
+	}
+
+	if *doPauseAtExit {
+		log.Print("Pause at exit is enabled, containers will not expire")
+	} else {
+		const expireSeconds = 90
+		_ = zkResource.Expire(expireSeconds)
+		log.Printf("Container expiration set to %d seconds", expireSeconds)
+	}
+
+	zkConn, _, err := zk.Connect(
+		[]string{fmt.Sprintf("%s:%s", ip, zkResource.GetPort(fmt.Sprintf("%s/%s", zkPort, protocol)))}, 10*time.Second)
+	if err != nil {
+		log.Fatalf("Could not connect to the zookeeper: %s", err)
+	}
+	defer zkConn.Close()
+
+	if err != nil {
+		log.Fatalf("Starting docker pool: %v", err)
+	}
+
+	retryFn := func() error {
+		switch zkConn.State() {
+		case zk.StateHasSession, zk.StateConnected:
+			return nil
+		default:
+			return errors.New("Not yet connected")
+		}
+	}
+
+	if err = pool.Retry(retryFn); err != nil {
+		log.Fatalf("Could not connect to the zookeeper: %s", err)
+	}
+
+	portBinding := fmt.Sprintf("%s/tcp", kafkaOutPort)
+	kafkaResource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Name:       "kafka-EventSinkTest",
+		Repository: "wurstmeister/kafka",
+		Tag:        "2.13-2.7.1",
+		NetworkID:  network.ID,
+		Hostname:   "kafka",
+		Env: []string{
+			fmt.Sprintf("KAFKA_ADVERTISED_LISTENERS=INSIDE://kafka:%s,OUTSIDE://%s:%s", kafkaInPort, ip, kafkaOutPort),
+			fmt.Sprintf("KAFKA_LISTENERS=INSIDE://0.0.0.0:%s,OUTSIDE://0.0.0.0:%s", kafkaInPort, kafkaOutPort),
+			fmt.Sprintf("KAFKA_ZOOKEEPER_CONNECT=zookeeper:%s", zkPort),
+			"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT",
+			"KAFKA_INTER_BROKER_LISTENER_NAME=INSIDE",
+			"KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1",
+		},
+		PortBindings: map[docker.Port][]docker.PortBinding{
+			"9093/tcp": {{HostIP: ip, HostPort: portBinding}},
+		},
+		ExposedPorts: []string{fmt.Sprintf("%s/%s", kafkaOutPort, protocol)},
+	})
+	if err != nil {
+		log.Fatalf("Could not get the kafkaResource: %s", err)
+	}
+
+	conn := fmt.Sprintf("%s:%s", ip, kafkaResource.GetPort(fmt.Sprintf("%s/%s", kafkaOutPort, protocol)))
+	var producer sarama.SyncProducer
+
+	if err := pool.Retry(func() error {
+		sink, err := NewEventSink(conn, chainID)
+		if err != nil {
+			return err
+		}
+
+		producer = sink.Producer() // set global for test use
+		return nil
+	}); err != nil {
+		log.Fatalf("Connecting to database: %v", err)
+	}
+
+	// Set up the hook for tests to get the shared producer handle.
+	testProducer = func() sarama.SyncProducer { return producer }
+
+	// Run the selected test cases.
+	code := m.Run()
+
+	// Clean up and shut down the database container.
+	if *doPauseAtExit {
+		log.Print("Testing complete, pausing for inspection. Send SIGINT to resume teardown")
+		util.WaitForInterrupt()
+		log.Print("(resuming)")
+	}
+
+	if err := producer.Close(); err != nil {
+		log.Printf("WARNING: Closing kafka producer failed: %v", err)
+	}
+
+	log.Print("Shutting down zookeeper&kafka service")
+	if err := zkResource.Close(); err != nil {
+		log.Printf("WARNING: could not close zookeeperResource: %v", err)
+	}
+	if err := pool.Purge(zkResource); err != nil {
+		log.Printf("WARNING: could not purge zookeeperResource: %v", err)
+	}
+
+	if err := kafkaResource.Close(); err != nil {
+		log.Printf("WARNING: could not close zookeeperResource: %v", err)
+	}
+	if err := pool.Purge(kafkaResource); err != nil {
+		log.Printf("WARNING: could not purge zookeeperResource: %v", err)
+	}
+	if err := pool.Client.RemoveNetwork(network.ID); err != nil {
+		log.Printf("WARNING: could not remove %s network: %s", network.Name, err)
+	}
+
+	os.Exit(code)
+}
+
+func TestType(t *testing.T) {
+	kafkaSink := &EventSink{chainID: chainID, producer: testProducer()}
+	assert.Equal(t, indexer.KAFKA, kafkaSink.Type())
+}
+
+func TestIndexing(t *testing.T) {
+	t.Run("IndexBlockEvents", func(t *testing.T) {
+		indexer := &EventSink{chainID: chainID, producer: testProducer()}
+		err := indexer.IndexBlockEvents(newTestBlockHeader())
+		require.NoError(t, err)
+
+		verifyBlock(t, 1)
+
+		util.VerifyNotImplemented(t, "hasBlock", string(indexer.Type()), func() (bool, error) {
+			return indexer.HasBlock(1)
+		})
+
+		util.VerifyNotImplemented(t, "block search", string(indexer.Type()), func() (bool, error) {
+			v, err := indexer.SearchBlockEvents(context.Background(), nil)
+			return v != nil, err
+		})
+
+		// Attempting to reindex the same events should gracefully succeed.
+		require.NoError(t, indexer.IndexBlockEvents(newTestBlockHeader()))
+	})
+
+	t.Run("IndexTxEvents", func(t *testing.T) {
+		indexer := &EventSink{chainID: chainID, producer: testProducer()}
+
+		txResult := util.TxResultWithEvents([]abci.Event{
+			makeIndexedEvent("account.number", "1"),
+			makeIndexedEvent("account.owner", "Ivan"),
+			makeIndexedEvent("account.owner", "Yulieta"),
+
+			{Type: "", Attributes: []abci.EventAttribute{{Key: "not_allowed", Value: "Vlad", Index: true}}},
+		})
+		require.NoError(t, indexer.IndexTxEvents([]*abci.TxResult{txResult}))
+
+		verifyTx(t, txResult)
+
+		util.VerifyNotImplemented(t, "getTxByHash", string(indexer.Type()), func() (bool, error) {
+			txr, err := indexer.GetTxByHash(types.Tx(txResult.Tx).Hash())
+			return txr != nil, err
+		})
+		util.VerifyNotImplemented(t, "tx search", string(indexer.Type()), func() (bool, error) {
+			txr, err := indexer.SearchTxEvents(context.Background(), nil)
+			return txr != nil, err
+		})
+
+		// try to insert the duplicate tx events.
+		err := indexer.IndexTxEvents([]*abci.TxResult{txResult})
+		require.NoError(t, err)
+	})
+}
+
+func verifyBlock(t *testing.T, height int64) {
+	consumer, err := sarama.NewConsumer([]string{"localhost:9093"}, nil)
+	if err != nil {
+		t.Errorf("No able to create the consumer: %v", err)
+	}
+	defer consumer.Close()
+
+	topicHeight := fmt.Sprintf("%s.block", chainID)
+	partitionConsumer, err := consumer.ConsumePartition(topicHeight, 0, 0)
+	if err != nil {
+		t.Errorf("Not able to create the partitionConsumer-%s: %v", topicHeight, err)
+	}
+
+	msg := <-partitionConsumer.Messages()
+	partitionConsumer.Close()
+	// Check that the blocks table contains an entry for this height.
+	assert.Equal(t, []byte(fmt.Sprint(height)), msg.Value)
+
+	// Verify the first presence of begin_block
+	topicBeginEvent := fmt.Sprintf("%s.begin_event", chainID)
+	partitionConsumer, err = consumer.ConsumePartition(topicBeginEvent, 0, 0)
+	if err != nil {
+		t.Errorf("Not able to create the partitionConsumer-%s: %v", topicBeginEvent, err)
+	}
+
+	msg = <-partitionConsumer.Messages()
+	partitionConsumer.Close()
+	key, _ := orderedcode.Append(nil, "proposer", height)
+	assert.Equal(t, key, msg.Key)
+	assert.Equal(t, []byte("FCAA001"), msg.Value)
+
+	// Verify the second presence of begin_block
+	topicThingy := fmt.Sprintf("%s.thingy", chainID)
+	partitionConsumer, err = consumer.ConsumePartition(topicThingy, 0, 0)
+	if err != nil {
+		t.Errorf("Not able to create the partitionConsumer-%s: %v", topicThingy, err)
+	}
+
+	// There are two messages for topic thingy, so we need to read twice
+	msg = <-partitionConsumer.Messages()
+	key, _ = orderedcode.Append(nil, "whatzit", height)
+	assert.Equal(t, key, msg.Key)
+	assert.Equal(t, []byte("O.O"), msg.Value)
+
+	msg = <-partitionConsumer.Messages()
+	partitionConsumer.Close()
+	assert.Equal(t, key, msg.Key)
+	assert.Equal(t, []byte("-.O"), msg.Value)
+
+	// Verify the first presence of end_block
+	topicEndEvent := fmt.Sprintf("%s.end_event", chainID)
+	partitionConsumer, err = consumer.ConsumePartition(topicEndEvent, 0, 0)
+	if err != nil {
+		t.Errorf("Not able to create the partitionConsumer-%s: %v", partitionConsumer, err)
+	}
+
+	msg = <-partitionConsumer.Messages()
+	partitionConsumer.Close()
+	key, _ = orderedcode.Append(nil, "foo", height)
+	assert.Equal(t, key, msg.Key)
+	assert.Equal(t, []byte("100"), msg.Value)
+}
+
+func verifyTx(t *testing.T, txResult *abci.TxResult) {
+
+	consumer, err := sarama.NewConsumer([]string{"localhost:9093"}, nil)
+	if err != nil {
+		t.Errorf("Not able to create the consumer: %v", err)
+	}
+	defer consumer.Close()
+
+	// Check that the message has indexed the tx height.
+	topicTx := fmt.Sprintf("%s.tx", chainID)
+	partitionConsumer, err := consumer.ConsumePartition(topicTx, 0, 0)
+	if err != nil {
+		t.Errorf("Not able to create the partitionConsumer-%s: %v", topicTx, err)
+	}
+
+	select {
+	case msg := <-partitionConsumer.Messages():
+		key, _ := orderedcode.Append(nil, "height")
+		assert.Equal(t, key, msg.Key)
+		assert.Equal(t, []byte(fmt.Sprint(txResult.Height)), msg.Value)
+	case err := <-partitionConsumer.Errors():
+		t.Errorf("Not able to consume the %s message: %v", topicTx, err)
+	}
+
+	hash := fmt.Sprintf("%X", types.Tx(txResult.Tx).Hash())
+
+	// Check that the message has indexed the tx hash.
+	select {
+	case msg := <-partitionConsumer.Messages():
+		key, _ := orderedcode.Append(nil, "hash", txResult.Height)
+		assert.Equal(t, key, msg.Key)
+		assert.Equal(t, []byte(hash), msg.Value)
+	case err := <-partitionConsumer.Errors():
+		t.Errorf("Not able to consume the %s message: %v", topicTx, err)
+	}
+
+	txRaw, err := proto.Marshal(txResult)
+	if err != nil {
+		t.Errorf("marshaling tx_result: %v", err)
+	}
+
+	// Check that the message has indexed the tx raw data.
+	select {
+	case msg := <-partitionConsumer.Messages():
+		key, _ := orderedcode.Append(nil, "hash", hash)
+		assert.Equal(t, key, msg.Key)
+		assert.Equal(t, txRaw, msg.Value)
+	case err := <-partitionConsumer.Errors():
+		t.Errorf("Not able to consume the %s message: %v", topicTx, err)
+	}
+	partitionConsumer.Close()
+
+	// Check that the message has indexed the tx account.
+	topicAccount := fmt.Sprintf("%s.account", chainID)
+	partitionConsumer, err = consumer.ConsumePartition(topicAccount, 0, 0)
+	if err != nil {
+		t.Errorf("Not able to create the partitionConsumer-%s: %v", topicAccount, err)
+	}
+
+	for _, e := range txResult.Result.Events {
+		// The empty event type will not be indexed.
+		if len(e.GetType()) == 0 {
+			continue
+		}
+
+		select {
+		case msg := <-partitionConsumer.Messages():
+			key, _ := orderedcode.Append(nil, e.Attributes[0].Key, txResult.Height, hash)
+			assert.Equal(t, key, msg.Key)
+			assert.Equal(t, []byte(e.Attributes[0].Value), msg.Value)
+		case err := <-partitionConsumer.Errors():
+			t.Errorf("Not able to consume the %s message: %v", topicAccount, err)
+		}
+	}
+	partitionConsumer.Close()
+}
+
+// newTestBlockHeader constructs a fresh copy of a block header containing
+// known test values to exercise the indexer.
+func newTestBlockHeader() types.EventDataNewBlockHeader {
+	return types.EventDataNewBlockHeader{
+		Header: types.Header{Height: 1},
+		ResultBeginBlock: abci.ResponseBeginBlock{
+			Events: []abci.Event{
+				makeIndexedEvent("begin_event.proposer", "FCAA001"),
+				makeIndexedEvent("thingy.whatzit", "O.O"),
+			},
+		},
+		ResultEndBlock: abci.ResponseEndBlock{
+			Events: []abci.Event{
+				makeIndexedEvent("end_event.foo", "100"),
+				makeIndexedEvent("thingy.whatzit", "-.O"),
+			},
+		},
+	}
+}

--- a/internal/state/indexer/sink/psql/psql_test.go
+++ b/internal/state/indexer/sink/psql/psql_test.go
@@ -99,7 +99,7 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			return err
 		}
-		db = sink.DB() // set global for test use
+		db = sink.DB() // Set global for test use.
 		return db.Ping()
 	}); err != nil {
 		log.Fatalf("Connecting to database: %v", err)

--- a/internal/state/indexer/sink/sink.go
+++ b/internal/state/indexer/sink/sink.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/state/indexer"
+	"github.com/tendermint/tendermint/internal/state/indexer/sink/kafka"
 	"github.com/tendermint/tendermint/internal/state/indexer/sink/kv"
 	"github.com/tendermint/tendermint/internal/state/indexer/sink/null"
 	"github.com/tendermint/tendermint/internal/state/indexer/sink/psql"
@@ -50,6 +51,14 @@ func EventSinksFromConfig(cfg *config.Config, dbProvider config.DBProvider, chai
 			}
 
 			es, err := psql.NewEventSink(conn, chainID)
+			if err != nil {
+				return nil, err
+			}
+			eventSinks = append(eventSinks, es)
+		case indexer.KAFKA:
+			conn := cfg.TxIndex.KafkaConn
+
+			es, err := kafka.NewEventSink(conn, chainID)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/state/indexer/sink/util/testutil.go
+++ b/internal/state/indexer/sink/util/testutil.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/types"
+)
+
+// WaitForInterrupt blocks until a SIGINT is received by the process.
+func WaitForInterrupt() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	<-ch
+}
+
+// VerifyNotImplemented calls f and verifies that it returns both a
+// false-valued flag and a non-nil error whose string matching the expected
+// "not supported" message with label prefixed.
+func VerifyNotImplemented(t *testing.T, label string, sinkType string, f func() (bool, error)) {
+	t.Helper()
+	t.Logf("Verifying that %q reports it is not implemented", label)
+
+	want := label + fmt.Sprintf(" is not supported via the %s event sink", sinkType)
+	ok, err := f()
+	assert.False(t, ok)
+	require.NotNil(t, err)
+	assert.Equal(t, want, err.Error())
+}
+
+// TxResultWithEvents constructs a fresh transaction result with fixed values
+// for testing, that includes the specified events.
+func TxResultWithEvents(events []abci.Event) *abci.TxResult {
+	return &abci.TxResult{
+		Height: 1,
+		Index:  0,
+		Tx:     types.Tx("HELLO WORLD"),
+		Result: abci.ResponseDeliverTx{
+			Data:   []byte{0},
+			Code:   abci.CodeTypeOK,
+			Log:    "",
+			Events: events,
+		},
+	}
+}


### PR DESCRIPTION
Indexer supports apache kafka event sink - WIP, mainly the decision for the kafka producer config we want to expose into the Tendermint config

- [x] EventSink function implementation
        Use [SyncProducer](https://github.com/Shopify/sarama/blob/556ddf712c31a475ec4e08b3550156c35a62ede1/sync_producer.go#L15) to send the messages to the kafka/zookeeper service. So the user should set up the kafka/zookeeper services to receive the message.
- [ ] kafka env setup
        The kafka supports various env setup, we might need to expose some settings in`Producer` and the `Net` category.
        Which options we should add to the Tendermint config?
        https://github.com/Shopify/sarama/blob/556ddf712c31a475ec4e08b3550156c35a62ede1/config.go#L21
- [ ] Document how we index the event to the kafka message
       The kafka message contains Topic-key-value. Try to bring a similar logic with the `psql sink`. 
       Therefore, this implementation: 
        - Combines the `chainID` with the event type as the message topic. E.g. `testchain-id.block`, `testchain-id.tx`.
        - Combines the `block height` or `txhash` with the event argument key as the message key.  E.g.  byteEncode the `sender` + `blockHeight` + `txhash`


Closes #6584
