### PR TITLE
service: cleanup close channel in reactors

### DIFF
--- a/internal/statesync/dispatcher.go
+++ b/internal/statesync/dispatcher.go
@@ -27,7 +27,6 @@ var (
 type Dispatcher struct {
 	// the channel with which to send light block requests on
 	requestCh chan<- p2p.Envelope
-	closeCh   chan struct{}
 
 	mtx sync.Mutex
 	// all pending calls that have been dispatched and are awaiting an answer
@@ -37,7 +36,6 @@ type Dispatcher struct {
 func NewDispatcher(requestCh chan<- p2p.Envelope) *Dispatcher {
 	return &Dispatcher{
 		requestCh: requestCh,
-		closeCh:   make(chan struct{}),
 		calls:     make(map[types.NodeID]chan *types.LightBlock),
 	}
 }
@@ -47,7 +45,7 @@ func NewDispatcher(requestCh chan<- p2p.Envelope) *Dispatcher {
 // LightBlock response is used to signal that the peer doesn't have the requested LightBlock.
 func (d *Dispatcher) LightBlock(ctx context.Context, height int64, peer types.NodeID) (*types.LightBlock, error) {
 	// dispatch the request to the peer
-	callCh, err := d.dispatch(peer, height)
+	callCh, err := d.dispatch(ctx, peer, height)
 	if err != nil {
 		return nil, err
 	}
@@ -69,19 +67,16 @@ func (d *Dispatcher) LightBlock(ctx context.Context, height int64, peer types.No
 
 	case <-ctx.Done():
 		return nil, ctx.Err()
-
-	case <-d.closeCh:
-		return nil, errDisconnected
 	}
 }
 
 // dispatch takes a peer and allocates it a channel so long as it's not already
 // busy and the receiving channel is still running. It then dispatches the message
-func (d *Dispatcher) dispatch(peer types.NodeID, height int64) (chan *types.LightBlock, error) {
+func (d *Dispatcher) dispatch(ctx context.Context, peer types.NodeID, height int64) (chan *types.LightBlock, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	select {
-	case <-d.closeCh:
+	case <-ctx.Done():
 		return nil, errDisconnected
 	default:
 	}
@@ -141,15 +136,10 @@ func (d *Dispatcher) Respond(lb *tmproto.LightBlock, peer types.NodeID) error {
 func (d *Dispatcher) Close() {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
-	close(d.closeCh)
 	for peer, call := range d.calls {
 		delete(d.calls, peer)
 		close(call)
 	}
-}
-
-func (d *Dispatcher) Done() <-chan struct{} {
-	return d.closeCh
 }
 
 //----------------------------------------------------------------

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -142,7 +142,6 @@ type Reactor struct {
 	blockCh     *p2p.Channel
 	paramsCh    *p2p.Channel
 	peerUpdates *p2p.PeerUpdates
-	closeCh     chan struct{}
 
 	// Dispatcher is used to multiplex light block requests and responses over multiple
 	// peers used by the p2p state provider and in reverse sync.
@@ -192,7 +191,6 @@ func NewReactor(
 		blockCh:       blockCh,
 		paramsCh:      paramsCh,
 		peerUpdates:   peerUpdates,
-		closeCh:       make(chan struct{}),
 		tempDir:       tempDir,
 		stateStore:    stateStore,
 		blockStore:    blockStore,
@@ -227,12 +225,6 @@ func (r *Reactor) OnStart(ctx context.Context) error {
 func (r *Reactor) OnStop() {
 	// tell the dispatcher to stop sending any more requests
 	r.dispatcher.Close()
-	// wait for any remaining requests to complete
-	<-r.dispatcher.Done()
-
-	// Close closeCh to signal to all spawned goroutines to gracefully exit. All
-	// p2p Channels should execute Close().
-	close(r.closeCh)
 
 	<-r.peerUpdates.Done()
 }
@@ -268,7 +260,6 @@ func (r *Reactor) Sync(ctx context.Context) (sm.State, error) {
 		r.stateProvider,
 		r.snapshotCh.Out,
 		r.chunkCh.Out,
-		ctx.Done(),
 		r.tempDir,
 		r.metrics,
 	)
@@ -290,7 +281,6 @@ func (r *Reactor) Sync(ctx context.Context) (sm.State, error) {
 
 		select {
 		case <-ctx.Done():
-		case <-r.closeCh:
 		case r.snapshotCh.Out <- msg:
 		}
 	}
@@ -446,9 +436,6 @@ func (r *Reactor) backfill(
 	// verify all light blocks
 	for {
 		select {
-		case <-r.closeCh:
-			queue.close()
-			return nil
 		case <-ctx.Done():
 			queue.close()
 			return nil
@@ -816,6 +803,7 @@ func (r *Reactor) processCh(ctx context.Context, ch *p2p.Channel, chName string)
 	for {
 		select {
 		case <-ctx.Done():
+			r.logger.Debug("channel closed", "channel", chName)
 			return
 		case envelope := <-ch.In:
 			if err := r.handleMessage(ch.ID, envelope); err != nil {
@@ -829,17 +817,13 @@ func (r *Reactor) processCh(ctx context.Context, ch *p2p.Channel, chName string)
 					Err:    err,
 				}
 			}
-
-		case <-r.closeCh:
-			r.logger.Debug("channel closed", "channel", chName)
-			return
 		}
 	}
 }
 
 // processPeerUpdate processes a PeerUpdate, returning an error upon failing to
 // handle the PeerUpdate or if a panic is recovered.
-func (r *Reactor) processPeerUpdate(peerUpdate p2p.PeerUpdate) {
+func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpdate) {
 	r.logger.Info("received peer update", "peer", peerUpdate.NodeID, "status", peerUpdate.Status)
 
 	switch peerUpdate.Status {
@@ -859,7 +843,7 @@ func (r *Reactor) processPeerUpdate(peerUpdate p2p.PeerUpdate) {
 	case p2p.PeerStatusUp:
 		newProvider := NewBlockProvider(peerUpdate.NodeID, r.chainID, r.dispatcher)
 		r.providers[peerUpdate.NodeID] = newProvider
-		err := r.syncer.AddPeer(peerUpdate.NodeID)
+		err := r.syncer.AddPeer(ctx, peerUpdate.NodeID)
 		if err != nil {
 			r.logger.Error("error adding peer to syncer", "error", err)
 			return
@@ -886,13 +870,10 @@ func (r *Reactor) processPeerUpdates(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case peerUpdate := <-r.peerUpdates.Updates():
-			r.processPeerUpdate(peerUpdate)
-
-		case <-r.closeCh:
 			r.logger.Debug("stopped listening on peer updates channel; closing...")
 			return
+		case peerUpdate := <-r.peerUpdates.Updates():
+			r.processPeerUpdate(ctx, peerUpdate)
 		}
 	}
 }
@@ -980,9 +961,6 @@ func (r *Reactor) waitForEnoughPeers(ctx context.Context, numPeers int) error {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("operation canceled while waiting for peers after %.2fs [%d/%d]",
-				time.Since(startAt).Seconds(), r.peers.Len(), numPeers)
-		case <-r.closeCh:
-			return fmt.Errorf("shutdown while waiting for peers after %.2fs [%d/%d]",
 				time.Since(startAt).Seconds(), r.peers.Len(), numPeers)
 		case <-t.C:
 			continue

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -172,7 +172,6 @@ func setup(
 		stateProvider,
 		rts.snapshotOutCh,
 		rts.chunkOutCh,
-		ctx.Done(),
 		"",
 		rts.reactor.metrics,
 	)

--- a/internal/statesync/syncer.go
+++ b/internal/statesync/syncer.go
@@ -70,7 +70,6 @@ type syncer struct {
 	avgChunkTime             int64
 	lastSyncedSnapshotHeight int64
 	processingSnapshot       *snapshot
-	closeCh                  <-chan struct{}
 }
 
 // newSyncer creates a new syncer.
@@ -82,7 +81,6 @@ func newSyncer(
 	stateProvider StateProvider,
 	snapshotCh chan<- p2p.Envelope,
 	chunkCh chan<- p2p.Envelope,
-	closeCh <-chan struct{},
 	tempDir string,
 	metrics *Metrics,
 ) *syncer {
@@ -98,7 +96,6 @@ func newSyncer(
 		fetchers:      cfg.Fetchers,
 		retryTimeout:  cfg.ChunkRequestTimeout,
 		metrics:       metrics,
-		closeCh:       closeCh,
 	}
 }
 
@@ -141,7 +138,7 @@ func (s *syncer) AddSnapshot(peerID types.NodeID, snapshot *snapshot) (bool, err
 
 // AddPeer adds a peer to the pool. For now we just keep it simple and send a
 // single request to discover snapshots, later we may want to do retries and stuff.
-func (s *syncer) AddPeer(peerID types.NodeID) (err error) {
+func (s *syncer) AddPeer(ctx context.Context, peerID types.NodeID) (err error) {
 	defer func() {
 		// TODO: remove panic recover once AddPeer can no longer accientally send on
 		// closed channel.
@@ -160,7 +157,7 @@ func (s *syncer) AddPeer(peerID types.NodeID) (err error) {
 	}
 
 	select {
-	case <-s.closeCh:
+	case <-ctx.Done():
 	case s.snapshotCh <- msg:
 	}
 	return err
@@ -494,8 +491,6 @@ func (s *syncer) fetchChunks(ctx context.Context, snapshot *snapshot, chunks *ch
 				select {
 				case <-ctx.Done():
 					return
-				case <-s.closeCh:
-					return
 				case <-time.After(2 * time.Second):
 					continue
 				}
@@ -511,7 +506,7 @@ func (s *syncer) fetchChunks(ctx context.Context, snapshot *snapshot, chunks *ch
 		ticker := time.NewTicker(s.retryTimeout)
 		defer ticker.Stop()
 
-		s.requestChunk(snapshot, index)
+		s.requestChunk(ctx, snapshot, index)
 
 		select {
 		case <-chunks.WaitFor(index):
@@ -522,8 +517,6 @@ func (s *syncer) fetchChunks(ctx context.Context, snapshot *snapshot, chunks *ch
 
 		case <-ctx.Done():
 			return
-		case <-s.closeCh:
-			return
 		}
 
 		ticker.Stop()
@@ -531,7 +524,7 @@ func (s *syncer) fetchChunks(ctx context.Context, snapshot *snapshot, chunks *ch
 }
 
 // requestChunk requests a chunk from a peer.
-func (s *syncer) requestChunk(snapshot *snapshot, chunk uint32) {
+func (s *syncer) requestChunk(ctx context.Context, snapshot *snapshot, chunk uint32) {
 	peer := s.snapshots.GetPeer(snapshot)
 	if peer == "" {
 		s.logger.Error("No valid peers found for snapshot", "height", snapshot.Height,
@@ -558,7 +551,7 @@ func (s *syncer) requestChunk(snapshot *snapshot, chunk uint32) {
 
 	select {
 	case s.chunkCh <- msg:
-	case <-s.closeCh:
+	case <-ctx.Done():
 	}
 }
 

--- a/internal/statesync/syncer_test.go
+++ b/internal/statesync/syncer_test.go
@@ -78,13 +78,13 @@ func TestSyncer_SyncAny(t *testing.T) {
 	require.Error(t, err)
 
 	// Adding a couple of peers should trigger snapshot discovery messages
-	err = rts.syncer.AddPeer(peerAID)
+	err = rts.syncer.AddPeer(ctx, peerAID)
 	require.NoError(t, err)
 	e := <-rts.snapshotOutCh
 	require.Equal(t, &ssproto.SnapshotsRequest{}, e.Message)
 	require.Equal(t, peerAID, e.To)
 
-	err = rts.syncer.AddPeer(peerBID)
+	err = rts.syncer.AddPeer(ctx, peerBID)
 	require.NoError(t, err)
 	e = <-rts.snapshotOutCh
 	require.Equal(t, &ssproto.SnapshotsRequest{}, e.Message)


### PR DESCRIPTION
This is another (large) chunk of #7384 (and a follow up to #7392), but
omits the troublesome mempool case.