### PR TITLE
rpc: clean up the RPCFunc constructor signature

### DIFF
--- a/internal/inspect/rpc/rpc.go
+++ b/internal/inspect/rpc/rpc.go
@@ -38,16 +38,16 @@ func Routes(cfg config.RPCConfig, s state.Store, bs state.BlockStore, es []index
 		Logger:     logger,
 	}
 	return core.RoutesMap{
-		"blockchain":       server.NewRPCFunc(env.BlockchainInfo, "minHeight,maxHeight"),
+		"blockchain":       server.NewRPCFunc(env.BlockchainInfo, "minHeight", "maxHeight"),
 		"consensus_params": server.NewRPCFunc(env.ConsensusParams, "height"),
 		"block":            server.NewRPCFunc(env.Block, "height"),
 		"block_by_hash":    server.NewRPCFunc(env.BlockByHash, "hash"),
 		"block_results":    server.NewRPCFunc(env.BlockResults, "height"),
 		"commit":           server.NewRPCFunc(env.Commit, "height"),
-		"validators":       server.NewRPCFunc(env.Validators, "height,page,per_page"),
-		"tx":               server.NewRPCFunc(env.Tx, "hash,prove"),
-		"tx_search":        server.NewRPCFunc(env.TxSearch, "query,prove,page,per_page,order_by"),
-		"block_search":     server.NewRPCFunc(env.BlockSearch, "query,page,per_page,order_by"),
+		"validators":       server.NewRPCFunc(env.Validators, "height", "page", "per_page"),
+		"tx":               server.NewRPCFunc(env.Tx, "hash", "prove"),
+		"tx_search":        server.NewRPCFunc(env.TxSearch, "query", "prove", "page", "per_page", "order_by"),
+		"block_search":     server.NewRPCFunc(env.BlockSearch, "query", "page", "per_page", "order_by"),
 	}
 }
 

