### PR TITLE
abci/client: simplify client interface

### DIFF
--- a/abci/client/client.go
+++ b/abci/client/client.go
@@ -33,35 +33,24 @@ type Client interface {
 
 	// Asynchronous requests
 	FlushAsync(context.Context) (*ReqRes, error)
-	EchoAsync(ctx context.Context, msg string) (*ReqRes, error)
-	InfoAsync(context.Context, types.RequestInfo) (*ReqRes, error)
 	DeliverTxAsync(context.Context, types.RequestDeliverTx) (*ReqRes, error)
 	CheckTxAsync(context.Context, types.RequestCheckTx) (*ReqRes, error)
-	QueryAsync(context.Context, types.RequestQuery) (*ReqRes, error)
-	CommitAsync(context.Context) (*ReqRes, error)
-	InitChainAsync(context.Context, types.RequestInitChain) (*ReqRes, error)
-	BeginBlockAsync(context.Context, types.RequestBeginBlock) (*ReqRes, error)
-	EndBlockAsync(context.Context, types.RequestEndBlock) (*ReqRes, error)
-	ListSnapshotsAsync(context.Context, types.RequestListSnapshots) (*ReqRes, error)
-	OfferSnapshotAsync(context.Context, types.RequestOfferSnapshot) (*ReqRes, error)
-	LoadSnapshotChunkAsync(context.Context, types.RequestLoadSnapshotChunk) (*ReqRes, error)
-	ApplySnapshotChunkAsync(context.Context, types.RequestApplySnapshotChunk) (*ReqRes, error)
 
 	// Synchronous requests
-	FlushSync(context.Context) error
-	EchoSync(ctx context.Context, msg string) (*types.ResponseEcho, error)
-	InfoSync(context.Context, types.RequestInfo) (*types.ResponseInfo, error)
-	DeliverTxSync(context.Context, types.RequestDeliverTx) (*types.ResponseDeliverTx, error)
-	CheckTxSync(context.Context, types.RequestCheckTx) (*types.ResponseCheckTx, error)
-	QuerySync(context.Context, types.RequestQuery) (*types.ResponseQuery, error)
-	CommitSync(context.Context) (*types.ResponseCommit, error)
-	InitChainSync(context.Context, types.RequestInitChain) (*types.ResponseInitChain, error)
-	BeginBlockSync(context.Context, types.RequestBeginBlock) (*types.ResponseBeginBlock, error)
-	EndBlockSync(context.Context, types.RequestEndBlock) (*types.ResponseEndBlock, error)
-	ListSnapshotsSync(context.Context, types.RequestListSnapshots) (*types.ResponseListSnapshots, error)
-	OfferSnapshotSync(context.Context, types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error)
-	LoadSnapshotChunkSync(context.Context, types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error)
-	ApplySnapshotChunkSync(context.Context, types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error)
+	Flush(context.Context) error
+	Echo(ctx context.Context, msg string) (*types.ResponseEcho, error)
+	Info(context.Context, types.RequestInfo) (*types.ResponseInfo, error)
+	DeliverTx(context.Context, types.RequestDeliverTx) (*types.ResponseDeliverTx, error)
+	CheckTx(context.Context, types.RequestCheckTx) (*types.ResponseCheckTx, error)
+	Query(context.Context, types.RequestQuery) (*types.ResponseQuery, error)
+	Commit(context.Context) (*types.ResponseCommit, error)
+	InitChain(context.Context, types.RequestInitChain) (*types.ResponseInitChain, error)
+	BeginBlock(context.Context, types.RequestBeginBlock) (*types.ResponseBeginBlock, error)
+	EndBlock(context.Context, types.RequestEndBlock) (*types.ResponseEndBlock, error)
+	ListSnapshots(context.Context, types.RequestListSnapshots) (*types.ResponseListSnapshots, error)
+	OfferSnapshot(context.Context, types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error)
+	LoadSnapshotChunk(context.Context, types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error)
+	ApplySnapshotChunk(context.Context, types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error)
 }
 
 //----------------------------------------

