### PR TITLE
log: remove support for traces

### DIFF
--- a/abci/cmd/abci-cli/abci-cli.go
+++ b/abci/cmd/abci-cli/abci-cli.go
@@ -60,7 +60,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		if logger == nil {
-			logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+			logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 		}
 
 		if client == nil {
@@ -575,7 +575,7 @@ func cmdQuery(cmd *cobra.Command, args []string) error {
 }
 
 func cmdKVStore(cmd *cobra.Command, args []string) error {
-	logger := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	logger := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 
 	// Create the application - in memory or persisted to disk
 	var app types.Application

--- a/cmd/priv_val_server/main.go
+++ b/cmd/priv_val_server/main.go
@@ -46,7 +46,7 @@ func main() {
 		rootCA           = flag.String("rootcafile", "", "absolute path to root CA")
 		prometheusAddr   = flag.String("prometheus-addr", "", "address for prometheus endpoint (host:port)")
 
-		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false).
+		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo).
 			With("module", "priv_val")
 	)
 	flag.Parse()

--- a/cmd/tendermint/commands/debug/debug.go
+++ b/cmd/tendermint/commands/debug/debug.go
@@ -15,7 +15,7 @@ var (
 	flagProfAddr    = "pprof-laddr"
 	flagFrequency   = "frequency"
 
-	logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 )
 
 // DebugCmd defines the root command containing subcommands that assist in

--- a/cmd/tendermint/commands/light.go
+++ b/cmd/tendermint/commands/light.go
@@ -102,7 +102,7 @@ func init() {
 }
 
 func runProxy(cmd *cobra.Command, args []string) error {
-	logger, err := log.NewDefaultLogger(logFormat, logLevel, false)
+	logger, err := log.NewDefaultLogger(logFormat, logLevel)
 	if err != nil {
 		return err
 	}

--- a/cmd/tendermint/commands/root.go
+++ b/cmd/tendermint/commands/root.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	config     = cfg.DefaultConfig()
-	logger     = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	logger     = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 	ctxTimeout = 4 * time.Second
 )
 
@@ -55,7 +55,7 @@ var RootCmd = &cobra.Command{
 			return err
 		}
 
-		logger, err = log.NewDefaultLogger(config.LogFormat, config.LogLevel, false)
+		logger, err = log.NewDefaultLogger(config.LogFormat, config.LogLevel)
 		if err != nil {
 			return err
 		}

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -161,13 +161,15 @@ func setup(
 		}
 	}
 
