### PR TITLE
Update Mergify configuration.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,7 +13,10 @@ pull_request_rules:
       queue:
         method: squash
         name: default
-        commit_message: title+body
+        commit_message_template: |
+          {{ title }} (#{{ number }})
+
+          {{ body }}
   - name: backport patches to v0.34.x branch
     conditions:
       - base=master


### PR DESCRIPTION
Per https://docs.mergify.com/actions/merge/#commit-message, the
title+body commit_message option is deprecated and will be removed 
in 2022. Replace it with the template suggested here:

https://docs.mergify.com/actions/queue/
