### PR TITLE
rpc: replace custom context-like argument with context.Context

### DIFF
--- a/internal/rpc/core/abci.go
+++ b/internal/rpc/core/abci.go
@@ -1,23 +1,24 @@
 package core
 
 import (
+	"context"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/internal/proxy"
 	"github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // ABCIQuery queries the application for some information.
 // More: https://docs.tendermint.com/master/rpc/#/ABCI/abci_query
 func (env *Environment) ABCIQuery(
-	ctx *rpctypes.Context,
+	ctx context.Context,
 	path string,
 	data bytes.HexBytes,
 	height int64,
 	prove bool,
 ) (*coretypes.ResultABCIQuery, error) {
-	resQuery, err := env.ProxyAppQuery.QuerySync(ctx.Context(), abci.RequestQuery{
+	resQuery, err := env.ProxyAppQuery.QuerySync(ctx, abci.RequestQuery{
 		Path:   path,
 		Data:   data,
 		Height: height,
@@ -32,8 +33,8 @@ func (env *Environment) ABCIQuery(
 
 // ABCIInfo gets some info about the application.
 // More: https://docs.tendermint.com/master/rpc/#/ABCI/abci_info
-func (env *Environment) ABCIInfo(ctx *rpctypes.Context) (*coretypes.ResultABCIInfo, error) {
-	resInfo, err := env.ProxyAppQuery.InfoSync(ctx.Context(), proxy.RequestInfo)
+func (env *Environment) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
+	resInfo, err := env.ProxyAppQuery.InfoSync(ctx, proxy.RequestInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rpc/core/blocks.go
+++ b/internal/rpc/core/blocks.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/tendermint/tendermint/libs/bytes"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -24,7 +24,7 @@ import (
 //
 // More: https://docs.tendermint.com/master/rpc/#/Info/blockchain
 func (env *Environment) BlockchainInfo(
-	ctx *rpctypes.Context,
+	ctx context.Context,
 	minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
 
 	const limit int64 = 20
@@ -92,7 +92,7 @@ func filterMinMax(base, height, min, max, limit int64) (int64, int64, error) {
 // Block gets block at a given height.
 // If no height is provided, it will fetch the latest block.
 // More: https://docs.tendermint.com/master/rpc/#/Info/block
-func (env *Environment) Block(ctx *rpctypes.Context, heightPtr *int64) (*coretypes.ResultBlock, error) {
+func (env *Environment) Block(ctx context.Context, heightPtr *int64) (*coretypes.ResultBlock, error) {
 	height, err := env.getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ func (env *Environment) Block(ctx *rpctypes.Context, heightPtr *int64) (*coretyp
 
 // BlockByHash gets block by hash.
 // More: https://docs.tendermint.com/master/rpc/#/Info/block_by_hash
-func (env *Environment) BlockByHash(ctx *rpctypes.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error) {
+func (env *Environment) BlockByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error) {
 	// N.B. The hash parameter is HexBytes so that the reflective parameter
 	// decoding logic in the HTTP service will correctly translate from JSON.
 	// See https://github.com/tendermint/tendermint/issues/6802 for context.
@@ -126,7 +126,7 @@ func (env *Environment) BlockByHash(ctx *rpctypes.Context, hash bytes.HexBytes) 
 // Header gets block header at a given height.
 // If no height is provided, it will fetch the latest header.
 // More: https://docs.tendermint.com/master/rpc/#/Info/header
-func (env *Environment) Header(ctx *rpctypes.Context, heightPtr *int64) (*coretypes.ResultHeader, error) {
+func (env *Environment) Header(ctx context.Context, heightPtr *int64) (*coretypes.ResultHeader, error) {
 	height, err := env.getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (env *Environment) Header(ctx *rpctypes.Context, heightPtr *int64) (*corety
 
 // HeaderByHash gets header by hash.
 // More: https://docs.tendermint.com/master/rpc/#/Info/header_by_hash
-func (env *Environment) HeaderByHash(ctx *rpctypes.Context, hash bytes.HexBytes) (*coretypes.ResultHeader, error) {
+func (env *Environment) HeaderByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultHeader, error) {
 	// N.B. The hash parameter is HexBytes so that the reflective parameter
 	// decoding logic in the HTTP service will correctly translate from JSON.
 	// See https://github.com/tendermint/tendermint/issues/6802 for context.
@@ -158,7 +158,7 @@ func (env *Environment) HeaderByHash(ctx *rpctypes.Context, hash bytes.HexBytes)
 // Commit gets block commit at a given height.
 // If no height is provided, it will fetch the commit for the latest block.
 // More: https://docs.tendermint.com/master/rpc/#/Info/commit
-func (env *Environment) Commit(ctx *rpctypes.Context, heightPtr *int64) (*coretypes.ResultCommit, error) {
+func (env *Environment) Commit(ctx context.Context, heightPtr *int64) (*coretypes.ResultCommit, error) {
 	height, err := env.getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
 		return nil, err
@@ -196,7 +196,7 @@ func (env *Environment) Commit(ctx *rpctypes.Context, heightPtr *int64) (*corety
 // Thus response.results.deliver_tx[5] is the results of executing
 // getBlock(h).Txs[5]
 // More: https://docs.tendermint.com/master/rpc/#/Info/block_results
-func (env *Environment) BlockResults(ctx *rpctypes.Context, heightPtr *int64) (*coretypes.ResultBlockResults, error) {
+func (env *Environment) BlockResults(ctx context.Context, heightPtr *int64) (*coretypes.ResultBlockResults, error) {
 	height, err := env.getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
 		return nil, err
@@ -226,7 +226,7 @@ func (env *Environment) BlockResults(ctx *rpctypes.Context, heightPtr *int64) (*
 // BlockSearch searches for a paginated set of blocks matching BeginBlock and
 // EndBlock event search criteria.
 func (env *Environment) BlockSearch(
-	ctx *rpctypes.Context,
+	ctx context.Context,
 	query string,
 	pagePtr, perPagePtr *int,
 	orderBy string,
@@ -248,7 +248,7 @@ func (env *Environment) BlockSearch(
 		}
 	}
 
-	results, err := kvsink.SearchBlockEvents(ctx.Context(), q)
+	results, err := kvsink.SearchBlockEvents(ctx, q)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rpc/core/blocks_test.go
+++ b/internal/rpc/core/blocks_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/tendermint/tendermint/internal/state/mocks"
 	tmstate "github.com/tendermint/tendermint/proto/tendermint/state"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 func TestBlockchainInfo(t *testing.T) {
@@ -108,8 +108,9 @@ func TestBlockResults(t *testing.T) {
 		}},
 	}
 
+	ctx := context.Background()
 	for _, tc := range testCases {
-		res, err := env.BlockResults(&rpctypes.Context{}, &tc.height)
+		res, err := env.BlockResults(ctx, &tc.height)
 		if tc.wantErr {
 			assert.Error(t, err)
 		} else {

--- a/internal/rpc/core/consensus.go
+++ b/internal/rpc/core/consensus.go
@@ -1,9 +1,10 @@
 package core
 
 import (
+	"context"
+
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // Validators gets the validator set at the given block height.
@@ -14,7 +15,7 @@ import (
 //
 // More: https://docs.tendermint.com/master/rpc/#/Info/validators
 func (env *Environment) Validators(
-	ctx *rpctypes.Context,
+	ctx context.Context,
 	heightPtr *int64,
 	pagePtr, perPagePtr *int) (*coretypes.ResultValidators, error) {
 
@@ -50,7 +51,7 @@ func (env *Environment) Validators(
 // DumpConsensusState dumps consensus state.
 // UNSTABLE
 // More: https://docs.tendermint.com/master/rpc/#/Info/dump_consensus_state
-func (env *Environment) DumpConsensusState(ctx *rpctypes.Context) (*coretypes.ResultDumpConsensusState, error) {
+func (env *Environment) DumpConsensusState(ctx context.Context) (*coretypes.ResultDumpConsensusState, error) {
 	// Get Peer consensus states.
 
 	var peerStates []coretypes.PeerStateInfo
@@ -91,7 +92,7 @@ func (env *Environment) DumpConsensusState(ctx *rpctypes.Context) (*coretypes.Re
 // ConsensusState returns a concise summary of the consensus state.
 // UNSTABLE
 // More: https://docs.tendermint.com/master/rpc/#/Info/consensus_state
-func (env *Environment) GetConsensusState(ctx *rpctypes.Context) (*coretypes.ResultConsensusState, error) {
+func (env *Environment) GetConsensusState(ctx context.Context) (*coretypes.ResultConsensusState, error) {
 	// Get self round state.
 	bz, err := env.ConsensusState.GetRoundStateSimpleJSON()
 	return &coretypes.ResultConsensusState{RoundState: bz}, err
@@ -101,7 +102,7 @@ func (env *Environment) GetConsensusState(ctx *rpctypes.Context) (*coretypes.Res
 // If no height is provided, it will fetch the latest consensus params.
 // More: https://docs.tendermint.com/master/rpc/#/Info/consensus_params
 func (env *Environment) ConsensusParams(
-	ctx *rpctypes.Context,
+	ctx context.Context,
 	heightPtr *int64) (*coretypes.ResultConsensusParams, error) {
 
 	// The latest consensus params that we know is the consensus params after the

--- a/internal/rpc/core/dev.go
+++ b/internal/rpc/core/dev.go
@@ -1,12 +1,13 @@
 package core
 
 import (
+	"context"
+
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // UnsafeFlushMempool removes all transactions from the mempool.
-func (env *Environment) UnsafeFlushMempool(ctx *rpctypes.Context) (*coretypes.ResultUnsafeFlushMempool, error) {
+func (env *Environment) UnsafeFlushMempool(ctx context.Context) (*coretypes.ResultUnsafeFlushMempool, error) {
 	env.Mempool.Flush()
 	return &coretypes.ResultUnsafeFlushMempool{}, nil
 }

--- a/internal/rpc/core/evidence.go
+++ b/internal/rpc/core/evidence.go
@@ -1,17 +1,17 @@
 package core
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
 
 // BroadcastEvidence broadcasts evidence of the misbehavior.
 // More: https://docs.tendermint.com/master/rpc/#/Evidence/broadcast_evidence
 func (env *Environment) BroadcastEvidence(
-	ctx *rpctypes.Context,
+	ctx context.Context,
 	ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
 
 	if ev == nil {

--- a/internal/rpc/core/health.go
+++ b/internal/rpc/core/health.go
@@ -1,13 +1,14 @@
 package core
 
 import (
+	"context"
+
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // Health gets node health. Returns empty result (200 OK) on success, no
 // response - in case of an error.
 // More: https://docs.tendermint.com/master/rpc/#/Info/health
-func (env *Environment) Health(ctx *rpctypes.Context) (*coretypes.ResultHealth, error) {
+func (env *Environment) Health(ctx context.Context) (*coretypes.ResultHealth, error) {
 	return &coretypes.ResultHealth{}, nil
 }

--- a/internal/rpc/core/net.go
+++ b/internal/rpc/core/net.go
@@ -1,16 +1,16 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // NetInfo returns network info.
 // More: https://docs.tendermint.com/master/rpc/#/Info/net_info
-func (env *Environment) NetInfo(ctx *rpctypes.Context) (*coretypes.ResultNetInfo, error) {
+func (env *Environment) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, error) {
 	peerList := env.PeerManager.Peers()
 
 	peers := make([]coretypes.Peer, 0, len(peerList))
@@ -36,7 +36,7 @@ func (env *Environment) NetInfo(ctx *rpctypes.Context) (*coretypes.ResultNetInfo
 
 // Genesis returns genesis file.
 // More: https://docs.tendermint.com/master/rpc/#/Info/genesis
-func (env *Environment) Genesis(ctx *rpctypes.Context) (*coretypes.ResultGenesis, error) {
+func (env *Environment) Genesis(ctx context.Context) (*coretypes.ResultGenesis, error) {
 	if len(env.genChunks) > 1 {
 		return nil, errors.New("genesis response is large, please use the genesis_chunked API instead")
 	}
@@ -44,7 +44,7 @@ func (env *Environment) Genesis(ctx *rpctypes.Context) (*coretypes.ResultGenesis
 	return &coretypes.ResultGenesis{Genesis: env.GenDoc}, nil
 }
 
-func (env *Environment) GenesisChunked(ctx *rpctypes.Context, chunk uint) (*coretypes.ResultGenesisChunk, error) {
+func (env *Environment) GenesisChunked(ctx context.Context, chunk uint) (*coretypes.ResultGenesisChunk, error) {
 	if env.genChunks == nil {
 		return nil, fmt.Errorf("service configuration error, genesis chunks are not initialized")
 	}

--- a/internal/rpc/core/status.go
+++ b/internal/rpc/core/status.go
@@ -2,18 +2,18 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"time"
 
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
 
 // Status returns Tendermint status including node info, pubkey, latest block
 // hash, app hash, block height, current max peer block height, and time.
 // More: https://docs.tendermint.com/master/rpc/#/Info/status
-func (env *Environment) Status(ctx *rpctypes.Context) (*coretypes.ResultStatus, error) {
+func (env *Environment) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
 	var (
 		earliestBlockHeight   int64
 		earliestBlockHash     tmbytes.HexBytes

--- a/internal/rpc/core/tx.go
+++ b/internal/rpc/core/tx.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -10,7 +11,6 @@ import (
 	"github.com/tendermint/tendermint/libs/bytes"
 	tmmath "github.com/tendermint/tendermint/libs/math"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -18,7 +18,7 @@ import (
 // transaction is in the mempool, invalidated, or was not sent in the first
 // place.
 // More: https://docs.tendermint.com/master/rpc/#/Info/tx
-func (env *Environment) Tx(ctx *rpctypes.Context, hash bytes.HexBytes, prove bool) (*coretypes.ResultTx, error) {
+func (env *Environment) Tx(ctx context.Context, hash bytes.HexBytes, prove bool) (*coretypes.ResultTx, error) {
 	// if index is disabled, return error
 
 	// N.B. The hash parameter is HexBytes so that the reflective parameter
@@ -63,7 +63,7 @@ func (env *Environment) Tx(ctx *rpctypes.Context, hash bytes.HexBytes, prove boo
 // list of transactions (maximum ?per_page entries) and the total count.
 // More: https://docs.tendermint.com/master/rpc/#/Info/tx_search
 func (env *Environment) TxSearch(
-	ctx *rpctypes.Context,
+	ctx context.Context,
 	query string,
 	prove bool,
 	pagePtr, perPagePtr *int,
@@ -83,7 +83,7 @@ func (env *Environment) TxSearch(
 
 	for _, sink := range env.EventSinks {
 		if sink.Type() == indexer.KV {
-			results, err := sink.SearchTxEvents(ctx.Context(), q)
+			results, err := sink.SearchTxEvents(ctx, q)
 			if err != nil {
 				return nil, err
 			}

--- a/light/proxy/routes.go
+++ b/light/proxy/routes.go
@@ -1,12 +1,13 @@
 package proxy
 
 import (
+	"context"
+
 	"github.com/tendermint/tendermint/libs/bytes"
 	lrpc "github.com/tendermint/tendermint/light/rpc"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/coretypes"
 	rpcserver "github.com/tendermint/tendermint/rpc/jsonrpc/server"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -54,113 +55,113 @@ func RPCRoutes(c *lrpc.Client) map[string]*rpcserver.RPCFunc {
 	}
 }
 
-type rpcHealthFunc func(ctx *rpctypes.Context) (*coretypes.ResultHealth, error)
+type rpcHealthFunc func(ctx context.Context) (*coretypes.ResultHealth, error)
 
 func makeHealthFunc(c *lrpc.Client) rpcHealthFunc {
-	return func(ctx *rpctypes.Context) (*coretypes.ResultHealth, error) {
-		return c.Health(ctx.Context())
+	return func(ctx context.Context) (*coretypes.ResultHealth, error) {
+		return c.Health(ctx)
 	}
 }
 
-type rpcStatusFunc func(ctx *rpctypes.Context) (*coretypes.ResultStatus, error)
+type rpcStatusFunc func(ctx context.Context) (*coretypes.ResultStatus, error)
 
 // nolint: interfacer
 func makeStatusFunc(c *lrpc.Client) rpcStatusFunc {
-	return func(ctx *rpctypes.Context) (*coretypes.ResultStatus, error) {
-		return c.Status(ctx.Context())
+	return func(ctx context.Context) (*coretypes.ResultStatus, error) {
+		return c.Status(ctx)
 	}
 }
 
-type rpcNetInfoFunc func(ctx *rpctypes.Context) (*coretypes.ResultNetInfo, error)
+type rpcNetInfoFunc func(ctx context.Context) (*coretypes.ResultNetInfo, error)
 
 func makeNetInfoFunc(c *lrpc.Client) rpcNetInfoFunc {
-	return func(ctx *rpctypes.Context) (*coretypes.ResultNetInfo, error) {
-		return c.NetInfo(ctx.Context())
+	return func(ctx context.Context) (*coretypes.ResultNetInfo, error) {
+		return c.NetInfo(ctx)
 	}
 }
 
-type rpcBlockchainInfoFunc func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error)
+type rpcBlockchainInfoFunc func(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error)
 
 func makeBlockchainInfoFunc(c *lrpc.Client) rpcBlockchainInfoFunc {
-	return func(ctx *rpctypes.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
-		return c.BlockchainInfo(ctx.Context(), minHeight, maxHeight)
+	return func(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
+		return c.BlockchainInfo(ctx, minHeight, maxHeight)
 	}
 }
 
-type rpcGenesisFunc func(ctx *rpctypes.Context) (*coretypes.ResultGenesis, error)
+type rpcGenesisFunc func(ctx context.Context) (*coretypes.ResultGenesis, error)
 
 func makeGenesisFunc(c *lrpc.Client) rpcGenesisFunc {
-	return func(ctx *rpctypes.Context) (*coretypes.ResultGenesis, error) {
-		return c.Genesis(ctx.Context())
+	return func(ctx context.Context) (*coretypes.ResultGenesis, error) {
+		return c.Genesis(ctx)
 	}
 }
 
-type rpcGenesisChunkedFunc func(ctx *rpctypes.Context, chunk uint) (*coretypes.ResultGenesisChunk, error)
+type rpcGenesisChunkedFunc func(ctx context.Context, chunk uint) (*coretypes.ResultGenesisChunk, error)
 
 func makeGenesisChunkedFunc(c *lrpc.Client) rpcGenesisChunkedFunc {
-	return func(ctx *rpctypes.Context, chunk uint) (*coretypes.ResultGenesisChunk, error) {
-		return c.GenesisChunked(ctx.Context(), chunk)
+	return func(ctx context.Context, chunk uint) (*coretypes.ResultGenesisChunk, error) {
+		return c.GenesisChunked(ctx, chunk)
 	}
 }
 
-type rpcHeaderFunc func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultHeader, error)
+type rpcHeaderFunc func(ctx context.Context, height *int64) (*coretypes.ResultHeader, error)
 
 func makeHeaderFunc(c *lrpc.Client) rpcHeaderFunc {
-	return func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultHeader, error) {
-		return c.Header(ctx.Context(), height)
+	return func(ctx context.Context, height *int64) (*coretypes.ResultHeader, error) {
+		return c.Header(ctx, height)
 	}
 }
 
-type rpcHeaderByHashFunc func(ctx *rpctypes.Context, hash []byte) (*coretypes.ResultHeader, error)
+type rpcHeaderByHashFunc func(ctx context.Context, hash []byte) (*coretypes.ResultHeader, error)
 
 func makeHeaderByHashFunc(c *lrpc.Client) rpcHeaderByHashFunc {
-	return func(ctx *rpctypes.Context, hash []byte) (*coretypes.ResultHeader, error) {
-		return c.HeaderByHash(ctx.Context(), hash)
+	return func(ctx context.Context, hash []byte) (*coretypes.ResultHeader, error) {
+		return c.HeaderByHash(ctx, hash)
 	}
 }
 
-type rpcBlockFunc func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultBlock, error)
+type rpcBlockFunc func(ctx context.Context, height *int64) (*coretypes.ResultBlock, error)
 
 func makeBlockFunc(c *lrpc.Client) rpcBlockFunc {
-	return func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultBlock, error) {
-		return c.Block(ctx.Context(), height)
+	return func(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
+		return c.Block(ctx, height)
 	}
 }
 
-type rpcBlockByHashFunc func(ctx *rpctypes.Context, hash []byte) (*coretypes.ResultBlock, error)
+type rpcBlockByHashFunc func(ctx context.Context, hash []byte) (*coretypes.ResultBlock, error)
 
 func makeBlockByHashFunc(c *lrpc.Client) rpcBlockByHashFunc {
-	return func(ctx *rpctypes.Context, hash []byte) (*coretypes.ResultBlock, error) {
-		return c.BlockByHash(ctx.Context(), hash)
+	return func(ctx context.Context, hash []byte) (*coretypes.ResultBlock, error) {
+		return c.BlockByHash(ctx, hash)
 	}
 }
 
-type rpcBlockResultsFunc func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultBlockResults, error)
+type rpcBlockResultsFunc func(ctx context.Context, height *int64) (*coretypes.ResultBlockResults, error)
 
 func makeBlockResultsFunc(c *lrpc.Client) rpcBlockResultsFunc {
-	return func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultBlockResults, error) {
-		return c.BlockResults(ctx.Context(), height)
+	return func(ctx context.Context, height *int64) (*coretypes.ResultBlockResults, error) {
+		return c.BlockResults(ctx, height)
 	}
 }
 
-type rpcCommitFunc func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultCommit, error)
+type rpcCommitFunc func(ctx context.Context, height *int64) (*coretypes.ResultCommit, error)
 
 func makeCommitFunc(c *lrpc.Client) rpcCommitFunc {
-	return func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultCommit, error) {
-		return c.Commit(ctx.Context(), height)
+	return func(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
+		return c.Commit(ctx, height)
 	}
 }
 
-type rpcTxFunc func(ctx *rpctypes.Context, hash []byte, prove bool) (*coretypes.ResultTx, error)
+type rpcTxFunc func(ctx context.Context, hash []byte, prove bool) (*coretypes.ResultTx, error)
 
 func makeTxFunc(c *lrpc.Client) rpcTxFunc {
-	return func(ctx *rpctypes.Context, hash []byte, prove bool) (*coretypes.ResultTx, error) {
-		return c.Tx(ctx.Context(), hash, prove)
+	return func(ctx context.Context, hash []byte, prove bool) (*coretypes.ResultTx, error) {
+		return c.Tx(ctx, hash, prove)
 	}
 }
 
 type rpcTxSearchFunc func(
-	ctx *rpctypes.Context,
+	ctx context.Context,
 	query string,
 	prove bool,
 	page, perPage *int,
@@ -169,18 +170,18 @@ type rpcTxSearchFunc func(
 
 func makeTxSearchFunc(c *lrpc.Client) rpcTxSearchFunc {
 	return func(
-		ctx *rpctypes.Context,
+		ctx context.Context,
 		query string,
 		prove bool,
 		page, perPage *int,
 		orderBy string,
 	) (*coretypes.ResultTxSearch, error) {
-		return c.TxSearch(ctx.Context(), query, prove, page, perPage, orderBy)
+		return c.TxSearch(ctx, query, prove, page, perPage, orderBy)
 	}
 }
 
 type rpcBlockSearchFunc func(
-	ctx *rpctypes.Context,
+	ctx context.Context,
 	query string,
 	prove bool,
 	page, perPage *int,
@@ -189,116 +190,116 @@ type rpcBlockSearchFunc func(
 
 func makeBlockSearchFunc(c *lrpc.Client) rpcBlockSearchFunc {
 	return func(
-		ctx *rpctypes.Context,
+		ctx context.Context,
 		query string,
 		prove bool,
 		page, perPage *int,
 		orderBy string,
 	) (*coretypes.ResultBlockSearch, error) {
-		return c.BlockSearch(ctx.Context(), query, page, perPage, orderBy)
+		return c.BlockSearch(ctx, query, page, perPage, orderBy)
 	}
 }
 
-type rpcValidatorsFunc func(ctx *rpctypes.Context, height *int64,
+type rpcValidatorsFunc func(ctx context.Context, height *int64,
 	page, perPage *int) (*coretypes.ResultValidators, error)
 
 func makeValidatorsFunc(c *lrpc.Client) rpcValidatorsFunc {
-	return func(ctx *rpctypes.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
-		return c.Validators(ctx.Context(), height, page, perPage)
+	return func(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
+		return c.Validators(ctx, height, page, perPage)
 	}
 }
 
-type rpcDumpConsensusStateFunc func(ctx *rpctypes.Context) (*coretypes.ResultDumpConsensusState, error)
+type rpcDumpConsensusStateFunc func(ctx context.Context) (*coretypes.ResultDumpConsensusState, error)
 
 func makeDumpConsensusStateFunc(c *lrpc.Client) rpcDumpConsensusStateFunc {
-	return func(ctx *rpctypes.Context) (*coretypes.ResultDumpConsensusState, error) {
-		return c.DumpConsensusState(ctx.Context())
+	return func(ctx context.Context) (*coretypes.ResultDumpConsensusState, error) {
+		return c.DumpConsensusState(ctx)
 	}
 }
 
-type rpcConsensusStateFunc func(ctx *rpctypes.Context) (*coretypes.ResultConsensusState, error)
+type rpcConsensusStateFunc func(ctx context.Context) (*coretypes.ResultConsensusState, error)
 
 func makeConsensusStateFunc(c *lrpc.Client) rpcConsensusStateFunc {
-	return func(ctx *rpctypes.Context) (*coretypes.ResultConsensusState, error) {
-		return c.ConsensusState(ctx.Context())
+	return func(ctx context.Context) (*coretypes.ResultConsensusState, error) {
+		return c.ConsensusState(ctx)
 	}
 }
 
-type rpcConsensusParamsFunc func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultConsensusParams, error)
+type rpcConsensusParamsFunc func(ctx context.Context, height *int64) (*coretypes.ResultConsensusParams, error)
 
 func makeConsensusParamsFunc(c *lrpc.Client) rpcConsensusParamsFunc {
-	return func(ctx *rpctypes.Context, height *int64) (*coretypes.ResultConsensusParams, error) {
-		return c.ConsensusParams(ctx.Context(), height)
+	return func(ctx context.Context, height *int64) (*coretypes.ResultConsensusParams, error) {
+		return c.ConsensusParams(ctx, height)
 	}
 }
 
-type rpcUnconfirmedTxsFunc func(ctx *rpctypes.Context, limit *int) (*coretypes.ResultUnconfirmedTxs, error)
+type rpcUnconfirmedTxsFunc func(ctx context.Context, limit *int) (*coretypes.ResultUnconfirmedTxs, error)
 
 func makeUnconfirmedTxsFunc(c *lrpc.Client) rpcUnconfirmedTxsFunc {
-	return func(ctx *rpctypes.Context, limit *int) (*coretypes.ResultUnconfirmedTxs, error) {
-		return c.UnconfirmedTxs(ctx.Context(), limit)
+	return func(ctx context.Context, limit *int) (*coretypes.ResultUnconfirmedTxs, error) {
+		return c.UnconfirmedTxs(ctx, limit)
 	}
 }
 
-type rpcNumUnconfirmedTxsFunc func(ctx *rpctypes.Context) (*coretypes.ResultUnconfirmedTxs, error)
+type rpcNumUnconfirmedTxsFunc func(ctx context.Context) (*coretypes.ResultUnconfirmedTxs, error)
 
 func makeNumUnconfirmedTxsFunc(c *lrpc.Client) rpcNumUnconfirmedTxsFunc {
-	return func(ctx *rpctypes.Context) (*coretypes.ResultUnconfirmedTxs, error) {
-		return c.NumUnconfirmedTxs(ctx.Context())
+	return func(ctx context.Context) (*coretypes.ResultUnconfirmedTxs, error) {
+		return c.NumUnconfirmedTxs(ctx)
 	}
 }
 
-type rpcBroadcastTxCommitFunc func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error)
+type rpcBroadcastTxCommitFunc func(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error)
 
 func makeBroadcastTxCommitFunc(c *lrpc.Client) rpcBroadcastTxCommitFunc {
-	return func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
-		return c.BroadcastTxCommit(ctx.Context(), tx)
+	return func(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
+		return c.BroadcastTxCommit(ctx, tx)
 	}
 }
 
-type rpcBroadcastTxSyncFunc func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error)
+type rpcBroadcastTxSyncFunc func(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error)
 
 func makeBroadcastTxSyncFunc(c *lrpc.Client) rpcBroadcastTxSyncFunc {
-	return func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
-		return c.BroadcastTxSync(ctx.Context(), tx)
+	return func(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
+		return c.BroadcastTxSync(ctx, tx)
 	}
 }
 
-type rpcBroadcastTxAsyncFunc func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error)
+type rpcBroadcastTxAsyncFunc func(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error)
 
 func makeBroadcastTxAsyncFunc(c *lrpc.Client) rpcBroadcastTxAsyncFunc {
-	return func(ctx *rpctypes.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
-		return c.BroadcastTxAsync(ctx.Context(), tx)
+	return func(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
+		return c.BroadcastTxAsync(ctx, tx)
 	}
 }
 
-type rpcABCIQueryFunc func(ctx *rpctypes.Context, path string,
+type rpcABCIQueryFunc func(ctx context.Context, path string,
 	data bytes.HexBytes, height int64, prove bool) (*coretypes.ResultABCIQuery, error)
 
 func makeABCIQueryFunc(c *lrpc.Client) rpcABCIQueryFunc {
-	return func(ctx *rpctypes.Context, path string, data bytes.HexBytes,
+	return func(ctx context.Context, path string, data bytes.HexBytes,
 		height int64, prove bool) (*coretypes.ResultABCIQuery, error) {
 
-		return c.ABCIQueryWithOptions(ctx.Context(), path, data, rpcclient.ABCIQueryOptions{
+		return c.ABCIQueryWithOptions(ctx, path, data, rpcclient.ABCIQueryOptions{
 			Height: height,
 			Prove:  prove,
 		})
 	}
 }
 
-type rpcABCIInfoFunc func(ctx *rpctypes.Context) (*coretypes.ResultABCIInfo, error)
+type rpcABCIInfoFunc func(ctx context.Context) (*coretypes.ResultABCIInfo, error)
 
 func makeABCIInfoFunc(c *lrpc.Client) rpcABCIInfoFunc {
-	return func(ctx *rpctypes.Context) (*coretypes.ResultABCIInfo, error) {
-		return c.ABCIInfo(ctx.Context())
+	return func(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
+		return c.ABCIInfo(ctx)
 	}
 }
 
-type rpcBroadcastEvidenceFunc func(ctx *rpctypes.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error)
+type rpcBroadcastEvidenceFunc func(ctx context.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error)
 
 // nolint: interfacer
 func makeBroadcastEvidenceFunc(c *lrpc.Client) rpcBroadcastEvidenceFunc {
-	return func(ctx *rpctypes.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
-		return c.BroadcastEvidence(ctx.Context(), ev)
+	return func(ctx context.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
+		return c.BroadcastEvidence(ctx, ev)
 	}
 }

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -14,7 +14,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -41,7 +40,6 @@ backoff (10ms -> 20ms -> 40ms) until successful.
 type Local struct {
 	*eventbus.EventBus
 	Logger log.Logger
-	ctx    *rpctypes.Context
 	env    *rpccore.Environment
 }
 
@@ -61,7 +59,6 @@ func New(node NodeService) (*Local, error) {
 	return &Local{
 		EventBus: node.EventBus(),
 		Logger:   log.NewNopLogger(),
-		ctx:      &rpctypes.Context{},
 		env:      env,
 	}, nil
 }
@@ -74,11 +71,11 @@ func (c *Local) SetLogger(l log.Logger) {
 }
 
 func (c *Local) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
-	return c.env.Status(c.ctx)
+	return c.env.Status(ctx)
 }
 
 func (c *Local) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
-	return c.env.ABCIInfo(c.ctx)
+	return c.env.ABCIInfo(ctx)
 }
 
 func (c *Local) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*coretypes.ResultABCIQuery, error) {
@@ -90,31 +87,31 @@ func (c *Local) ABCIQueryWithOptions(
 	path string,
 	data bytes.HexBytes,
 	opts rpcclient.ABCIQueryOptions) (*coretypes.ResultABCIQuery, error) {
-	return c.env.ABCIQuery(c.ctx, path, data, opts.Height, opts.Prove)
+	return c.env.ABCIQuery(ctx, path, data, opts.Height, opts.Prove)
 }
 
 func (c *Local) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
-	return c.env.BroadcastTxCommit(c.ctx, tx)
+	return c.env.BroadcastTxCommit(ctx, tx)
 }
 
 func (c *Local) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
-	return c.env.BroadcastTxAsync(c.ctx, tx)
+	return c.env.BroadcastTxAsync(ctx, tx)
 }
 
 func (c *Local) BroadcastTxSync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
-	return c.env.BroadcastTxSync(c.ctx, tx)
+	return c.env.BroadcastTxSync(ctx, tx)
 }
 
 func (c *Local) UnconfirmedTxs(ctx context.Context, limit *int) (*coretypes.ResultUnconfirmedTxs, error) {
-	return c.env.UnconfirmedTxs(c.ctx, limit)
+	return c.env.UnconfirmedTxs(ctx, limit)
 }
 
 func (c *Local) NumUnconfirmedTxs(ctx context.Context) (*coretypes.ResultUnconfirmedTxs, error) {
-	return c.env.NumUnconfirmedTxs(c.ctx)
+	return c.env.NumUnconfirmedTxs(ctx)
 }
 
 func (c *Local) CheckTx(ctx context.Context, tx types.Tx) (*coretypes.ResultCheckTx, error) {
-	return c.env.CheckTx(c.ctx, tx)
+	return c.env.CheckTx(ctx, tx)
 }
 
 func (c *Local) RemoveTx(ctx context.Context, txKey types.TxKey) error {
@@ -122,91 +119,91 @@ func (c *Local) RemoveTx(ctx context.Context, txKey types.TxKey) error {
 }
 
 func (c *Local) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, error) {
-	return c.env.NetInfo(c.ctx)
+	return c.env.NetInfo(ctx)
 }
 
 func (c *Local) DumpConsensusState(ctx context.Context) (*coretypes.ResultDumpConsensusState, error) {
-	return c.env.DumpConsensusState(c.ctx)
+	return c.env.DumpConsensusState(ctx)
 }
 
 func (c *Local) ConsensusState(ctx context.Context) (*coretypes.ResultConsensusState, error) {
-	return c.env.GetConsensusState(c.ctx)
+	return c.env.GetConsensusState(ctx)
 }
 
 func (c *Local) ConsensusParams(ctx context.Context, height *int64) (*coretypes.ResultConsensusParams, error) {
-	return c.env.ConsensusParams(c.ctx, height)
+	return c.env.ConsensusParams(ctx, height)
 }
 
 func (c *Local) Health(ctx context.Context) (*coretypes.ResultHealth, error) {
-	return c.env.Health(c.ctx)
+	return c.env.Health(ctx)
 }
 
 func (c *Local) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
-	return c.env.BlockchainInfo(c.ctx, minHeight, maxHeight)
+	return c.env.BlockchainInfo(ctx, minHeight, maxHeight)
 }
 
 func (c *Local) Genesis(ctx context.Context) (*coretypes.ResultGenesis, error) {
-	return c.env.Genesis(c.ctx)
+	return c.env.Genesis(ctx)
 }
 
 func (c *Local) GenesisChunked(ctx context.Context, id uint) (*coretypes.ResultGenesisChunk, error) {
-	return c.env.GenesisChunked(c.ctx, id)
+	return c.env.GenesisChunked(ctx, id)
 }
 
 func (c *Local) Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
-	return c.env.Block(c.ctx, height)
+	return c.env.Block(ctx, height)
 }
 
 func (c *Local) BlockByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error) {
-	return c.env.BlockByHash(c.ctx, hash)
+	return c.env.BlockByHash(ctx, hash)
 }
 
 func (c *Local) BlockResults(ctx context.Context, height *int64) (*coretypes.ResultBlockResults, error) {
-	return c.env.BlockResults(c.ctx, height)
+	return c.env.BlockResults(ctx, height)
 }
 
 func (c *Local) Header(ctx context.Context, height *int64) (*coretypes.ResultHeader, error) {
-	return c.env.Header(c.ctx, height)
+	return c.env.Header(ctx, height)
 }
 
 func (c *Local) HeaderByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultHeader, error) {
-	return c.env.HeaderByHash(c.ctx, hash)
+	return c.env.HeaderByHash(ctx, hash)
 }
 
 func (c *Local) Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
-	return c.env.Commit(c.ctx, height)
+	return c.env.Commit(ctx, height)
 }
 
 func (c *Local) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
-	return c.env.Validators(c.ctx, height, page, perPage)
+	return c.env.Validators(ctx, height, page, perPage)
 }
 
 func (c *Local) Tx(ctx context.Context, hash bytes.HexBytes, prove bool) (*coretypes.ResultTx, error) {
-	return c.env.Tx(c.ctx, hash, prove)
+	return c.env.Tx(ctx, hash, prove)
 }
 
 func (c *Local) TxSearch(
-	_ context.Context,
+	ctx context.Context,
 	queryString string,
 	prove bool,
 	page,
 	perPage *int,
 	orderBy string,
 ) (*coretypes.ResultTxSearch, error) {
-	return c.env.TxSearch(c.ctx, queryString, prove, page, perPage, orderBy)
+	return c.env.TxSearch(ctx, queryString, prove, page, perPage, orderBy)
 }
 
 func (c *Local) BlockSearch(
-	_ context.Context,
+	ctx context.Context,
 	queryString string,
 	page, perPage *int,
 	orderBy string,
 ) (*coretypes.ResultBlockSearch, error) {
-	return c.env.BlockSearch(c.ctx, queryString, page, perPage, orderBy)
+	return c.env.BlockSearch(ctx, queryString, page, perPage, orderBy)
 }
 
 func (c *Local) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
-	return c.env.BroadcastEvidence(c.ctx, ev)
+	return c.env.BroadcastEvidence(ctx, ev)
 }
 
 func (c *Local) Subscribe(

--- a/rpc/client/mock/client.go
+++ b/rpc/client/mock/client.go
@@ -22,7 +22,6 @@ import (
 	"github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/rpc/client"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -76,11 +75,11 @@ func (c Call) GetResponse(args interface{}) (interface{}, error) {
 }
 
 func (c Client) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
-	return c.env.Status(&rpctypes.Context{})
+	return c.env.Status(ctx)
 }
 
 func (c Client) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
-	return c.env.ABCIInfo(&rpctypes.Context{})
+	return c.env.ABCIInfo(ctx)
 }
 
 func (c Client) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*coretypes.ResultABCIQuery, error) {
@@ -92,69 +91,69 @@ func (c Client) ABCIQueryWithOptions(
 	path string,
 	data bytes.HexBytes,
 	opts client.ABCIQueryOptions) (*coretypes.ResultABCIQuery, error) {
-	return c.env.ABCIQuery(&rpctypes.Context{}, path, data, opts.Height, opts.Prove)
+	return c.env.ABCIQuery(ctx, path, data, opts.Height, opts.Prove)
 }
 
 func (c Client) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
-	return c.env.BroadcastTxCommit(&rpctypes.Context{}, tx)
+	return c.env.BroadcastTxCommit(ctx, tx)
 }
 
 func (c Client) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
-	return c.env.BroadcastTxAsync(&rpctypes.Context{}, tx)
+	return c.env.BroadcastTxAsync(ctx, tx)
 }
 
 func (c Client) BroadcastTxSync(ctx context.Context, tx types.Tx) (*coretypes.ResultBroadcastTx, error) {
-	return c.env.BroadcastTxSync(&rpctypes.Context{}, tx)
+	return c.env.BroadcastTxSync(ctx, tx)
 }
 
 func (c Client) CheckTx(ctx context.Context, tx types.Tx) (*coretypes.ResultCheckTx, error) {
-	return c.env.CheckTx(&rpctypes.Context{}, tx)
+	return c.env.CheckTx(ctx, tx)
 }
 
 func (c Client) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, error) {
-	return c.env.NetInfo(&rpctypes.Context{})
+	return c.env.NetInfo(ctx)
 }
 
 func (c Client) ConsensusState(ctx context.Context) (*coretypes.ResultConsensusState, error) {
-	return c.env.GetConsensusState(&rpctypes.Context{})
+	return c.env.GetConsensusState(ctx)
 }
 
 func (c Client) DumpConsensusState(ctx context.Context) (*coretypes.ResultDumpConsensusState, error) {
-	return c.env.DumpConsensusState(&rpctypes.Context{})
+	return c.env.DumpConsensusState(ctx)
 }
 
 func (c Client) ConsensusParams(ctx context.Context, height *int64) (*coretypes.ResultConsensusParams, error) {
-	return c.env.ConsensusParams(&rpctypes.Context{}, height)
+	return c.env.ConsensusParams(ctx, height)
 }
 
 func (c Client) Health(ctx context.Context) (*coretypes.ResultHealth, error) {
-	return c.env.Health(&rpctypes.Context{})
+	return c.env.Health(ctx)
 }
 
 func (c Client) BlockchainInfo(ctx context.Context, minHeight, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
-	return c.env.BlockchainInfo(&rpctypes.Context{}, minHeight, maxHeight)
+	return c.env.BlockchainInfo(ctx, minHeight, maxHeight)
 }
 
 func (c Client) Genesis(ctx context.Context) (*coretypes.ResultGenesis, error) {
-	return c.env.Genesis(&rpctypes.Context{})
+	return c.env.Genesis(ctx)
 }
 
 func (c Client) Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
-	return c.env.Block(&rpctypes.Context{}, height)
+	return c.env.Block(ctx, height)
 }
 
 func (c Client) BlockByHash(ctx context.Context, hash bytes.HexBytes) (*coretypes.ResultBlock, error) {
-	return c.env.BlockByHash(&rpctypes.Context{}, hash)
+	return c.env.BlockByHash(ctx, hash)
 }
 
 func (c Client) Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
-	return c.env.Commit(&rpctypes.Context{}, height)
+	return c.env.Commit(ctx, height)
 }
 
 func (c Client) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
-	return c.env.Validators(&rpctypes.Context{}, height, page, perPage)
+	return c.env.Validators(ctx, height, page, perPage)
 }
 
 func (c Client) BroadcastEvidence(ctx context.Context, ev types.Evidence) (*coretypes.ResultBroadcastEvidence, error) {
-	return c.env.BroadcastEvidence(&rpctypes.Context{}, ev)
+	return c.env.BroadcastEvidence(ctx, ev)
 }

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/rpc/jsonrpc/client"
 	"github.com/tendermint/tendermint/rpc/jsonrpc/server"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // Client and Server should work over tcp or unix sockets
@@ -61,23 +60,23 @@ var Routes = map[string]*server.RPCFunc{
 	"echo_int":        server.NewRPCFunc(EchoIntResult, "arg", false),
 }
 
-func EchoResult(ctx *rpctypes.Context, v string) (*ResultEcho, error) {
+func EchoResult(ctx context.Context, v string) (*ResultEcho, error) {
 	return &ResultEcho{v}, nil
 }
 
-func EchoWSResult(ctx *rpctypes.Context, v string) (*ResultEcho, error) {
+func EchoWSResult(ctx context.Context, v string) (*ResultEcho, error) {
 	return &ResultEcho{v}, nil
 }
 
-func EchoIntResult(ctx *rpctypes.Context, v int) (*ResultEchoInt, error) {
+func EchoIntResult(ctx context.Context, v int) (*ResultEchoInt, error) {
 	return &ResultEchoInt{v}, nil
 }
 
-func EchoBytesResult(ctx *rpctypes.Context, v []byte) (*ResultEchoBytes, error) {
+func EchoBytesResult(ctx context.Context, v []byte) (*ResultEchoBytes, error) {
 	return &ResultEchoBytes{v}, nil
 }
 
-func EchoDataBytesResult(ctx *rpctypes.Context, v tmbytes.HexBytes) (*ResultEchoDataBytes, error) {
+func EchoDataBytesResult(ctx context.Context, v tmbytes.HexBytes) (*ResultEchoDataBytes, error) {
 	return &ResultEchoDataBytes{v}, nil
 }
 

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -206,10 +206,11 @@ func arrayParamsToArgs(
 // parseParams parses the JSON parameters of rpcReq into the arguments of fn,
 // returning the corresponding argument values or an error.
 func parseParams(fn *RPCFunc, httpReq *http.Request, rpcReq rpctypes.RPCRequest) ([]reflect.Value, error) {
-	args := []reflect.Value{reflect.ValueOf(&rpctypes.Context{
-		JSONReq: &rpcReq,
-		HTTPReq: httpReq,
-	})}
+	ctx := rpctypes.WithCallInfo(httpReq.Context(), &rpctypes.CallInfo{
+		RPCRequest:  &rpcReq,
+		HTTPRequest: httpReq,
+	})
+	args := []reflect.Value{reflect.ValueOf(ctx)}
 	if len(rpcReq.Params) == 0 {
 		return args, nil
 	}
@@ -224,7 +225,7 @@ func parseParams(fn *RPCFunc, httpReq *http.Request, rpcReq rpctypes.RPCRequest)
 // array.
 //
 // Example:
-//   rpcFunc.args = [rpctypes.Context string]
+//   rpcFunc.args = [context.Context string]
 //   rpcFunc.argNames = ["arg"]
 func jsonParamsToArgs(rpcFunc *RPCFunc, raw []byte) ([]reflect.Value, error) {
 	const argsOffset = 1

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -17,8 +18,8 @@ import (
 
 func testMux() *http.ServeMux {
 	funcMap := map[string]*RPCFunc{
-		"c":     NewRPCFunc(func(ctx *rpctypes.Context, s string, i int) (string, error) { return "foo", nil }, "s,i", false),
-		"block": NewRPCFunc(func(ctx *rpctypes.Context, h int) (string, error) { return "block", nil }, "height", true),
+		"c":     NewRPCFunc(func(ctx context.Context, s string, i int) (string, error) { return "foo", nil }, "s,i", false),
+		"block": NewRPCFunc(func(ctx context.Context, h int) (string, error) { return "block", nil }, "height", true),
 	}
 	mux := http.NewServeMux()
 	logger := log.NewNopLogger()

--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -39,7 +39,7 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger.Debug("HTTP HANDLER", "req", dumpHTTPRequest(r))
 
-		ctx := &rpctypes.Context{HTTPReq: r}
+		ctx := rpctypes.WithCallInfo(r.Context(), &rpctypes.CallInfo{HTTPRequest: r})
 		args := []reflect.Value{reflect.ValueOf(ctx)}
 
 		fnArgs, err := httpParamsToArgs(rpcFunc, r)

--- a/rpc/jsonrpc/server/parse_test.go
+++ b/rpc/jsonrpc/server/parse_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/tendermint/tendermint/libs/bytes"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 func TestParseJSONMap(t *testing.T) {
@@ -134,7 +134,7 @@ func TestParseJSONArray(t *testing.T) {
 }
 
 func TestParseJSONRPC(t *testing.T) {
-	demo := func(ctx *rpctypes.Context, height int, name string) {}
+	demo := func(ctx context.Context, height int, name string) {}
 	call := NewRPCFunc(demo, "height,name", false)
 
 	cases := []struct {
@@ -171,7 +171,7 @@ func TestParseJSONRPC(t *testing.T) {
 }
 
 func TestParseURI(t *testing.T) {
-	demo := func(ctx *rpctypes.Context, height int, name string) {}
+	demo := func(ctx context.Context, height int, name string) {}
 	call := NewRPCFunc(demo, "height,name", false)
 
 	cases := []struct {

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -369,7 +369,7 @@ func (wsc *wsConnection) readRoutine(ctx context.Context) {
 				continue
 			}
 
-			fctx := rpctypes.WithCallInfo(ctx, &rpctypes.CallInfo{
+			fctx := rpctypes.WithCallInfo(wsc.Context(), &rpctypes.CallInfo{
 				RPCRequest: &request,
 				WSConn:     wsc,
 			})

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -369,8 +369,11 @@ func (wsc *wsConnection) readRoutine(ctx context.Context) {
 				continue
 			}
 
-			ctx := &rpctypes.Context{JSONReq: &request, WSConn: wsc}
-			args := []reflect.Value{reflect.ValueOf(ctx)}
+			fctx := rpctypes.WithCallInfo(ctx, &rpctypes.CallInfo{
+				RPCRequest: &request,
+				WSConn:     wsc,
+			})
+			args := []reflect.Value{reflect.ValueOf(fctx)}
 			if len(request.Params) > 0 {
 				fnArgs, err := jsonParamsToArgs(rpcFunc, request.Params)
 				if err != nil {

--- a/rpc/jsonrpc/server/ws_handler_test.go
+++ b/rpc/jsonrpc/server/ws_handler_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,7 +47,7 @@ func TestWebsocketManagerHandler(t *testing.T) {
 
 func newWSServer(t *testing.T, logger log.Logger) *httptest.Server {
 	funcMap := map[string]*RPCFunc{
-		"c": NewWSRPCFunc(func(ctx *rpctypes.Context, s string, i int) (string, error) { return "foo", nil }, "s,i"),
+		"c": NewWSRPCFunc(func(ctx context.Context, s string, i int) (string, error) { return "foo", nil }, "s,i"),
 	}
 	wm := NewWebsocketManager(funcMap)
 

--- a/rpc/jsonrpc/test/main.go
+++ b/rpc/jsonrpc/test/main.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 	rpcserver "github.com/tendermint/tendermint/rpc/jsonrpc/server"
-	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 var routes = map[string]*rpcserver.RPCFunc{
 	"hello_world": rpcserver.NewRPCFunc(HelloWorld, "name,num", false),
 }
 
-func HelloWorld(ctx *rpctypes.Context, name string, num int) (Result, error) {
+func HelloWorld(ctx context.Context, name string, num int) (Result, error) {
 	return Result{fmt.Sprintf("hi %s %d", name, num)}, nil
 }
 

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -254,7 +254,7 @@ type WSRPCConnection interface {
 // JSON-RPC. It can be recovered from the context with GetCallInfo.
 type CallInfo struct {
 	RPCRequest  *RPCRequest     // non-nil for requests via HTTP or websocket
-	HTTPRequesg *http.Request   // non-nil for requests via HTTP
+	HTTPRequest *http.Request   // non-nil for requests via HTTP
 	WSConn      WSRPCConnection // non-nil for requests via websocket
 }
 
@@ -281,12 +281,12 @@ func GetCallInfo(ctx context.Context) *CallInfo {
 // WS:
 //		result of GetRemoteAddr
 func (ci *CallInfo) RemoteAddr() string {
-	if ctx == nil {
+	if ci == nil {
 		return ""
-	} else if ctx.HTTPRequest != nil {
-		return ctx.HTTPRequest.RemoteAddr
-	} else if ctx.WSConn != nil {
-		return ctx.WSConn.GetRemoteAddr()
+	} else if ci.HTTPRequest != nil {
+		return ci.HTTPRequest.RemoteAddr
+	} else if ci.WSConn != nil {
+		return ci.WSConn.GetRemoteAddr()
 	}
 	return ""
 }

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -274,12 +274,11 @@ func GetCallInfo(ctx context.Context) *CallInfo {
 	return nil
 }
 
-// RemoteAddr returns the remote address (usually a string "IP:port").
-// If neither HTTPReq nor WSConn is set, an empty string is returned.
-// HTTP:
-//		http.Request#RemoteAddr
-// WS:
-//		result of GetRemoteAddr
+// RemoteAddr returns the remote address (usually a string "IP:port").  If
+// neither HTTPRequest nor WSConn is set, an empty string is returned.
+//
+// For HTTP requests, this reports the request's RemoteAddr.
+// For websocket requests, this reports the connection's GetRemoteAddr.
 func (ci *CallInfo) RemoteAddr() string {
 	if ci == nil {
 		return ""

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -250,19 +250,28 @@ type WSRPCConnection interface {
 	Context() context.Context
 }
 
-// Context is the first parameter for all functions. It carries a json-rpc
-// request, http request and websocket connection.
-//
-// - JSONReq is non-nil when JSONRPC is called over websocket or HTTP.
-// - WSConn is non-nil when we're connected via a websocket.
-// - HTTPReq is non-nil when URI or JSONRPC is called over HTTP.
-type Context struct {
-	// json-rpc request
-	JSONReq *RPCRequest
-	// websocket connection
-	WSConn WSRPCConnection
-	// http request
-	HTTPReq *http.Request
+// CallInfo carries JSON-RPC request metadata for RPC functions invoked via
+// JSON-RPC. It can be recovered from the context with GetCallInfo.
+type CallInfo struct {
+	RPCRequest  *RPCRequest     // non-nil for requests via HTTP or websocket
+	HTTPRequesg *http.Request   // non-nil for requests via HTTP
+	WSConn      WSRPCConnection // non-nil for requests via websocket
+}
+
+type callInfoKey struct{}
+
+// WithCallInfo returns a child context of ctx with the ci attached.
+func WithCallInfo(ctx context.Context, ci *CallInfo) context.Context {
+	return context.WithValue(ctx, callInfoKey{}, ci)
+}
+
+// GetCallInfo returns the CallInfo record attached to ctx, or nil if ctx does
+// not contain a call record.
+func GetCallInfo(ctx context.Context) *CallInfo {
+	if v := ctx.Value(callInfoKey{}); v != nil {
+		return v.(*CallInfo)
+	}
+	return nil
 }
 
 // RemoteAddr returns the remote address (usually a string "IP:port").
@@ -271,29 +280,15 @@ type Context struct {
 //		http.Request#RemoteAddr
 // WS:
 //		result of GetRemoteAddr
-func (ctx *Context) RemoteAddr() string {
-	if ctx.HTTPReq != nil {
-		return ctx.HTTPReq.RemoteAddr
+func (ci *CallInfo) RemoteAddr() string {
+	if ctx == nil {
+		return ""
+	} else if ctx.HTTPRequest != nil {
+		return ctx.HTTPRequest.RemoteAddr
 	} else if ctx.WSConn != nil {
 		return ctx.WSConn.GetRemoteAddr()
 	}
 	return ""
-}
-
-// Context returns the request's context.
-// The returned context is always non-nil; it defaults to the background context.
-// HTTP:
-//		The context is canceled when the client's connection closes, the request
-//		is canceled (with HTTP/2), or when the ServeHTTP method returns.
-// WS:
-//		The context is canceled when the client's connections closes.
-func (ctx *Context) Context() context.Context {
-	if ctx.HTTPReq != nil {
-		return ctx.HTTPReq.Context()
-	} else if ctx.WSConn != nil {
-		return ctx.WSConn.Context()
-	}
-	return context.Background()
 }
 
 //----------------------------------------


### PR DESCRIPTION
This is a large but uncomplicated refactoring of the RPC method handler interface. No functional changes are intended. The main effects are:

1. Rename the RPC `Context` type to `CallInfo`, and add helpers to attach and recover values of that type on a context.
2. Update all the RPC method handlers to accept a `context` context.
3. Update usage of the original type to use `CallInfo`.

Part (3) is the most "interesting" part of this change (relatively speaking), the rest is mostly macro-scriptable.