### PR TITLE
abci/client: use a no-op logger in the test

### DIFF
--- a/abci/client/socket_client_test.go
+++ b/abci/client/socket_client_test.go
@@ -23,7 +23,7 @@ func TestProperSyncCalls(t *testing.T) {
 	defer cancel()
 
 	app := slowApp{}
-	logger := log.NewTestingLogger(t)
+	logger := log.TestingLogger()
 
 	_, c := setupClientServer(ctx, t, logger, app)
 


### PR DESCRIPTION
This averts a log-after-close issue. We should probably also chase the shutdown
issues, but since ABCI clients should generally only shut down once per process
I don't think this is a real priority, and the trace is hairy.
