### PR TITLE
privval: do not use old proposal timestamp

### DIFF
--- a/privval/file.go
+++ b/privval/file.go
@@ -388,8 +388,6 @@ func (pv *FilePV) signVote(chainID string, vote *tmproto.Vote) error {
 }
 
 // signProposal checks if the proposal is good to sign and sets the proposal signature.
-// It may need to set the timestamp as well if the proposal is otherwise the same as
-// a previously signed proposal ie. we crashed after signing but before the proposal hit the WAL).
 func (pv *FilePV) signProposal(chainID string, proposal *tmproto.Proposal) error {
 	height, round, step := proposal.Height, proposal.Round, stepPropose
 
@@ -405,8 +403,6 @@ func (pv *FilePV) signProposal(chainID string, proposal *tmproto.Proposal) error
 	// We might crash before writing to the wal,
 	// causing us to try to re-sign for the same HRS.
 	// If signbytes are the same, use the last signature.
-	// If they only differ by timestamp, use last timestamp and signature
-	// Otherwise, return error
 	if sameHRS {
 		if !bytes.Equal(signBytes, lss.SignBytes) {
 			return errors.New("conflicting data")

--- a/privval/file.go
+++ b/privval/file.go
@@ -99,7 +99,7 @@ type FilePVLastSignState struct {
 	filePath string
 }
 
-// CheckHRS checks the given height, round, step (HRS) against that of the
+// checkHRS checks the given height, round, step (HRS) against that of the
 // FilePVLastSignState. It returns an error if the arguments constitute a regression,
 // or if they match but the SignBytes are empty.
 // The returned boolean indicates whether the last Signature should be reused -


### PR DESCRIPTION
After #7592, @cmwaters noticed that the logic for re-using old timestamps for proposals may not work with proposer-based timestamps. This change removes the logic to re-use old proposal timestamps since it is no longer correct. Two proposals with different timestamps can no longer be treated as equivalent. Signing a proposal that only differs by timestamp in the new algorithm can be thought of as roughly equivalent to signing a proposal that only differs by `BlockID` in the old scheme. 

I also investigated the codebase and checked for any place we updated a timestamp using the pattern `(Timestamp = |Timestamp: )` and saw no additional places where we are updating the timestamp of a proposal message. 

Here is the output of that search:

```
privval/file.go:372:			vote.Timestamp = timestamp
privval/file.go:453:	lastVote.Timestamp = now
privval/file.go:454:	newVote.Timestamp = now
internal/test/factory/commit.go:25:			Timestamp:        now,
internal/test/factory/vote.go:34:		Timestamp:        time,
internal/consensus/state.go:2261:		Timestamp:        cs.voteTime(),
internal/consensus/state.go:2286:	vote.Timestamp = v.Timestamp
light/detector.go:414:		ev.Timestamp = common.Time
light/detector.go:418:		ev.Timestamp = trusted.Time
types/block.go:616:		Timestamp:        ts,
types/block.go:725:		Timestamp:        cs.Timestamp,
types/block.go:736:	cs.Timestamp = csp.Timestamp
types/block.go:800:		Timestamp:        commitSig.Timestamp,
types/evidence.go:84:		Timestamp:        blockTime,
types/evidence.go:190:	dve.Timestamp = evidenceTime
types/evidence.go:202:		Timestamp:        dve.Timestamp,
types/evidence.go:228:		Timestamp:        pb.Timestamp,
types/evidence.go:382:		Timestamp: %v}#%X`,
types/evidence.go:491:	l.Timestamp = evidenceTime
types/evidence.go:517:		Timestamp:           l.Timestamp,
types/evidence.go:546:		Timestamp:           lpb.Timestamp,
types/evidence.go:722:		Timestamp:        time,
types/vote.go:80:		Timestamp:        vote.Timestamp,
types/vote.go:216:		Timestamp:        vote.Timestamp,
types/vote.go:240:	vote.Timestamp = pv.Timestamp
types/test_util.go:27:			Timestamp:        now,
types/proposal.go:44:		Timestamp: tmtime.Now(),
types/proposal.go:132:	pb.Timestamp = p.Timestamp
types/proposal.go:157:	p.Timestamp = pp.Timestamp
types/canonical.go:49:		Timestamp: proposal.Timestamp,
types/canonical.go:62:		Timestamp: vote.Timestamp,
test/e2e/runner/evidence.go:186:		Timestamp:        evTime,
```