### PR TITLE
ci: skip docker image builds during PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,6 @@ name: Docker
 #  Build & Push rebuilds the tendermint docker image on every push to master and creation of tags
 # and pushes the image to https://hub.docker.com/r/interchainio/simapp/tags
 on:
-  pull_request:
   push:
     branches:
       - master
@@ -39,7 +38,7 @@ jobs:
         with:
           platforms: all
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker Build
         uses: docker/setup-buildx-action@v1.6.0
 
       - name: Login to DockerHub


### PR DESCRIPTION
These can take 8 mins and don't provide meaningful signal on top of
whatever we're doing in the corresponding make target.