### PR TITLE
node: new concrete type for seed node implementation

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -51,7 +51,7 @@ Special thanks to external contributors on this release:
 - [internal/protoio] \#7325 Optimized `MarshalDelimited` by inlining the common case and using a `sync.Pool` in the worst case. (@odeke-em)
 
 - [pubsub] \#7319 Performance improvements for the event query API (@creachadair)
-
+- [node] \#6775 Define concrete type for seed node implementation (@spacech1mp)
 ### BUG FIXES
 
 - fix: assignment copies lock value in `BitArray.UnmarshalJSON()` (@lklimek)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -51,7 +51,8 @@ Special thanks to external contributors on this release:
 - [internal/protoio] \#7325 Optimized `MarshalDelimited` by inlining the common case and using a `sync.Pool` in the worst case. (@odeke-em)
 
 - [pubsub] \#7319 Performance improvements for the event query API (@creachadair)
-- [node] \#6775 Define concrete type for seed node implementation (@spacech1mp)
+- [node] \#7521 Define concrete type for seed node implementation (@spacech1mp)
+
 ### BUG FIXES
 
 - fix: assignment copies lock value in `BitArray.UnmarshalJSON()` (@lklimek)

--- a/node/node.go
+++ b/node/node.go
@@ -628,7 +628,7 @@ func (n *nodeImpl) OnStart(ctx context.Context) error {
 
 	// Start the RPC server before the P2P server
 	// so we can eg. receive txs for the first block
-	if n.config.RPC.ListenAddress != "" && n.config.Mode != config.ModeSeed {
+	if n.config.RPC.ListenAddress != "" {
 		listeners, err := n.startRPC(ctx)
 		if err != nil {
 			return err
@@ -646,30 +646,24 @@ func (n *nodeImpl) OnStart(ctx context.Context) error {
 	}
 	n.isListening = true
 
-	if n.config.Mode != config.ModeSeed {
-		if err := n.bcReactor.Start(ctx); err != nil {
-			return err
-		}
+	if err := n.bcReactor.Start(ctx); err != nil {
+		return err
+	}
 
-		// Start the real consensus reactor separately since the switch uses the shim.
-		if err := n.consensusReactor.Start(ctx); err != nil {
-			return err
-		}
+	if err := n.consensusReactor.Start(ctx); err != nil {
+		return err
+	}
 
-		// Start the real state sync reactor separately since the switch uses the shim.
-		if err := n.stateSyncReactor.Start(ctx); err != nil {
-			return err
-		}
+	if err := n.stateSyncReactor.Start(ctx); err != nil {
+		return err
+	}
 
-		// Start the real mempool reactor separately since the switch uses the shim.
-		if err := n.mempoolReactor.Start(ctx); err != nil {
-			return err
-		}
+	if err := n.mempoolReactor.Start(ctx); err != nil {
+		return err
+	}
 
-		// Start the real evidence reactor separately since the switch uses the shim.
-		if err := n.evidenceReactor.Start(ctx); err != nil {
-			return err
-		}
+	if err := n.evidenceReactor.Start(ctx); err != nil {
+		return err
 	}
 
 	if n.config.P2P.PexReactor {
@@ -768,13 +762,11 @@ func (n *nodeImpl) OnStop() {
 		}
 	}
 
-	if n.config.Mode != config.ModeSeed {
-		n.bcReactor.Wait()
-		n.consensusReactor.Wait()
-		n.stateSyncReactor.Wait()
-		n.mempoolReactor.Wait()
-		n.evidenceReactor.Wait()
-	}
+	n.bcReactor.Wait()
+	n.consensusReactor.Wait()
+	n.stateSyncReactor.Wait()
+	n.mempoolReactor.Wait()
+	n.evidenceReactor.Wait()
 	n.pexReactor.Wait()
 	n.router.Wait()
 	n.isListening = false

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -556,7 +556,7 @@ func TestNodeNewSeedNode(t *testing.T) {
 	t.Cleanup(ns.Wait)
 
 	require.NoError(t, err)
-	n, ok := ns.(*nodeImpl)
+	n, ok := ns.(*seedNodeImpl)
 	require.True(t, ok)
 
 	err = n.Start(ctx)


### PR DESCRIPTION
Defines a different concrete struct for the seed node that satisfies the service interface.

Fixes #6775

Closes #6775


