### PR TITLE
Wait for the autofile group to finish on WAL shutdown.

### DIFF
--- a/internal/consensus/wal.go
+++ b/internal/consensus/wal.go
@@ -171,6 +171,7 @@ func (wal *BaseWAL) OnStop() {
 			wal.logger.Error("error trying to stop wal", "error", err)
 		}
 	}
+	wal.group.Wait()
 	wal.group.Close()
 }
 


### PR DESCRIPTION
The base WAL wrapper supposedly waits for the autofile group, but only if it
does not see the group already stopped. If the OnStop hook has already been
hit, this wait will not take place, and OnStop doesn't wait on its own.
I suspect this may lead to WAL cleanup racing with test exit.

