### PR TITLE
consensus: remove unused closer construct

### DIFF
--- a/internal/consensus/peer_state.go
+++ b/internal/consensus/peer_state.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	cstypes "github.com/tendermint/tendermint/internal/consensus/types"
-	tmsync "github.com/tendermint/tendermint/internal/libs/sync"
 	"github.com/tendermint/tendermint/libs/bits"
 	"github.com/tendermint/tendermint/libs/log"
 	tmtime "github.com/tendermint/tendermint/libs/time"
@@ -46,7 +45,6 @@ type PeerState struct {
 	Stats   *peerStateStats        `json:"stats"`
 
 	broadcastWG sync.WaitGroup
-	closer      *tmsync.Closer
 }
 
 // NewPeerState returns a new PeerState for the given node ID.
@@ -54,7 +52,6 @@ func NewPeerState(logger log.Logger, peerID types.NodeID) *PeerState {
 	return &PeerState{
 		peerID: peerID,
 		logger: logger,
-		closer: tmsync.NewCloser(),
 		PRS: cstypes.PeerRoundState{
 			Round:              -1,
 			ProposalPOLRound:   -1,


### PR DESCRIPTION
This is clearly a cob-web in the code, and may predict a solution to #7729, though this is difficult to backport because we don't have contexts in 0.35