+	logger := log.NewTestingLogger(t)
+
 	var err error
 	rts.reactor, err = NewReactor(
 		ctx,
 		factory.DefaultTestChainID,
 		1,
 		*cfg,
-		log.TestingLogger(),
+		logger.With("component", "reactor"),
 		conn,
 		connQuery,
 		chCreator,
@@ -181,7 +183,7 @@ func setup(
 
 	rts.syncer = newSyncer(
 		*cfg,
-		log.NewNopLogger(),
+		logger.With("component", "syncer"),
 		conn,
 		connQuery,
 		stateProvider,

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -161,15 +161,13 @@ func setup(
 		}
 	}
 
-	logger := log.NewTestingLogger(t)
-
 	var err error
 	rts.reactor, err = NewReactor(
 		ctx,
 		factory.DefaultTestChainID,
 		1,
 		*cfg,
-		logger.With("component", "reactor"),
+		log.TestingLogger(),
 		conn,
 		connQuery,
 		chCreator,
@@ -183,7 +181,7 @@ func setup(
 
 	rts.syncer = newSyncer(
 		*cfg,
-		logger.With("component", "syncer"),
+		log.NewNopLogger(),
 		conn,
 		connQuery,
 		stateProvider,

--- a/libs/log/default_test.go
+++ b/libs/log/default_test.go
@@ -34,11 +34,11 @@ func TestNewDefaultLogger(t *testing.T) {
 		tc := tc
 
 		t.Run(name, func(t *testing.T) {
-			_, err := log.NewDefaultLogger(tc.format, tc.level, false)
+			_, err := log.NewDefaultLogger(tc.format, tc.level)
 			if tc.expectErr {
 				require.Error(t, err)
 				require.Panics(t, func() {
-					_ = log.MustNewDefaultLogger(tc.format, tc.level, false)
+					_ = log.MustNewDefaultLogger(tc.format, tc.level)
 				})
 			} else {
 				require.NoError(t, err)

--- a/libs/log/nop.go
+++ b/libs/log/nop.go
@@ -7,6 +7,5 @@ import (
 func NewNopLogger() Logger {
 	return defaultLogger{
 		Logger: zerolog.Nop(),
-		trace:  false,
 	}
 }

--- a/libs/log/testing.go
+++ b/libs/log/testing.go
@@ -32,7 +32,7 @@ func TestingLogger() Logger {
 	}
 
 	if testing.Verbose() {
-		testingLogger = MustNewDefaultLogger(LogFormatText, LogLevelDebug, true)
+		testingLogger = MustNewDefaultLogger(LogFormatText, LogLevelDebug)
 	} else {
 		testingLogger = NewNopLogger()
 	}
@@ -73,13 +73,8 @@ func NewTestingLoggerWithLevel(t testing.TB, level string) Logger {
 	if err != nil {
 		t.Fatalf("failed to parse log level (%s): %v", level, err)
 	}
-	trace := false
-	if testing.Verbose() {
-		trace = true
-	}
 
 	return defaultLogger{
 		Logger: zerolog.New(newSyncWriter(testingWriter{t})).Level(logLevel),
-		trace:  trace,
 	}
 }

--- a/light/example_test.go
+++ b/light/example_test.go
@@ -26,7 +26,7 @@ func ExampleClient() {
 		stdlog.Fatal(err)
 	}
 
-	logger, err := log.NewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	logger, err := log.NewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 	if err != nil {
 		stdlog.Fatal(err)
 	}

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -94,7 +94,7 @@ func TestMain(m *testing.M) {
 
 // launch unix and tcp servers
 func setup(ctx context.Context) error {
-	logger := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	logger := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 
 	cmd := exec.Command("rm", "-f", unixSocket)
 	err := cmd.Start()

--- a/rpc/jsonrpc/test/main.go
+++ b/rpc/jsonrpc/test/main.go
@@ -28,7 +28,7 @@ type Result struct {
 func main() {
 	var (
 		mux    = http.NewServeMux()
-		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 	)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -89,7 +89,7 @@ func StartTendermint(
 	if nodeOpts.suppressStdout {
 		logger = log.NewNopLogger()
 	} else {
-		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+		logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 	}
 	papp := abciclient.NewLocalCreator(app)
 	tmNode, err := node.New(ctx, conf, logger, papp, nil)

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -89,7 +89,7 @@ func NewApplication(cfg *Config) (*Application, error) {
 		return nil, err
 	}
 	return &Application{
-		logger:    log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false),
+		logger:    log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo),
 		state:     state,
 		snapshots: snapshots,
 		cfg:       cfg,

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -17,7 +17,7 @@ const (
 	randomSeed int64 = 4827085738
 )
 
-var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 
 func main() {
 	NewCLI().Run()

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -34,7 +34,7 @@ import (
 	e2e "github.com/tendermint/tendermint/test/e2e/pkg"
 )
 
-var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 
 // main is the binary entrypoint.
 func main() {
@@ -297,7 +297,7 @@ func setupNode() (*config.Config, log.Logger, error) {
 		return nil, nil, fmt.Errorf("error in config file: %w", err)
 	}
 
-	nodeLogger, err := log.NewDefaultLogger(tmcfg.LogFormat, tmcfg.LogLevel, false)
+	nodeLogger, err := log.NewDefaultLogger(tmcfg.LogFormat, tmcfg.LogLevel)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -16,7 +16,7 @@ import (
 
 const randomSeed = 2308084734268
 
-var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+var logger = log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 
 func main() {
 	NewCLI().Run()

--- a/test/fuzz/rpc/jsonrpc/server/handler.go
+++ b/test/fuzz/rpc/jsonrpc/server/handler.go
@@ -19,7 +19,7 @@ var mux *http.ServeMux
 
 func init() {
 	mux = http.NewServeMux()
-	lgr := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo, false)
+	lgr := log.MustNewDefaultLogger(log.LogFormatPlain, log.LogLevelInfo)
 	rs.RegisterRPCFuncs(mux, rpcFuncMap, lgr)
 }
 


### PR DESCRIPTION
Seems like we were only using this facility for the test logger with
verbose, and it wasn't providing a lot of value.