### PR TITLE
test: uniquify prom IDs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -683,7 +683,6 @@ func TestP2PConfig() *P2PConfig {
 	cfg.ListenAddress = "tcp://127.0.0.1:36656"
 	cfg.AllowDuplicateIP = true
 	cfg.FlushThrottleTimeout = 10 * time.Millisecond
-
 	return cfg
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	tmos "github.com/tendermint/tendermint/libs/os"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
 )
 
 // DefaultDirPerm is the default permissions used when creating directories.
@@ -549,6 +550,7 @@ func ResetTestRootWithChainID(testName string, chainID string) (*Config, error) 
 	}
 
 	config := TestConfig().SetRoot(rootDir)
+	config.Instrumentation.Namespace = fmt.Sprintf("test-prom-%s-%s", testName, tmrand.Str(16))
 	return config, nil
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -550,7 +550,7 @@ func ResetTestRootWithChainID(testName string, chainID string) (*Config, error) 
 	}
 
 	config := TestConfig().SetRoot(rootDir)
-	config.Instrumentation.Namespace = fmt.Sprintf("test-prom-%s-%s", testName, tmrand.Str(16))
+	config.Instrumentation.Namespace = fmt.Sprintf("%s_%s_%s", testName, chainID, tmrand.Str(16))
 	return config, nil
 }
 


### PR DESCRIPTION
This addresses a problem with rerunning tests within a single process. 

I think the real solution to this problem would be to clean up and avoid the use of go-kit.