### PR TITLE
consensus+state: improve shutdown grace

### DIFF
--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -262,6 +262,10 @@ func (app *localClient) CommitSync(ctx context.Context) (*types.ResponseCommit, 
 	app.mtx.Lock()
 	defer app.mtx.Unlock()
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	res := app.Application.Commit()
 	return &res, nil
 }

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -250,14 +250,12 @@ func (blockExec *BlockExecutor) Commit(
 	// in the ABCI app before Commit.
 	err := blockExec.mempool.FlushAppConn(ctx)
 	if err != nil {
-		blockExec.logger.Error("client error during mempool.FlushAppConn", "err", err)
 		return nil, 0, err
 	}
 
 	// Commit block, get hash back
 	res, err := blockExec.proxyApp.CommitSync(ctx)
 	if err != nil {
-		blockExec.logger.Error("client error during proxyAppConn.CommitSync", "err", err)
 		return nil, 0, err
 	}
 


### PR DESCRIPTION
This should help address the problems in `TestWALPeriodicSync`, though
I think it's only a partial solution. This patch removes some cases
where we log right before returning an error (which is an
anti-pattern) and forces the local client to return an error in the
case of a canceled context. 

Most suspiciously it elides an error logging message in the case that
the state machine sees a panic after the context is canceled.