### PR TITLE
Fix a panic in the indexer service test.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -32,7 +32,7 @@ Special thanks to external contributors on this release:
   - [blocksync] \#7046 Remove v2 implementation of the blocksync service and recactor, which was disabled in the previous release. (@tychoish)
   - [p2p] \#7064 Remove WDRR queue implementation. (@tychoish)
   - [config] \#7169 `WriteConfigFile` now returns an error. (@tychoish)
-  - [libs/service] \#7288 Remove SetLogger method on `service.Service` interface. (@tychosih)
+  - [libs/service] \#7288 Remove SetLogger method on `service.Service` interface. (@tychoish)
 
 
 - Blockchain Protocol

--- a/internal/state/indexer/indexer_service_test.go
+++ b/internal/state/indexer/indexer_service_test.go
@@ -39,14 +39,6 @@ var (
 	dbName   = "postgres"
 )
 
-// NewIndexerService returns a new service instance.
-func NewIndexerService(es []indexer.EventSink, eventBus *eventbus.EventBus) *indexer.Service {
-	return indexer.NewService(indexer.ServiceArgs{
-		Sinks:    es,
-		EventBus: eventBus,
-	})
-}
-
 func TestIndexerServiceIndexesBlocks(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -70,7 +62,11 @@ func TestIndexerServiceIndexesBlocks(t *testing.T) {
 	assert.True(t, indexer.KVSinkEnabled(eventSinks))
 	assert.True(t, indexer.IndexingEnabled(eventSinks))
 
-	service := NewIndexerService(eventSinks, eventBus)
+	service := indexer.NewService(indexer.ServiceArgs{
+		Logger:   logger,
+		Sinks:    eventSinks,
+		EventBus: eventBus,
+	})
 	require.NoError(t, service.Start(ctx))
 	t.Cleanup(service.Wait)
 


### PR DESCRIPTION
The test service was starting up without a logger and crashing while trying to log. We changed the defaults in #7288, and I missed this case during review.
