### PR TITLE
mempool: reactor concurrency test tweaks

### DIFF
--- a/internal/mempool/reactor_test.go
+++ b/internal/mempool/reactor_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
-	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/config"
 	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/internal/p2p"
@@ -210,68 +209,6 @@ func TestReactorBroadcastTxs(t *testing.T) {
 	// Wait till all secondary suites (reactor) received all mempool txs from the
 	// primary suite (node).
 	rts.waitForTxns(t, convertTex(txs), secondaries...)
-}
-
-// regression test for https://github.com/tendermint/tendermint/issues/5408
-func TestReactorConcurrency(t *testing.T) {
-	numTxs := 5
-	numNodes := 2
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	rts := setupReactors(ctx, t, numNodes, 0)
-
-	primary := rts.nodes[0]
-	secondary := rts.nodes[1]
-
-	rts.start(ctx, t)
-
-	var wg sync.WaitGroup
-
-	for i := 0; i < 1000; i++ {
-		wg.Add(2)
-
-		// 1. submit a bunch of txs
-		// 2. update the whole mempool
-
-		txs := checkTxs(ctx, t, rts.reactors[primary].mempool, numTxs, UnknownPeerID)
-		go func() {
-			defer wg.Done()
-
-			mempool := rts.mempools[primary]
-
-			mempool.Lock()
-			defer mempool.Unlock()
-
-			deliverTxResponses := make([]*abci.ResponseDeliverTx, len(txs))
-			for i := range txs {
-				deliverTxResponses[i] = &abci.ResponseDeliverTx{Code: 0}
-			}
-
-			require.NoError(t, mempool.Update(ctx, 1, convertTex(txs), deliverTxResponses, nil, nil))
-		}()
-
-		// 1. submit a bunch of txs
-		// 2. update none
-		_ = checkTxs(ctx, t, rts.reactors[secondary].mempool, numTxs, UnknownPeerID)
-		go func() {
-			defer wg.Done()
-
-			mempool := rts.mempools[secondary]
-
-			mempool.Lock()
-			defer mempool.Unlock()
-
-			err := mempool.Update(ctx, 1, []types.Tx{}, make([]*abci.ResponseDeliverTx, 0), nil, nil)
-			require.NoError(t, err)
-		}()
-
-		// flush the mempool
-		rts.mempools[secondary].Flush()
-	}
-
-	wg.Wait()
 }
 
 func TestReactorNoBroadcastToSender(t *testing.T) {


### PR DESCRIPTION
Despite the useful-seeming name this isn't a particularly high value
test, and it mostly just serves to smoke out potential panics due to
poorly handled concurrency. It may also detect race conditions, though
the placement of the mutexes make this unlikely. The mutexes as used
also make it unlikely that there is much meaningful concurrent
execution.

While it does run the reactors, and it does have a parallel workload,
it's also *not really* a test of reactor concurrency as the test
operations mostly deal with the mempool rather than the reactor, which
is a bit confusing.

Unfortunitley the test does fail sometimes, which makes it something
of a bother. Looking at it's history, it's a regression test for the
previous implementation, so while it may be worth keeping around, the
way that it's being carried forward and relies of access to the
internals of the mempool to prevent a bug that really can't happen
anymore might inspire us to delete it in the future. For the moment,
I've dropped the Flush call which accounted for 20% of the test
execution time and isn't implicated in the original bug. I've also
reduced the size of the test to so that it should force the thread
scheduler to do some work and muck with the timing, but also reduce
the chance that we run into system capacity problems: this reduced the
test runtime by 75%.