### PR TITLE
queue: waiting should respect context

### DIFF
--- a/internal/libs/queue/queue.go
+++ b/internal/libs/queue/queue.go
@@ -151,11 +151,17 @@ func (q *Queue) Wait(ctx context.Context) (interface{}, error) {
 		if q.closed {
 			return nil, ErrQueueClosed
 		}
+
+		sig := make(chan struct{})
+		go func() {
+			defer close(sig)
+			q.nempty.Wait()
+		}()
+
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		default:
-			q.nempty.Wait()
+		case <-sig:
 		}
 	}
 	return q.popFront(), nil


### PR DESCRIPTION
Wanted to be able to make sure that queue waiting can unblock if the
context cancels. This risks leaking one goroutine if the context
cancels until the cond-var fires (which would happen on queue close,
but also fairly often otherwise as well, so it doesn't feel like a
large risk.)