### PR TITLE
e2e: use more simple strings for generated transactions (#7513)

### DIFF
--- a/libs/rand/random.go
+++ b/libs/rand/random.go
@@ -44,15 +44,20 @@ func Reseed() {
 
 // Str constructs a random alphanumeric string of given length
 // from math/rand's global default Source.
-func Str(length int) string {
+func Str(length int) string { return buildString(length, mrand.Int63) }
+
+// StrFromSource produces a random string of a specified length from
+// the specified random source.
+func StrFromSource(r *mrand.Rand, length int) string { return buildString(length, r.Int63) }
+
+func buildString(length int, picker func() int64) string {
 	if length <= 0 {
 		return ""
 	}
 
 	chars := make([]byte, 0, length)
 	for {
-		// nolint:gosec // G404: Use of weak random number generator
-		val := mrand.Int63()
+		val := picker()
 		for i := 0; i < 10; i++ {
 			v := int(val & 0x3f) // rightmost 6 bits
 			if v >= 62 {         // only 62 characters in strChars

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -158,7 +158,7 @@ func generateTestnet(r *rand.Rand, opt map[string]interface{}) (e2e.Manifest, er
 		KeyType:          keyType.Choose(r).(string),
 		Evidence:         evidence.Choose(r).(int),
 		QueueType:        opt["queueType"].(string),
-		TxSize:           int64(txSize.Choose(r).(int)),
+		TxSize:           txSize.Choose(r).(int),
 	}
 
 	p2pMode := opt["p2p"].(P2PMode)

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -64,7 +64,7 @@ type Manifest struct {
 	QueueType string `toml:"queue_type"`
 
 	// Number of bytes per tx. Default is 1kb (1024)
-	TxSize int64
+	TxSize int
 
 	// ABCIProtocol specifies the protocol used to communicate with the ABCI
 	// application: "unix", "tcp", "grpc", or "builtin". Defaults to builtin.

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -70,7 +70,7 @@ type Testnet struct {
 	KeyType          string
 	Evidence         int
 	LogLevel         string
-	TxSize           int64
+	TxSize           int
 	ABCIProtocol     string
 }
 

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"time"
 
+	tmrand "github.com/tendermint/tendermint/libs/rand"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	e2e "github.com/tendermint/tendermint/test/e2e/pkg"
 	"github.com/tendermint/tendermint/types"
@@ -85,7 +86,7 @@ func Load(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet) error {
 // generation is primarily the result of backpressure from the
 // broadcast transaction, though there is still some timer-based
 // limiting.
-func loadGenerate(ctx context.Context, r *rand.Rand, chTx chan<- types.Tx, txSize int64, networkSize int) {
+func loadGenerate(ctx context.Context, r *rand.Rand, chTx chan<- types.Tx, txSize int, networkSize int) {
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 	defer close(chTx)
@@ -101,12 +102,7 @@ func loadGenerate(ctx context.Context, r *rand.Rand, chTx chan<- types.Tx, txSiz
 		// space, while reduce the size of the data in the app.
 		id := r.Int63n(100)
 
-		bz := make([]byte, txSize)
-		_, err := r.Read(bz)
-		if err != nil {
-			panic(fmt.Sprintf("Failed to read random bytes: %v", err))
-		}
-		tx := types.Tx(fmt.Sprintf("load-%X=%x", id, bz))
+		tx := types.Tx(fmt.Sprintf("load-%X=%s", id, tmrand.StrFromSource(r, txSize)))
 
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
(cherry picked from commit 8564c5079f7f8a11bcae7cc16db29caea5feac69)