### PR TITLE
tests: remove in-test logging

### DIFF
--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -139,7 +139,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			i := 0
 			for _, ps := range bzReactor.peers {
 				if i < len(bzReactor.peers)/2 {
-					bzNodeState.logger.Info("signed and pushed vote", "vote", prevote1, "peer", ps.peerID)
 					require.NoError(t, bzReactor.voteCh.Send(ctx,
 						p2p.Envelope{
 							To: ps.peerID,
@@ -148,7 +147,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 							},
 						}))
 				} else {
-					bzNodeState.logger.Info("signed and pushed vote", "vote", prevote2, "peer", ps.peerID)
 					require.NoError(t, bzReactor.voteCh.Send(ctx,
 						p2p.Envelope{
 							To: ps.peerID,
@@ -161,7 +159,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				i++
 			}
 		} else {
-			bzNodeState.logger.Info("behaving normally")
 			bzNodeState.defaultDoPrevote(ctx, height, round)
 		}
 	}
@@ -173,7 +170,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	lazyNodeState := states[1]
 
 	lazyNodeState.decideProposal = func(ctx context.Context, height int64, round int32) {
-		lazyNodeState.logger.Info("Lazy Proposer proposing condensed commit")
 		require.NotNil(t, lazyNodeState.privValidator)
 
 		var commit *types.Commit
@@ -227,8 +223,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 					lazyNodeState.Height, lazyNodeState.Round, part,
 				}, ""})
 			}
-			lazyNodeState.logger.Info("Signed proposal", "height", height, "round", round, "proposal", proposal)
-			lazyNodeState.logger.Debug(fmt.Sprintf("Signed proposal block: %v", block))
 		} else if !lazyNodeState.replayMode {
 			lazyNodeState.logger.Error("enterPropose: Error signing proposal", "height", height, "round", round, "err", err)
 		}

