### PR TITLE
rpc: rework how responses are written back via HTTP

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,7 +12,8 @@ Special thanks to external contributors on this release:
 
 - CLI/RPC/Config
 
-  - [rpc] Remove the deprecated gRPC interface to the RPC service. (@creachadair)
+  - [rpc] \#7575 Rework how RPC responses are written back via HTTP. (@creachadair)
+  - [rpc] \#7121 Remove the deprecated gRPC interface to the RPC service. (@creachadair)
   - [blocksync] \#7159 Remove support for disabling blocksync in any circumstance. (@tychoish)
   - [mempool] \#7171 Remove legacy mempool implementation. (@tychoish)
 

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -152,7 +152,7 @@ func writeHTTPResponse(w http.ResponseWriter, log log.Logger, rsp rpctypes.RPCRe
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(body)
+	_, _ = w.Write(body)
 }
 
 // writeRPCResponse writes one or more JSON-RPC responses to w. A single
@@ -175,7 +175,7 @@ func writeRPCResponse(w http.ResponseWriter, log log.Logger, rsps ...rpctypes.RP
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(body)
+	_, _ = w.Write(body)
 }
 
 //-----------------------------------------------------------------------------

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -276,9 +276,7 @@ func RecoverAndLogHandler(handler http.Handler, logger log.Logger) http.Handler 
 
 				// If RPCResponse
 				if res, ok := e.(rpctypes.RPCResponse); ok {
-					if wErr := WriteRPCResponseHTTP(rww, res); wErr != nil {
-						logger.Error("failed to write response", "res", res, "err", wErr)
-					}
+					writeRPCResponse(rww, logger, res)
 				} else {
 					// Panics can contain anything, attempt to normalize it as an error.
 					var err error
@@ -292,12 +290,8 @@ func RecoverAndLogHandler(handler http.Handler, logger log.Logger) http.Handler 
 					default:
 					}
 
-					logger.Error("panic in RPC HTTP handler", "err", e, "stack", string(debug.Stack()))
-
-					res := rpctypes.RPCInternalError(rpctypes.JSONRPCIntID(-1), err)
-					if wErr := WriteRPCResponseHTTPError(rww, res); wErr != nil {
-						logger.Error("failed to write response", "res", res, "err", wErr)
-					}
+					logger.Error("Panic in RPC HTTP handler", "err", e, "stack", string(debug.Stack()))
+					writeInternalError(rww, err)
 				}
 			}
 

--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -26,30 +26,24 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 	dummyID := rpctypes.JSONRPCIntID(-1) // URIClientRequestID
 
 	// Exception for websocket endpoints
