### PR TITLE
rpc: clean up unused non-default websocket options

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,10 +12,11 @@ Special thanks to external contributors on this release:
 
 - CLI/RPC/Config
 
-  - [rpc] \#7575 Rework how RPC responses are written back via HTTP. (@creachadair)
   - [rpc] \#7121 Remove the deprecated gRPC interface to the RPC service. (@creachadair)
   - [blocksync] \#7159 Remove support for disabling blocksync in any circumstance. (@tychoish)
   - [mempool] \#7171 Remove legacy mempool implementation. (@tychoish)
+  - [rpc] \#7575 Rework how RPC responses are written back via HTTP. (@creachadair)
+  - [rpc] \#7713 Remove unused options for websocket clients. (@creachadair)
 
 - Apps
 
@@ -58,6 +59,7 @@ Special thanks to external contributors on this release:
 - [consensus] \#7711 Use the proposer timestamp for the first height instead of the genesis time. Chains will still start consensus at the genesis time. (@anca)
 
 ### IMPROVEMENTS
+
 - [internal/protoio] \#7325 Optimized `MarshalDelimited` by inlining the common case and using a `sync.Pool` in the worst case. (@odeke-em)
 - [consensus] \#6969 remove logic to 'unlock' a locked block.
 - [pubsub] \#7319 Performance improvements for the event query API (@creachadair)

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -123,18 +123,9 @@ func NewWithTimeout(remote string, t time.Duration) (*HTTP, error) {
 }
 
 // NewWithClient allows you to set a custom http client. An error is returned
