### PR TITLE
Replace uses of libs/json with encoding/json.

### DIFF
--- a/internal/consensus/peer_state.go
+++ b/internal/consensus/peer_state.go
@@ -23,8 +23,8 @@ var (
 
 // peerStateStats holds internal statistics for a peer.
 type peerStateStats struct {
-	Votes      int `json:"votes"`
-	BlockParts int `json:"block_parts"`
+	Votes      int `json:"votes,string"`
+	BlockParts int `json:"block_parts,string"`
 }
 
 func (pss peerStateStats) String() string {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -20,7 +21,6 @@ import (
 	"github.com/tendermint/tendermint/internal/libs/fail"
 	sm "github.com/tendermint/tendermint/internal/state"
 	tmevents "github.com/tendermint/tendermint/libs/events"
-	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	tmos "github.com/tendermint/tendermint/libs/os"
@@ -253,14 +253,14 @@ func (cs *State) GetRoundState() *cstypes.RoundState {
 func (cs *State) GetRoundStateJSON() ([]byte, error) {
 	cs.mtx.RLock()
 	defer cs.mtx.RUnlock()
-	return tmjson.Marshal(cs.RoundState)
+	return json.Marshal(cs.RoundState)
 }
 
 // GetRoundStateSimpleJSON returns a json of RoundStateSimple
 func (cs *State) GetRoundStateSimpleJSON() ([]byte, error) {
 	cs.mtx.RLock()
 	defer cs.mtx.RUnlock()
-	return tmjson.Marshal(cs.RoundState.RoundStateSimple())
+	return json.Marshal(cs.RoundState.RoundStateSimple())
 }
 
 // GetValidators returns a copy of the current validators.

--- a/internal/consensus/types/height_vote_set.go
+++ b/internal/consensus/types/height_vote_set.go
@@ -1,12 +1,12 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"sync"
 
-	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
@@ -237,7 +237,7 @@ func (hvs *HeightVoteSet) StringIndented(indent string) string {
 func (hvs *HeightVoteSet) MarshalJSON() ([]byte, error) {
 	hvs.mtx.Lock()
 	defer hvs.mtx.Unlock()
-	return tmjson.Marshal(hvs.toAllRoundVotes())
+	return json.Marshal(hvs.toAllRoundVotes())
 }
 
 func (hvs *HeightVoteSet) toAllRoundVotes() []roundVotes {

--- a/internal/consensus/types/peer_round_state.go
+++ b/internal/consensus/types/peer_round_state.go
@@ -13,9 +13,9 @@ import (
 // PeerRoundState contains the known state of a peer.
 // NOTE: Read-only when returned by PeerState.GetRoundState().
 type PeerRoundState struct {
-	Height int64         `json:"height"` // Height peer is at
-	Round  int32         `json:"round"`  // Round peer is at, -1 if unknown.
-	Step   RoundStepType `json:"step"`   // Step peer is at
+	Height int64         `json:"height,string"` // Height peer is at
+	Round  int32         `json:"round"`         // Round peer is at, -1 if unknown.
+	Step   RoundStepType `json:"step"`          // Step peer is at
 
 	// Estimated start of round 0 at this height
 	StartTime time.Time `json:"start_time"`

--- a/privval/file.go
+++ b/privval/file.go
@@ -3,6 +3,7 @@ package privval
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -72,7 +73,7 @@ func (pvKey FilePVKey) Save() error {
 
 // FilePVLastSignState stores the mutable part of PrivValidator.
 type FilePVLastSignState struct {
-	Height    int64            `json:"height"`
+	Height    int64            `json:"height,string"`
 	Round     int32            `json:"round"`
 	Step      int8             `json:"step"`
 	Signature []byte           `json:"signature,omitempty"`
@@ -128,7 +129,7 @@ func (lss *FilePVLastSignState) Save() error {
 	if outFile == "" {
 		return errors.New("cannot save FilePVLastSignState: filePath not set")
 	}
-	jsonBytes, err := tmjson.MarshalIndent(lss, "", "  ")
+	jsonBytes, err := json.MarshalIndent(lss, "", "  ")
 	if err != nil {
 		return err
 	}
@@ -215,7 +216,7 @@ func loadFilePV(keyFilePath, stateFilePath string, loadState bool) (*FilePV, err
 		if err != nil {
 			return nil, err
 		}
-		err = tmjson.Unmarshal(stateJSONBytes, &pvState)
+		err = json.Unmarshal(stateJSONBytes, &pvState)
 		if err != nil {
 			return nil, fmt.Errorf("error reading PrivValidator state from %v: %w", stateFilePath, err)
 		}

--- a/privval/file_test.go
+++ b/privval/file_test.go
@@ -3,6 +3,7 @@ package privval
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -105,7 +106,7 @@ func TestUnmarshalValidatorState(t *testing.T) {
 	}`
 
 	val := FilePVLastSignState{}
-	err := tmjson.Unmarshal([]byte(serialized), &val)
+	err := json.Unmarshal([]byte(serialized), &val)
 	require.NoError(t, err)
 
 	// make sure the values match
@@ -114,7 +115,7 @@ func TestUnmarshalValidatorState(t *testing.T) {
 	assert.EqualValues(t, val.Step, 1)
 
 	// export it and make sure it is the same
-	out, err := tmjson.Marshal(val)
+	out, err := json.Marshal(val)
 	require.NoError(t, err)
 	assert.JSONEq(t, serialized, string(out))
 }

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -10,7 +11,6 @@ import (
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/libs/bits"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
-	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
@@ -365,7 +365,7 @@ func (ps *PartSet) MarshalJSON() ([]byte, error) {
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
 
-	return tmjson.Marshal(struct {
+	return json.Marshal(struct {
 		CountTotal    string         `json:"count/total"`
 		PartsBitArray *bits.BitArray `json:"parts_bit_array"`
 	}{

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -2,12 +2,12 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/tendermint/tendermint/libs/bits"
-	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
@@ -495,7 +495,7 @@ func (voteSet *VoteSet) StringIndented(indent string) string {
 func (voteSet *VoteSet) MarshalJSON() ([]byte, error) {
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
-	return tmjson.Marshal(VoteSetJSON{
+	return json.Marshal(VoteSetJSON{
 		voteSet.voteStrings(),
 		voteSet.bitArrayString(),
 		voteSet.peerMaj23s,


### PR DESCRIPTION
This is a small step toward confining and eventually removing the custom JSON encoding package. Future changes will dig into more complex cases, but I wanted to get the trivial and safe steps out of the way first.

Where possible, replace uses of the custom JSON library with the standard
library. The custom library treats interface and unnamed lteral types
differently, so this change avoids those even where it would probably be safe
to switch them.