+	//
+	// TODO(creachadair): Rather than reporting errors for these, we should
+	// remove them from the routing list entirely on this endpoint.
 	if rpcFunc.ws {
 		return func(w http.ResponseWriter, r *http.Request) {
-			res := rpctypes.RPCMethodNotFoundError(dummyID)
-			if wErr := WriteRPCResponseHTTPError(w, res); wErr != nil {
-				logger.Error("failed to write response", "res", res, "err", wErr)
-			}
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}
 
 	// All other endpoints
 	return func(w http.ResponseWriter, r *http.Request) {
-		logger.Debug("HTTP HANDLER", "req", dumpHTTPRequest(r))
-
 		ctx := rpctypes.WithCallInfo(r.Context(), &rpctypes.CallInfo{HTTPRequest: r})
 		args := []reflect.Value{reflect.ValueOf(ctx)}
 
 		fnArgs, err := httpParamsToArgs(rpcFunc, r)
 		if err != nil {
-			res := rpctypes.RPCInvalidParamsError(dummyID,
-				fmt.Errorf("error converting http params to arguments: %w", err),
-			)
-			if wErr := WriteRPCResponseHTTPError(w, res); wErr != nil {
-				logger.Error("failed to write response", "res", res, "err", wErr)
-			}
+			writeHTTPResponse(w, logger, rpctypes.RPCInvalidParamsError(
+				dummyID, fmt.Errorf("error converting http params to arguments: %w", err)))
 			return
 		}
 		args = append(args, fnArgs...)
@@ -61,36 +55,23 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 		switch e := err.(type) {
 		// if no error then return a success response
 		case nil:
-			res := rpctypes.NewRPCSuccessResponse(dummyID, result)
-			if wErr := WriteRPCResponseHTTP(w, res); wErr != nil {
-				logger.Error("failed to write response", "res", res, "err", wErr)
-			}
+			writeHTTPResponse(w, logger, rpctypes.NewRPCSuccessResponse(dummyID, result))
 
 		// if this already of type RPC error then forward that error.
 		case *rpctypes.RPCError:
-			res := rpctypes.NewRPCErrorResponse(dummyID, e.Code, e.Message, e.Data)
-			if wErr := WriteRPCResponseHTTPError(w, res); wErr != nil {
-				logger.Error("failed to write response", "res", res, "err", wErr)
-			}
+			writeHTTPResponse(w, logger, rpctypes.NewRPCErrorResponse(dummyID, e.Code, e.Message, e.Data))
 
 		default: // we need to unwrap the error and parse it accordingly
-			var res rpctypes.RPCResponse
-
 			switch errors.Unwrap(err) {
 			case coretypes.ErrZeroOrNegativeHeight,
 				coretypes.ErrZeroOrNegativePerPage,
 				coretypes.ErrPageOutOfRange,
 				coretypes.ErrInvalidRequest:
-				res = rpctypes.RPCInvalidRequestError(dummyID, err)
+				writeHTTPResponse(w, logger, rpctypes.RPCInvalidRequestError(dummyID, err))
 			default: // ctypes.ErrHeightNotAvailable, ctypes.ErrHeightExceedsChainHead:
-				res = rpctypes.RPCInternalError(dummyID, err)
-			}
-
-			if wErr := WriteRPCResponseHTTPError(w, res); wErr != nil {
-				logger.Error("failed to write response", "res", res, "err", wErr)
+				writeHTTPResponse(w, logger, rpctypes.RPCInternalError(dummyID, err))
 			}
 		}
-
 	}
 }
 

--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"reflect"
 	"regexp"
 	"strings"
@@ -213,13 +212,4 @@ func getParam(r *http.Request, param string) string {
 		s = r.FormValue(param)
 	}
 	return s
-}
-
-func dumpHTTPRequest(r *http.Request) string {
-	d, e := httputil.DumpRequest(r, true)
-	if e != nil {
-		return e.Error()
-	}
-
-	return string(d)
 }

--- a/test/app/kvstore_test.sh
+++ b/test/app/kvstore_test.sh
@@ -57,7 +57,7 @@ echo "... testing query with /abci_query 2"
 
 # we should be able to look up the key
 RESPONSE=`curl -s "127.0.0.1:26657/abci_query?path=\"\"&data=$(toHex $KEY)&prove=false"`
-RESPONSE=`echo $RESPONSE | jq .result.response.log`
+RESPONSE=`echo $RESPONSE | jq .response.log`
 
 set +e
 A=`echo $RESPONSE | grep 'exists'`
@@ -70,7 +70,7 @@ set -e
 
 # we should not be able to look up the value
 RESPONSE=`curl -s "127.0.0.1:26657/abci_query?path=\"\"&data=$(toHex $VALUE)&prove=false"`
-RESPONSE=`echo $RESPONSE | jq .result.response.log`
+RESPONSE=`echo $RESPONSE | jq .response.log`
 set +e
 A=`echo $RESPONSE | grep 'exists'`
 if [[ $? == 0 ]]; then


### PR DESCRIPTION
Add writeRPCResponse and writeHTTPResponse helpers, that handle the way RPC
responses are written to HTTP replies. These replace the exported helpers.

In particular:

- When writing a response to a URL (GET) request, do not marshal the whole
  JSON-RPC object into the body, only encode the result or the error object.
  This is a user-visible change.

- Do not change the HTTP status code for RPC errors. The RPC error already
  reports what went wrong, the HTTP status should only report problems with the
  HTTP transaction itself. This is a user-visible change.

- Encode JSON without indentation in response bodies. This is mainly cosmetic
  but saves quite a bit of response data. Users on the command line can pipe
  through jq to get indented output, the server doesn't need to do it.

- Log less aggressively where practical.
  In particular: avoid marshaling every message twice.

- Fix up test cases.
- Clean up an obsolete TODO.
- Improve error reporting for startup failures.

Points to note:

- JSON results are now marshaled without indentation on POST.
- HTTP status codes are now normalized.
- Cache control headers are no longer set.
