### PR TITLE
rpc: remove positional parameter encoding from clients

### DIFF
--- a/rpc/jsonrpc/client/ws_client.go
+++ b/rpc/jsonrpc/client/ws_client.go
@@ -224,16 +224,6 @@ func (c *WSClient) Call(ctx context.Context, method string, params map[string]in
 	return c.Send(ctx, request)
 }
 
-// CallWithArrayParams enqueues a call request onto the Send queue. Params are
-// in a form of array (e.g. []interface{}{"abcd"}). Requests are JSON encoded.
-func (c *WSClient) CallWithArrayParams(ctx context.Context, method string, params []interface{}) error {
-	request, err := rpctypes.ArrayToRequest(c.nextRequestID(), method, params)
-	if err != nil {
-		return err
-	}
-	return c.Send(ctx, request)
-}
-
 // Private methods
 
 func (c *WSClient) nextRequestID() rpctypes.JSONRPCIntID {

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -329,37 +329,6 @@ func TestWSNewWSRPCFunc(t *testing.T) {
 	assert.Equal(t, got, val)
 }
 
-func TestWSHandlesArrayParams(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cl, err := client.NewWS(tcpAddr, websocketEndpoint)
-	require.NoError(t, err)
-
-	cl.Logger = log.NewTestingLogger(t)
-	require.Nil(t, cl.Start(ctx))
-	t.Cleanup(func() {
-		if err := cl.Stop(); err != nil {
-			t.Error(err)
-		}
-	})
-
-	val := testVal
-	params := []interface{}{val}
-	err = cl.CallWithArrayParams(ctx, "echo_ws", params)
-	require.NoError(t, err)
-
-	msg := <-cl.ResponsesCh
-	if msg.Error != nil {
-		t.Fatalf("%+v", err)
-	}
-	result := new(ResultEcho)
-	err = json.Unmarshal(msg.Result, result)
-	require.NoError(t, err)
-	got := result.Value
-	assert.Equal(t, got, val)
-}
-
 // TestWSClientPingPong checks that a client & server exchange pings
 // & pongs so connection stays alive.
 func TestWSClientPingPong(t *testing.T) {

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -116,24 +116,6 @@ func MapToRequest(id jsonrpcid, method string, params map[string]interface{}) (R
 	return NewRPCRequest(id, method, payload), nil
 }
 
-func ArrayToRequest(id jsonrpcid, method string, params []interface{}) (RPCRequest, error) {
-	var paramsMap = make([]json.RawMessage, len(params))
-	for i, value := range params {
-		valueJSON, err := tmjson.Marshal(value)
-		if err != nil {
-			return RPCRequest{}, err
-		}
-		paramsMap[i] = valueJSON
-	}
-
-	payload, err := json.Marshal(paramsMap)
-	if err != nil {
-		return RPCRequest{}, err
-	}
-
-	return NewRPCRequest(id, method, payload), nil
-}
-
 //----------------------------------------
 // RESPONSE
 


### PR DESCRIPTION
Apart from the tests for the websocket client, positional parameters are not
used by RPC clients. The server supports both arrays and objects, but the
client only needs to provide one or the other.
