### PR TITLE
params: increase default synchrony params

### DIFF
--- a/types/params.go
+++ b/types/params.go
@@ -132,7 +132,7 @@ func DefaultSynchronyParams() SynchronyParams {
 	// https://github.com/tendermint/tendermint/issues/7202
 	return SynchronyParams{
 		Precision:    500 * time.Millisecond,
-		MessageDelay: 2 * time.Second,
+		MessageDelay: 3 * time.Second,
 	}
 }
 


### PR DESCRIPTION
This is being done to prevent flaky failures of the `TestReactorValidatorSetChanges`