### PR TITLE
consensus: check proposal non-nil in prevote message delay metric

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2399,11 +2399,16 @@ func (cs *State) checkDoubleSigningRisk(height int64) error {
 }
 
 func (cs *State) calculatePrevoteMessageDelayMetrics() {
+	if cs.Proposal == nil {
+		return
+	}
 	ps := cs.Votes.Prevotes(cs.Round)
 	pl := ps.List()
+
 	sort.Slice(pl, func(i, j int) bool {
 		return pl[i].Timestamp.Before(pl[j].Timestamp)
 	})
+
 	var votingPowerSeen int64
 	for _, v := range pl {
 		_, val := cs.Validators.GetByAddress(v.ValidatorAddress)


### PR DESCRIPTION
Noticed spurious panic in test related to the `Proposal` being nil here. 
The other fields being used here, `Votes` and `Validators` should not be nil.
`Votes` is set at the beginning of each round, and `Validators` is initialized from the genesis file.  