-// on invalid remote. The function returns an error when client is nil
-// or an invalid remote.
+// on invalid remote. The function returns an error when client is nil or an
+// invalid remote.
 func NewWithClient(remote string, c *http.Client) (*HTTP, error) {
-	if c == nil {
-		return nil, errors.New("nil client")
-	}
-	return NewWithClientAndWSOptions(remote, c, DefaultWSOptions())
-}
-
-// NewWithClientAndWSOptions allows you to set a custom http client and
-// WebSocket options. An error is returned on invalid remote or nil client.
-func NewWithClientAndWSOptions(remote string, c *http.Client, wso WSOptions) (*HTTP, error) {
 	if c == nil {
 		return nil, errors.New("nil client")
 	}
@@ -143,7 +134,7 @@ func NewWithClientAndWSOptions(remote string, c *http.Client, wso WSOptions) (*H
 		return nil, err
 	}
 
-	wsEvents, err := newWsEvents(remote, wso)
+	wsEvents, err := newWsEvents(remote)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -122,9 +122,8 @@ func NewWithTimeout(remote string, t time.Duration) (*HTTP, error) {
 	return NewWithClient(remote, c)
 }
 
-// NewWithClient allows you to set a custom http client. An error is returned
-// on invalid remote. The function returns an error when client is nil or an
-// invalid remote.
+// NewWithClient constructs an RPC client using a custom HTTP client.
+// An error is reported if c == nil or remote is an invalid address.
 func NewWithClient(remote string, c *http.Client) (*HTTP, error) {
 	if c == nil {
 		return nil, errors.New("nil client")

--- a/rpc/client/http/ws.go
+++ b/rpc/client/http/ws.go
@@ -32,19 +32,13 @@ type wsSubscription struct {
 var _ rpcclient.EventsClient = (*wsEvents)(nil)
 
 func newWsEvents(remote string) (*wsEvents, error) {
-	// remove the trailing / from the remote else the websocket endpoint
-	// won't parse correctly
-	if remote[len(remote)-1] == '/' {
-		remote = remote[:len(remote)-1]
-	}
-
 	w := &wsEvents{
+		RunState:      rpcclient.NewRunState("wsEvents", nil),
 		subscriptions: make(map[string]*wsSubscription),
 	}
-	w.RunState = rpcclient.NewRunState("wsEvents", nil)
 
 	var err error
-	w.ws, err = jsonrpcclient.NewWS(remote, "/websocket")
+	w.ws, err = jsonrpcclient.NewWS(strings.TrimSuffix(remote, "/"), "/websocket")
 	if err != nil {
 		return nil, fmt.Errorf("can't create WS client: %w", err)
 	}

--- a/rpc/client/http/ws.go
+++ b/rpc/client/http/ws.go
@@ -3,7 +3,6 @@ package http
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -14,34 +13,6 @@ import (
 	"github.com/tendermint/tendermint/rpc/coretypes"
 	jsonrpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
 )
-
-// WSOptions for the WS part of the HTTP client.
-type WSOptions struct {
-	Path string // path (e.g. "/ws")
-
-	jsonrpcclient.WSOptions // WSClient options
-}
-
-// DefaultWSOptions returns default WS options.
-// See jsonrpcclient.DefaultWSOptions.
-func DefaultWSOptions() WSOptions {
-	return WSOptions{
-		Path:      "/websocket",
-		WSOptions: jsonrpcclient.DefaultWSOptions(),
-	}
-}
-
-// Validate performs a basic validation of WSOptions.
-func (wso WSOptions) Validate() error {
-	if len(wso.Path) <= 1 {
-		return errors.New("empty Path")
-	}
-	if wso.Path[0] != '/' {
-		return errors.New("leading slash is missing in Path")
-	}
-
-	return nil
-}
 
 // wsEvents is a wrapper around WSClient, which implements EventsClient.
 type wsEvents struct {
@@ -60,12 +31,7 @@ type wsSubscription struct {
 
 var _ rpcclient.EventsClient = (*wsEvents)(nil)
 
-func newWsEvents(remote string, wso WSOptions) (*wsEvents, error) {
-	// validate options
-	if err := wso.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid WSOptions: %w", err)
-	}
-
+func newWsEvents(remote string) (*wsEvents, error) {
 	// remove the trailing / from the remote else the websocket endpoint
 	// won't parse correctly
 	if remote[len(remote)-1] == '/' {
@@ -78,7 +44,7 @@ func newWsEvents(remote string, wso WSOptions) (*wsEvents, error) {
 	w.RunState = rpcclient.NewRunState("wsEvents", nil)
 
 	var err error
-	w.ws, err = jsonrpcclient.NewWSWithOptions(remote, wso.Path, wso.WSOptions)
+	w.ws, err = jsonrpcclient.NewWS(remote, "/websocket")
 	if err != nil {
 		return nil, fmt.Errorf("can't create WS client: %w", err)
 	}

--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -150,8 +150,8 @@ func New(remote string) (*Client, error) {
 }
 
 // NewWithHTTPClient returns a Client pointed at the given address using a
-// custom http client. An error is returned on invalid remote. The function
-// panics when client is nil.
+// custom HTTP client. It reports an error if c == nil or if remote is not a
+// valid URL.
 func NewWithHTTPClient(remote string, c *http.Client) (*Client, error) {
 	if c == nil {
 		return nil, errors.New("nil client")

--- a/rpc/jsonrpc/client/ws_client_test.go
+++ b/rpc/jsonrpc/client/ws_client_test.go
@@ -26,7 +26,7 @@ func init() {
 	metrics.UseNilMetrics = true
 }
 
-var wsCallTimeout = 5 * time.Second
+const wsCallTimeout = 5 * time.Second
 
 type myTestHandler struct {
 	closeConnAfterRead bool

--- a/rpc/jsonrpc/client/ws_client_test.go
+++ b/rpc/jsonrpc/client/ws_client_test.go
@@ -12,11 +12,19 @@ import (
 
 	"github.com/fortytw2/leaktest"
 	"github.com/gorilla/websocket"
+	metrics "github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/libs/log"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
+
+func init() {
+	// Disable go-metrics metrics in tests, since they start unsupervised
+	// goroutines that trip the leak tester. Calling Stop on the metric is not
+	// sufficient, as that does not wait for the goroutine.
+	metrics.UseNilMetrics = true
+}
 
 var wsCallTimeout = 5 * time.Second
 
@@ -223,9 +231,7 @@ func startClient(ctx context.Context, t *testing.T, addr string) *WSClient {
 
 	t.Cleanup(leaktest.Check(t))
 
-	opts := DefaultWSOptions()
-	opts.SkipMetrics = true
-	c, err := NewWSWithOptions(addr, "/websocket", opts)
+	c, err := NewWS(addr, "/websocket")
 
 	require.NoError(t, err)
 	err = c.Start(ctx)

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -287,9 +287,7 @@ func TestServersAndClientsBasic(t *testing.T) {
 			fmt.Printf("=== testing server on %s using JSONRPC client", addr)
 			testWithHTTPClient(ctx, t, cl2)
 
-			opts := client.DefaultWSOptions()
-			opts.SkipMetrics = true
-			cl3, err := client.NewWSWithOptions(addr, websocketEndpoint, opts)
+			cl3, err := client.NewWS(addr, websocketEndpoint)
 			require.NoError(t, err)
 			cl3.Logger = logger
 			err = cl3.Start(ctx)
@@ -307,9 +305,7 @@ func TestWSNewWSRPCFunc(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	opts := client.DefaultWSOptions()
-	opts.SkipMetrics = true
-	cl, err := client.NewWSWithOptions(tcpAddr, websocketEndpoint, opts)
+	cl, err := client.NewWS(tcpAddr, websocketEndpoint)
 	require.NoError(t, err)
 	cl.Logger = log.NewNopLogger()
 	err = cl.Start(ctx)
@@ -346,9 +342,7 @@ func TestWSClientPingPong(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	opts := client.DefaultWSOptions()
-	opts.SkipMetrics = true
-	cl, err := client.NewWSWithOptions(tcpAddr, websocketEndpoint, opts)
+	cl, err := client.NewWS(tcpAddr, websocketEndpoint)
 	require.NoError(t, err)
 	cl.Logger = log.NewNopLogger()
 	err = cl.Start(ctx)


### PR DESCRIPTION
Unexport and/or remove the WSOptions types, which were never used with non-default values except in our own tests. Fix up the tests to not require the options.

Searches of cs.github.com reveal no non-default use.