### PR TITLE
rpc: simplify and consolidate response construction

### DIFF
--- a/internal/rpc/core/events.go
+++ b/internal/rpc/core/events.go
@@ -67,7 +67,7 @@ func (env *Environment) Subscribe(ctx context.Context, query string) (*coretypes
 				return
 			} else if errors.Is(err, tmpubsub.ErrTerminated) {
 				// The subscription was terminated by the publisher.
-				resp := callInfo.RPCRequest.MakeErrorf(rpctypes.CodeServerError, err.Error())
+				resp := callInfo.RPCRequest.MakeError(err)
 				ok := callInfo.WSConn.TryWriteRPCResponse(opctx, resp)
 				if !ok {
 					env.Logger.Info("Unable to write response (slow client)",

--- a/internal/rpc/core/events.go
+++ b/internal/rpc/core/events.go
@@ -67,7 +67,7 @@ func (env *Environment) Subscribe(ctx context.Context, query string) (*coretypes
 				return
 			} else if errors.Is(err, tmpubsub.ErrTerminated) {
 				// The subscription was terminated by the publisher.
-				resp := rpctypes.RPCServerError(subscriptionID, err)
+				resp := callInfo.RPCRequest.MakeErrorf(rpctypes.CodeServerError, err.Error())
 				ok := callInfo.WSConn.TryWriteRPCResponse(opctx, resp)
 				if !ok {
 					env.Logger.Info("Unable to write response (slow client)",
@@ -77,7 +77,7 @@ func (env *Environment) Subscribe(ctx context.Context, query string) (*coretypes
 			}
 
 			// We have a message to deliver to the client.
-			resp := rpctypes.NewRPCSuccessResponse(subscriptionID, &coretypes.ResultEvent{
+			resp := callInfo.RPCRequest.MakeResponse(&coretypes.ResultEvent{
 				Query:  query,
 				Data:   msg.Data(),
 				Events: msg.Events(),

--- a/light/provider/http/http_test.go
+++ b/light/provider/http/http_test.go
@@ -80,12 +80,12 @@ func TestProvider(t *testing.T) {
 	lb, err = p.LightBlock(ctx, 9001)
 	require.Error(t, err)
 	require.Nil(t, lb)
-	assert.Equal(t, provider.ErrHeightTooHigh, err)
+	assert.ErrorIs(t, err, provider.ErrHeightTooHigh)
 
 	lb, err = p.LightBlock(ctx, 1)
 	require.Error(t, err)
 	require.Nil(t, lb)
-	assert.Equal(t, provider.ErrLightBlockNotFound, err)
+	assert.ErrorIs(t, err, provider.ErrLightBlockNotFound)
 
 	// if the provider is unable to provide four more blocks then we should return
 	// an unreliable peer error

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -655,11 +655,7 @@ func (c *Client) SubscribeWS(ctx context.Context, query string) (*coretypes.Resu
 			case resultEvent := <-out:
 				// We should have a switch here that performs a validation
 				// depending on the event's type.
-				callInfo.WSConn.TryWriteRPCResponse(bctx,
-					rpctypes.NewRPCSuccessResponse(
-						rpctypes.JSONRPCStringID(fmt.Sprintf("%v#event", callInfo.RPCRequest.ID)),
-						resultEvent,
-					))
+				callInfo.WSConn.TryWriteRPCResponse(bctx, callInfo.RPCRequest.MakeResponse(resultEvent))
 			case <-bctx.Done():
 				return
 			}

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -25,15 +25,15 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 		// For POST requests, reject a non-root URL path. This should not happen
 		// in the standard configuration, since the wrapper checks the path.
 		if hreq.URL.Path != "/" {
-			writeRPCResponse(w, logger, rpctypes.RPCInvalidRequestError(
-				nil, fmt.Errorf("invalid path: %q", hreq.URL.Path)))
+			writeRPCResponse(w, logger, rpctypes.RPCRequest{}.MakeErrorf(
+				rpctypes.CodeInvalidRequest, "invalid path: %q", hreq.URL.Path))
 			return
 		}
 
 		b, err := io.ReadAll(hreq.Body)
 		if err != nil {
-			writeRPCResponse(w, logger, rpctypes.RPCInvalidRequestError(
-				nil, fmt.Errorf("reading request body: %w", err)))
+			writeRPCResponse(w, logger, rpctypes.RPCRequest{}.MakeErrorf(
+				rpctypes.CodeInvalidRequest, "reading request body: %v", err))
 			return
 		}
 
@@ -46,7 +46,8 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 
 		requests, err := parseRequests(b)
 		if err != nil {
-			writeRPCResponse(w, logger, rpctypes.RPCParseError(fmt.Errorf("decoding request: %w", err)))
+			writeRPCResponse(w, logger, rpctypes.RPCRequest{}.MakeErrorf(
+				rpctypes.CodeParseError, "decoding request: %v", err))
 			return
 		}
 
@@ -60,7 +61,7 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 
 			rpcFunc, ok := funcMap[req.Method]
 			if !ok || rpcFunc.ws {
-				responses = append(responses, rpctypes.RPCMethodNotFoundError(req.ID))
+				responses = append(responses, req.MakeErrorf(rpctypes.CodeMethodNotFound, req.Method))
 				continue
 			}
 
@@ -71,8 +72,8 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 			})
 			args, err := parseParams(ctx, rpcFunc, req.Params)
 			if err != nil {
-				responses = append(responses, rpctypes.RPCInvalidParamsError(
-					req.ID, fmt.Errorf("converting JSON parameters: %w", err)))
+				responses = append(responses,
+					req.MakeErrorf(rpctypes.CodeInvalidParams, "converting JSON parameters: %v", err))
 				continue
 			}
 
@@ -82,20 +83,20 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 			switch e := err.(type) {
 			// if no error then return a success response
 			case nil:
-				responses = append(responses, rpctypes.NewRPCSuccessResponse(req.ID, result))
+				responses = append(responses, req.MakeResponse(result))
 
 			// if this already of type RPC error then forward that error
 			case *rpctypes.RPCError:
-				responses = append(responses, rpctypes.NewRPCErrorResponse(req.ID, e.Code, e.Message, e.Data))
+				responses = append(responses, req.MakeErrorf(e.Code, e.Message))
 			default: // we need to unwrap the error and parse it accordingly
 				switch errors.Unwrap(err) {
 				// check if the error was due to an invald request
 				case coretypes.ErrZeroOrNegativeHeight, coretypes.ErrZeroOrNegativePerPage,
 					coretypes.ErrPageOutOfRange, coretypes.ErrInvalidRequest:
-					responses = append(responses, rpctypes.RPCInvalidRequestError(req.ID, err))
+					responses = append(responses, req.MakeErrorf(rpctypes.CodeInvalidRequest, err.Error()))
 				// lastly default all remaining errors as internal errors
 				default: // includes ctypes.ErrHeightNotAvailable and ctypes.ErrHeightExceedsChainHead
-					responses = append(responses, rpctypes.RPCInternalError(req.ID, err))
+					responses = append(responses, req.MakeErrorf(rpctypes.CodeInternalError, err.Error()))
 				}
 			}
 		}

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -69,7 +69,6 @@ func TestRPCParams(t *testing.T) {
 		blob, err := io.ReadAll(res.Body)
 		require.NoError(t, err, "#%d: reading body", i)
 		require.NoError(t, res.Body.Close())
-		t.Logf("MJF :: blob=%#q", string(blob))
 
 		recv := new(rpctypes.RPCResponse)
 		assert.Nil(t, json.Unmarshal(blob, recv), "#%d: expecting successful parsing of an RPCResponse:\nblob: %s", i, blob)

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -63,14 +63,13 @@ func TestRPCParams(t *testing.T) {
 		rec := httptest.NewRecorder()
 		mux.ServeHTTP(rec, req)
 		res := rec.Result()
-		defer res.Body.Close()
+
 		// Always expecting back a JSONRPCResponse
 		assert.NotZero(t, res.StatusCode, "#%d: should always return code", i)
 		blob, err := io.ReadAll(res.Body)
-		if err != nil {
-			t.Errorf("#%d: err reading body: %v", i, err)
-			continue
-		}
+		require.NoError(t, err, "#%d: reading body", i)
+		require.NoError(t, res.Body.Close())
+		t.Logf("MJF :: blob=%#q", string(blob))
 
 		recv := new(rpctypes.RPCResponse)
 		assert.Nil(t, json.Unmarshal(blob, recv), "#%d: expecting successful parsing of an RPCResponse:\nblob: %s", i, blob)

--- a/rpc/jsonrpc/server/http_server_test.go
+++ b/rpc/jsonrpc/server/http_server_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -126,16 +125,15 @@ func TestServeTLS(t *testing.T) {
 }
 
 func TestWriteRPCResponse(t *testing.T) {
-	id := rpctypes.JSONRPCIntID(-1)
+	req := rpctypes.RPCRequest{ID: rpctypes.JSONRPCIntID(-1)}
 
 	// one argument
 	w := httptest.NewRecorder()
 	logger := log.NewNopLogger()
-	writeRPCResponse(w, logger,
-		rpctypes.NewRPCSuccessResponse(id, &sampleResult{"hello"}))
+	writeRPCResponse(w, logger, req.MakeResponse(&sampleResult{"hello"}))
 	resp := w.Result()
 	body, err := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
@@ -145,12 +143,12 @@ func TestWriteRPCResponse(t *testing.T) {
 	// multiple arguments
 	w = httptest.NewRecorder()
 	writeRPCResponse(w, logger,
-		rpctypes.NewRPCSuccessResponse(id, &sampleResult{"hello"}),
-		rpctypes.NewRPCSuccessResponse(id, &sampleResult{"world"}),
+		req.MakeResponse(&sampleResult{"hello"}),
+		req.MakeResponse(&sampleResult{"world"}),
 	)
 	resp = w.Result()
 	body, err = io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 
 	assert.Equal(t, 200, resp.StatusCode)
@@ -162,13 +160,13 @@ func TestWriteRPCResponse(t *testing.T) {
 func TestWriteHTTPResponse(t *testing.T) {
 	w := httptest.NewRecorder()
 	logger := log.NewNopLogger()
-	writeHTTPResponse(w, logger,
-		rpctypes.RPCInternalError(rpctypes.JSONRPCIntID(-1), errors.New("foo")))
+	req := rpctypes.RPCRequest{ID: rpctypes.JSONRPCIntID(-1)}
+	writeHTTPResponse(w, logger, req.MakeErrorf(rpctypes.CodeInternalError, "Internal error: %s", "foo"))
 	resp := w.Result()
 	body, err := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	assert.Equal(t, `{"code":-32603,"message":"Internal error","data":"foo"}`, string(body))
+	assert.Equal(t, `{"code":-32603,"message":"Internal error: foo"}`, string(body))
 }

--- a/rpc/jsonrpc/server/http_server_test.go
+++ b/rpc/jsonrpc/server/http_server_test.go
@@ -161,12 +161,12 @@ func TestWriteHTTPResponse(t *testing.T) {
 	w := httptest.NewRecorder()
 	logger := log.NewNopLogger()
 	req := rpctypes.RPCRequest{ID: rpctypes.JSONRPCIntID(-1)}
-	writeHTTPResponse(w, logger, req.MakeErrorf(rpctypes.CodeInternalError, "Internal error: %s", "foo"))
+	writeHTTPResponse(w, logger, req.MakeErrorf(rpctypes.CodeInternalError, "foo"))
 	resp := w.Result()
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	assert.Equal(t, `{"code":-32603,"message":"Internal error: foo"}`, string(body))
+	assert.Equal(t, `{"code":-32603,"message":"Internal error","data":"foo"}`, string(body))
 }

--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -33,6 +33,7 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 			fmt.Fprintln(w, err.Error())
 			return
 		}
+		jreq := rpctypes.RPCRequest{ID: uriReqID}
 		outs := rpcFunc.f.Call(args)
 
 		logger.Debug("HTTPRestRPC", "method", req.URL.Path, "args", args, "returns", outs)
@@ -40,11 +41,11 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 		switch e := err.(type) {
 		// if no error then return a success response
 		case nil:
-			writeHTTPResponse(w, logger, rpctypes.NewRPCSuccessResponse(uriReqID, result))
+			writeHTTPResponse(w, logger, jreq.MakeResponse(result))
 
 		// if this already of type RPC error then forward that error.
 		case *rpctypes.RPCError:
-			writeHTTPResponse(w, logger, rpctypes.NewRPCErrorResponse(uriReqID, e.Code, e.Message, e.Data))
+			writeHTTPResponse(w, logger, jreq.MakeErrorf(e.Code, e.Message))
 
 		default: // we need to unwrap the error and parse it accordingly
 			switch errors.Unwrap(err) {
@@ -52,9 +53,9 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 				coretypes.ErrZeroOrNegativePerPage,
 				coretypes.ErrPageOutOfRange,
 				coretypes.ErrInvalidRequest:
-				writeHTTPResponse(w, logger, rpctypes.RPCInvalidRequestError(uriReqID, err))
+				writeHTTPResponse(w, logger, jreq.MakeErrorf(rpctypes.CodeInvalidRequest, err.Error()))
 			default: // ctypes.ErrHeightNotAvailable, ctypes.ErrHeightExceedsChainHead:
-				writeHTTPResponse(w, logger, rpctypes.RPCInternalError(uriReqID, err))
+				writeHTTPResponse(w, logger, jreq.MakeErrorf(rpctypes.CodeInternalError, err.Error()))
 			}
 		}
 	}

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -131,15 +131,14 @@ func (req RPCRequest) MakeResponse(result interface{}) RPCResponse {
 	if err != nil {
 		return req.MakeErrorf(CodeInternalError, "marshaling result: %v", err)
 	}
-	return RPCResponse{JSONRPC: "2.0", ID: req.ID, Result: data}
+	return RPCResponse{ID: req.ID, Result: data}
 }
 
 // MakeErrorf constructs an error response to req with the given code and a
 // message constructed by formatting msg with args.
 func (req RPCRequest) MakeErrorf(code ErrorCode, msg string, args ...interface{}) RPCResponse {
 	return RPCResponse{
-		JSONRPC: "2.0",
-		ID:      req.ID,
+		ID: req.ID,
 		Error: &RPCError{
 			Code:    int(code),
 			Message: code.String(),

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -58,11 +58,11 @@ func (e ErrorCode) String() string {
 
 // Constants defining the standard JSON-RPC error codes.
 const (
-	CodeParseError     = -32700 // Invalid JSON received by the server
-	CodeInvalidRequest = -32600 // The JSON sent is not a valid request object
-	CodeMethodNotFound = -32601 // The method does not exist or is unavailable
-	CodeInvalidParams  = -32602 // Invalid method parameters
-	CodeInternalError  = -32603 // Internal JSON-RPC error
+	CodeParseError     ErrorCode = -32700 // Invalid JSON received by the server
+	CodeInvalidRequest ErrorCode = -32600 // The JSON sent is not a valid request object
+	CodeMethodNotFound ErrorCode = -32601 // The method does not exist or is unavailable
+	CodeInvalidParams  ErrorCode = -32602 // Invalid method parameters
+	CodeInternalError  ErrorCode = -32603 // Internal JSON-RPC error
 )
 
 var errorCodeString = map[ErrorCode]string{
@@ -161,13 +161,15 @@ func (req RPCRequest) MakeError(err error) RPCResponse {
 		errors.Is(err, coretypes.ErrPageOutOfRange) ||
 		errors.Is(err, coretypes.ErrInvalidRequest) {
 		return RPCResponse{ID: req.ID, Error: &RPCError{
-			Code:    CodeInvalidRequest,
-			Message: err.Error(),
+			Code:    int(CodeInvalidRequest),
+			Message: CodeInvalidRequest.String(),
+			Data:    err.Error(),
 		}}
 	}
 	return RPCResponse{ID: req.ID, Error: &RPCError{
-		Code:    CodeInternalError,
-		Message: err.Error(),
+		Code:    int(CodeInternalError),
+		Message: CodeInternalError.String(),
+		Data:    err.Error(),
 	}}
 }
 

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -50,6 +50,7 @@ const (
 	CodeMethodNotFound = -32601 // The method does not exist or is unavailable
 	CodeInvalidParams  = -32602 // Invalid method parameters
 	CodeInternalError  = -32603 // Internal JSON-RPC error
+	CodeServerError    = -32000 // Tendermint service error
 )
 
 //----------------------------------------
@@ -201,56 +202,11 @@ func (resp RPCResponse) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func NewRPCSuccessResponse(id jsonrpcid, res interface{}) RPCResponse {
-	result, err := json.Marshal(res)
-	if err != nil {
-		return RPCInternalError(id, fmt.Errorf("error marshaling response: %w", err))
-	}
-	return RPCResponse{ID: id, Result: result}
-}
-
-func NewRPCErrorResponse(id jsonrpcid, code int, msg string, data string) RPCResponse {
-	return RPCResponse{
-		ID:    id,
-		Error: &RPCError{Code: code, Message: msg, Data: data},
-	}
-}
-
 func (resp RPCResponse) String() string {
 	if resp.Error == nil {
 		return fmt.Sprintf("RPCResponse{%s %X}", resp.ID, resp.Result)
 	}
 	return fmt.Sprintf("RPCResponse{%s %v}", resp.ID, resp.Error)
-}
-
-// From the JSON-RPC 2.0 spec:
-//	If there was an error in detecting the id in the Request object (e.g. Parse
-// 	error/Invalid Request), it MUST be Null.
-func RPCParseError(err error) RPCResponse {
-	return NewRPCErrorResponse(nil, -32700, "Parse error", err.Error())
-}
-
-// From the JSON-RPC 2.0 spec:
-//	If there was an error in detecting the id in the Request object (e.g. Parse
-// 	error/Invalid Request), it MUST be Null.
-func RPCInvalidRequestError(id jsonrpcid, err error) RPCResponse {
-	return NewRPCErrorResponse(id, -32600, "Invalid Request", err.Error())
-}
-
-func RPCMethodNotFoundError(id jsonrpcid) RPCResponse {
-	return NewRPCErrorResponse(id, -32601, "Method not found", "")
-}
-
-func RPCInvalidParamsError(id jsonrpcid, err error) RPCResponse {
-	return NewRPCErrorResponse(id, -32602, "Invalid params", err.Error())
-}
-
-func RPCInternalError(id jsonrpcid, err error) RPCResponse {
-	return NewRPCErrorResponse(id, -32603, "Internal error", err.Error())
-}
-
-func RPCServerError(id jsonrpcid, err error) RPCResponse {
-	return NewRPCErrorResponse(id, -32000, "Server error", err.Error())
 }
 
 //----------------------------------------

--- a/rpc/jsonrpc/types/types_test.go
+++ b/rpc/jsonrpc/types/types_test.go
@@ -38,14 +38,16 @@ func TestResponses(t *testing.T) {
 		s := fmt.Sprintf(`{"jsonrpc":"2.0","id":%v,"result":{"Value":"hello"}}`, tt.expected)
 		assert.Equal(t, s, string(b))
 
-		d := RPCParseError(errors.New("hello world"))
-		e, _ := json.Marshal(d)
-		f := `{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"hello world"}}`
+		d := req.MakeErrorf(CodeParseError, "hello world")
+		e, err := json.Marshal(d)
+		require.NoError(t, err)
+		f := fmt.Sprintf(`{"jsonrpc":"2.0","id":%v,"error":{"code":-32700,"message":"Parse error","data":"hello world"}}`, tt.expected)
 		assert.Equal(t, f, string(e))
 
-		g := RPCMethodNotFoundError(jsonid)
-		h, _ := json.Marshal(g)
-		i := fmt.Sprintf(`{"jsonrpc":"2.0","id":%v,"error":{"code":-32601,"message":"Method not found"}}`, tt.expected)
+		g := req.MakeErrorf(CodeMethodNotFound, "foo")
+		h, err := json.Marshal(g)
+		require.NoError(t, err)
+		i := fmt.Sprintf(`{"jsonrpc":"2.0","id":%v,"error":{"code":-32601,"message":"Method not found","data":"foo"}}`, tt.expected)
 		assert.Equal(t, string(h), i)
 	}
 }

--- a/rpc/jsonrpc/types/types_test.go
+++ b/rpc/jsonrpc/types/types_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -32,9 +31,14 @@ var responseTests = []responseTest{
 
 func TestResponses(t *testing.T) {
 	for _, tt := range responseTests {
-		jsonid := tt.id
-		a := NewRPCSuccessResponse(jsonid, &SampleResult{"hello"})
-		b, _ := json.Marshal(a)
+		req := RPCRequest{
+			ID:     tt.id,
+			Method: "whatever",
+		}
+
+		a := req.MakeResponse(&SampleResult{"hello"})
+		b, err := json.Marshal(a)
+		require.NoError(t, err)
 		s := fmt.Sprintf(`{"jsonrpc":"2.0","id":%v,"result":{"Value":"hello"}}`, tt.expected)
 		assert.Equal(t, s, string(b))
 
@@ -61,7 +65,8 @@ func TestUnmarshallResponses(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		a := NewRPCSuccessResponse(tt.id, &SampleResult{"hello"})
+		req := RPCRequest{ID: tt.id}
+		a := req.MakeResponse(&SampleResult{"hello"})
 		assert.Equal(t, *response, a)
 	}
 	response := &RPCResponse{}


### PR DESCRIPTION
Rework the way JSON-RPC responses are constructed to simplify the plumbing of request IDs, reduce the surface area of the `rpc/jsonrpc/types` package, and eliminate duplication of error introspection logic across the three RPC flavours (HTTP GET, HTTP POST, and websocket).

- remove the top-level response constructors
- add code constants and response methods
- update usage
- update test cases

This change affects the Go package API, but does not change the behaviour of the RPCs.