### PR TITLE
ci: move test execution to makefile

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,7 @@ jobs:
             "!test/"
             go.mod
             go.sum
+            Makefile
       - name: install
         run: GOOS=linux GOARCH=${{ matrix.goarch }} make build
         if: "env.GIT_DIFF != ''"
@@ -51,6 +52,7 @@ jobs:
             "!test/"
             go.mod
             go.sum
+            Makefile
       - name: test & coverage report creation
         run: |
           make test-group-${{ matrix.part }} NUM_SPLIT=4
@@ -72,6 +74,7 @@ jobs:
             "!test/"
             go.mod
             go.sum
+            Makefile
       - uses: actions/download-artifact@v2
         with:
           name: "${{ github.sha }}-00-coverage"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,32 +9,6 @@ on:
       - release/**
 
 jobs:
-  split-test-files:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.4.0
-      - name: Create a file with all the pkgs
-        run: go list ./... > pkgs.txt
-      - name: Split pkgs into 4 files
-        run: split -d -n l/4 pkgs.txt pkgs.txt.part.
-      # cache multiple
-      - uses: actions/upload-artifact@v2
-        with:
-          name: "${{ github.sha }}-00"
-          path: ./pkgs.txt.part.00
-      - uses: actions/upload-artifact@v2
-        with:
-          name: "${{ github.sha }}-01"
-          path: ./pkgs.txt.part.01
-      - uses: actions/upload-artifact@v2
-        with:
-          name: "${{ github.sha }}-02"
-          path: ./pkgs.txt.part.02
-      - uses: actions/upload-artifact@v2
-        with:
-          name: "${{ github.sha }}-03"
-          path: ./pkgs.txt.part.03
-
   build-linux:
     name: Build
     runs-on: ubuntu-latest
@@ -61,7 +35,6 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    needs: split-test-files
     strategy:
       fail-fast: false
       matrix:
@@ -78,22 +51,14 @@ jobs:
             "!test/"
             go.mod
             go.sum
-      - uses: actions/download-artifact@v2
-        with:
-          name: "${{ github.sha }}-${{ matrix.part }}"
-        if: env.GIT_DIFF
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: "1.17"
       - name: test & coverage report creation
         run: |
-          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 15m -race -coverprofile=${{ matrix.part }}profile.out
+          make test-group-${{ matrix.part }} NUM_SPLIT=4
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v2
         with:
           name: "${{ github.sha }}-${{ matrix.part }}-coverage"
-          path: ./${{ matrix.part }}profile.out
+          path: ./build/${{ matrix.part }}.profile.out
 
   upload-coverage-report:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ build-reproducible:
 .PHONY: build-reproducible
 
 # Implements test splitting and running. This is pulled directly from
-# the github action workflows for better local reproducability.
+# the github action workflows for better local reproducibility.
 
 GO_TEST_FILES := $(shell find $(CURDIR) -name "*_test.go")
 

--- a/Makefile
+++ b/Makefile
@@ -296,8 +296,11 @@ GO_TEST_FILES != find $(CURDIR) -name "*_test.go"
 # default to four splits by default
 NUM_SPLIT ?= 4
 
+$(BUILDDIR):
+	mkdir -p $@
+
 # the format statement filters out all packages that don't have tests.
-$(BUILDDIR)/packages.txt:$(GO_TEST_FILES)
+$(BUILDDIR)/packages.txt:$(GO_TEST_FILES) $(BUILDDIR)
 	go list -f "{{ if .TestGoFiles }}{{ .ImportPath }}{{ end }}" ./... | sort > $@
 
 split-test-packages:$(BUILDDIR)/packages.txt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 #!/usr/bin/make -f
 
-PACKAGES=$(shell go list ./...)
 BUILDDIR ?= $(CURDIR)/build
 
 BUILD_TAGS?=tendermint
@@ -103,7 +102,7 @@ install_abci:
 .PHONY: install_abci
 
 ###############################################################################
-###                           	Privval Server                              ###
+###				Privval Server                              ###
 ###############################################################################
 
 build_privval_server:
@@ -288,3 +287,22 @@ build-reproducible:
 		--name latest-build cosmossdk/rbuilder:latest
 	docker cp -a latest-build:/home/builder/artifacts/ $(CURDIR)/
 .PHONY: build-reproducible
+
+# Implements test splitting and running. This is pulled directly from
+# the github action workflows for better local reproducability.
+
+GO_TEST_FILES := $(shell find $(CURDIR) -name "*_test.go")
+
+# default to four splits by default
+ifeq (,$(NUM_SPLIT))
+NUM_SPLIT := 4
+endif
+
+# the format statement filters out all packages that don't have tests.
+$(BUILDDIR)/packages.txt:$(GO_TEST_FILES)
+	go list -f "{{ if .TestGoFiles }}{{ .ImportPath }}{{ end }}" ./... | sort > $@
+
+split-test-packages:$(BUILDDIR)/packages.txt
+	split -d -n l/$(NUM_SPLIT) $< $<.
+test-group-%:split-test-packages
+	cat $(BUILDDIR)/packages.txt.$* | xargs go test -mod=readonly -timeout=15m -race -coverprofile=$(BUILDDIR)/$*.profile.out

--- a/Makefile
+++ b/Makefile
@@ -291,12 +291,10 @@ build-reproducible:
 # Implements test splitting and running. This is pulled directly from
 # the github action workflows for better local reproducibility.
 
-GO_TEST_FILES := $(shell find $(CURDIR) -name "*_test.go")
+GO_TEST_FILES != find $(CURDIR) -name "*_test.go"
 
 # default to four splits by default
-ifeq (,$(NUM_SPLIT))
-NUM_SPLIT := 4
-endif
+NUM_SPLIT ?= 4
 
 # the format statement filters out all packages that don't have tests.
 $(BUILDDIR)/packages.txt:$(GO_TEST_FILES)


### PR DESCRIPTION
This moves a bit of irritating CI orchestration into the makefile for
better local repoducabiliy, and also slims down what runs in tests (to
avoid noop cases where we try and run tests that don't exist.)