--- a/internal/rpc/core/routes.go
+++ b/internal/rpc/core/routes.go
@@ -31,14 +31,14 @@ func NewRoutesMap(svc RPCService, opts *RouteOptions) RoutesMap {
 		// subscribe/unsubscribe are reserved for websocket events.
 		"subscribe":       rpc.NewWSRPCFunc(svc.Subscribe, "query"),
 		"unsubscribe":     rpc.NewWSRPCFunc(svc.Unsubscribe, "query"),
-		"unsubscribe_all": rpc.NewWSRPCFunc(svc.UnsubscribeAll, ""),
+		"unsubscribe_all": rpc.NewWSRPCFunc(svc.UnsubscribeAll),
 
 		// info API
-		"health":               rpc.NewRPCFunc(svc.Health, ""),
-		"status":               rpc.NewRPCFunc(svc.Status, ""),
-		"net_info":             rpc.NewRPCFunc(svc.NetInfo, ""),
-		"blockchain":           rpc.NewRPCFunc(svc.BlockchainInfo, "minHeight,maxHeight"),
-		"genesis":              rpc.NewRPCFunc(svc.Genesis, ""),
+		"health":               rpc.NewRPCFunc(svc.Health),
+		"status":               rpc.NewRPCFunc(svc.Status),
+		"net_info":             rpc.NewRPCFunc(svc.NetInfo),
+		"blockchain":           rpc.NewRPCFunc(svc.BlockchainInfo, "minHeight", "maxHeight"),
+		"genesis":              rpc.NewRPCFunc(svc.Genesis),
 		"genesis_chunked":      rpc.NewRPCFunc(svc.GenesisChunked, "chunk"),
 		"header":               rpc.NewRPCFunc(svc.Header, "height"),
 		"header_by_hash":       rpc.NewRPCFunc(svc.HeaderByHash, "hash"),
@@ -48,15 +48,15 @@ func NewRoutesMap(svc RPCService, opts *RouteOptions) RoutesMap {
 		"commit":               rpc.NewRPCFunc(svc.Commit, "height"),
 		"check_tx":             rpc.NewRPCFunc(svc.CheckTx, "tx"),
 		"remove_tx":            rpc.NewRPCFunc(svc.RemoveTx, "txkey"),
-		"tx":                   rpc.NewRPCFunc(svc.Tx, "hash,prove"),
-		"tx_search":            rpc.NewRPCFunc(svc.TxSearch, "query,prove,page,per_page,order_by"),
-		"block_search":         rpc.NewRPCFunc(svc.BlockSearch, "query,page,per_page,order_by"),
-		"validators":           rpc.NewRPCFunc(svc.Validators, "height,page,per_page"),
-		"dump_consensus_state": rpc.NewRPCFunc(svc.DumpConsensusState, ""),
-		"consensus_state":      rpc.NewRPCFunc(svc.GetConsensusState, ""),
+		"tx":                   rpc.NewRPCFunc(svc.Tx, "hash", "prove"),
+		"tx_search":            rpc.NewRPCFunc(svc.TxSearch, "query", "prove", "page", "per_page", "order_by"),
+		"block_search":         rpc.NewRPCFunc(svc.BlockSearch, "query", "page", "per_page", "order_by"),
+		"validators":           rpc.NewRPCFunc(svc.Validators, "height", "page", "per_page"),
+		"dump_consensus_state": rpc.NewRPCFunc(svc.DumpConsensusState),
+		"consensus_state":      rpc.NewRPCFunc(svc.GetConsensusState),
 		"consensus_params":     rpc.NewRPCFunc(svc.ConsensusParams, "height"),
 		"unconfirmed_txs":      rpc.NewRPCFunc(svc.UnconfirmedTxs, "limit"),
-		"num_unconfirmed_txs":  rpc.NewRPCFunc(svc.NumUnconfirmedTxs, ""),
+		"num_unconfirmed_txs":  rpc.NewRPCFunc(svc.NumUnconfirmedTxs),
 
 		// tx broadcast API
 		"broadcast_tx_commit": rpc.NewRPCFunc(svc.BroadcastTxCommit, "tx"),
@@ -64,14 +64,14 @@ func NewRoutesMap(svc RPCService, opts *RouteOptions) RoutesMap {
 		"broadcast_tx_async":  rpc.NewRPCFunc(svc.BroadcastTxAsync, "tx"),
 
 		// abci API
-		"abci_query": rpc.NewRPCFunc(svc.ABCIQuery, "path,data,height,prove"),
-		"abci_info":  rpc.NewRPCFunc(svc.ABCIInfo, ""),
+		"abci_query": rpc.NewRPCFunc(svc.ABCIQuery, "path", "data", "height", "prove"),
+		"abci_info":  rpc.NewRPCFunc(svc.ABCIInfo),
 
 		// evidence API
 		"broadcast_evidence": rpc.NewRPCFunc(svc.BroadcastEvidence, "evidence"),
 	}
 	if u, ok := svc.(RPCUnsafe); ok && opts.Unsafe {
-		out["unsafe_flush_mempool"] = rpc.NewRPCFunc(u.UnsafeFlushMempool, "")
+		out["unsafe_flush_mempool"] = rpc.NewRPCFunc(u.UnsafeFlushMempool)
 	}
 	return out
 }

--- a/rpc/jsonrpc/doc.go
+++ b/rpc/jsonrpc/doc.go
@@ -55,7 +55,7 @@
 // Define some routes
 //
 //   var Routes = map[string]*rpcserver.RPCFunc{
-//	    "status": rpcserver.NewRPCFunc(Status, "arg", false),
+//	    "status": rpcserver.NewRPCFunc(Status, "arg"),
 //   }
 //
 // An rpc function:

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -18,7 +18,7 @@ import (
 
 func testMux() *http.ServeMux {
 	funcMap := map[string]*RPCFunc{
-		"c":     NewRPCFunc(func(ctx context.Context, s string, i int) (string, error) { return "foo", nil }, "s,i"),
+		"c":     NewRPCFunc(func(ctx context.Context, s string, i int) (string, error) { return "foo", nil }, "s", "i"),
 		"block": NewRPCFunc(func(ctx context.Context, h int) (string, error) { return "block", nil }, "height"),
 	}
 	mux := http.NewServeMux()

--- a/rpc/jsonrpc/server/parse_test.go
+++ b/rpc/jsonrpc/server/parse_test.go
@@ -135,7 +135,7 @@ func TestParseJSONArray(t *testing.T) {
 
 func TestParseJSONRPC(t *testing.T) {
 	demo := func(ctx context.Context, height int, name string) {}
-	call := NewRPCFunc(demo, "height,name")
+	call := NewRPCFunc(demo, "height", "name")
 
 	cases := []struct {
 		raw    string
@@ -172,7 +172,7 @@ func TestParseJSONRPC(t *testing.T) {
 
 func TestParseURI(t *testing.T) {
 	demo := func(ctx context.Context, height int, name string) {}
-	call := NewRPCFunc(demo, "height,name")
+	call := NewRPCFunc(demo, "height", "name")
 
 	cases := []struct {
 		raw    []string

--- a/rpc/jsonrpc/server/rpc_func.go
+++ b/rpc/jsonrpc/server/rpc_func.go
@@ -3,7 +3,6 @@ package server
 import (
 	"net/http"
 	"reflect"
-	"strings"
 
 	"github.com/tendermint/tendermint/libs/log"
 )
@@ -35,26 +34,22 @@ type RPCFunc struct {
 
 // NewRPCFunc wraps a function for introspection.
 // f is the function, args are comma separated argument names
-func NewRPCFunc(f interface{}, args string) *RPCFunc {
-	return newRPCFunc(f, args, false)
+func NewRPCFunc(f interface{}, argNames ...string) *RPCFunc {
+	return newRPCFunc(f, argNames, false)
 }
 
 // NewWSRPCFunc wraps a function for introspection and use in the websockets.
-func NewWSRPCFunc(f interface{}, args string) *RPCFunc {
-	return newRPCFunc(f, args, true)
+func NewWSRPCFunc(f interface{}, argNames ...string) *RPCFunc {
+	return newRPCFunc(f, argNames, true)
 }
 
-func newRPCFunc(f interface{}, args string, ws bool) *RPCFunc {
-	var argNames []string
-	if args != "" {
-		argNames = strings.Split(args, ",")
-	}
+func newRPCFunc(f interface{}, argNames []string, wsOnly bool) *RPCFunc {
 	return &RPCFunc{
 		f:        reflect.ValueOf(f),
 		args:     funcArgTypes(f),
 		returns:  funcReturnTypes(f),
 		argNames: argNames,
-		ws:       ws,
+		ws:       wsOnly,
 	}
 }
 

--- a/rpc/jsonrpc/server/ws_handler_test.go
+++ b/rpc/jsonrpc/server/ws_handler_test.go
@@ -47,7 +47,7 @@ func TestWebsocketManagerHandler(t *testing.T) {
 
 func newWSServer(t *testing.T, logger log.Logger) *httptest.Server {
 	funcMap := map[string]*RPCFunc{
-		"c": NewWSRPCFunc(func(ctx context.Context, s string, i int) (string, error) { return "foo", nil }, "s,i"),
+		"c": NewWSRPCFunc(func(ctx context.Context, s string, i int) (string, error) { return "foo", nil }, "s", "i"),
 	}
 	wm := NewWebsocketManager(logger, funcMap)
 

--- a/rpc/jsonrpc/test/main.go
+++ b/rpc/jsonrpc/test/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var routes = map[string]*rpcserver.RPCFunc{
-	"hello_world": rpcserver.NewRPCFunc(HelloWorld, "name,num"),
+	"hello_world": rpcserver.NewRPCFunc(HelloWorld, "name", "num"),
 }
 
 func HelloWorld(ctx context.Context, name string, num int) (Result, error) {

--- a/test/fuzz/rpc/jsonrpc/server/handler.go
+++ b/test/fuzz/rpc/jsonrpc/server/handler.go
@@ -13,7 +13,7 @@ import (
 )
 
 var rpcFuncMap = map[string]*rs.RPCFunc{
-	"c": rs.NewRPCFunc(func(s string, i int) (string, int) { return "foo", 200 }, "s,i"),
+	"c": rs.NewRPCFunc(func(s string, i int) (string, int) { return "foo", 200 }, "s", "i"),
 }
 var mux *http.ServeMux
 


### PR DESCRIPTION
Instead of taking a comma-separated string of parameter names, take each
parameter name as a separate argument. Now that we no longer have an extra flag
for caching, this fits nicely into a variadic trailer.
