### PR TITLE
rpc: collapse Caller and HTTPClient interfaces.

### DIFF
--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -106,12 +106,6 @@ func (u parsedURL) GetTrimmedURL() string {
 
 //-------------------------------------------------------------
 
-// HTTPClient is a common interface for JSON-RPC HTTP clients.
-type HTTPClient interface {
-	// Call calls the given method with the params and returns a result.
-	Call(ctx context.Context, method string, params map[string]interface{}, result interface{}) (interface{}, error)
-}
-
 // Caller implementers can facilitate calling the JSON-RPC endpoint.
 type Caller interface {
 	Call(ctx context.Context, method string, params map[string]interface{}, result interface{}) (interface{}, error)
@@ -133,8 +127,6 @@ type Client struct {
 	mtx       sync.Mutex
 	nextReqID int
 }
-
-var _ HTTPClient = (*Client)(nil)
 
 // Both Client and RequestBatch can facilitate calls to the JSON
 // RPC endpoint.

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -187,7 +187,7 @@ func echoDataBytesViaHTTP(ctx context.Context, cl client.Caller, bytes tmbytes.H
 	return result.Value, nil
 }
 
-func testWithHTTPClient(ctx context.Context, t *testing.T, cl client.HTTPClient) {
+func testWithHTTPClient(ctx context.Context, t *testing.T, cl client.Caller) {
 	val := testVal
 	got, err := echoViaHTTP(ctx, cl, val)
 	require.NoError(t, err)


### PR DESCRIPTION
These two interfaces are identical, and besides HTTPClient being confusingly
named, all but one location uses Caller. Update that one location, and drop the
redundant interface.
