### PR TITLE
consensus: remove reactor options

### DIFF
--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -96,6 +96,7 @@ func setup(
 			rts.voteSetBitsChannels[nodeID],
 			node.MakePeerUpdates(ctx, t),
 			true,
+			NopMetrics(),
 		)
 
 		reactor.SetEventBus(state.eventBus)

--- a/node/setup.go
+++ b/node/setup.go
@@ -334,7 +334,7 @@ func createConsensusReactor(
 		channels[consensus.VoteSetBitsChannel],
 		peerManager.Subscribe(ctx),
 		waitSync,
-		consensus.ReactorMetrics(csMetrics),
+		csMetrics,
 	)
 
 	// Services which will be publishing and/or subscribing for messages (events)


### PR DESCRIPTION
There's no compelling reason to have variadic options to reactor
construction like this, given that these components are internal.