### PR TITLE
protoio: fix incorrect test assertion

### DIFF
--- a/internal/libs/protoio/io_test.go
+++ b/internal/libs/protoio/io_test.go
@@ -95,7 +95,7 @@ func iotest(t *testing.T, writer protoio.WriteCloser, reader protoio.ReadCloser)
 		}
 		i++
 	}
-	require.NotEqual(t, size, i)
+	require.Equal(t, size, i, "messages read ≠ messages written")
 	if err := reader.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
After writing and then reading a bunch of random messages, the test was
checking that it did not read the same number of messages that it wrote.
The sense of this check was inverted; they should match.

Introduced by accident in #7522. I'm not sure why this did not show up in CI.

Edit: I now know why it didn't show up in ci: #7608.