### PR TITLE
Update README.md

### DIFF
--- a/docs/tendermint-core/README.md
+++ b/docs/tendermint-core/README.md
@@ -18,7 +18,7 @@ This section dives into the internals of Go-Tendermint.
 - [Mempool](./mempool/README.md)
 - [Light Client](./light-client.md)
 - [Consensus](./consensus/README.md)
-- [Peer Exachange (PEX)](./pex/README.md)
+- [Peer Exchange (PEX)](./pex/README.md)
 - [Evidence](./evidence/README.md)
 
 For full specifications refer to the [spec repo](https://github.com/tendermint/spec).


### PR DESCRIPTION
Fixed typo in documentation overview page "Exachange" => "Exchange".

