### PR TITLE
privval: synchronize leak check with shutdown

### DIFF
--- a/privval/signer_client_test.go
+++ b/privval/signer_client_test.go
@@ -73,14 +73,15 @@ func TestSignerClose(t *testing.T) {
 
 	for _, tc := range getSignerTestCases(bctx, t, logger) {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Cleanup(leaktest.Check(t))
-
-			defer tc.closer()
+			defer leaktest.Check(t)
+			defer func() {
+				tc.closer()
+				tc.signerClient.endpoint.Wait()
+				tc.signerServer.Wait()
+			}()
 
 			assert.NoError(t, tc.signerClient.Close())
 			assert.NoError(t, tc.signerServer.Stop())
-			t.Cleanup(tc.signerClient.endpoint.Wait)
-			t.Cleanup(tc.signerServer.Wait)
 		})
 	}
 }


### PR DESCRIPTION
The interaction between defers and t.Cleanup can be delicate.
For this case, which regularly flakes in CI, be explicit:
Defer the closes and waits before making any attempt to leaktest.
