### PR TITLE
statesync: use specific testing.T logger for tests

### DIFF
--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -161,13 +161,15 @@ func setup(
 		}
 	}
 
+	logger := log.NewTestingLogger(t)
+
 	var err error
 	rts.reactor, err = NewReactor(
 		ctx,
 		factory.DefaultTestChainID,
 		1,
 		*cfg,
-		log.TestingLogger(),
+		logger.With("component", "reactor"),
 		conn,
 		connQuery,
 		chCreator,
@@ -181,7 +183,7 @@ func setup(
 
 	rts.syncer = newSyncer(
 		*cfg,
-		log.NewNopLogger(),
+		logger.With("component", "syncer"),
 		conn,
 		connQuery,
 		stateProvider,


### PR DESCRIPTION
This will help clarify the testing logger for the statesync package,
and hopefully make it easier to tracedown an infrequent test failure
in the test suite for this package.