--- a/internal/consensus/invalid_test.go
+++ b/internal/consensus/invalid_test.go
@@ -123,7 +123,6 @@ func invalidDoPrevoteFunc(
 		cs.mtx.Unlock()
 
 		for _, ps := range r.peers {
-			cs.logger.Info("sending bad vote", "block", blockHash, "peer", ps.peerID)
 			require.NoError(t, r.voteCh.Send(ctx, p2p.Envelope{
 				To: ps.peerID,
 				Message: &tmcons.Vote{

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -99,7 +99,6 @@ func TestMempoolProgressInHigherRound(t *testing.T) {
 		if cs.Height == 2 && cs.Round == 0 {
 			// dont set the proposal in round 0 so we timeout and
 			// go to next round
-			cs.logger.Info("Ignoring set proposal at height 2, round 0")
 			return nil
 		}
 		return cs.defaultSetProposal(proposal)

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -696,7 +696,6 @@ func TestMockProxyApp(t *testing.T) {
 				if txRes.Code == abci.CodeTypeOK {
 					validTxs++
 				} else {
-					logger.Debug("Invalid tx", "code", txRes.Code, "log", txRes.Log)
 					invalidTxs++
 				}
 				abciRes.DeliverTxs[txIndex] = txRes

--- a/internal/p2p/pex/reactor_test.go
+++ b/internal/p2p/pex/reactor_test.go
@@ -487,7 +487,6 @@ func (r *reactorTestSuite) listenFor(
 }
 
 func (r *reactorTestSuite) listenForRequest(ctx context.Context, t *testing.T, fromNode, toNode int, waitPeriod time.Duration) {
-	r.logger.Info("Listening for request", "from", fromNode, "to", toNode)
 	to, from := r.checkNodePair(t, toNode, fromNode)
 	conditional := func(msg *p2p.Envelope) bool {
 		_, ok := msg.Message.(*p2pproto.PexRequest)
@@ -508,7 +507,7 @@ func (r *reactorTestSuite) pingAndlistenForNAddresses(
 	addresses int,
 ) {
 	t.Helper()
-	r.logger.Info("Listening for addresses", "from", fromNode, "to", toNode)
+
 	to, from := r.checkNodePair(t, toNode, fromNode)
 	conditional := func(msg *p2p.Envelope) bool {
 		_, ok := msg.Message.(*p2pproto.PexResponse)
@@ -541,11 +540,9 @@ func (r *reactorTestSuite) listenForResponse(
 	waitPeriod time.Duration,
 	addresses []p2pproto.PexAddress,
 ) {
-	r.logger.Info("Listening for response", "from", fromNode, "to", toNode)
 	to, from := r.checkNodePair(t, toNode, fromNode)
 	conditional := func(msg *p2p.Envelope) bool {
 		_, ok := msg.Message.(*p2pproto.PexResponse)
-		r.logger.Info("message", msg, "ok", ok)
 		return ok && msg.From == from
 	}
 	assertion := func(t *testing.T, msg *p2p.Envelope) bool {
@@ -658,7 +655,6 @@ func (r *reactorTestSuite) connectN(ctx context.Context, t *testing.T, n int) {
 func (r *reactorTestSuite) connectPeers(ctx context.Context, t *testing.T, sourceNode, targetNode int) {
 	t.Helper()
 	node1, node2 := r.checkNodePair(t, sourceNode, targetNode)
-	r.logger.Info("connecting peers", "sourceNode", sourceNode, "targetNode", targetNode)
 
 	n1 := r.network.Nodes[node1]
 	if n1 == nil {
@@ -676,16 +672,12 @@ func (r *reactorTestSuite) connectPeers(ctx context.Context, t *testing.T, sourc
 	targetSub := n2.PeerManager.Subscribe(ctx)
 
 	sourceAddress := n1.NodeAddress
-	r.logger.Debug("source address", "address", sourceAddress)
 	targetAddress := n2.NodeAddress
-	r.logger.Debug("target address", "address", targetAddress)
 
 	added, err := n1.PeerManager.Add(targetAddress)
 	require.NoError(t, err)
 
 	if !added {
-		r.logger.Debug("nodes already know about one another",
-			"sourceNode", sourceNode, "targetNode", targetNode)
 		return
 	}
 
@@ -695,19 +687,16 @@ func (r *reactorTestSuite) connectPeers(ctx context.Context, t *testing.T, sourc
 			NodeID: node1,
 			Status: p2p.PeerStatusUp,
 		}, peerUpdate)
-		r.logger.Debug("target connected with source")
 	case <-time.After(2 * time.Second):
 		require.Fail(t, "timed out waiting for peer", "%v accepting %v",
 			targetNode, sourceNode)
 	}
-
 	select {
 	case peerUpdate := <-sourceSub.Updates():
 		require.Equal(t, p2p.PeerUpdate{
 			NodeID: node2,
 			Status: p2p.PeerStatusUp,
 		}, peerUpdate)
-		r.logger.Debug("source connected with target")
 	case <-time.After(2 * time.Second):
 		require.Fail(t, "timed out waiting for peer", "%v dialing %v",
 			sourceNode, targetNode)

--- a/privval/signer_client_test.go
+++ b/privval/signer_client_test.go
@@ -298,9 +298,7 @@ func TestSignerVoteKeepAlive(t *testing.T) {
 
 			// in this particular case, we use the dialer logger to ensure that
 			// test messages are properly interleaved in the test logs
-			tc.signerServer.endpoint.logger.Debug("TEST: Forced Wait -------------------------------------------------")
 			time.Sleep(testTimeoutReadWrite * 3)
-			tc.signerServer.endpoint.logger.Debug("TEST: Forced Wait DONE---------------------------------------------")
 
 			require.NoError(t, tc.mockPV.SignVote(ctx, tc.chainID, want.ToProto()))
 			require.NoError(t, tc.signerClient.SignVote(ctx, tc.chainID, have.ToProto()))

--- a/privval/signer_endpoint.go
+++ b/privval/signer_endpoint.go
@@ -20,7 +20,7 @@ type signerEndpoint struct {
 	service.BaseService
 	logger log.Logger
 
-	connMtx sync.Mutex
+	connMtx sync.MutexC
 	conn    net.Conn
 
 	timeoutReadWrite time.Duration

--- a/privval/signer_endpoint.go
+++ b/privval/signer_endpoint.go
@@ -20,7 +20,7 @@ type signerEndpoint struct {
 	service.BaseService
 	logger log.Logger
 
-	connMtx sync.MutexC
+	connMtx sync.Mutex
 	conn    net.Conn
 
 	timeoutReadWrite time.Duration

--- a/privval/signer_listener_endpoint_test.go
+++ b/privval/signer_listener_endpoint_test.go
@@ -144,7 +144,6 @@ func newSignerListenerEndpoint(t *testing.T, logger log.Logger, addr string, tim
 	proto, address := tmnet.ProtocolAndAddress(addr)
 
 	ln, err := net.Listen(proto, address)
-	logger.Info("SignerListener: Listening", "proto", proto, "address", address)
 	require.NoError(t, err)
 
 	var listener net.Listener


### PR DESCRIPTION
Logging in tests is largely unusable so pulling out these messages
which aren't presently providing value is useful.