### PR TITLE
testing: use noop loger with leakteset in more places

### DIFF
--- a/privval/signer_client_test.go
+++ b/privval/signer_client_test.go
@@ -69,7 +69,7 @@ func TestSignerClose(t *testing.T) {
 	bctx, bcancel := context.WithCancel(context.Background())
 	defer bcancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getSignerTestCases(bctx, t, logger) {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,7 +91,7 @@ func TestSignerPing(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getSignerTestCases(ctx, t, logger) {
 		err := tc.signerClient.Ping(ctx)
@@ -105,7 +105,7 @@ func TestSignerGetPubKey(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getSignerTestCases(ctx, t, logger) {
 		t.Run(tc.name, func(t *testing.T) {
@@ -135,7 +135,7 @@ func TestSignerProposal(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getSignerTestCases(ctx, t, logger) {
 		t.Run(tc.name, func(t *testing.T) {
@@ -175,7 +175,7 @@ func TestSignerVote(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getSignerTestCases(ctx, t, logger) {
 		t.Run(tc.name, func(t *testing.T) {
@@ -218,7 +218,7 @@ func TestSignerVoteResetDeadline(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getSignerTestCases(ctx, t, logger) {
 		t.Run(tc.name, func(t *testing.T) {
@@ -269,7 +269,7 @@ func TestSignerVoteKeepAlive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getSignerTestCases(ctx, t, logger) {
 		t.Run(tc.name, func(t *testing.T) {
@@ -319,7 +319,7 @@ func TestSignerSignProposalErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getSignerTestCases(ctx, t, logger) {
 		t.Run(tc.name, func(t *testing.T) {
@@ -360,7 +360,7 @@ func TestSignerSignVoteErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getSignerTestCases(ctx, t, logger) {
 		t.Run(tc.name, func(t *testing.T) {
@@ -426,7 +426,7 @@ func TestSignerUnexpectedResponse(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getSignerTestCases(ctx, t, logger) {
 		t.Run(tc.name, func(t *testing.T) {

--- a/privval/signer_listener_endpoint_test.go
+++ b/privval/signer_listener_endpoint_test.go
@@ -40,10 +40,12 @@ func TestSignerRemoteRetryTCPOnly(t *testing.T) {
 		retries   = 10
 	)
 
+	t.Cleanup(leaktest.Check(t))
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -95,7 +97,7 @@ func TestRetryConnToRemoteSigner(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	for _, tc := range getDialerTestCases(t) {
 		var (

--- a/rpc/jsonrpc/client/ws_client_test.go
+++ b/rpc/jsonrpc/client/ws_client_test.go
@@ -220,6 +220,9 @@ func TestNotBlockingOnStop(t *testing.T) {
 
 func startClient(ctx context.Context, t *testing.T, addr string) *WSClient {
 	t.Helper()
+
+	t.Cleanup(leaktest.Check(t))
+
 	opts := DefaultWSOptions()
 	opts.SkipMetrics = true
 	c, err := NewWSWithOptions(addr, "/websocket", opts)
@@ -227,7 +230,7 @@ func startClient(ctx context.Context, t *testing.T, addr string) *WSClient {
 	require.NoError(t, err)
 	err = c.Start(ctx)
 	require.NoError(t, err)
-	c.Logger = log.NewTestingLogger(t)
+	c.Logger = log.NewNopLogger()
 	return c
 }
 

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -271,10 +272,12 @@ func TestServersAndClientsBasic(t *testing.T) {
 	serverAddrs := [...]string{tcpAddr, unixAddr}
 	for _, addr := range serverAddrs {
 		t.Run(addr, func(t *testing.T) {
+			t.Cleanup(leaktest.Check(t))
+
 			ctx, cancel := context.WithCancel(bctx)
 			defer cancel()
 
-			logger := log.NewTestingLogger(t)
+			logger := log.NewNopLogger()
 
 			cl2, err := client.New(addr)
 			require.NoError(t, err)
@@ -294,12 +297,14 @@ func TestServersAndClientsBasic(t *testing.T) {
 }
 
 func TestWSNewWSRPCFunc(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	cl, err := client.NewWS(tcpAddr, websocketEndpoint)
 	require.NoError(t, err)
-	cl.Logger = log.NewTestingLogger(t)
+	cl.Logger = log.NewNopLogger()
 	err = cl.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -329,12 +334,14 @@ func TestWSNewWSRPCFunc(t *testing.T) {
 // TestWSClientPingPong checks that a client & server exchange pings
 // & pongs so connection stays alive.
 func TestWSClientPingPong(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	cl, err := client.NewWS(tcpAddr, websocketEndpoint)
 	require.NoError(t, err)
-	cl.Logger = log.NewTestingLogger(t)
+	cl.Logger = log.NewNopLogger()
 	err = cl.Start(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -266,14 +266,17 @@ func testWithWSClient(ctx context.Context, t *testing.T, cl *client.WSClient) {
 //-------------
 
 func TestServersAndClientsBasic(t *testing.T) {
-	bctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// TODO: reenable the leak detector once the test fixture is
+	// managed in the context of this test.
+	//
+	// t.Cleanup(leaktest.Check(t))
+
+	bctx, bcancel := context.WithCancel(context.Background())
+	defer bcancel()
 
 	serverAddrs := [...]string{tcpAddr, unixAddr}
 	for _, addr := range serverAddrs {
 		t.Run(addr, func(t *testing.T) {
-			t.Cleanup(leaktest.Check(t))
-
 			ctx, cancel := context.WithCancel(bctx)
 			defer cancel()
 
@@ -284,7 +287,9 @@ func TestServersAndClientsBasic(t *testing.T) {
 			fmt.Printf("=== testing server on %s using JSONRPC client", addr)
 			testWithHTTPClient(ctx, t, cl2)
 
-			cl3, err := client.NewWS(addr, websocketEndpoint)
+			opts := client.DefaultWSOptions()
+			opts.SkipMetrics = true
+			cl3, err := client.NewWSWithOptions(addr, websocketEndpoint, opts)
 			require.NoError(t, err)
 			cl3.Logger = logger
 			err = cl3.Start(ctx)
@@ -302,7 +307,9 @@ func TestWSNewWSRPCFunc(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cl, err := client.NewWS(tcpAddr, websocketEndpoint)
+	opts := client.DefaultWSOptions()
+	opts.SkipMetrics = true
+	cl, err := client.NewWSWithOptions(tcpAddr, websocketEndpoint, opts)
 	require.NoError(t, err)
 	cl.Logger = log.NewNopLogger()
 	err = cl.Start(ctx)
@@ -339,7 +346,9 @@ func TestWSClientPingPong(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cl, err := client.NewWS(tcpAddr, websocketEndpoint)
+	opts := client.DefaultWSOptions()
+	opts.SkipMetrics = true
+	cl, err := client.NewWSWithOptions(tcpAddr, websocketEndpoint, opts)
 	require.NoError(t, err)
 	cl.Logger = log.NewNopLogger()
 	err = cl.Start(ctx)

--- a/rpc/jsonrpc/server/ws_handler_test.go
+++ b/rpc/jsonrpc/server/ws_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 
@@ -14,10 +15,12 @@ import (
 )
 
 func TestWebsocketManagerHandler(t *testing.T) {
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	s := newWSServer(t, logger)
 	defer s.Close()
+
+	t.Cleanup(leaktest.Check(t))
 
 	// check upgrader works
 	d := websocket.Dialer{}


### PR DESCRIPTION
Switch to the testing logger in more places, but also add in the leak
test detector to explicitly catche the cases that would have been
caught by log-after-test panics.