### PR TITLE
rpc: simplify panic recovery in the server middleware

### DIFF
--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -187,7 +187,7 @@ func RecoverAndLogHandler(handler http.Handler, logger log.Logger) http.Handler 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Capture the HTTP status written by the handler.
 		var httpStatus int
-		rww := StatusWriter(w, &httpStatus)
+		rww := newStatusWriter(w, &httpStatus)
 
 		// Recover panics from inside handler and try to send the client
 		// 500 Internal server error. If the handler panicked after already
@@ -249,9 +249,9 @@ func (h maxBytesHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h.handler.ServeHTTP(w, req)
 }
 
-// StatusWriter wraps an http.ResponseWriter to capture the HTTP status code in
-// *code.
-func StatusWriter(w http.ResponseWriter, code *int) statusWriter {
+// newStatusWriter wraps an http.ResponseWriter to capture the HTTP status code
+// in *code.
+func newStatusWriter(w http.ResponseWriter, code *int) statusWriter {
 	return statusWriter{
 		ResponseWriter: w,
 		Hijacker:       w.(http.Hijacker),

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -215,7 +215,7 @@ func recoverAndLogHandler(handler http.Handler, logger log.Logger) http.Handler 
 				"method", r.Method,
 				"url", r.URL,
 				"status", httpStatus,
-				"duration", int(elapsed/time.Millisecond),
+				"duration-sec", elapsed.Seconds(),
 				"remoteAddr", r.RemoteAddr,
 			)
 		}()


### PR DESCRIPTION
Rather than installing two separate panic handlers, defer the bookkeeping separately from recovery, and lift the delegated handler call out to the top level of the wrapper.

Also, regularize the server middleware wrappers. Some of the wrappers use constructors, others are explicitly written out as composite literals. To improve legibility, give all of them constructors and add documentation.

No functional changes.