### PR TITLE
rpc: fix mock test cases

### DIFF
--- a/rpc/client/mock/abci_test.go
+++ b/rpc/client/mock/abci_test.go
@@ -62,7 +62,7 @@ func TestABCIMock(t *testing.T) {
 
 	// non-commit calls always return errors
 	_, err = m.BroadcastTxSync(ctx, goodTx)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "must commit", err.Error())
 	_, err = m.BroadcastTxAsync(ctx, goodTx)
 	require.Error(t, err)

--- a/rpc/client/mock/abci_test.go
+++ b/rpc/client/mock/abci_test.go
@@ -48,7 +48,7 @@ func TestABCIMock(t *testing.T) {
 
 	// now, let's try to make some calls
 	_, err := m.ABCIInfo(ctx)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "foobar", err.Error())
 
 	// query always returns the response
@@ -62,7 +62,7 @@ func TestABCIMock(t *testing.T) {
 
 	// non-commit calls always return errors
 	_, err = m.BroadcastTxSync(ctx, goodTx)
-	require.NoError(t, err)
+	require.NotNil(t, err)
 	assert.Equal(t, "must commit", err.Error())
 	_, err = m.BroadcastTxAsync(ctx, goodTx)
 	require.Error(t, err)
@@ -70,7 +70,7 @@ func TestABCIMock(t *testing.T) {
 
 	// commit depends on the input
 	_, err = m.BroadcastTxCommit(ctx, badTx)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "bad tx", err.Error())
 	bres, err := m.BroadcastTxCommit(ctx, goodTx)
 	require.NoError(t, err, "%+v", err)
@@ -106,7 +106,7 @@ func TestABCIRecorder(t *testing.T) {
 		bytes.HexBytes("data"),
 		client.ABCIQueryOptions{Prove: false},
 	)
-	assert.NoError(t, err, "expected error on query")
+	assert.Error(t, err, "expected error on query")
 	require.Equal(t, 2, len(r.Calls))
 
 	info := r.Calls[0]


### PR DESCRIPTION
In two cases, we check for the content of an error right after asserting that
no error occurs. Fix the sense of those checks.

In one case, we check that there is no error with the diagnostic "expected
error". It's not clear whether this means "an error was expected" (which is
what I believe) or "we got the expected error". However, given the way the mock
plumbing is set up, the first interpretation seems right.
