### PR TITLE
types: fix path handling in node key tests

### DIFF
--- a/types/node_key_test.go
+++ b/types/node_key_test.go
@@ -13,7 +13,7 @@ import (
 func mustTempPath(t *testing.T, name string) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", t.Name()+"*")
+	dir, err := os.MkdirTemp(t.TempDir(), t.Name()+"*")
 	require.NoError(t, err)
 	t.Cleanup(func() { os.RemoveAll(dir) })
 	return filepath.Join(dir, name)

--- a/types/node_key_test.go
+++ b/types/node_key_test.go
@@ -14,9 +14,7 @@ func mustTempPath(t *testing.T, name string) string {
 	t.Helper()
 
 	dir, err := os.MkdirTemp("", t.Name()+"*")
-	if err != nil {
-		t.Fatalf("Creating temporary directory: %v", err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { os.RemoveAll(dir) })
 	return filepath.Join(dir, name)
 }

--- a/types/node_key_test.go
+++ b/types/node_key_test.go
@@ -7,12 +7,22 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	tmrand "github.com/tendermint/tendermint/libs/rand"
 	"github.com/tendermint/tendermint/types"
 )
 
+func mustTempPath(t *testing.T, name string) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", t.Name()+"*")
+	if err != nil {
+		t.Fatalf("Creating temporary directory: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, name)
+}
+
 func TestLoadOrGenNodeKey(t *testing.T) {
-	filePath := filepath.Join(os.TempDir(), tmrand.Str(12)+"_peer_id.json")
+	filePath := mustTempPath(t, "peer_id.json")
 
 	nodeKey, err := types.LoadOrGenNodeKey(filePath)
 	require.Nil(t, err)
@@ -23,7 +33,7 @@ func TestLoadOrGenNodeKey(t *testing.T) {
 }
 
 func TestLoadNodeKey(t *testing.T) {
-	filePath := filepath.Join(os.TempDir(), tmrand.Str(12)+"_peer_id.json")
+	filePath := mustTempPath(t, "peer_id.json")
 
 	_, err := types.LoadNodeKey(filePath)
 	require.True(t, os.IsNotExist(err))
@@ -37,7 +47,7 @@ func TestLoadNodeKey(t *testing.T) {
 }
 
 func TestNodeKeySaveAs(t *testing.T) {
-	filePath := filepath.Join(os.TempDir(), tmrand.Str(12)+"_peer_id.json")
+	filePath := mustTempPath(t, "peer_id.json")
 	require.NoFileExists(t, filePath)
 
 	nodeKey := types.GenNodeKey()

--- a/types/node_key_test.go
+++ b/types/node_key_test.go
@@ -10,17 +10,8 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-func mustTempPath(t *testing.T, name string) string {
-	t.Helper()
-
-	dir, err := os.MkdirTemp(t.TempDir(), t.Name()+"*")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	return filepath.Join(dir, name)
-}
-
 func TestLoadOrGenNodeKey(t *testing.T) {
-	filePath := mustTempPath(t, "peer_id.json")
+	filePath := filepath.Join(t.TempDir(), "peer_id.json")
 
 	nodeKey, err := types.LoadOrGenNodeKey(filePath)
 	require.Nil(t, err)
@@ -31,7 +22,7 @@ func TestLoadOrGenNodeKey(t *testing.T) {
 }
 
 func TestLoadNodeKey(t *testing.T) {
-	filePath := mustTempPath(t, "peer_id.json")
+	filePath := filepath.Join(t.TempDir(), "peer_id.json")
 
 	_, err := types.LoadNodeKey(filePath)
 	require.True(t, os.IsNotExist(err))
@@ -45,7 +36,7 @@ func TestLoadNodeKey(t *testing.T) {
 }
 
 func TestNodeKeySaveAs(t *testing.T) {
-	filePath := mustTempPath(t, "peer_id.json")
+	filePath := filepath.Join(t.TempDir(), "peer_id.json")
 	require.NoFileExists(t, filePath)
 
 	nodeKey := types.GenNodeKey()


### PR DESCRIPTION
(this is a minor cleanup, no functionality is changed)

These tests use a deterministic and unseeded random source to generate
non-colliding filenames for testing. When testing locally, this means tests are
not hermetic from one run to the next.

Use proper temp directories, and clean up after they're done.
