### PR TITLE
internal/consensus: prevote nil if proposal timestamp does not match

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -41,6 +41,7 @@ Special thanks to external contributors on this release:
 
 - [cli] [#7033](https://github.com/tendermint/tendermint/pull/7033) Add a `rollback` command to rollback to the previous tendermint state in the event of non-determinstic app hash or reverting an upgrade.
 - [mempool, rpc] \#7041  Add removeTx operation to the RPC layer. (@tychoish)
+- [consensus] \#7376 Update the proposal logic per the Propose-based timestamps specification so that the proposer will wait for the previous block time to occur before proposing the next block. (@williambanfield)
 
 ### IMPROVEMENTS
 

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -214,7 +214,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 
 		// Make proposal
 		propBlockID := types.BlockID{Hash: block.Hash(), PartSetHeader: blockParts.Header()}
-		proposal := types.NewProposal(height, round, lazyNodeState.ValidRound, propBlockID)
+		proposal := types.NewProposal(height, round, lazyNodeState.ValidRound, propBlockID, block.Header.Time)
 		p := proposal.ToProto()
 		if err := lazyNodeState.privValidator.SignProposal(ctx, lazyNodeState.state.ChainID, p); err == nil {
 			proposal.Signature = p.Signature

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -682,10 +682,17 @@ func ensureRelock(t *testing.T, relockCh <-chan tmpubsub.Message, height int64, 
 }
 
 func ensureProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID) {
-	msg := ensureMessageBeforeTimeout(t, proposalCh, ensureTimeout)
+	ensureProposalWithTimeout(t, proposalCh, height, round, propID, ensureTimeout)
+}
+
+// nolint: lll
+func ensureProposalWithTimeout(t *testing.T, proposalCh <-chan tmpubsub.Message, height int64, round int32, propID types.BlockID, timeout time.Duration) {
+	t.Helper()
+	msg := ensureMessageBeforeTimeout(t, proposalCh, timeout)
 	proposalEvent, ok := msg.Data().(types.EventDataCompleteProposal)
 	if !ok {
-		t.Fatalf("expected a EventDataCompleteProposal, got %T. Wrong subscription channel?", msg.Data())
+		t.Fatalf("expected a EventDataCompleteProposal, got %T. Wrong subscription channel?",
+			msg.Data())
 	}
 	if proposalEvent.Height != height {
 		t.Fatalf("expected height %v, got %v", height, proposalEvent.Height)
@@ -697,7 +704,6 @@ func ensureProposal(t *testing.T, proposalCh <-chan tmpubsub.Message, height int
 		t.Fatalf("Proposed block does not match expected block (%v != %v)", proposalEvent.BlockID, propID)
 	}
 }
-
 func ensurePrecommit(t *testing.T, voteCh <-chan tmpubsub.Message, height int64, round int32) {
 	t.Helper()
 	ensureVote(t, voteCh, height, round, tmproto.PrecommitType)

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -248,7 +248,7 @@ func decideProposal(
 
 	// Make proposal
 	polRound, propBlockID := validRound, types.BlockID{Hash: block.Hash(), PartSetHeader: blockParts.Header()}
-	proposal = types.NewProposal(height, round, polRound, propBlockID)
+	proposal = types.NewProposal(height, round, polRound, propBlockID, block.Header.Time)
 	p := proposal.ToProto()
 	if err := vs.SignProposal(ctx, chainID, p); err != nil {
 		t.Fatalf("error signing proposal: %s", err)

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -324,74 +324,6 @@ func (hr heightResult) isComplete() bool {
 	return !hr.proposalIssuedAt.IsZero() && !hr.prevoteIssuedAt.IsZero() && hr.prevote != nil
 }
 
-// TestReceiveProposalWaitsForPreviousBlockTime tests that a validator receiving
-// a proposal waits until the previous block time passes before issuing a prevote.
-// The test delivers the block to the validator after the configured `timeout-propose`,
-// but before the proposer-based timestamp bound on block delivery and checks that
-// the consensus algorithm correctly waits for the new block to be delivered
-// and issues a prevote for it.
-func TestReceiveProposalWaitsForPreviousBlockTime(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	initialTime := time.Now().Add(50 * time.Millisecond)
-	cfg := pbtsTestConfiguration{
-		timingParams: types.TimingParams{
-			Precision:    100 * time.Millisecond,
-			MessageDelay: 500 * time.Millisecond,
-		},
-		timeoutPropose:             50 * time.Millisecond,
-		genesisTime:                initialTime,
-		height2ProposalDeliverTime: initialTime.Add(450 * time.Millisecond),
-		height2ProposedBlockTime:   initialTime.Add(350 * time.Millisecond),
-	}
-
-	pbtsTest := newPBTSTestHarness(ctx, t, cfg)
-	results := pbtsTest.run()
-
-	// Check that the validator waited until after the proposer-based timestamp
-	// waitingTime bound.
-	assert.True(t, results.height2.prevoteIssuedAt.After(cfg.height2ProposalDeliverTime))
-	maxWaitingTime := cfg.genesisTime.Add(cfg.timingParams.Precision).Add(cfg.timingParams.MessageDelay)
-	assert.True(t, results.height2.prevoteIssuedAt.Before(maxWaitingTime))
-
-	// Check that the validator did not prevote for nil.
-	assert.NotNil(t, results.height2.prevote.BlockID.Hash)
-}
-
-// TestReceiveProposalTimesOutOnSlowDelivery tests that a validator receiving
-// a proposal times out and prevotes nil if the block is not delivered by the
-// within the proposer-based timestamp algorithm's waitingTime bound.
-// The test delivers the block to the validator after the previous block's time
-// and after the proposer-based timestamp bound on block delivery.
-// The test then checks that the validator correctly waited for the new block
-// and prevoted nil after timing out.
-func TestReceiveProposalTimesOutOnSlowDelivery(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	initialTime := time.Now()
-	cfg := pbtsTestConfiguration{
-		timingParams: types.TimingParams{
-			Precision:    100 * time.Millisecond,
-			MessageDelay: 500 * time.Millisecond,
-		},
-		timeoutPropose:             50 * time.Millisecond,
-		genesisTime:                initialTime,
-		height2ProposalDeliverTime: initialTime.Add(660 * time.Millisecond),
-		height2ProposedBlockTime:   initialTime.Add(350 * time.Millisecond),
-	}
-
-	pbtsTest := newPBTSTestHarness(ctx, t, cfg)
-	results := pbtsTest.run()
-
-	// Check that the validator waited until after the proposer-based timestamp
-	// waitinTime bound.
-	maxWaitingTime := initialTime.Add(cfg.timingParams.Precision).Add(cfg.timingParams.MessageDelay)
-	assert.True(t, results.height2.prevoteIssuedAt.After(maxWaitingTime))
-
-	// Ensure that the validator issued a prevote for nil.
-	assert.Nil(t, results.height2.prevote.BlockID.Hash)
-}
-
 // TestProposerWaitsForGenesisTime tests that a proposer will not propose a block
 // until after the genesis time has passed. The test sets the genesis time in the
 // future and then ensures that the observed validator waits to propose a block.
@@ -488,59 +420,6 @@ func TestProposerWaitTime(t *testing.T) {
 
 			ti := proposerWaitTime(mockSource, testCase.previousBlockTime)
 			assert.Equal(t, testCase.expectedWait, ti)
-		})
-	}
-}
-
-func TestProposalTimeout(t *testing.T) {
-	genesisTime, err := time.Parse(time.RFC3339, "2019-03-13T23:00:00Z")
-	require.NoError(t, err)
-	testCases := []struct {
-		name              string
-		localTime         time.Time
-		previousBlockTime time.Time
-		precision         time.Duration
-		msgDelay          time.Duration
-		expectedDuration  time.Duration
-	}{
-		{
-			name:              "MsgDelay + Precision has not quite elapsed",
-			localTime:         genesisTime.Add(525 * time.Millisecond),
-			previousBlockTime: genesisTime.Add(6 * time.Millisecond),
-			precision:         time.Millisecond * 20,
-			msgDelay:          time.Millisecond * 500,
-			expectedDuration:  1 * time.Millisecond,
-		},
-		{
-			name:              "MsgDelay + Precision equals current time",
-			localTime:         genesisTime.Add(525 * time.Millisecond),
-			previousBlockTime: genesisTime.Add(5 * time.Millisecond),
-			precision:         time.Millisecond * 20,
-			msgDelay:          time.Millisecond * 500,
-			expectedDuration:  0,
-		},
-		{
-			name:              "MsgDelay + Precision has elapsed",
-			localTime:         genesisTime.Add(725 * time.Millisecond),
-			previousBlockTime: genesisTime.Add(5 * time.Millisecond),
-			precision:         time.Millisecond * 20,
-			msgDelay:          time.Millisecond * 500,
-			expectedDuration:  0,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-
-			mockSource := new(tmtimemocks.Source)
-			mockSource.On("Now").Return(testCase.localTime)
-
-			tp := types.TimingParams{
-				Precision:    testCase.precision,
-				MessageDelay: testCase.msgDelay,
-			}
-
-			ti := proposalStepWaitingTime(mockSource, testCase.previousBlockTime, tp)
-			assert.Equal(t, testCase.expectedDuration, ti)
 		})
 	}
 }

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -204,7 +204,7 @@ func (p *pbtsTestHarness) nextHeight(proposer types.PrivValidator, deliverTime, 
 	b.Header.ProposerAddress = k.Address()
 	ps := b.MakePartSet(types.BlockPartSizeBytes)
 	bid := types.BlockID{Hash: b.Hash(), PartSetHeader: ps.Header()}
-	prop := types.NewProposal(p.currentHeight, 0, -1, bid)
+	prop := types.NewProposal(p.currentHeight, 0, -1, bid, proposedTime)
 	tp := prop.ToProto()
 
 	if err := proposer.SignProposal(context.Background(), p.observedState.state.ChainID, tp); err != nil {

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -384,7 +384,7 @@ func setupSimulator(ctx context.Context, t *testing.T) *simulatorTestSuite {
 	propBlockParts := propBlock.MakePartSet(partSize)
 	blockID := types.BlockID{Hash: propBlock.Hash(), PartSetHeader: propBlockParts.Header()}
 
-	proposal := types.NewProposal(vss[1].Height, round, -1, blockID)
+	proposal := types.NewProposal(vss[1].Height, round, -1, blockID, propBlock.Header.Time)
 	p := proposal.ToProto()
 	if err := vss[1].SignProposal(ctx, cfg.ChainID(), p); err != nil {
 		t.Fatal("failed to sign bad proposal", err)
@@ -416,7 +416,7 @@ func setupSimulator(ctx context.Context, t *testing.T) *simulatorTestSuite {
 	propBlockParts = propBlock.MakePartSet(partSize)
 	blockID = types.BlockID{Hash: propBlock.Hash(), PartSetHeader: propBlockParts.Header()}
 
-	proposal = types.NewProposal(vss[2].Height, round, -1, blockID)
+	proposal = types.NewProposal(vss[2].Height, round, -1, blockID, propBlock.Header.Time)
 	p = proposal.ToProto()
 	if err := vss[2].SignProposal(ctx, cfg.ChainID(), p); err != nil {
 		t.Fatal("failed to sign bad proposal", err)
@@ -475,7 +475,7 @@ func setupSimulator(ctx context.Context, t *testing.T) *simulatorTestSuite {
 
 	selfIndex := valIndexFn(0)
 
-	proposal = types.NewProposal(vss[3].Height, round, -1, blockID)
+	proposal = types.NewProposal(vss[3].Height, round, -1, blockID, propBlock.Header.Time)
 	p = proposal.ToProto()
 	if err := vss[3].SignProposal(ctx, cfg.ChainID(), p); err != nil {
 		t.Fatal("failed to sign bad proposal", err)
@@ -540,7 +540,7 @@ func setupSimulator(ctx context.Context, t *testing.T) *simulatorTestSuite {
 	sort.Sort(ValidatorStubsByPower(newVss))
 
 	selfIndex = valIndexFn(0)
-	proposal = types.NewProposal(vss[1].Height, round, -1, blockID)
+	proposal = types.NewProposal(vss[1].Height, round, -1, blockID, propBlock.Header.Time)
 	p = proposal.ToProto()
 	if err := vss[1].SignProposal(ctx, cfg.ChainID(), p); err != nil {
 		t.Fatal("failed to sign bad proposal", err)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -268,7 +268,7 @@ func (state State) MakeBlock(
 	if height == state.InitialHeight {
 		timestamp = state.LastBlockTime // genesis time
 	} else {
-		timestamp = MedianTime(commit, state.LastValidators)
+		timestamp = time.Now()
 	}
 
 	// Fill rest of header with state data.
@@ -281,29 +281,6 @@ func (state State) MakeBlock(
 	)
 
 	return block, block.MakePartSet(types.BlockPartSizeBytes)
-}
-
-// MedianTime computes a median time for a given Commit (based on Timestamp field of votes messages) and the
-// corresponding validator set. The computed time is always between timestamps of
-// the votes sent by honest processes, i.e., a faulty processes can not arbitrarily increase or decrease the
-// computed value.
-func MedianTime(commit *types.Commit, validators *types.ValidatorSet) time.Time {
-	weightedTimes := make([]*weightedTime, len(commit.Signatures))
-	totalVotingPower := int64(0)
-
-	for i, commitSig := range commit.Signatures {
-		if commitSig.Absent() {
-			continue
-		}
-		_, validator := validators.GetByAddress(commitSig.ValidatorAddress)
-		// If there's no condition, TestValidateBlockCommit panics; not needed normally.
-		if validator != nil {
-			totalVotingPower += validator.VotingPower
-			weightedTimes[i] = newWeightedTime(commitSig.Timestamp, validator.VotingPower)
-		}
-	}
-
-	return weightedMedian(weightedTimes, totalVotingPower)
 }
 
 //------------------------------------------------------------------------

--- a/internal/state/validation.go
+++ b/internal/state/validation.go
@@ -114,13 +114,6 @@ func validateBlock(state State, block *types.Block) error {
 				state.LastBlockTime,
 			)
 		}
-		medianTime := MedianTime(block.LastCommit, state.LastValidators)
-		if !block.Time.Equal(medianTime) {
-			return fmt.Errorf("invalid block time. Expected %v, got %v",
-				medianTime,
-				block.Time,
-			)
-		}
 
 	case block.Height == state.InitialHeight:
 		genesisTime := state.LastBlockTime

--- a/internal/state/validation_test.go
+++ b/internal/state/validation_test.go
@@ -64,7 +64,6 @@ func TestValidateBlockHeader(t *testing.T) {
 		{"ChainID wrong", func(block *types.Block) { block.ChainID = "not-the-real-one" }},
 		{"Height wrong", func(block *types.Block) { block.Height += 10 }},
 		{"Time wrong", func(block *types.Block) { block.Time = block.Time.Add(-time.Second * 1) }},
-		{"Time wrong 2", func(block *types.Block) { block.Time = block.Time.Add(time.Second * 1) }},
 
 		{"LastBlockID wrong", func(block *types.Block) { block.LastBlockID.PartSetHeader.Total += 10 }},
 		{"LastCommitHash wrong", func(block *types.Block) { block.LastCommitHash = wrongHash }},

--- a/types/proposal.go
+++ b/types/proposal.go
@@ -34,14 +34,14 @@ type Proposal struct {
 
 // NewProposal returns a new Proposal.
 // If there is no POLRound, polRound should be -1.
-func NewProposal(height int64, round int32, polRound int32, blockID BlockID) *Proposal {
+func NewProposal(height int64, round int32, polRound int32, blockID BlockID, ts time.Time) *Proposal {
 	return &Proposal{
 		Type:      tmproto.ProposalType,
 		Height:    height,
 		Round:     round,
 		BlockID:   blockID,
 		POLRound:  polRound,
-		Timestamp: tmtime.Now(),
+		Timestamp: tmtime.Canonical(ts),
 	}
 }
 

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	"github.com/tendermint/tendermint/internal/libs/protoio"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmtime "github.com/tendermint/tendermint/libs/time"
 	tmtimemocks "github.com/tendermint/tendermint/libs/time/mocks"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
@@ -63,7 +64,7 @@ func TestProposalVerifySignature(t *testing.T) {
 
 	prop := NewProposal(
 		4, 2, 2,
-		BlockID{tmrand.Bytes(tmhash.Size), PartSetHeader{777, tmrand.Bytes(tmhash.Size)}})
+		BlockID{tmrand.Bytes(tmhash.Size), PartSetHeader{777, tmrand.Bytes(tmhash.Size)}}, tmtime.Now())
 	p := prop.ToProto()
 	signBytes := ProposalSignBytes("test_chain_id", p)
 
@@ -154,7 +155,7 @@ func TestProposalValidateBasic(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			prop := NewProposal(
 				4, 2, 2,
-				blockID)
+				blockID, tmtime.Now())
 			p := prop.ToProto()
 			err := privVal.SignProposal(context.Background(), "test_chain_id", p)
 			prop.Signature = p.Signature
@@ -166,9 +167,9 @@ func TestProposalValidateBasic(t *testing.T) {
 }
 
 func TestProposalProtoBuf(t *testing.T) {
-	proposal := NewProposal(1, 2, 3, makeBlockID([]byte("hash"), 2, []byte("part_set_hash")))
+	proposal := NewProposal(1, 2, 3, makeBlockID([]byte("hash"), 2, []byte("part_set_hash")), tmtime.Now())
 	proposal.Signature = []byte("sig")
-	proposal2 := NewProposal(1, 2, 3, BlockID{})
+	proposal2 := NewProposal(1, 2, 3, BlockID{}, tmtime.Now())
 
 	testCases := []struct {
 		msg     string


### PR DESCRIPTION
This change updates the proposal logic to use the block's timestamp in the proposal message. It adds an additional piece of validation logic to the prevote step to check that the block's timestamp matches the proposal message's timestamp.

This change also adds two tests that ensure that 1. if the proposal message timestamp does match, we prevote the proposal, 2. if the proposal message does not match we prevote nil.

related to: #6942 