### PR TITLE
pex: do not send nil envelopes to the reactor

### DIFF
--- a/internal/p2p/pex/reactor.go
+++ b/internal/p2p/pex/reactor.go
@@ -171,10 +171,14 @@ func (r *Reactor) processPexCh(ctx context.Context) {
 		defer close(incoming)
 		iter := r.pexCh.Receive(ctx)
 		for iter.Next(ctx) {
+			env := iter.Envelope()
+			if env == nil {
+				break
+			}
 			select {
 			case <-ctx.Done():
 				return
-			case incoming <- iter.Envelope():
+			case incoming <- env:
 			}
 		}
 	}()


### PR DESCRIPTION
I believe it is possible that a channel may be closed after reporting `true` from its `Next` method, but before the caller retrieves the value of its current item (by calling `Envelope`).

This appears to lead to an occasional nil-indirection panic in the PEX reactor, which pushes envelopes from the iterator concurrently with context cancellation.
