### PR TITLE
chore: return early if indexer is null

### DIFF
--- a/internal/state/indexer/indexer_service.go
+++ b/internal/state/indexer/indexer_service.go
@@ -83,6 +83,9 @@ func (is *Service) publish(msg pubsub.Message) error {
 	if curr.Pending == 0 {
 		// INDEX: We have all the transactions we expect for the current block.
 		for _, sink := range is.eventSinks {
+			if sink.Type() == NULL {
+				return nil // if indexer is set to null return early
+			}
 			start := time.Now()
 			if err := sink.IndexBlockEvents(is.currentBlock.header); err != nil {
 				is.logger.Error("failed to index block header",


### PR DESCRIPTION
# Description

Want to see if something like this would be accepted, its minimal and avoids going into the indexer if indexing is set to null. 

