### PR TITLE
rpc: clean up unmarshaling of batch-valued responses

### DIFF
--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -271,7 +271,10 @@ func (c *Client) sendBatch(ctx context.Context, requests []*jsonRPCBufferedReque
 		ids[i] = req.request.ID.(rpctypes.JSONRPCIntID)
 	}
 
-	return unmarshalResponseBytesArray(responseBytes, ids, results)
+	if err := unmarshalResponseBytesArray(responseBytes, ids, results); err != nil {
+		return nil, err
+	}
+	return results, nil
 }
 
 func (c *Client) nextRequestID() rpctypes.JSONRPCIntID {


### PR DESCRIPTION
Update the interface of the batch decoder to match the type signature of the
single-response case. The caller provides the outputs, so there is no need to
return them as well.

No functional changes.
