### PR TITLE
internal/consensus: proposer waits for previous block time

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -41,6 +41,7 @@ Special thanks to external contributors on this release:
 
 - [cli] [#7033](https://github.com/tendermint/tendermint/pull/7033) Add a `rollback` command to rollback to the previous tendermint state in the event of non-determinstic app hash or reverting an upgrade.
 - [mempool, rpc] \#7041  Add removeTx operation to the RPC layer. (@tychoish)
+- [consensus] []() Update the proposal logic per the Propose-based timestamps specification so that the proposer will wait for the previous block time to occur before proposing the next block.
 
 ### IMPROVEMENTS
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -41,7 +41,7 @@ Special thanks to external contributors on this release:
 
 - [cli] [#7033](https://github.com/tendermint/tendermint/pull/7033) Add a `rollback` command to rollback to the previous tendermint state in the event of non-determinstic app hash or reverting an upgrade.
 - [mempool, rpc] \#7041  Add removeTx operation to the RPC layer. (@tychoish)
-- [consensus] []() Update the proposal logic per the Propose-based timestamps specification so that the proposer will wait for the previous block time to occur before proposing the next block.
+- [consensus] \#7376 Update the proposal logic per the Propose-based timestamps specification so that the proposer will wait for the previous block time to occur before proposing the next block. (@williambanfield)
 
 ### IMPROVEMENTS
 

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -682,10 +682,16 @@ func ensureRelock(t *testing.T, relockCh <-chan tmpubsub.Message, height int64, 
 }
 
 func ensureProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID) {
+	ensureProposalWithTimeout(t, proposalCh, height, round, propID, ensureTimeout)
+}
+
+func ensureProposalWithTimeout(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID, timeout time.Duration) {
+	t.Helper()
 	msg := ensureMessageBeforeTimeout(t, proposalCh, ensureTimeout)
 	proposalEvent, ok := msg.Data().(types.EventDataCompleteProposal)
 	if !ok {
-		t.Fatalf("expected a EventDataCompleteProposal, got %T. Wrong subscription channel?", msg.Data())
+		t.Fatalf("expected a EventDataCompleteProposal, got %T. Wrong subscription channel?",
+			msg.Data())
 	}
 	if proposalEvent.Height != height {
 		t.Fatalf("expected height %v, got %v", height, proposalEvent.Height)
@@ -695,29 +701,6 @@ func ensureProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int
 	}
 	if !proposalEvent.BlockID.Equals(propID) {
 		t.Fatalf("Proposed block does not match expected block (%v != %v)", proposalEvent.BlockID, propID)
-	}
-}
-
-func ensureProposalWithTimeout(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID, timeout time.Duration) {
-	t.Helper()
-	select {
-	case <-time.After(timeout):
-		t.Fatalf("Timeout expired while waiting for NewProposal event")
-	case msg := <-proposalCh:
-		proposalEvent, ok := msg.Data().(types.EventDataCompleteProposal)
-		if !ok {
-			t.Fatalf("expected a EventDataCompleteProposal, got %T. Wrong subscription channel?",
-				msg.Data())
-		}
-		if proposalEvent.Height != height {
-			t.Fatalf("expected height %v, got %v", height, proposalEvent.Height)
-		}
-		if proposalEvent.Round != round {
-			t.Fatalf("expected round %v, got %v", round, proposalEvent.Round)
-		}
-		if !proposalEvent.BlockID.Equals(propID) {
-			t.Fatalf("Proposed block does not match expected block (%v != %v)", proposalEvent.BlockID, propID)
-		}
 	}
 }
 func ensurePrecommit(t *testing.T, voteCh <-chan tmpubsub.Message, height int64, round int32) {

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -685,6 +685,7 @@ func ensureProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int
 	ensureProposalWithTimeout(t, proposalCh, height, round, propID, ensureTimeout)
 }
 
+// nolint: lll
 func ensureProposalWithTimeout(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID, timeout time.Duration) {
 	t.Helper()
 	msg := ensureMessageBeforeTimeout(t, proposalCh, timeout)

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -687,7 +687,7 @@ func ensureProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int
 
 func ensureProposalWithTimeout(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID, timeout time.Duration) {
 	t.Helper()
-	msg := ensureMessageBeforeTimeout(t, proposalCh, ensureTimeout)
+	msg := ensureMessageBeforeTimeout(t, proposalCh, timeout)
 	proposalEvent, ok := msg.Data().(types.EventDataCompleteProposal)
 	if !ok {
 		t.Fatalf("expected a EventDataCompleteProposal, got %T. Wrong subscription channel?",

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -74,7 +74,7 @@ type pbtsTestConfiguration struct {
 	// The timestamp of the block proposed at height 2.
 	height2ProposedBlockTime time.Time
 
-	// The timestamp of the block proposed at height 2.
+	// The timestamp of the block proposed at height 4.
 	height4ProposedBlockTime time.Time
 }
 

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -233,7 +233,11 @@ func (p *pbtsTestHarness) nextHeight(proposer types.PrivValidator, deliverTime, 
 
 func timestampedCollector(ctx context.Context, t *testing.T, eb *eventbus.EventBus) <-chan timestampedEvent {
 	t.Helper()
+
+	// Since eventCh is not read until the end of each height, it must be large
+	// enough to hold all of the events produced during a single height.
 	eventCh := make(chan timestampedEvent, 100)
+
 	if err := eb.Observe(ctx, func(msg tmpubsub.Message) error {
 		eventCh <- timestampedEvent{
 			ts: time.Now(),

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -276,10 +276,12 @@ func collectHeightResults(ctx context.Context, t *testing.T, eventCh <-chan time
 			res.proposalIssuedAt = event.ts
 		}
 		if res.isComplete() {
-			break
+			return res
 		}
 	}
-	return res
+	t.Fatalf("complete height result never seen for height %d", height)
+
+	panic("unreachable")
 }
 
 type timestampedEvent struct {

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -378,9 +378,9 @@ func TestProposerWaitsForGenesisTime(t *testing.T) {
 	// create a genesis time far (enough) in the future.
 	initialTime := time.Now().Add(800 * time.Millisecond)
 	cfg := pbtsTestConfiguration{
-		timingParams: types.TimingParams{
-			Precision:    10 * time.Millisecond,
-			MessageDelay: 10 * time.Millisecond,
+		timestampParams: types.TimestampParams{
+			Precision: 10 * time.Millisecond,
+			MsgDelay:  10 * time.Millisecond,
 		},
 		timeoutPropose:             10 * time.Millisecond,
 		genesisTime:                initialTime,
@@ -406,9 +406,9 @@ func TestProposerWaitsForPreviousBlock(t *testing.T) {
 	defer cancel()
 	initialTime := time.Now().Add(time.Millisecond * 50)
 	cfg := pbtsTestConfiguration{
-		timingParams: types.TimingParams{
-			Precision:    100 * time.Millisecond,
-			MessageDelay: 500 * time.Millisecond,
+		timestampParams: types.TimestampParams{
+			Precision: 100 * time.Millisecond,
+			MsgDelay:  500 * time.Millisecond,
 		},
 		timeoutPropose:             50 * time.Millisecond,
 		genesisTime:                initialTime,

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1109,7 +1109,6 @@ func (cs *State) enterPropose(height int64, round int32) {
 	if cs.isProposer(ourAddress) {
 		proposerWaitTime := proposerWaitTime(tmtime.DefaultSource{}, cs.state.LastBlockTime)
 		if proposerWaitTime > 0 {
-			fmt.Println("scheduling a wait!")
 			cs.scheduleTimeout(proposerWaitTime, height, round, cstypes.RoundStepNewRound)
 			return
 		}
@@ -1208,6 +1207,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 	ctx, cancel := context.WithTimeout(context.TODO(), cs.config.TimeoutPropose)
 	defer cancel()
 	if err := cs.privValidator.SignProposal(ctx, cs.state.ChainID, p); err == nil {
+		fmt.Printf("signed the proposal with time %v for height %d\n", block.Header.Time, block.Height)
 		proposal.Signature = p.Signature
 
 		// send proposal and block parts on internal msg queue

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1207,7 +1207,6 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 	ctx, cancel := context.WithTimeout(context.TODO(), cs.config.TimeoutPropose)
 	defer cancel()
 	if err := cs.privValidator.SignProposal(ctx, cs.state.ChainID, p); err == nil {
-		fmt.Printf("signed the proposal with time %v for height %d\n", block.Header.Time, block.Height)
 		proposal.Signature = p.Signature
 
 		// send proposal and block parts on internal msg queue


### PR DESCRIPTION
This change introduces the logic to have the proposer wait until the previous block time has passed before attempting to propose the next block. 

The change achieves this by by adding a new clause into the `enterPropose` state machine method. The method now checks if the validator is the proposer and if the validator's clock is behind the previous block's time. If the validator's clock is behind the previous block time, it schedules a timeout to re-enter the enter propose method after enough time has passed.

This change also introduces a mild refactor to the `pbts_test.go` file. It updates the test harness to include a channel of `time.Time`, `pubsub.Message` pairs. This timestamped events channel provides a slightly more generalizable way to collect events from the observed validator associated with the time that they occured in the test.