--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -184,16 +184,6 @@ func (cli *grpcClient) SetResponseCallback(resCb Callback) {
 //----------------------------------------
 
 // NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) EchoAsync(ctx context.Context, msg string) (*ReqRes, error) {
-	req := types.ToRequestEcho(msg)
-	res, err := cli.client.Echo(ctx, req.GetEcho(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_Echo{Echo: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
 func (cli *grpcClient) FlushAsync(ctx context.Context) (*ReqRes, error) {
 	req := types.ToRequestFlush()
 	res, err := cli.client.Flush(ctx, req.GetFlush(), grpc.WaitForReady(true))
@@ -201,16 +191,6 @@ func (cli *grpcClient) FlushAsync(ctx context.Context) (*ReqRes, error) {
 		return nil, err
 	}
 	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_Flush{Flush: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) InfoAsync(ctx context.Context, params types.RequestInfo) (*ReqRes, error) {
-	req := types.ToRequestInfo(params)
-	res, err := cli.client.Info(ctx, req.GetInfo(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_Info{Info: res}})
 }
 
 // NOTE: call is synchronous, use ctx to break early if needed
@@ -231,106 +211,6 @@ func (cli *grpcClient) CheckTxAsync(ctx context.Context, params types.RequestChe
 		return nil, err
 	}
 	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_CheckTx{CheckTx: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) QueryAsync(ctx context.Context, params types.RequestQuery) (*ReqRes, error) {
-	req := types.ToRequestQuery(params)
-	res, err := cli.client.Query(ctx, req.GetQuery(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_Query{Query: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) CommitAsync(ctx context.Context) (*ReqRes, error) {
-	req := types.ToRequestCommit()
-	res, err := cli.client.Commit(ctx, req.GetCommit(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_Commit{Commit: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) InitChainAsync(ctx context.Context, params types.RequestInitChain) (*ReqRes, error) {
-	req := types.ToRequestInitChain(params)
-	res, err := cli.client.InitChain(ctx, req.GetInitChain(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_InitChain{InitChain: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) BeginBlockAsync(ctx context.Context, params types.RequestBeginBlock) (*ReqRes, error) {
-	req := types.ToRequestBeginBlock(params)
-	res, err := cli.client.BeginBlock(ctx, req.GetBeginBlock(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_BeginBlock{BeginBlock: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) EndBlockAsync(ctx context.Context, params types.RequestEndBlock) (*ReqRes, error) {
-	req := types.ToRequestEndBlock(params)
-	res, err := cli.client.EndBlock(ctx, req.GetEndBlock(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_EndBlock{EndBlock: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) ListSnapshotsAsync(ctx context.Context, params types.RequestListSnapshots) (*ReqRes, error) {
-	req := types.ToRequestListSnapshots(params)
-	res, err := cli.client.ListSnapshots(ctx, req.GetListSnapshots(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_ListSnapshots{ListSnapshots: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) OfferSnapshotAsync(ctx context.Context, params types.RequestOfferSnapshot) (*ReqRes, error) {
-	req := types.ToRequestOfferSnapshot(params)
-	res, err := cli.client.OfferSnapshot(ctx, req.GetOfferSnapshot(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_OfferSnapshot{OfferSnapshot: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) LoadSnapshotChunkAsync(
-	ctx context.Context,
-	params types.RequestLoadSnapshotChunk,
-) (*ReqRes, error) {
-	req := types.ToRequestLoadSnapshotChunk(params)
-	res, err := cli.client.LoadSnapshotChunk(ctx, req.GetLoadSnapshotChunk(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(ctx, req, &types.Response{Value: &types.Response_LoadSnapshotChunk{LoadSnapshotChunk: res}})
-}
-
-// NOTE: call is synchronous, use ctx to break early if needed
-func (cli *grpcClient) ApplySnapshotChunkAsync(
-	ctx context.Context,
-	params types.RequestApplySnapshotChunk,
-) (*ReqRes, error) {
-	req := types.ToRequestApplySnapshotChunk(params)
-	res, err := cli.client.ApplySnapshotChunk(ctx, req.GetApplySnapshotChunk(), grpc.WaitForReady(true))
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishAsyncCall(
-		ctx,
-		req,
-		&types.Response{Value: &types.Response_ApplySnapshotChunk{ApplySnapshotChunk: res}},
-	)
 }
 
 // finishAsyncCall creates a ReqRes for an async call, and immediately populates it
@@ -376,30 +256,22 @@ func (cli *grpcClient) finishSyncCall(reqres *ReqRes) *types.Response {
 
 //----------------------------------------
 
-func (cli *grpcClient) FlushSync(ctx context.Context) error {
-	return nil
+func (cli *grpcClient) Flush(ctx context.Context) error { return nil }
+
+func (cli *grpcClient) Echo(ctx context.Context, msg string) (*types.ResponseEcho, error) {
+	req := types.ToRequestEcho(msg)
+	return cli.client.Echo(ctx, req.GetEcho(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) EchoSync(ctx context.Context, msg string) (*types.ResponseEcho, error) {
-	reqres, err := cli.EchoAsync(ctx, msg)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetEcho(), cli.Error()
-}
-
-func (cli *grpcClient) InfoSync(
+func (cli *grpcClient) Info(
 	ctx context.Context,
-	req types.RequestInfo,
+	params types.RequestInfo,
 ) (*types.ResponseInfo, error) {
-	reqres, err := cli.InfoAsync(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetInfo(), cli.Error()
+	req := types.ToRequestInfo(params)
+	return cli.client.Info(ctx, req.GetInfo(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) DeliverTxSync(
+func (cli *grpcClient) DeliverTx(
 	ctx context.Context,
 	params types.RequestDeliverTx,
 ) (*types.ResponseDeliverTx, error) {
@@ -411,7 +283,7 @@ func (cli *grpcClient) DeliverTxSync(
 	return cli.finishSyncCall(reqres).GetDeliverTx(), cli.Error()
 }
 
-func (cli *grpcClient) CheckTxSync(
+func (cli *grpcClient) CheckTx(
 	ctx context.Context,
 	params types.RequestCheckTx,
 ) (*types.ResponseCheckTx, error) {
@@ -423,103 +295,76 @@ func (cli *grpcClient) CheckTxSync(
 	return cli.finishSyncCall(reqres).GetCheckTx(), cli.Error()
 }
 
-func (cli *grpcClient) QuerySync(
+func (cli *grpcClient) Query(
 	ctx context.Context,
-	req types.RequestQuery,
+	params types.RequestQuery,
 ) (*types.ResponseQuery, error) {
-	reqres, err := cli.QueryAsync(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetQuery(), cli.Error()
+	req := types.ToRequestQuery(params)
+	return cli.client.Query(ctx, req.GetQuery(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) CommitSync(ctx context.Context) (*types.ResponseCommit, error) {
-	reqres, err := cli.CommitAsync(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetCommit(), cli.Error()
+func (cli *grpcClient) Commit(ctx context.Context) (*types.ResponseCommit, error) {
+	req := types.ToRequestCommit()
+	return cli.client.Commit(ctx, req.GetCommit(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) InitChainSync(
+func (cli *grpcClient) InitChain(
 	ctx context.Context,
 	params types.RequestInitChain,
 ) (*types.ResponseInitChain, error) {
 
-	reqres, err := cli.InitChainAsync(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetInitChain(), cli.Error()
+	req := types.ToRequestInitChain(params)
+	return cli.client.InitChain(ctx, req.GetInitChain(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) BeginBlockSync(
+func (cli *grpcClient) BeginBlock(
 	ctx context.Context,
 	params types.RequestBeginBlock,
 ) (*types.ResponseBeginBlock, error) {
 
-	reqres, err := cli.BeginBlockAsync(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetBeginBlock(), cli.Error()
+	req := types.ToRequestBeginBlock(params)
+	return cli.client.BeginBlock(ctx, req.GetBeginBlock(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) EndBlockSync(
+func (cli *grpcClient) EndBlock(
 	ctx context.Context,
 	params types.RequestEndBlock,
 ) (*types.ResponseEndBlock, error) {
 
-	reqres, err := cli.EndBlockAsync(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetEndBlock(), cli.Error()
+	req := types.ToRequestEndBlock(params)
+	return cli.client.EndBlock(ctx, req.GetEndBlock(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) ListSnapshotsSync(
+func (cli *grpcClient) ListSnapshots(
 	ctx context.Context,
 	params types.RequestListSnapshots,
 ) (*types.ResponseListSnapshots, error) {
 
-	reqres, err := cli.ListSnapshotsAsync(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetListSnapshots(), cli.Error()
+	req := types.ToRequestListSnapshots(params)
+	return cli.client.ListSnapshots(ctx, req.GetListSnapshots(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) OfferSnapshotSync(
+func (cli *grpcClient) OfferSnapshot(
 	ctx context.Context,
 	params types.RequestOfferSnapshot,
 ) (*types.ResponseOfferSnapshot, error) {
 
-	reqres, err := cli.OfferSnapshotAsync(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetOfferSnapshot(), cli.Error()
+	req := types.ToRequestOfferSnapshot(params)
+	return cli.client.OfferSnapshot(ctx, req.GetOfferSnapshot(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) LoadSnapshotChunkSync(
+func (cli *grpcClient) LoadSnapshotChunk(
 	ctx context.Context,
 	params types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
 
-	reqres, err := cli.LoadSnapshotChunkAsync(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetLoadSnapshotChunk(), cli.Error()
+	req := types.ToRequestLoadSnapshotChunk(params)
+	return cli.client.LoadSnapshotChunk(ctx, req.GetLoadSnapshotChunk(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) ApplySnapshotChunkSync(
+func (cli *grpcClient) ApplySnapshotChunk(
 	ctx context.Context,
 	params types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
 
-	reqres, err := cli.ApplySnapshotChunkAsync(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return cli.finishSyncCall(reqres).GetApplySnapshotChunk(), cli.Error()
+	req := types.ToRequestApplySnapshotChunk(params)
+	return cli.client.ApplySnapshotChunk(ctx, req.GetApplySnapshotChunk(), grpc.WaitForReady(true))
 }

--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -58,27 +58,6 @@ func (app *localClient) FlushAsync(ctx context.Context) (*ReqRes, error) {
 	return newLocalReqRes(types.ToRequestFlush(), nil), nil
 }
 
-func (app *localClient) EchoAsync(ctx context.Context, msg string) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	return app.callback(
-		types.ToRequestEcho(msg),
-		types.ToResponseEcho(msg),
-	), nil
-}
-
-func (app *localClient) InfoAsync(ctx context.Context, req types.RequestInfo) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	res := app.Application.Info(req)
-	return app.callback(
-		types.ToRequestInfo(req),
-		types.ToResponseInfo(res),
-	), nil
-}
-
 func (app *localClient) DeliverTxAsync(ctx context.Context, params types.RequestDeliverTx) (*ReqRes, error) {
 	app.mtx.Lock()
 	defer app.mtx.Unlock()
@@ -101,122 +80,17 @@ func (app *localClient) CheckTxAsync(ctx context.Context, req types.RequestCheck
 	), nil
 }
 
-func (app *localClient) QueryAsync(ctx context.Context, req types.RequestQuery) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	res := app.Application.Query(req)
-	return app.callback(
-		types.ToRequestQuery(req),
-		types.ToResponseQuery(res),
-	), nil
-}
-
-func (app *localClient) CommitAsync(ctx context.Context) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	res := app.Application.Commit()
-	return app.callback(
-		types.ToRequestCommit(),
-		types.ToResponseCommit(res),
-	), nil
-}
-
-func (app *localClient) InitChainAsync(ctx context.Context, req types.RequestInitChain) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	res := app.Application.InitChain(req)
-	return app.callback(
-		types.ToRequestInitChain(req),
-		types.ToResponseInitChain(res),
-	), nil
-}
-
-func (app *localClient) BeginBlockAsync(ctx context.Context, req types.RequestBeginBlock) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	res := app.Application.BeginBlock(req)
-	return app.callback(
-		types.ToRequestBeginBlock(req),
-		types.ToResponseBeginBlock(res),
-	), nil
-}
-
-func (app *localClient) EndBlockAsync(ctx context.Context, req types.RequestEndBlock) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	res := app.Application.EndBlock(req)
-	return app.callback(
-		types.ToRequestEndBlock(req),
-		types.ToResponseEndBlock(res),
-	), nil
-}
-
-func (app *localClient) ListSnapshotsAsync(ctx context.Context, req types.RequestListSnapshots) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	res := app.Application.ListSnapshots(req)
-	return app.callback(
-		types.ToRequestListSnapshots(req),
-		types.ToResponseListSnapshots(res),
-	), nil
-}
-
-func (app *localClient) OfferSnapshotAsync(ctx context.Context, req types.RequestOfferSnapshot) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	res := app.Application.OfferSnapshot(req)
-	return app.callback(
-		types.ToRequestOfferSnapshot(req),
-		types.ToResponseOfferSnapshot(res),
-	), nil
-}
-
-func (app *localClient) LoadSnapshotChunkAsync(
-	ctx context.Context,
-	req types.RequestLoadSnapshotChunk,
-) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	res := app.Application.LoadSnapshotChunk(req)
-	return app.callback(
-		types.ToRequestLoadSnapshotChunk(req),
-		types.ToResponseLoadSnapshotChunk(res),
-	), nil
-}
-
-func (app *localClient) ApplySnapshotChunkAsync(
-	ctx context.Context,
-	req types.RequestApplySnapshotChunk,
-) (*ReqRes, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
-	res := app.Application.ApplySnapshotChunk(req)
-	return app.callback(
-		types.ToRequestApplySnapshotChunk(req),
-		types.ToResponseApplySnapshotChunk(res),
-	), nil
-}
-
 //-------------------------------------------------------
 
-func (app *localClient) FlushSync(ctx context.Context) error {
+func (app *localClient) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (app *localClient) EchoSync(ctx context.Context, msg string) (*types.ResponseEcho, error) {
+func (app *localClient) Echo(ctx context.Context, msg string) (*types.ResponseEcho, error) {
 	return &types.ResponseEcho{Message: msg}, nil
 }
 
-func (app *localClient) InfoSync(ctx context.Context, req types.RequestInfo) (*types.ResponseInfo, error) {
+func (app *localClient) Info(ctx context.Context, req types.RequestInfo) (*types.ResponseInfo, error) {
 	app.mtx.Lock()
 	defer app.mtx.Unlock()
 
@@ -224,7 +98,7 @@ func (app *localClient) InfoSync(ctx context.Context, req types.RequestInfo) (*t
 	return &res, nil
 }
 
-func (app *localClient) DeliverTxSync(
+func (app *localClient) DeliverTx(
 	ctx context.Context,
 	req types.RequestDeliverTx,
 ) (*types.ResponseDeliverTx, error) {
@@ -236,7 +110,7 @@ func (app *localClient) DeliverTxSync(
 	return &res, nil
 }
 
-func (app *localClient) CheckTxSync(
+func (app *localClient) CheckTx(
 	ctx context.Context,
 	req types.RequestCheckTx,
 ) (*types.ResponseCheckTx, error) {
@@ -247,7 +121,7 @@ func (app *localClient) CheckTxSync(
 	return &res, nil
 }
 
-func (app *localClient) QuerySync(
+func (app *localClient) Query(
 	ctx context.Context,
 	req types.RequestQuery,
 ) (*types.ResponseQuery, error) {
@@ -258,7 +132,7 @@ func (app *localClient) QuerySync(
 	return &res, nil
 }
 
-func (app *localClient) CommitSync(ctx context.Context) (*types.ResponseCommit, error) {
+func (app *localClient) Commit(ctx context.Context) (*types.ResponseCommit, error) {
 	app.mtx.Lock()
 	defer app.mtx.Unlock()
 
@@ -266,7 +140,7 @@ func (app *localClient) CommitSync(ctx context.Context) (*types.ResponseCommit, 
 	return &res, nil
 }
 
-func (app *localClient) InitChainSync(
+func (app *localClient) InitChain(
 	ctx context.Context,
 	req types.RequestInitChain,
 ) (*types.ResponseInitChain, error) {
@@ -278,7 +152,7 @@ func (app *localClient) InitChainSync(
 	return &res, nil
 }
 
-func (app *localClient) BeginBlockSync(
+func (app *localClient) BeginBlock(
 	ctx context.Context,
 	req types.RequestBeginBlock,
 ) (*types.ResponseBeginBlock, error) {
@@ -290,7 +164,7 @@ func (app *localClient) BeginBlockSync(
 	return &res, nil
 }
 
-func (app *localClient) EndBlockSync(
+func (app *localClient) EndBlock(
 	ctx context.Context,
 	req types.RequestEndBlock,
 ) (*types.ResponseEndBlock, error) {
@@ -302,7 +176,7 @@ func (app *localClient) EndBlockSync(
 	return &res, nil
 }
 
-func (app *localClient) ListSnapshotsSync(
+func (app *localClient) ListSnapshots(
 	ctx context.Context,
 	req types.RequestListSnapshots,
 ) (*types.ResponseListSnapshots, error) {
@@ -314,7 +188,7 @@ func (app *localClient) ListSnapshotsSync(
 	return &res, nil
 }
 
-func (app *localClient) OfferSnapshotSync(
+func (app *localClient) OfferSnapshot(
 	ctx context.Context,
 	req types.RequestOfferSnapshot,
 ) (*types.ResponseOfferSnapshot, error) {
@@ -326,7 +200,7 @@ func (app *localClient) OfferSnapshotSync(
 	return &res, nil
 }
 
-func (app *localClient) LoadSnapshotChunkSync(
+func (app *localClient) LoadSnapshotChunk(
 	ctx context.Context,
 	req types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
 
@@ -337,7 +211,7 @@ func (app *localClient) LoadSnapshotChunkSync(
 	return &res, nil
 }
 
-func (app *localClient) ApplySnapshotChunkSync(
+func (app *localClient) ApplySnapshotChunk(
 	ctx context.Context,
 	req types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
 

--- a/abci/client/mocks/client.go
+++ b/abci/client/mocks/client.go
@@ -17,31 +17,8 @@ type Client struct {
 	mock.Mock
 }
 
-// ApplySnapshotChunkAsync provides a mock function with given fields: _a0, _a1
-func (_m *Client) ApplySnapshotChunkAsync(_a0 context.Context, _a1 types.RequestApplySnapshotChunk) (*abciclient.ReqRes, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestApplySnapshotChunk) *abciclient.ReqRes); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestApplySnapshotChunk) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ApplySnapshotChunkSync provides a mock function with given fields: _a0, _a1
-func (_m *Client) ApplySnapshotChunkSync(_a0 context.Context, _a1 types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
+// ApplySnapshotChunk provides a mock function with given fields: _a0, _a1
+func (_m *Client) ApplySnapshotChunk(_a0 context.Context, _a1 types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseApplySnapshotChunk
@@ -63,31 +40,8 @@ func (_m *Client) ApplySnapshotChunkSync(_a0 context.Context, _a1 types.RequestA
 	return r0, r1
 }
 
-// BeginBlockAsync provides a mock function with given fields: _a0, _a1
-func (_m *Client) BeginBlockAsync(_a0 context.Context, _a1 types.RequestBeginBlock) (*abciclient.ReqRes, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestBeginBlock) *abciclient.ReqRes); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestBeginBlock) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// BeginBlockSync provides a mock function with given fields: _a0, _a1
-func (_m *Client) BeginBlockSync(_a0 context.Context, _a1 types.RequestBeginBlock) (*types.ResponseBeginBlock, error) {
+// BeginBlock provides a mock function with given fields: _a0, _a1
+func (_m *Client) BeginBlock(_a0 context.Context, _a1 types.RequestBeginBlock) (*types.ResponseBeginBlock, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseBeginBlock
@@ -101,6 +55,29 @@ func (_m *Client) BeginBlockSync(_a0 context.Context, _a1 types.RequestBeginBloc
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, types.RequestBeginBlock) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CheckTx provides a mock function with given fields: _a0, _a1
+func (_m *Client) CheckTx(_a0 context.Context, _a1 types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 *types.ResponseCheckTx
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestCheckTx) *types.ResponseCheckTx); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.ResponseCheckTx)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, types.RequestCheckTx) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
@@ -132,54 +109,8 @@ func (_m *Client) CheckTxAsync(_a0 context.Context, _a1 types.RequestCheckTx) (*
 	return r0, r1
 }
 
-// CheckTxSync provides a mock function with given fields: _a0, _a1
-func (_m *Client) CheckTxSync(_a0 context.Context, _a1 types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *types.ResponseCheckTx
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestCheckTx) *types.ResponseCheckTx); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.ResponseCheckTx)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestCheckTx) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// CommitAsync provides a mock function with given fields: _a0
-func (_m *Client) CommitAsync(_a0 context.Context) (*abciclient.ReqRes, error) {
-	ret := _m.Called(_a0)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context) *abciclient.ReqRes); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// CommitSync provides a mock function with given fields: _a0
-func (_m *Client) CommitSync(_a0 context.Context) (*types.ResponseCommit, error) {
+// Commit provides a mock function with given fields: _a0
+func (_m *Client) Commit(_a0 context.Context) (*types.ResponseCommit, error) {
 	ret := _m.Called(_a0)
 
 	var r0 *types.ResponseCommit
@@ -194,6 +125,29 @@ func (_m *Client) CommitSync(_a0 context.Context) (*types.ResponseCommit, error)
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
 		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DeliverTx provides a mock function with given fields: _a0, _a1
+func (_m *Client) DeliverTx(_a0 context.Context, _a1 types.RequestDeliverTx) (*types.ResponseDeliverTx, error) {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 *types.ResponseDeliverTx
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestDeliverTx) *types.ResponseDeliverTx); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.ResponseDeliverTx)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, types.RequestDeliverTx) error); ok {
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -224,54 +178,8 @@ func (_m *Client) DeliverTxAsync(_a0 context.Context, _a1 types.RequestDeliverTx
 	return r0, r1
 }
 
-// DeliverTxSync provides a mock function with given fields: _a0, _a1
-func (_m *Client) DeliverTxSync(_a0 context.Context, _a1 types.RequestDeliverTx) (*types.ResponseDeliverTx, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *types.ResponseDeliverTx
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestDeliverTx) *types.ResponseDeliverTx); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.ResponseDeliverTx)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestDeliverTx) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// EchoAsync provides a mock function with given fields: ctx, msg
-func (_m *Client) EchoAsync(ctx context.Context, msg string) (*abciclient.ReqRes, error) {
-	ret := _m.Called(ctx, msg)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context, string) *abciclient.ReqRes); ok {
-		r0 = rf(ctx, msg)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, msg)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// EchoSync provides a mock function with given fields: ctx, msg
-func (_m *Client) EchoSync(ctx context.Context, msg string) (*types.ResponseEcho, error) {
+// Echo provides a mock function with given fields: ctx, msg
+func (_m *Client) Echo(ctx context.Context, msg string) (*types.ResponseEcho, error) {
 	ret := _m.Called(ctx, msg)
 
 	var r0 *types.ResponseEcho
@@ -293,31 +201,8 @@ func (_m *Client) EchoSync(ctx context.Context, msg string) (*types.ResponseEcho
 	return r0, r1
 }
 
-// EndBlockAsync provides a mock function with given fields: _a0, _a1
-func (_m *Client) EndBlockAsync(_a0 context.Context, _a1 types.RequestEndBlock) (*abciclient.ReqRes, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestEndBlock) *abciclient.ReqRes); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestEndBlock) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// EndBlockSync provides a mock function with given fields: _a0, _a1
-func (_m *Client) EndBlockSync(_a0 context.Context, _a1 types.RequestEndBlock) (*types.ResponseEndBlock, error) {
+// EndBlock provides a mock function with given fields: _a0, _a1
+func (_m *Client) EndBlock(_a0 context.Context, _a1 types.RequestEndBlock) (*types.ResponseEndBlock, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseEndBlock
@@ -353,6 +238,20 @@ func (_m *Client) Error() error {
 	return r0
 }
 
+// Flush provides a mock function with given fields: _a0
+func (_m *Client) Flush(_a0 context.Context) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // FlushAsync provides a mock function with given fields: _a0
 func (_m *Client) FlushAsync(_a0 context.Context) (*abciclient.ReqRes, error) {
 	ret := _m.Called(_a0)
@@ -376,45 +275,8 @@ func (_m *Client) FlushAsync(_a0 context.Context) (*abciclient.ReqRes, error) {
 	return r0, r1
 }
 
-// FlushSync provides a mock function with given fields: _a0
-func (_m *Client) FlushSync(_a0 context.Context) error {
-	ret := _m.Called(_a0)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// InfoAsync provides a mock function with given fields: _a0, _a1
-func (_m *Client) InfoAsync(_a0 context.Context, _a1 types.RequestInfo) (*abciclient.ReqRes, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestInfo) *abciclient.ReqRes); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestInfo) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// InfoSync provides a mock function with given fields: _a0, _a1
-func (_m *Client) InfoSync(_a0 context.Context, _a1 types.RequestInfo) (*types.ResponseInfo, error) {
+// Info provides a mock function with given fields: _a0, _a1
+func (_m *Client) Info(_a0 context.Context, _a1 types.RequestInfo) (*types.ResponseInfo, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseInfo
@@ -436,31 +298,8 @@ func (_m *Client) InfoSync(_a0 context.Context, _a1 types.RequestInfo) (*types.R
 	return r0, r1
 }
 
-// InitChainAsync provides a mock function with given fields: _a0, _a1
-func (_m *Client) InitChainAsync(_a0 context.Context, _a1 types.RequestInitChain) (*abciclient.ReqRes, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestInitChain) *abciclient.ReqRes); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestInitChain) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// InitChainSync provides a mock function with given fields: _a0, _a1
-func (_m *Client) InitChainSync(_a0 context.Context, _a1 types.RequestInitChain) (*types.ResponseInitChain, error) {
+// InitChain provides a mock function with given fields: _a0, _a1
+func (_m *Client) InitChain(_a0 context.Context, _a1 types.RequestInitChain) (*types.ResponseInitChain, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseInitChain
@@ -496,31 +335,8 @@ func (_m *Client) IsRunning() bool {
 	return r0
 }
 
-// ListSnapshotsAsync provides a mock function with given fields: _a0, _a1
-func (_m *Client) ListSnapshotsAsync(_a0 context.Context, _a1 types.RequestListSnapshots) (*abciclient.ReqRes, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestListSnapshots) *abciclient.ReqRes); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestListSnapshots) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ListSnapshotsSync provides a mock function with given fields: _a0, _a1
-func (_m *Client) ListSnapshotsSync(_a0 context.Context, _a1 types.RequestListSnapshots) (*types.ResponseListSnapshots, error) {
+// ListSnapshots provides a mock function with given fields: _a0, _a1
+func (_m *Client) ListSnapshots(_a0 context.Context, _a1 types.RequestListSnapshots) (*types.ResponseListSnapshots, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseListSnapshots
@@ -542,31 +358,8 @@ func (_m *Client) ListSnapshotsSync(_a0 context.Context, _a1 types.RequestListSn
 	return r0, r1
 }
 
-// LoadSnapshotChunkAsync provides a mock function with given fields: _a0, _a1
-func (_m *Client) LoadSnapshotChunkAsync(_a0 context.Context, _a1 types.RequestLoadSnapshotChunk) (*abciclient.ReqRes, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestLoadSnapshotChunk) *abciclient.ReqRes); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestLoadSnapshotChunk) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// LoadSnapshotChunkSync provides a mock function with given fields: _a0, _a1
-func (_m *Client) LoadSnapshotChunkSync(_a0 context.Context, _a1 types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
+// LoadSnapshotChunk provides a mock function with given fields: _a0, _a1
+func (_m *Client) LoadSnapshotChunk(_a0 context.Context, _a1 types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseLoadSnapshotChunk
@@ -588,31 +381,8 @@ func (_m *Client) LoadSnapshotChunkSync(_a0 context.Context, _a1 types.RequestLo
 	return r0, r1
 }
 
-// OfferSnapshotAsync provides a mock function with given fields: _a0, _a1
-func (_m *Client) OfferSnapshotAsync(_a0 context.Context, _a1 types.RequestOfferSnapshot) (*abciclient.ReqRes, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestOfferSnapshot) *abciclient.ReqRes); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestOfferSnapshot) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// OfferSnapshotSync provides a mock function with given fields: _a0, _a1
-func (_m *Client) OfferSnapshotSync(_a0 context.Context, _a1 types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error) {
+// OfferSnapshot provides a mock function with given fields: _a0, _a1
+func (_m *Client) OfferSnapshot(_a0 context.Context, _a1 types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseOfferSnapshot
@@ -634,31 +404,8 @@ func (_m *Client) OfferSnapshotSync(_a0 context.Context, _a1 types.RequestOfferS
 	return r0, r1
 }
 
-// QueryAsync provides a mock function with given fields: _a0, _a1
-func (_m *Client) QueryAsync(_a0 context.Context, _a1 types.RequestQuery) (*abciclient.ReqRes, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *abciclient.ReqRes
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestQuery) *abciclient.ReqRes); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abciclient.ReqRes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestQuery) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// QuerySync provides a mock function with given fields: _a0, _a1
-func (_m *Client) QuerySync(_a0 context.Context, _a1 types.RequestQuery) (*types.ResponseQuery, error) {
+// Query provides a mock function with given fields: _a0, _a1
+func (_m *Client) Query(_a0 context.Context, _a1 types.RequestQuery) (*types.ResponseQuery, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseQuery

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -222,16 +222,8 @@ func (cli *socketClient) didRecvResponse(res *types.Response) error {
 
 //----------------------------------------
 
-func (cli *socketClient) EchoAsync(ctx context.Context, msg string) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestEcho(msg))
-}
-
 func (cli *socketClient) FlushAsync(ctx context.Context) (*ReqRes, error) {
 	return cli.queueRequestAsync(ctx, types.ToRequestFlush())
-}
-
-func (cli *socketClient) InfoAsync(ctx context.Context, req types.RequestInfo) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestInfo(req))
 }
 
 func (cli *socketClient) DeliverTxAsync(ctx context.Context, req types.RequestDeliverTx) (*ReqRes, error) {
@@ -242,51 +234,9 @@ func (cli *socketClient) CheckTxAsync(ctx context.Context, req types.RequestChec
 	return cli.queueRequestAsync(ctx, types.ToRequestCheckTx(req))
 }
 
-func (cli *socketClient) QueryAsync(ctx context.Context, req types.RequestQuery) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestQuery(req))
-}
-
-func (cli *socketClient) CommitAsync(ctx context.Context) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestCommit())
-}
-
-func (cli *socketClient) InitChainAsync(ctx context.Context, req types.RequestInitChain) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestInitChain(req))
-}
-
-func (cli *socketClient) BeginBlockAsync(ctx context.Context, req types.RequestBeginBlock) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestBeginBlock(req))
-}
-
-func (cli *socketClient) EndBlockAsync(ctx context.Context, req types.RequestEndBlock) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestEndBlock(req))
-}
-
-func (cli *socketClient) ListSnapshotsAsync(ctx context.Context, req types.RequestListSnapshots) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestListSnapshots(req))
-}
-
-func (cli *socketClient) OfferSnapshotAsync(ctx context.Context, req types.RequestOfferSnapshot) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestOfferSnapshot(req))
-}
-
-func (cli *socketClient) LoadSnapshotChunkAsync(
-	ctx context.Context,
-	req types.RequestLoadSnapshotChunk,
-) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestLoadSnapshotChunk(req))
-}
-
-func (cli *socketClient) ApplySnapshotChunkAsync(
-	ctx context.Context,
-	req types.RequestApplySnapshotChunk,
-) (*ReqRes, error) {
-	return cli.queueRequestAsync(ctx, types.ToRequestApplySnapshotChunk(req))
-}
-
 //----------------------------------------
 
-func (cli *socketClient) FlushSync(ctx context.Context) error {
+func (cli *socketClient) Flush(ctx context.Context) error {
 	reqRes, err := cli.queueRequest(ctx, types.ToRequestFlush(), true)
 	if err != nil {
 		return queueErr(err)
@@ -311,7 +261,7 @@ func (cli *socketClient) FlushSync(ctx context.Context) error {
 	}
 }
 
-func (cli *socketClient) EchoSync(ctx context.Context, msg string) (*types.ResponseEcho, error) {
+func (cli *socketClient) Echo(ctx context.Context, msg string) (*types.ResponseEcho, error) {
 	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestEcho(msg))
 	if err != nil {
 		return nil, err
@@ -319,7 +269,7 @@ func (cli *socketClient) EchoSync(ctx context.Context, msg string) (*types.Respo
 	return reqres.Response.GetEcho(), nil
 }
 
-func (cli *socketClient) InfoSync(
+func (cli *socketClient) Info(
 	ctx context.Context,
 	req types.RequestInfo,
 ) (*types.ResponseInfo, error) {
@@ -330,7 +280,7 @@ func (cli *socketClient) InfoSync(
 	return reqres.Response.GetInfo(), nil
 }
 
-func (cli *socketClient) DeliverTxSync(
+func (cli *socketClient) DeliverTx(
 	ctx context.Context,
 	req types.RequestDeliverTx,
 ) (*types.ResponseDeliverTx, error) {
@@ -342,7 +292,7 @@ func (cli *socketClient) DeliverTxSync(
 	return reqres.Response.GetDeliverTx(), nil
 }
 
-func (cli *socketClient) CheckTxSync(
+func (cli *socketClient) CheckTx(
 	ctx context.Context,
 	req types.RequestCheckTx,
 ) (*types.ResponseCheckTx, error) {
@@ -353,7 +303,7 @@ func (cli *socketClient) CheckTxSync(
 	return reqres.Response.GetCheckTx(), nil
 }
 
-func (cli *socketClient) QuerySync(
+func (cli *socketClient) Query(
 	ctx context.Context,
 	req types.RequestQuery,
 ) (*types.ResponseQuery, error) {
@@ -364,7 +314,7 @@ func (cli *socketClient) QuerySync(
 	return reqres.Response.GetQuery(), nil
 }
 
-func (cli *socketClient) CommitSync(ctx context.Context) (*types.ResponseCommit, error) {
+func (cli *socketClient) Commit(ctx context.Context) (*types.ResponseCommit, error) {
 	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestCommit())
 	if err != nil {
 		return nil, err
@@ -372,7 +322,7 @@ func (cli *socketClient) CommitSync(ctx context.Context) (*types.ResponseCommit,
 	return reqres.Response.GetCommit(), nil
 }
 
-func (cli *socketClient) InitChainSync(
+func (cli *socketClient) InitChain(
 	ctx context.Context,
 	req types.RequestInitChain,
 ) (*types.ResponseInitChain, error) {
@@ -384,7 +334,7 @@ func (cli *socketClient) InitChainSync(
 	return reqres.Response.GetInitChain(), nil
 }
 
-func (cli *socketClient) BeginBlockSync(
+func (cli *socketClient) BeginBlock(
 	ctx context.Context,
 	req types.RequestBeginBlock,
 ) (*types.ResponseBeginBlock, error) {
@@ -396,7 +346,7 @@ func (cli *socketClient) BeginBlockSync(
 	return reqres.Response.GetBeginBlock(), nil
 }
 
-func (cli *socketClient) EndBlockSync(
+func (cli *socketClient) EndBlock(
 	ctx context.Context,
 	req types.RequestEndBlock,
 ) (*types.ResponseEndBlock, error) {
@@ -408,7 +358,7 @@ func (cli *socketClient) EndBlockSync(
 	return reqres.Response.GetEndBlock(), nil
 }
 
-func (cli *socketClient) ListSnapshotsSync(
+func (cli *socketClient) ListSnapshots(
 	ctx context.Context,
 	req types.RequestListSnapshots,
 ) (*types.ResponseListSnapshots, error) {
@@ -420,7 +370,7 @@ func (cli *socketClient) ListSnapshotsSync(
 	return reqres.Response.GetListSnapshots(), nil
 }
 
-func (cli *socketClient) OfferSnapshotSync(
+func (cli *socketClient) OfferSnapshot(
 	ctx context.Context,
 	req types.RequestOfferSnapshot,
 ) (*types.ResponseOfferSnapshot, error) {
@@ -432,7 +382,7 @@ func (cli *socketClient) OfferSnapshotSync(
 	return reqres.Response.GetOfferSnapshot(), nil
 }
 
-func (cli *socketClient) LoadSnapshotChunkSync(
+func (cli *socketClient) LoadSnapshotChunk(
 	ctx context.Context,
 	req types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
 
@@ -443,7 +393,7 @@ func (cli *socketClient) LoadSnapshotChunkSync(
 	return reqres.Response.GetLoadSnapshotChunk(), nil
 }
 
-func (cli *socketClient) ApplySnapshotChunkSync(
+func (cli *socketClient) ApplySnapshotChunk(
 	ctx context.Context,
 	req types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
 
@@ -507,7 +457,7 @@ func (cli *socketClient) queueRequestAndFlushSync(
 		return nil, queueErr(err)
 	}
 
-	if err := cli.FlushSync(ctx); err != nil {
+	if err := cli.Flush(ctx); err != nil {
 		return nil, err
 	}
 

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -262,7 +262,7 @@ func (cli *socketClient) Flush(ctx context.Context) error {
 }
 
 func (cli *socketClient) Echo(ctx context.Context, msg string) (*types.ResponseEcho, error) {
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestEcho(msg))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestEcho(msg))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (cli *socketClient) Info(
 	ctx context.Context,
 	req types.RequestInfo,
 ) (*types.ResponseInfo, error) {
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestInfo(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestInfo(req))
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (cli *socketClient) DeliverTx(
 	req types.RequestDeliverTx,
 ) (*types.ResponseDeliverTx, error) {
 
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestDeliverTx(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestDeliverTx(req))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func (cli *socketClient) CheckTx(
 	ctx context.Context,
 	req types.RequestCheckTx,
 ) (*types.ResponseCheckTx, error) {
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestCheckTx(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestCheckTx(req))
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (cli *socketClient) Query(
 	ctx context.Context,
 	req types.RequestQuery,
 ) (*types.ResponseQuery, error) {
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestQuery(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestQuery(req))
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (cli *socketClient) Query(
 }
 
 func (cli *socketClient) Commit(ctx context.Context) (*types.ResponseCommit, error) {
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestCommit())
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestCommit())
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func (cli *socketClient) InitChain(
 	req types.RequestInitChain,
 ) (*types.ResponseInitChain, error) {
 
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestInitChain(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestInitChain(req))
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +339,7 @@ func (cli *socketClient) BeginBlock(
 	req types.RequestBeginBlock,
 ) (*types.ResponseBeginBlock, error) {
 
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestBeginBlock(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestBeginBlock(req))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func (cli *socketClient) EndBlock(
 	req types.RequestEndBlock,
 ) (*types.ResponseEndBlock, error) {
 
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestEndBlock(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestEndBlock(req))
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func (cli *socketClient) ListSnapshots(
 	req types.RequestListSnapshots,
 ) (*types.ResponseListSnapshots, error) {
 
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestListSnapshots(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestListSnapshots(req))
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +375,7 @@ func (cli *socketClient) OfferSnapshot(
 	req types.RequestOfferSnapshot,
 ) (*types.ResponseOfferSnapshot, error) {
 
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestOfferSnapshot(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestOfferSnapshot(req))
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +386,7 @@ func (cli *socketClient) LoadSnapshotChunk(
 	ctx context.Context,
 	req types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
 
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestLoadSnapshotChunk(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestLoadSnapshotChunk(req))
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +397,7 @@ func (cli *socketClient) ApplySnapshotChunk(
 	ctx context.Context,
 	req types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
 
-	reqres, err := cli.queueRequestAndFlushSync(ctx, types.ToRequestApplySnapshotChunk(req))
+	reqres, err := cli.queueRequestAndFlush(ctx, types.ToRequestApplySnapshotChunk(req))
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +447,7 @@ func (cli *socketClient) queueRequestAsync(
 	return reqres, cli.Error()
 }
 
-func (cli *socketClient) queueRequestAndFlushSync(
+func (cli *socketClient) queueRequestAndFlush(
 	ctx context.Context,
 	req *types.Request,
 ) (*ReqRes, error) {

--- a/abci/client/socket_client_test.go
+++ b/abci/client/socket_client_test.go
@@ -29,13 +29,10 @@ func TestProperSyncCalls(t *testing.T) {
 
 	resp := make(chan error, 1)
 	go func() {
-		// This is BeginBlockSync unrolled....
-		reqres, err := c.BeginBlockAsync(ctx, types.RequestBeginBlock{})
+		rsp, err := c.BeginBlock(ctx, types.RequestBeginBlock{})
 		assert.NoError(t, err)
-		err = c.FlushSync(ctx)
-		assert.NoError(t, err)
-		res := reqres.Response.GetBeginBlock()
-		assert.NotNil(t, res)
+		assert.NoError(t, c.Flush(ctx))
+		assert.NotNil(t, rsp)
 		resp <- c.Error()
 	}()
 

--- a/abci/cmd/abci-cli/abci-cli.go
+++ b/abci/cmd/abci-cli/abci-cli.go
@@ -442,7 +442,7 @@ func cmdEcho(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		msg = args[0]
 	}
-	res, err := client.EchoSync(cmd.Context(), msg)
+	res, err := client.Echo(cmd.Context(), msg)
 	if err != nil {
 		return err
 	}
@@ -460,7 +460,7 @@ func cmdInfo(cmd *cobra.Command, args []string) error {
 	if len(args) == 1 {
 		version = args[0]
 	}
-	res, err := client.InfoSync(cmd.Context(), types.RequestInfo{Version: version})
+	res, err := client.Info(cmd.Context(), types.RequestInfo{Version: version})
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,7 @@ func cmdDeliverTx(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	res, err := client.DeliverTxSync(cmd.Context(), types.RequestDeliverTx{Tx: txBytes})
+	res, err := client.DeliverTx(cmd.Context(), types.RequestDeliverTx{Tx: txBytes})
 	if err != nil {
 		return err
 	}
@@ -511,7 +511,7 @@ func cmdCheckTx(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	res, err := client.CheckTxSync(cmd.Context(), types.RequestCheckTx{Tx: txBytes})
+	res, err := client.CheckTx(cmd.Context(), types.RequestCheckTx{Tx: txBytes})
 	if err != nil {
 		return err
 	}
@@ -526,7 +526,7 @@ func cmdCheckTx(cmd *cobra.Command, args []string) error {
 
 // Get application Merkle root hash
 func cmdCommit(cmd *cobra.Command, args []string) error {
-	res, err := client.CommitSync(cmd.Context())
+	res, err := client.Commit(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -551,7 +551,7 @@ func cmdQuery(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resQuery, err := client.QuerySync(cmd.Context(), types.RequestQuery{
+	resQuery, err := client.Query(cmd.Context(), types.RequestQuery{
 		Data:   queryBytes,
 		Path:   flagPath,
 		Height: int64(flagHeight),

--- a/abci/example/example_test.go
+++ b/abci/example/example_test.go
@@ -112,7 +112,7 @@ func testStream(ctx context.Context, t *testing.T, logger log.Logger, app types.
 
 		// Sometimes send flush messages
 		if counter%128 == 0 {
-			err = client.FlushSync(ctx)
+			err = client.Flush(ctx)
 			require.NoError(t, err)
 		}
 	}

--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -330,23 +330,23 @@ func runClientTests(ctx context.Context, t *testing.T, client abciclient.Client)
 }
 
 func testClient(ctx context.Context, t *testing.T, app abciclient.Client, tx []byte, key, value string) {
-	ar, err := app.DeliverTxSync(ctx, types.RequestDeliverTx{Tx: tx})
+	ar, err := app.DeliverTx(ctx, types.RequestDeliverTx{Tx: tx})
 	require.NoError(t, err)
 	require.False(t, ar.IsErr(), ar)
 	// repeating tx doesn't raise error
-	ar, err = app.DeliverTxSync(ctx, types.RequestDeliverTx{Tx: tx})
+	ar, err = app.DeliverTx(ctx, types.RequestDeliverTx{Tx: tx})
 	require.NoError(t, err)
 	require.False(t, ar.IsErr(), ar)
 	// commit
-	_, err = app.CommitSync(ctx)
+	_, err = app.Commit(ctx)
 	require.NoError(t, err)
 
-	info, err := app.InfoSync(ctx, types.RequestInfo{})
+	info, err := app.Info(ctx, types.RequestInfo{})
 	require.NoError(t, err)
 	require.NotZero(t, info.LastBlockHeight)
 
 	// make sure query is fine
-	resQuery, err := app.QuerySync(ctx, types.RequestQuery{
+	resQuery, err := app.Query(ctx, types.RequestQuery{
 		Path: "/store",
 		Data: []byte(key),
 	})
@@ -357,7 +357,7 @@ func testClient(ctx context.Context, t *testing.T, app abciclient.Client, tx []b
 	require.EqualValues(t, info.LastBlockHeight, resQuery.Height)
 
 	// make sure proof is fine
-	resQuery, err = app.QuerySync(ctx, types.RequestQuery{
+	resQuery, err = app.Query(ctx, types.RequestQuery{
 		Path:  "/store",
 		Data:  []byte(key),
 		Prove: true,

--- a/abci/tests/server/client.go
+++ b/abci/tests/server/client.go
@@ -21,7 +21,7 @@ func InitChain(ctx context.Context, client abciclient.Client) error {
 		power := mrand.Int()
 		vals[i] = types.UpdateValidator(pubkey, int64(power), "")
 	}
-	_, err := client.InitChainSync(ctx, types.RequestInitChain{
+	_, err := client.InitChain(ctx, types.RequestInitChain{
 		Validators: vals,
 	})
 	if err != nil {
@@ -33,7 +33,7 @@ func InitChain(ctx context.Context, client abciclient.Client) error {
 }
 
 func Commit(ctx context.Context, client abciclient.Client, hashExp []byte) error {
-	res, err := client.CommitSync(ctx)
+	res, err := client.Commit(ctx)
 	data := res.Data
 	if err != nil {
 		fmt.Println("Failed test: Commit")
@@ -50,7 +50,7 @@ func Commit(ctx context.Context, client abciclient.Client, hashExp []byte) error
 }
 
 func DeliverTx(ctx context.Context, client abciclient.Client, txBytes []byte, codeExp uint32, dataExp []byte) error {
-	res, _ := client.DeliverTxSync(ctx, types.RequestDeliverTx{Tx: txBytes})
+	res, _ := client.DeliverTx(ctx, types.RequestDeliverTx{Tx: txBytes})
 	code, data, log := res.Code, res.Data, res.Log
 	if code != codeExp {
 		fmt.Println("Failed test: DeliverTx")
@@ -69,7 +69,7 @@ func DeliverTx(ctx context.Context, client abciclient.Client, txBytes []byte, co
 }
 
 func CheckTx(ctx context.Context, client abciclient.Client, txBytes []byte, codeExp uint32, dataExp []byte) error {
-	res, _ := client.CheckTxSync(ctx, types.RequestCheckTx{Tx: txBytes})
+	res, _ := client.CheckTx(ctx, types.RequestCheckTx{Tx: txBytes})
 	code, data, log := res.Code, res.Data, res.Log
 	if code != codeExp {
 		fmt.Println("Failed test: CheckTx")

--- a/internal/consensus/replay.go
+++ b/internal/consensus/replay.go
@@ -240,7 +240,7 @@ func (h *Handshaker) NBlocks() int {
 func (h *Handshaker) Handshake(ctx context.Context, proxyApp proxy.AppConns) error {
 
 	// Handshake is done via ABCI Info on the query conn.
-	res, err := proxyApp.Query().InfoSync(ctx, proxy.RequestInfo)
+	res, err := proxyApp.Query().Info(ctx, proxy.RequestInfo)
 	if err != nil {
 		return fmt.Errorf("error calling Info: %w", err)
 	}
@@ -316,7 +316,7 @@ func (h *Handshaker) ReplayBlocks(
 			Validators:      nextVals,
 			AppStateBytes:   h.genDoc.AppState,
 		}
-		res, err := proxyApp.Consensus().InitChainSync(ctx, req)
+		res, err := proxyApp.Consensus().InitChain(ctx, req)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -844,7 +844,7 @@ func testHandshakeReplay(
 	require.NoError(t, err, "Error on abci handshake")
 
 	// get the latest app hash from the app
-	res, err := proxyApp.Query().InfoSync(ctx, abci.RequestInfo{Version: ""})
+	res, err := proxyApp.Query().Info(ctx, abci.RequestInfo{Version: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -910,7 +910,7 @@ func buildAppStateFromChain(
 
 	state.Version.Consensus.App = kvstore.ProtocolVersion // simulate handshake, receive app version
 	validators := types.TM2PB.ValidatorUpdates(state.Validators)
-	_, err := proxyApp.Consensus().InitChainSync(ctx, abci.RequestInitChain{
+	_, err := proxyApp.Consensus().InitChain(ctx, abci.RequestInitChain{
 		Validators: validators,
 	})
 	require.NoError(t, err)
@@ -967,7 +967,7 @@ func buildTMStateFromChain(
 
 	state.Version.Consensus.App = kvstore.ProtocolVersion // simulate handshake, receive app version
 	validators := types.TM2PB.ValidatorUpdates(state.Validators)
-	_, err := proxyApp.Consensus().InitChainSync(ctx, abci.RequestInitChain{
+	_, err := proxyApp.Consensus().InitChain(ctx, abci.RequestInitChain{
 		Validators: validators,
 	})
 	require.NoError(t, err)

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -176,7 +176,7 @@ func (txmp *TxMempool) SizeBytes() int64 {
 //
 // NOTE: The caller must obtain a write-lock prior to execution.
 func (txmp *TxMempool) FlushAppConn(ctx context.Context) error {
-	return txmp.proxyAppConn.FlushSync(ctx)
+	return txmp.proxyAppConn.Flush(ctx)
 }
 
 // WaitForNextTx returns a blocking channel that will be closed when the next

--- a/internal/proxy/app_conn.go
+++ b/internal/proxy/app_conn.go
@@ -18,12 +18,12 @@ type AppConnConsensus interface {
 	SetResponseCallback(abciclient.Callback)
 	Error() error
 
-	InitChainSync(context.Context, types.RequestInitChain) (*types.ResponseInitChain, error)
+	InitChain(context.Context, types.RequestInitChain) (*types.ResponseInitChain, error)
 
-	BeginBlockSync(context.Context, types.RequestBeginBlock) (*types.ResponseBeginBlock, error)
+	BeginBlock(context.Context, types.RequestBeginBlock) (*types.ResponseBeginBlock, error)
 	DeliverTxAsync(context.Context, types.RequestDeliverTx) (*abciclient.ReqRes, error)
-	EndBlockSync(context.Context, types.RequestEndBlock) (*types.ResponseEndBlock, error)
-	CommitSync(context.Context) (*types.ResponseCommit, error)
+	EndBlock(context.Context, types.RequestEndBlock) (*types.ResponseEndBlock, error)
+	Commit(context.Context) (*types.ResponseCommit, error)
 }
 
 type AppConnMempool interface {
@@ -31,27 +31,27 @@ type AppConnMempool interface {
 	Error() error
 
 	CheckTxAsync(context.Context, types.RequestCheckTx) (*abciclient.ReqRes, error)
-	CheckTxSync(context.Context, types.RequestCheckTx) (*types.ResponseCheckTx, error)
+	CheckTx(context.Context, types.RequestCheckTx) (*types.ResponseCheckTx, error)
 
 	FlushAsync(context.Context) (*abciclient.ReqRes, error)
-	FlushSync(context.Context) error
+	Flush(context.Context) error
 }
 
 type AppConnQuery interface {
 	Error() error
 
-	EchoSync(context.Context, string) (*types.ResponseEcho, error)
-	InfoSync(context.Context, types.RequestInfo) (*types.ResponseInfo, error)
-	QuerySync(context.Context, types.RequestQuery) (*types.ResponseQuery, error)
+	Echo(context.Context, string) (*types.ResponseEcho, error)
+	Info(context.Context, types.RequestInfo) (*types.ResponseInfo, error)
+	Query(context.Context, types.RequestQuery) (*types.ResponseQuery, error)
 }
 
 type AppConnSnapshot interface {
 	Error() error
 
-	ListSnapshotsSync(context.Context, types.RequestListSnapshots) (*types.ResponseListSnapshots, error)
-	OfferSnapshotSync(context.Context, types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error)
-	LoadSnapshotChunkSync(context.Context, types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error)
-	ApplySnapshotChunkSync(context.Context, types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error)
+	ListSnapshots(context.Context, types.RequestListSnapshots) (*types.ResponseListSnapshots, error)
+	OfferSnapshot(context.Context, types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error)
+	LoadSnapshotChunk(context.Context, types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error)
+	ApplySnapshotChunk(context.Context, types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error)
 }
 
 //-----------------------------------------------------------------------------------------
@@ -77,20 +77,20 @@ func (app *appConnConsensus) Error() error {
 	return app.appConn.Error()
 }
 
-func (app *appConnConsensus) InitChainSync(
+func (app *appConnConsensus) InitChain(
 	ctx context.Context,
 	req types.RequestInitChain,
 ) (*types.ResponseInitChain, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "init_chain", "type", "sync"))()
-	return app.appConn.InitChainSync(ctx, req)
+	return app.appConn.InitChain(ctx, req)
 }
 
-func (app *appConnConsensus) BeginBlockSync(
+func (app *appConnConsensus) BeginBlock(
 	ctx context.Context,
 	req types.RequestBeginBlock,
 ) (*types.ResponseBeginBlock, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "begin_block", "type", "sync"))()
-	return app.appConn.BeginBlockSync(ctx, req)
+	return app.appConn.BeginBlock(ctx, req)
 }
 
 func (app *appConnConsensus) DeliverTxAsync(
@@ -101,17 +101,17 @@ func (app *appConnConsensus) DeliverTxAsync(
 	return app.appConn.DeliverTxAsync(ctx, req)
 }
 
-func (app *appConnConsensus) EndBlockSync(
+func (app *appConnConsensus) EndBlock(
 	ctx context.Context,
 	req types.RequestEndBlock,
 ) (*types.ResponseEndBlock, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "deliver_tx", "type", "sync"))()
-	return app.appConn.EndBlockSync(ctx, req)
+	return app.appConn.EndBlock(ctx, req)
 }
 
-func (app *appConnConsensus) CommitSync(ctx context.Context) (*types.ResponseCommit, error) {
+func (app *appConnConsensus) Commit(ctx context.Context) (*types.ResponseCommit, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "commit", "type", "sync"))()
-	return app.appConn.CommitSync(ctx)
+	return app.appConn.Commit(ctx)
 }
 
 //------------------------------------------------
@@ -142,9 +142,9 @@ func (app *appConnMempool) FlushAsync(ctx context.Context) (*abciclient.ReqRes, 
 	return app.appConn.FlushAsync(ctx)
 }
 
-func (app *appConnMempool) FlushSync(ctx context.Context) error {
+func (app *appConnMempool) Flush(ctx context.Context) error {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "flush", "type", "sync"))()
-	return app.appConn.FlushSync(ctx)
+	return app.appConn.Flush(ctx)
 }
 
 func (app *appConnMempool) CheckTxAsync(ctx context.Context, req types.RequestCheckTx) (*abciclient.ReqRes, error) {
@@ -152,9 +152,9 @@ func (app *appConnMempool) CheckTxAsync(ctx context.Context, req types.RequestCh
 	return app.appConn.CheckTxAsync(ctx, req)
 }
 
-func (app *appConnMempool) CheckTxSync(ctx context.Context, req types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+func (app *appConnMempool) CheckTx(ctx context.Context, req types.RequestCheckTx) (*types.ResponseCheckTx, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "check_tx", "type", "sync"))()
-	return app.appConn.CheckTxSync(ctx, req)
+	return app.appConn.CheckTx(ctx, req)
 }
 
 //------------------------------------------------
@@ -176,19 +176,19 @@ func (app *appConnQuery) Error() error {
 	return app.appConn.Error()
 }
 
-func (app *appConnQuery) EchoSync(ctx context.Context, msg string) (*types.ResponseEcho, error) {
+func (app *appConnQuery) Echo(ctx context.Context, msg string) (*types.ResponseEcho, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "echo", "type", "sync"))()
-	return app.appConn.EchoSync(ctx, msg)
+	return app.appConn.Echo(ctx, msg)
 }
 
-func (app *appConnQuery) InfoSync(ctx context.Context, req types.RequestInfo) (*types.ResponseInfo, error) {
+func (app *appConnQuery) Info(ctx context.Context, req types.RequestInfo) (*types.ResponseInfo, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "info", "type", "sync"))()
-	return app.appConn.InfoSync(ctx, req)
+	return app.appConn.Info(ctx, req)
 }
 
-func (app *appConnQuery) QuerySync(ctx context.Context, reqQuery types.RequestQuery) (*types.ResponseQuery, error) {
+func (app *appConnQuery) Query(ctx context.Context, reqQuery types.RequestQuery) (*types.ResponseQuery, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "query", "type", "sync"))()
-	return app.appConn.QuerySync(ctx, reqQuery)
+	return app.appConn.Query(ctx, reqQuery)
 }
 
 //------------------------------------------------
@@ -210,34 +210,34 @@ func (app *appConnSnapshot) Error() error {
 	return app.appConn.Error()
 }
 
-func (app *appConnSnapshot) ListSnapshotsSync(
+func (app *appConnSnapshot) ListSnapshots(
 	ctx context.Context,
 	req types.RequestListSnapshots,
 ) (*types.ResponseListSnapshots, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "list_snapshots", "type", "sync"))()
-	return app.appConn.ListSnapshotsSync(ctx, req)
+	return app.appConn.ListSnapshots(ctx, req)
 }
 
-func (app *appConnSnapshot) OfferSnapshotSync(
+func (app *appConnSnapshot) OfferSnapshot(
 	ctx context.Context,
 	req types.RequestOfferSnapshot,
 ) (*types.ResponseOfferSnapshot, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "offer_snapshot", "type", "sync"))()
-	return app.appConn.OfferSnapshotSync(ctx, req)
+	return app.appConn.OfferSnapshot(ctx, req)
 }
 
-func (app *appConnSnapshot) LoadSnapshotChunkSync(
+func (app *appConnSnapshot) LoadSnapshotChunk(
 	ctx context.Context,
 	req types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "load_snapshot_chunk", "type", "sync"))()
-	return app.appConn.LoadSnapshotChunkSync(ctx, req)
+	return app.appConn.LoadSnapshotChunk(ctx, req)
 }
 
-func (app *appConnSnapshot) ApplySnapshotChunkSync(
+func (app *appConnSnapshot) ApplySnapshotChunk(
 	ctx context.Context,
 	req types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "apply_snapshot_chunk", "type", "sync"))()
-	return app.appConn.ApplySnapshotChunkSync(ctx, req)
+	return app.appConn.ApplySnapshotChunk(ctx, req)
 }
 
 // addTimeSample returns a function that, when called, adds an observation to m.

--- a/internal/proxy/app_conn_test.go
+++ b/internal/proxy/app_conn_test.go
@@ -18,9 +18,9 @@ import (
 //----------------------------------------
 
 type appConnTestI interface {
-	EchoAsync(ctx context.Context, msg string) (*abciclient.ReqRes, error)
-	FlushSync(context.Context) error
-	InfoSync(context.Context, types.RequestInfo) (*types.ResponseInfo, error)
+	Echo(context.Context, string) (*types.ResponseEcho, error)
+	Flush(context.Context) error
+	Info(context.Context, types.RequestInfo) (*types.ResponseInfo, error)
 }
 
 type appConnTest struct {
@@ -31,16 +31,16 @@ func newAppConnTest(appConn abciclient.Client) appConnTestI {
 	return &appConnTest{appConn}
 }
 
-func (app *appConnTest) EchoAsync(ctx context.Context, msg string) (*abciclient.ReqRes, error) {
-	return app.appConn.EchoAsync(ctx, msg)
+func (app *appConnTest) Echo(ctx context.Context, msg string) (*types.ResponseEcho, error) {
+	return app.appConn.Echo(ctx, msg)
 }
 
-func (app *appConnTest) FlushSync(ctx context.Context) error {
-	return app.appConn.FlushSync(ctx)
+func (app *appConnTest) Flush(ctx context.Context) error {
+	return app.appConn.Flush(ctx)
 }
 
-func (app *appConnTest) InfoSync(ctx context.Context, req types.RequestInfo) (*types.ResponseInfo, error) {
-	return app.appConn.InfoSync(ctx, req)
+func (app *appConnTest) Info(ctx context.Context, req types.RequestInfo) (*types.ResponseInfo, error) {
+	return app.appConn.Info(ctx, req)
 }
 
 //----------------------------------------
@@ -70,18 +70,18 @@ func TestEcho(t *testing.T) {
 	t.Log("Connected")
 
 	for i := 0; i < 1000; i++ {
-		_, err = proxy.EchoAsync(ctx, fmt.Sprintf("echo-%v", i))
+		_, err = proxy.Echo(ctx, fmt.Sprintf("echo-%v", i))
 		if err != nil {
 			t.Error(err)
 		}
 		// flush sometimes
 		if i%128 == 0 {
-			if err := proxy.FlushSync(ctx); err != nil {
+			if err := proxy.Flush(ctx); err != nil {
 				t.Error(err)
 			}
 		}
 	}
-	if err := proxy.FlushSync(ctx); err != nil {
+	if err := proxy.Flush(ctx); err != nil {
 		t.Error(err)
 	}
 }
@@ -112,23 +112,23 @@ func BenchmarkEcho(b *testing.B) {
 	b.StartTimer() // Start benchmarking tests
 
 	for i := 0; i < b.N; i++ {
-		_, err = proxy.EchoAsync(ctx, echoString)
+		_, err = proxy.Echo(ctx, echoString)
 		if err != nil {
 			b.Error(err)
 		}
 		// flush sometimes
 		if i%128 == 0 {
-			if err := proxy.FlushSync(ctx); err != nil {
+			if err := proxy.Flush(ctx); err != nil {
 				b.Error(err)
 			}
 		}
 	}
-	if err := proxy.FlushSync(ctx); err != nil {
+	if err := proxy.Flush(ctx); err != nil {
 		b.Error(err)
 	}
 
 	b.StopTimer()
-	// info := proxy.InfoSync(types.RequestInfo{""})
+	// info := proxy.Info(types.RequestInfo{""})
 	// b.Log("N: ", b.N, info)
 }
 
@@ -154,7 +154,7 @@ func TestInfo(t *testing.T) {
 	proxy := newAppConnTest(cli)
 	t.Log("Connected")
 
-	resInfo, err := proxy.InfoSync(ctx, RequestInfo)
+	resInfo, err := proxy.Info(ctx, RequestInfo)
 	require.NoError(t, err)
 
 	if resInfo.Data != "{\"size\":0}" {

--- a/internal/proxy/mocks/app_conn_consensus.go
+++ b/internal/proxy/mocks/app_conn_consensus.go
@@ -17,8 +17,8 @@ type AppConnConsensus struct {
 	mock.Mock
 }
 
-// BeginBlockSync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnConsensus) BeginBlockSync(_a0 context.Context, _a1 types.RequestBeginBlock) (*types.ResponseBeginBlock, error) {
+// BeginBlock provides a mock function with given fields: _a0, _a1
+func (_m *AppConnConsensus) BeginBlock(_a0 context.Context, _a1 types.RequestBeginBlock) (*types.ResponseBeginBlock, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseBeginBlock
@@ -40,8 +40,8 @@ func (_m *AppConnConsensus) BeginBlockSync(_a0 context.Context, _a1 types.Reques
 	return r0, r1
 }
 
-// CommitSync provides a mock function with given fields: _a0
-func (_m *AppConnConsensus) CommitSync(_a0 context.Context) (*types.ResponseCommit, error) {
+// Commit provides a mock function with given fields: _a0
+func (_m *AppConnConsensus) Commit(_a0 context.Context) (*types.ResponseCommit, error) {
 	ret := _m.Called(_a0)
 
 	var r0 *types.ResponseCommit
@@ -86,8 +86,8 @@ func (_m *AppConnConsensus) DeliverTxAsync(_a0 context.Context, _a1 types.Reques
 	return r0, r1
 }
 
-// EndBlockSync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnConsensus) EndBlockSync(_a0 context.Context, _a1 types.RequestEndBlock) (*types.ResponseEndBlock, error) {
+// EndBlock provides a mock function with given fields: _a0, _a1
+func (_m *AppConnConsensus) EndBlock(_a0 context.Context, _a1 types.RequestEndBlock) (*types.ResponseEndBlock, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseEndBlock
@@ -123,8 +123,8 @@ func (_m *AppConnConsensus) Error() error {
 	return r0
 }
 
-// InitChainSync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnConsensus) InitChainSync(_a0 context.Context, _a1 types.RequestInitChain) (*types.ResponseInitChain, error) {
+// InitChain provides a mock function with given fields: _a0, _a1
+func (_m *AppConnConsensus) InitChain(_a0 context.Context, _a1 types.RequestInitChain) (*types.ResponseInitChain, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseInitChain

--- a/internal/proxy/mocks/app_conn_mempool.go
+++ b/internal/proxy/mocks/app_conn_mempool.go
@@ -17,6 +17,29 @@ type AppConnMempool struct {
 	mock.Mock
 }
 
+// CheckTx provides a mock function with given fields: _a0, _a1
+func (_m *AppConnMempool) CheckTx(_a0 context.Context, _a1 types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 *types.ResponseCheckTx
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestCheckTx) *types.ResponseCheckTx); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.ResponseCheckTx)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, types.RequestCheckTx) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CheckTxAsync provides a mock function with given fields: _a0, _a1
 func (_m *AppConnMempool) CheckTxAsync(_a0 context.Context, _a1 types.RequestCheckTx) (*abciclient.ReqRes, error) {
 	ret := _m.Called(_a0, _a1)
@@ -40,29 +63,6 @@ func (_m *AppConnMempool) CheckTxAsync(_a0 context.Context, _a1 types.RequestChe
 	return r0, r1
 }
 
-// CheckTxSync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnMempool) CheckTxSync(_a0 context.Context, _a1 types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *types.ResponseCheckTx
-	if rf, ok := ret.Get(0).(func(context.Context, types.RequestCheckTx) *types.ResponseCheckTx); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.ResponseCheckTx)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.RequestCheckTx) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // Error provides a mock function with given fields:
 func (_m *AppConnMempool) Error() error {
 	ret := _m.Called()
@@ -70,6 +70,20 @@ func (_m *AppConnMempool) Error() error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Flush provides a mock function with given fields: _a0
+func (_m *AppConnMempool) Flush(_a0 context.Context) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -98,20 +112,6 @@ func (_m *AppConnMempool) FlushAsync(_a0 context.Context) (*abciclient.ReqRes, e
 	}
 
 	return r0, r1
-}
-
-// FlushSync provides a mock function with given fields: _a0
-func (_m *AppConnMempool) FlushSync(_a0 context.Context) error {
-	ret := _m.Called(_a0)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
 }
 
 // SetResponseCallback provides a mock function with given fields: _a0

--- a/internal/proxy/mocks/app_conn_query.go
+++ b/internal/proxy/mocks/app_conn_query.go
@@ -15,8 +15,8 @@ type AppConnQuery struct {
 	mock.Mock
 }
 
-// EchoSync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnQuery) EchoSync(_a0 context.Context, _a1 string) (*types.ResponseEcho, error) {
+// Echo provides a mock function with given fields: _a0, _a1
+func (_m *AppConnQuery) Echo(_a0 context.Context, _a1 string) (*types.ResponseEcho, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseEcho
@@ -52,8 +52,8 @@ func (_m *AppConnQuery) Error() error {
 	return r0
 }
 
-// InfoSync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnQuery) InfoSync(_a0 context.Context, _a1 types.RequestInfo) (*types.ResponseInfo, error) {
+// Info provides a mock function with given fields: _a0, _a1
+func (_m *AppConnQuery) Info(_a0 context.Context, _a1 types.RequestInfo) (*types.ResponseInfo, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseInfo
@@ -75,8 +75,8 @@ func (_m *AppConnQuery) InfoSync(_a0 context.Context, _a1 types.RequestInfo) (*t
 	return r0, r1
 }
 
-// QuerySync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnQuery) QuerySync(_a0 context.Context, _a1 types.RequestQuery) (*types.ResponseQuery, error) {
+// Query provides a mock function with given fields: _a0, _a1
+func (_m *AppConnQuery) Query(_a0 context.Context, _a1 types.RequestQuery) (*types.ResponseQuery, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseQuery

--- a/internal/proxy/mocks/app_conn_snapshot.go
+++ b/internal/proxy/mocks/app_conn_snapshot.go
@@ -15,8 +15,8 @@ type AppConnSnapshot struct {
 	mock.Mock
 }
 
-// ApplySnapshotChunkSync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnSnapshot) ApplySnapshotChunkSync(_a0 context.Context, _a1 types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
+// ApplySnapshotChunk provides a mock function with given fields: _a0, _a1
+func (_m *AppConnSnapshot) ApplySnapshotChunk(_a0 context.Context, _a1 types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseApplySnapshotChunk
@@ -52,8 +52,8 @@ func (_m *AppConnSnapshot) Error() error {
 	return r0
 }
 
-// ListSnapshotsSync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnSnapshot) ListSnapshotsSync(_a0 context.Context, _a1 types.RequestListSnapshots) (*types.ResponseListSnapshots, error) {
+// ListSnapshots provides a mock function with given fields: _a0, _a1
+func (_m *AppConnSnapshot) ListSnapshots(_a0 context.Context, _a1 types.RequestListSnapshots) (*types.ResponseListSnapshots, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseListSnapshots
@@ -75,8 +75,8 @@ func (_m *AppConnSnapshot) ListSnapshotsSync(_a0 context.Context, _a1 types.Requ
 	return r0, r1
 }
 
-// LoadSnapshotChunkSync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnSnapshot) LoadSnapshotChunkSync(_a0 context.Context, _a1 types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
+// LoadSnapshotChunk provides a mock function with given fields: _a0, _a1
+func (_m *AppConnSnapshot) LoadSnapshotChunk(_a0 context.Context, _a1 types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseLoadSnapshotChunk
@@ -98,8 +98,8 @@ func (_m *AppConnSnapshot) LoadSnapshotChunkSync(_a0 context.Context, _a1 types.
 	return r0, r1
 }
 
-// OfferSnapshotSync provides a mock function with given fields: _a0, _a1
-func (_m *AppConnSnapshot) OfferSnapshotSync(_a0 context.Context, _a1 types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error) {
+// OfferSnapshot provides a mock function with given fields: _a0, _a1
+func (_m *AppConnSnapshot) OfferSnapshot(_a0 context.Context, _a1 types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.ResponseOfferSnapshot

--- a/internal/rpc/core/abci.go
+++ b/internal/rpc/core/abci.go
@@ -18,7 +18,7 @@ func (env *Environment) ABCIQuery(
 	height int64,
 	prove bool,
 ) (*coretypes.ResultABCIQuery, error) {
-	resQuery, err := env.ProxyAppQuery.QuerySync(ctx, abci.RequestQuery{
+	resQuery, err := env.ProxyAppQuery.Query(ctx, abci.RequestQuery{
 		Path:   path,
 		Data:   data,
 		Height: height,
@@ -34,7 +34,7 @@ func (env *Environment) ABCIQuery(
 // ABCIInfo gets some info about the application.
 // More: https://docs.tendermint.com/master/rpc/#/ABCI/abci_info
 func (env *Environment) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
-	resInfo, err := env.ProxyAppQuery.InfoSync(ctx, proxy.RequestInfo)
+	resInfo, err := env.ProxyAppQuery.Info(ctx, proxy.RequestInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -153,7 +153,7 @@ func (env *Environment) NumUnconfirmedTxs(ctx context.Context) (*coretypes.Resul
 // be added to the mempool either.
 // More: https://docs.tendermint.com/master/rpc/#/Tx/check_tx
 func (env *Environment) CheckTx(ctx context.Context, tx types.Tx) (*coretypes.ResultCheckTx, error) {
-	res, err := env.ProxyAppMempool.CheckTxSync(ctx, abci.RequestCheckTx{Tx: tx})
+	res, err := env.ProxyAppMempool.CheckTx(ctx, abci.RequestCheckTx{Tx: tx})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -255,9 +255,9 @@ func (blockExec *BlockExecutor) Commit(
 	}
 
 	// Commit block, get hash back
-	res, err := blockExec.proxyApp.CommitSync(ctx)
+	res, err := blockExec.proxyApp.Commit(ctx)
 	if err != nil {
-		blockExec.logger.Error("client error during proxyAppConn.CommitSync", "err", err)
+		blockExec.logger.Error("client error during proxyAppConn.Commit", "err", err)
 		return nil, 0, err
 	}
 
@@ -336,7 +336,7 @@ func execBlockOnProxyApp(
 		return nil, errors.New("nil header")
 	}
 
-	abciResponses.BeginBlock, err = proxyAppConn.BeginBlockSync(
+	abciResponses.BeginBlock, err = proxyAppConn.BeginBlock(
 		ctx,
 		abci.RequestBeginBlock{
 			Hash:                block.Hash(),
@@ -358,7 +358,7 @@ func execBlockOnProxyApp(
 		}
 	}
 
-	abciResponses.EndBlock, err = proxyAppConn.EndBlockSync(ctx, abci.RequestEndBlock{Height: block.Height})
+	abciResponses.EndBlock, err = proxyAppConn.EndBlock(ctx, abci.RequestEndBlock{Height: block.Height})
 	if err != nil {
 		logger.Error("error in proxyAppConn.EndBlock", "err", err)
 		return nil, err
@@ -604,9 +604,9 @@ func ExecCommitBlock(
 	}
 
 	// Commit block, get hash back
-	res, err := appConnConsensus.CommitSync(ctx)
+	res, err := appConnConsensus.Commit(ctx)
 	if err != nil {
-		logger.Error("client error during proxyAppConn.CommitSync", "err", res)
+		logger.Error("client error during proxyAppConn.Commit", "err", res)
 		return nil, err
 	}
 

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -618,7 +618,7 @@ func (r *Reactor) handleChunkMessage(ctx context.Context, envelope *p2p.Envelope
 			"chunk", msg.Index,
 			"peer", envelope.From,
 		)
-		resp, err := r.conn.LoadSnapshotChunkSync(ctx, abci.RequestLoadSnapshotChunk{
+		resp, err := r.conn.LoadSnapshotChunk(ctx, abci.RequestLoadSnapshotChunk{
 			Height: msg.Height,
 			Format: msg.Format,
 			Chunk:  msg.Index,
@@ -911,7 +911,7 @@ func (r *Reactor) processPeerUpdates(ctx context.Context) {
 
 // recentSnapshots fetches the n most recent snapshots from the app
 func (r *Reactor) recentSnapshots(ctx context.Context, n uint32) ([]*snapshot, error) {
-	resp, err := r.conn.ListSnapshotsSync(ctx, abci.RequestListSnapshots{})
+	resp, err := r.conn.ListSnapshots(ctx, abci.RequestListSnapshots{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -214,15 +214,15 @@ func TestReactor_Sync(t *testing.T) {
 	rts := setup(ctx, t, nil, nil, nil, 2)
 	chain := buildLightBlockChain(ctx, t, 1, 10, time.Now())
 	// app accepts any snapshot
-	rts.conn.On("OfferSnapshotSync", ctx, mock.AnythingOfType("types.RequestOfferSnapshot")).
+	rts.conn.On("OfferSnapshot", ctx, mock.AnythingOfType("types.RequestOfferSnapshot")).
 		Return(&abci.ResponseOfferSnapshot{Result: abci.ResponseOfferSnapshot_ACCEPT}, nil)
 
 	// app accepts every chunk
-	rts.conn.On("ApplySnapshotChunkSync", ctx, mock.AnythingOfType("types.RequestApplySnapshotChunk")).
+	rts.conn.On("ApplySnapshotChunk", ctx, mock.AnythingOfType("types.RequestApplySnapshotChunk")).
 		Return(&abci.ResponseApplySnapshotChunk{Result: abci.ResponseApplySnapshotChunk_ACCEPT}, nil)
 
 	// app query returns valid state app hash
-	rts.connQuery.On("InfoSync", mock.Anything, proxy.RequestInfo).Return(&abci.ResponseInfo{
+	rts.connQuery.On("Info", mock.Anything, proxy.RequestInfo).Return(&abci.ResponseInfo{
 		AppVersion:       testAppVersion,
 		LastBlockHeight:  snapshotHeight,
 		LastBlockAppHash: chain[snapshotHeight+1].AppHash,
@@ -317,7 +317,7 @@ func TestReactor_ChunkRequest(t *testing.T) {
 
 			// mock ABCI connection to return local snapshots
 			conn := &proxymocks.AppConnSnapshot{}
-			conn.On("LoadSnapshotChunkSync", mock.Anything, abci.RequestLoadSnapshotChunk{
+			conn.On("LoadSnapshotChunk", mock.Anything, abci.RequestLoadSnapshotChunk{
 				Height: tc.request.Height,
 				Format: tc.request.Format,
 				Chunk:  tc.request.Index,
@@ -404,7 +404,7 @@ func TestReactor_SnapshotsRequest(t *testing.T) {
 
 			// mock ABCI connection to return local snapshots
 			conn := &proxymocks.AppConnSnapshot{}
-			conn.On("ListSnapshotsSync", mock.Anything, abci.RequestListSnapshots{}).Return(&abci.ResponseListSnapshots{
+			conn.On("ListSnapshots", mock.Anything, abci.RequestListSnapshots{}).Return(&abci.ResponseListSnapshots{
 				Snapshots: tc.snapshots,
 			}, nil)
 

--- a/internal/statesync/syncer.go
+++ b/internal/statesync/syncer.go
@@ -367,7 +367,7 @@ func (s *syncer) Sync(ctx context.Context, snapshot *snapshot, chunks *chunkQueu
 func (s *syncer) offerSnapshot(ctx context.Context, snapshot *snapshot) error {
 	s.logger.Info("Offering snapshot to ABCI app", "height", snapshot.Height,
 		"format", snapshot.Format, "hash", snapshot.Hash)
-	resp, err := s.conn.OfferSnapshotSync(ctx, abci.RequestOfferSnapshot{
+	resp, err := s.conn.OfferSnapshot(ctx, abci.RequestOfferSnapshot{
 		Snapshot: &abci.Snapshot{
 			Height:   snapshot.Height,
 			Format:   snapshot.Format,
@@ -409,7 +409,7 @@ func (s *syncer) applyChunks(ctx context.Context, chunks *chunkQueue, start time
 			return fmt.Errorf("failed to fetch chunk: %w", err)
 		}
 
-		resp, err := s.conn.ApplySnapshotChunkSync(ctx, abci.RequestApplySnapshotChunk{
+		resp, err := s.conn.ApplySnapshotChunk(ctx, abci.RequestApplySnapshotChunk{
 			Index:  chunk.Index,
 			Chunk:  chunk.Chunk,
 			Sender: string(chunk.Sender),
@@ -550,7 +550,7 @@ func (s *syncer) requestChunk(ctx context.Context, snapshot *snapshot, chunk uin
 // verifyApp verifies the sync, checking the app hash and last block height. It returns the
 // app version, which should be returned as part of the initial state.
 func (s *syncer) verifyApp(ctx context.Context, snapshot *snapshot) (uint64, error) {
-	resp, err := s.connQuery.InfoSync(ctx, proxy.RequestInfo)
+	resp, err := s.connQuery.Info(ctx, proxy.RequestInfo)
 	if err != nil {
 		return 0, fmt.Errorf("failed to query ABCI app for appHash: %w", err)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -754,7 +754,7 @@ func getRouterConfig(conf *config.Config, proxyApp proxy.AppConns) p2p.RouterOpt
 
 	if conf.FilterPeers && proxyApp != nil {
 		opts.FilterPeerByID = func(ctx context.Context, id types.NodeID) error {
-			res, err := proxyApp.Query().QuerySync(ctx, abci.RequestQuery{
+			res, err := proxyApp.Query().Query(ctx, abci.RequestQuery{
 				Path: fmt.Sprintf("/p2p/filter/id/%s", id),
 			})
 			if err != nil {
@@ -768,7 +768,7 @@ func getRouterConfig(conf *config.Config, proxyApp proxy.AppConns) p2p.RouterOpt
 		}
 
 		opts.FilterPeerByIP = func(ctx context.Context, ip net.IP, port uint16) error {
-			res, err := proxyApp.Query().QuerySync(ctx, abci.RequestQuery{
+			res, err := proxyApp.Query().Query(ctx, abci.RequestQuery{
 				Path: fmt.Sprintf("/p2p/filter/addr/%s", net.JoinHostPort(ip.String(), strconv.Itoa(int(port)))),
 			})
 			if err != nil {


### PR DESCRIPTION
As we discussed at the ABCI++ meeting, the rollout in v0.36 is an ideal time to clean up some  infelicities in the original implementation. This is a first step toward that cleanup. We will still have to address Flush, CommitTx, and DeliverTx separately, but getting the easy cases out of the way will help keep those diffs smaller.

N.B.: The diff in `grpc_client.go` is large, but less complicated than it looks. It folds the sync/async versions back together, strips out the unnecessary support code, and updates the names. The rename makes the diff look hairier than it should be.

This change has two main effects:

1. Remove most of the Async methods from the abci.Client interface.
   Remaining are FlushAsync, CommitTxAsync, and DeliverTxAsync.

2. Rename the synchronous methods to remove the "Sync" suffix.

The rest of the change is updating the implementations, subsets, and mocks of
the interface, along with the call sites that point to them.

TODO before merge:
- [ ] Update changelog.