### PR TITLE
consensus+p2p: change how consensus reactor is constructed

### DIFF
--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -256,10 +256,13 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				}
 
 				msg, err := s.Next(ctx)
-				if !assert.NoError(t, err) {
+
+				assert.NoError(t, err)
+				if err != nil {
 					cancel()
 					return
 				}
+
 				require.NotNil(t, msg)
 				block := msg.Data().(types.EventDataNewBlock).Block
 				if len(block.Evidence.Evidence) != 0 {

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -82,8 +82,6 @@ const (
 	listenerIDConsensus = "consensus-reactor"
 )
 
-type ReactorOption func(*Reactor)
-
 // NOTE: Temporary interface for switching to block sync, we should get rid of v0.
 // See: https://github.com/tendermint/tendermint/issues/4595
 type BlockSyncReactor interface {
@@ -139,7 +137,7 @@ func NewReactor(
 	channelCreator p2p.ChannelCreator,
 	peerUpdates *p2p.PeerUpdates,
 	waitSync bool,
-	options ...ReactorOption,
+	metrics *Metrics,
 ) (*Reactor, error) {
 	chans := getChannelDescriptors()
 	stateCh, err := channelCreator(ctx, chans[StateChannel])
@@ -166,7 +164,7 @@ func NewReactor(
 		state:         cs,
 		waitSync:      waitSync,
 		peers:         make(map[types.NodeID]*PeerState),
-		Metrics:       NopMetrics(),
+		Metrics:       metrics,
 		stateCh:       stateCh,
 		dataCh:        dataCh,
 		voteCh:        voteCh,
@@ -174,10 +172,6 @@ func NewReactor(
 		peerUpdates:   peerUpdates,
 	}
 	r.BaseService = *service.NewBaseService(logger, "Consensus", r)
-
-	for _, opt := range options {
-		opt(r)
-	}
 
 	return r, nil
 }
@@ -251,11 +245,6 @@ func (r *Reactor) WaitSync() bool {
 	defer r.mtx.RUnlock()
 
 	return r.waitSync
-}
-
-// ReactorMetrics sets the reactor's metrics as an option function.
-func ReactorMetrics(metrics *Metrics) ReactorOption {
-	return func(r *Reactor) { r.Metrics = metrics }
 }
 
 // SwitchToConsensus switches from block-sync mode to consensus mode. It resets

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -28,9 +28,9 @@ var (
 
 // GetChannelDescriptor produces an instance of a descriptor for this
 // package's required channels.
-func GetChannelDescriptors() []*p2p.ChannelDescriptor {
-	return []*p2p.ChannelDescriptor{
-		{
+func getChannelDescriptors() map[p2p.ChannelID]*p2p.ChannelDescriptor {
+	return map[p2p.ChannelID]*p2p.ChannelDescriptor{
+		StateChannel: {
 			ID:                  StateChannel,
 			MessageType:         new(tmcons.Message),
 			Priority:            8,
@@ -38,10 +38,10 @@ func GetChannelDescriptors() []*p2p.ChannelDescriptor {
 			RecvMessageCapacity: maxMsgSize,
 			RecvBufferCapacity:  128,
 		},
-		{
+		DataChannel: {
 			// TODO: Consider a split between gossiping current block and catchup
 			// stuff. Once we gossip the whole block there is nothing left to send
-			// until next height or round.
+			// until next height or round.q
 			ID:                  DataChannel,
 			MessageType:         new(tmcons.Message),
 			Priority:            12,
@@ -49,7 +49,7 @@ func GetChannelDescriptors() []*p2p.ChannelDescriptor {
 			RecvBufferCapacity:  512,
 			RecvMessageCapacity: maxMsgSize,
 		},
-		{
+		VoteChannel: {
 			ID:                  VoteChannel,
 			MessageType:         new(tmcons.Message),
 			Priority:            10,
@@ -57,7 +57,7 @@ func GetChannelDescriptors() []*p2p.ChannelDescriptor {
 			RecvBufferCapacity:  128,
 			RecvMessageCapacity: maxMsgSize,
 		},
-		{
+		VoteSetBitsChannel: {
 			ID:                  VoteSetBitsChannel,
 			MessageType:         new(tmcons.Message),
 			Priority:            5,
@@ -133,17 +133,34 @@ type Reactor struct {
 // to relevant p2p Channels and a channel to listen for peer updates on. The
 // reactor will close all p2p Channels when stopping.
 func NewReactor(
+	ctx context.Context,
 	logger log.Logger,
 	cs *State,
-	stateCh *p2p.Channel,
-	dataCh *p2p.Channel,
-	voteCh *p2p.Channel,
-	voteSetBitsCh *p2p.Channel,
+	channelCreator p2p.ChannelCreator,
 	peerUpdates *p2p.PeerUpdates,
 	waitSync bool,
 	options ...ReactorOption,
-) *Reactor {
+) (*Reactor, error) {
+	chans := getChannelDescriptors()
+	stateCh, err := channelCreator(ctx, chans[StateChannel])
+	if err != nil {
+		return nil, err
+	}
 
+	dataCh, err := channelCreator(ctx, chans[DataChannel])
+	if err != nil {
+		return nil, err
+	}
+
+	voteCh, err := channelCreator(ctx, chans[VoteChannel])
+	if err != nil {
+		return nil, err
+	}
+
+	voteSetBitsCh, err := channelCreator(ctx, chans[VoteSetBitsChannel])
+	if err != nil {
+		return nil, err
+	}
 	r := &Reactor{
 		logger:        logger,
 		state:         cs,
@@ -162,7 +179,7 @@ func NewReactor(
 		opt(r)
 	}
 
-	return r
+	return r, nil
 }
 
 // OnStart starts separate go routines for each p2p Channel and listens for

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -41,7 +41,7 @@ func getChannelDescriptors() map[p2p.ChannelID]*p2p.ChannelDescriptor {
 		DataChannel: {
 			// TODO: Consider a split between gossiping current block and catchup
 			// stuff. Once we gossip the whole block there is nothing left to send
-			// until next height or round.q
+			// until next height or round.
 			ID:                  DataChannel,
 			MessageType:         new(tmcons.Message),
 			Priority:            12,

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -87,7 +87,7 @@ func setup(
 		return func(ctx context.Context, desc *p2p.ChannelDescriptor) (*p2p.Channel, error) {
 			switch desc.ID {
 			case StateChannel:
-				return rts.voteChannels[nodeID], nil
+				return rts.stateChannels[nodeID], nil
 			case DataChannel:
 				return rts.dataChannels[nodeID], nil
 			case VoteChannel:

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -110,6 +110,7 @@ func setup(
 			chCreator(nodeID),
 			node.MakePeerUpdates(ctx, t),
 			true,
+			NopMetrics(),
 		)
 		require.NoError(t, err)
 

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -83,20 +83,35 @@ func setup(
 	ctx, cancel := context.WithCancel(ctx)
 	// Canceled during cleanup (see below).
 
+	chCreator := func(nodeID types.NodeID) p2p.ChannelCreator {
+		return func(ctx context.Context, desc *p2p.ChannelDescriptor) (*p2p.Channel, error) {
+			switch desc.ID {
+			case StateChannel:
+				return rts.voteChannels[nodeID], nil
+			case DataChannel:
+				return rts.dataChannels[nodeID], nil
+			case VoteChannel:
+				return rts.voteChannels[nodeID], nil
+			case VoteSetBitsChannel:
+				return rts.voteSetBitsChannels[nodeID], nil
+			default:
+				return nil, fmt.Errorf("invalid channel; %v", desc.ID)
+			}
+		}
+	}
+
 	i := 0
 	for nodeID, node := range rts.network.Nodes {
 		state := states[i]
 
-		reactor := NewReactor(
+		reactor, err := NewReactor(ctx,
 			state.logger.With("node", nodeID),
 			state,
-			rts.stateChannels[nodeID],
-			rts.dataChannels[nodeID],
-			rts.voteChannels[nodeID],
-			rts.voteSetBitsChannels[nodeID],
+			chCreator(nodeID),
 			node.MakePeerUpdates(ctx, t),
 			true,
 		)
+		require.NoError(t, err)
 
 		reactor.SetEventBus(state.eventBus)
 

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -254,6 +254,11 @@ func (r *Router) createQueueFactory(ctx context.Context) (func(int) queue, error
 	}
 }
 
+// ChannelCreator allows routers to construct their own channels,
+// either by receiving a reference to Router.OpenChannel or using some
+// kind shim for testing purposes.
+type ChannelCreator func(context.Context, *ChannelDescriptor) (*Channel, error)
+
 // OpenChannel opens a new channel for the given message type. The caller must
 // close the channel when done, before stopping the Router. messageType is the
 // type of message passed through the channel (used for unmarshaling), which can

--- a/node/setup.go
+++ b/node/setup.go
@@ -320,7 +320,7 @@ func createConsensusReactor(
 		router.OpenChannel,
 		peerManager.Subscribe(ctx),
 		waitSync,
-		consensus.ReactorMetrics(csMetrics),
+		csMetrics,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/node/setup.go
+++ b/node/setup.go
@@ -313,29 +313,18 @@ func createConsensusReactor(
 		consensusState.SetPrivValidator(ctx, privValidator)
 	}
 
-	csChDesc := consensus.GetChannelDescriptors()
-	channels := make(map[p2p.ChannelID]*p2p.Channel, len(csChDesc))
-	for idx := range csChDesc {
-		chd := csChDesc[idx]
-		ch, err := router.OpenChannel(ctx, chd)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		channels[ch.ID] = ch
-	}
-
-	reactor := consensus.NewReactor(
+	reactor, err := consensus.NewReactor(
+		ctx,
 		logger,
 		consensusState,
-		channels[consensus.StateChannel],
-		channels[consensus.DataChannel],
-		channels[consensus.VoteChannel],
-		channels[consensus.VoteSetBitsChannel],
+		router.OpenChannel,
 		peerManager.Subscribe(ctx),
 		waitSync,
 		consensus.ReactorMetrics(csMetrics),
 	)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Services which will be publishing and/or subscribing for messages (events)
 	// consensusReactor will set it on consensusState and blockExecutor.


### PR DESCRIPTION
This is an internal detail of the way that reactors (and therefore
nodes) are constructed, and is part of the larger project of pushing
initialization code out of the node package and into constructors for
reactors.

THis patch serves as a prototype for making a similar change for the
remaining reactors.