### PR TITLE
privval: avoid re-signing vote when RHS and signbytes are equal

### DIFF
--- a/privval/file.go
+++ b/privval/file.go
@@ -354,8 +354,8 @@ func (pv *FilePV) signVote(chainID string, vote *tmproto.Vote) error {
 
 			vote.Timestamp = timestamp
 			vote.Signature = lss.Signature
-			return nil
 		}
+		return nil
 	}
 
 	// It passed the checks. Sign the vote

--- a/privval/file.go
+++ b/privval/file.go
@@ -403,8 +403,8 @@ func (pv *FilePV) signProposal(chainID string, proposal *tmproto.Proposal) error
 			}
 			proposal.Timestamp = timestamp
 			proposal.Signature = lss.Signature
-			return nil
 		}
+		return nil
 	}
 
 	// It passed the checks. Sign the proposal


### PR DESCRIPTION
It seems sign procedure is always performed when RHS and signbytes are equal


