### PR TITLE
rpc: update fuzz criteria to match the implementation

### DIFF
--- a/test/fuzz/rpc/jsonrpc/server/handler.go
+++ b/test/fuzz/rpc/jsonrpc/server/handler.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -13,7 +14,9 @@ import (
 )
 
 var rpcFuncMap = map[string]*rs.RPCFunc{
-	"c": rs.NewRPCFunc(func(s string, i int) (string, int) { return "foo", 200 }, "s", "i"),
+	"c": rs.NewRPCFunc(func(ctx context.Context, s string, i int) (string, error) {
+		return "foo", nil
+	}, "s", "i"),
 }
 var mux *http.ServeMux
 


### PR DESCRIPTION
I missed this during my previous pass.

Requirements for handlers:

- First argument is context.Context.
- Last of two results is error.
