### PR TITLE
rpc: simplify the handling of JSON-RPC request and response IDs

### DIFF
--- a/rpc/jsonrpc/client/decode.go
+++ b/rpc/jsonrpc/client/decode.go
@@ -56,13 +56,13 @@ func unmarshalResponseBytesArray(responseBytes []byte, expectedIDs []string, res
 }
 
 func validateResponseIDs(ids, expectedIDs []string) error {
-	m := make(map[string]bool, len(expectedIDs))
+	m := make(map[string]struct{}, len(expectedIDs))
 	for _, id := range expectedIDs {
-		m[id] = true
+		m[id] = struct{}{}
 	}
 
 	for i, id := range ids {
-		if !m[id] {
+		if _, ok := m[id]; !ok {
 			return fmt.Errorf("unexpected response ID %d: %q", i, id)
 		}
 	}

--- a/rpc/jsonrpc/client/decode.go
+++ b/rpc/jsonrpc/client/decode.go
@@ -2,26 +2,25 @@ package client
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
-func unmarshalResponseBytes(responseBytes []byte, expectedID rpctypes.JSONRPCIntID, result interface{}) error {
+func unmarshalResponseBytes(responseBytes []byte, expectedID string, result interface{}) error {
 	// Read response.  If rpc/core/types is imported, the result will unmarshal
 	// into the correct type.
-	response := &rpctypes.RPCResponse{}
-	if err := json.Unmarshal(responseBytes, response); err != nil {
-		return fmt.Errorf("error unmarshaling: %w", err)
+	var response rpctypes.RPCResponse
+	if err := json.Unmarshal(responseBytes, &response); err != nil {
+		return fmt.Errorf("unmarshaling response: %w", err)
 	}
 
 	if response.Error != nil {
 		return response.Error
 	}
 
-	if err := validateAndVerifyID(response, expectedID); err != nil {
-		return fmt.Errorf("wrong ID: %w", err)
+	if got := response.ID(); got != expectedID {
+		return fmt.Errorf("got response ID %q, wanted %q", got, expectedID)
 	}
 
 	// Unmarshal the RawMessage into the result.
@@ -31,7 +30,7 @@ func unmarshalResponseBytes(responseBytes []byte, expectedID rpctypes.JSONRPCInt
 	return nil
 }
 
-func unmarshalResponseBytesArray(responseBytes []byte, expectedIDs []rpctypes.JSONRPCIntID, results []interface{}) error {
+func unmarshalResponseBytesArray(responseBytes []byte, expectedIDs []string, results []interface{}) error {
 	var responses []rpctypes.RPCResponse
 	if err := json.Unmarshal(responseBytes, &responses); err != nil {
 		return fmt.Errorf("unmarshaling responses: %w", err)
@@ -40,62 +39,32 @@ func unmarshalResponseBytesArray(responseBytes []byte, expectedIDs []rpctypes.JS
 	}
 
 	// Intersect IDs from responses with expectedIDs.
-	ids := make([]rpctypes.JSONRPCIntID, len(responses))
-	var ok bool
+	ids := make([]string, len(responses))
 	for i, resp := range responses {
-		ids[i], ok = resp.ID.(rpctypes.JSONRPCIntID)
-		if !ok {
-			return fmt.Errorf("expected JSONRPCIntID, got %T", resp.ID)
-		}
+		ids[i] = resp.ID()
 	}
 	if err := validateResponseIDs(ids, expectedIDs); err != nil {
 		return fmt.Errorf("wrong IDs: %w", err)
 	}
 
-	for i := 0; i < len(responses); i++ {
-		if err := json.Unmarshal(responses[i].Result, results[i]); err != nil {
-			return fmt.Errorf("error unmarshaling #%d result: %w", i, err)
+	for i, resp := range responses {
+		if err := json.Unmarshal(resp.Result, results[i]); err != nil {
+			return fmt.Errorf("unmarshaling result %d: %w", i, err)
 		}
 	}
 	return nil
 }
 
-func validateResponseIDs(ids, expectedIDs []rpctypes.JSONRPCIntID) error {
-	m := make(map[rpctypes.JSONRPCIntID]bool, len(expectedIDs))
-	for _, expectedID := range expectedIDs {
-		m[expectedID] = true
+func validateResponseIDs(ids, expectedIDs []string) error {
+	m := make(map[string]bool, len(expectedIDs))
+	for _, id := range expectedIDs {
+		m[id] = true
 	}
 
 	for i, id := range ids {
-		if m[id] {
-			delete(m, id)
-		} else {
-			return fmt.Errorf("unsolicited ID #%d: %v", i, id)
+		if !m[id] {
+			return fmt.Errorf("unexpected response ID %d: %q", i, id)
 		}
-	}
-
-	return nil
-}
-
-// From the JSON-RPC 2.0 spec:
-// id: It MUST be the same as the value of the id member in the Request Object.
-func validateAndVerifyID(res *rpctypes.RPCResponse, expectedID rpctypes.JSONRPCIntID) error {
-	if err := validateResponseID(res.ID); err != nil {
-		return err
-	}
-	if expectedID != res.ID.(rpctypes.JSONRPCIntID) { // validateResponseID ensured res.ID has the right type
-		return fmt.Errorf("response ID (%d) does not match request ID (%d)", res.ID, expectedID)
-	}
-	return nil
-}
-
-func validateResponseID(id interface{}) error {
-	if id == nil {
-		return errors.New("no ID")
-	}
-	_, ok := id.(rpctypes.JSONRPCIntID)
-	if !ok {
-		return fmt.Errorf("expected JSONRPCIntID, but got: %T", id)
 	}
 	return nil
 }

--- a/rpc/jsonrpc/client/ws_client_test.go
+++ b/rpc/jsonrpc/client/ws_client_test.go
@@ -64,7 +64,9 @@ func (h *myTestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}()
 
 		res := json.RawMessage(`{}`)
-		emptyRespBytes, _ := json.Marshal(rpctypes.RPCResponse{Result: res, ID: req.ID})
+
+		emptyRespBytes, err := json.Marshal(req.MakeResponse(res))
+		require.NoError(h.t, err)
 		if err := conn.WriteMessage(messageType, emptyRespBytes); err != nil {
 			return
 		}

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -53,7 +53,7 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 		var responses []rpctypes.RPCResponse
 		for _, req := range requests {
 			// Ignore notifications, which this service does not support.
-			if req.ID == nil {
+			if req.IsNotification() {
 				logger.Debug("Ignoring notification", "req", req)
 				continue
 			}

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -38,24 +38,24 @@ func TestRPCParams(t *testing.T) {
 	tests := []struct {
 		payload    string
 		wantErr    string
-		expectedID interface{}
+		expectedID string
 	}{
 		// bad
-		{`{"jsonrpc": "2.0", "id": "0"}`, "Method not found", rpctypes.JSONRPCStringID("0")},
-		{`{"jsonrpc": "2.0", "method": "y", "id": "0"}`, "Method not found", rpctypes.JSONRPCStringID("0")},
+		{`{"jsonrpc": "2.0", "id": "0"}`, "Method not found", `"0"`},
+		{`{"jsonrpc": "2.0", "method": "y", "id": "0"}`, "Method not found", `"0"`},
 		// id not captured in JSON parsing failures
-		{`{"method": "c", "id": "0", "params": a}`, "invalid character", nil},
-		{`{"method": "c", "id": "0", "params": ["a"]}`, "got 1", rpctypes.JSONRPCStringID("0")},
-		{`{"method": "c", "id": "0", "params": ["a", "b"]}`, "invalid syntax", rpctypes.JSONRPCStringID("0")},
-		{`{"method": "c", "id": "0", "params": [1, 1]}`, "of type string", rpctypes.JSONRPCStringID("0")},
+		{`{"method": "c", "id": "0", "params": a}`, "invalid character", ""},
+		{`{"method": "c", "id": "0", "params": ["a"]}`, "got 1", `"0"`},
+		{`{"method": "c", "id": "0", "params": ["a", "b"]}`, "invalid syntax", `"0"`},
+		{`{"method": "c", "id": "0", "params": [1, 1]}`, "of type string", `"0"`},
 
 		// no ID - notification
 		// {`{"jsonrpc": "2.0", "method": "c", "params": ["a", "10"]}`, false, nil},
 
 		// good
-		{`{"jsonrpc": "2.0", "method": "c", "id": "0", "params": null}`, "", rpctypes.JSONRPCStringID("0")},
-		{`{"method": "c", "id": "0", "params": {}}`, "", rpctypes.JSONRPCStringID("0")},
-		{`{"method": "c", "id": "0", "params": ["a", "10"]}`, "", rpctypes.JSONRPCStringID("0")},
+		{`{"jsonrpc": "2.0", "method": "c", "id": "0", "params": null}`, "", `"0"`},
+		{`{"method": "c", "id": "0", "params": {}}`, "", `"0"`},
+		{`{"method": "c", "id": "0", "params": ["a", "10"]}`, "", `"0"`},
 	}
 
 	for i, tt := range tests {
@@ -73,7 +73,7 @@ func TestRPCParams(t *testing.T) {
 		recv := new(rpctypes.RPCResponse)
 		assert.Nil(t, json.Unmarshal(blob, recv), "#%d: expecting successful parsing of an RPCResponse:\nblob: %s", i, blob)
 		assert.NotEqual(t, recv, new(rpctypes.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
-		assert.Equal(t, tt.expectedID, recv.ID, "#%d: expected ID not matched in RPCResponse", i)
+		assert.Equal(t, tt.expectedID, recv.ID(), "#%d: expected ID not matched in RPCResponse", i)
 		if tt.wantErr == "" {
 			assert.Nil(t, recv.Error, "#%d: not expecting an error", i)
 		} else {
@@ -89,19 +89,19 @@ func TestJSONRPCID(t *testing.T) {
 	tests := []struct {
 		payload    string
 		wantErr    bool
-		expectedID interface{}
+		expectedID string
 	}{
 		// good id
-		{`{"jsonrpc": "2.0", "method": "c", "id": "0", "params": ["a", "10"]}`, false, rpctypes.JSONRPCStringID("0")},
-		{`{"jsonrpc": "2.0", "method": "c", "id": "abc", "params": ["a", "10"]}`, false, rpctypes.JSONRPCStringID("abc")},
-		{`{"jsonrpc": "2.0", "method": "c", "id": 0, "params": ["a", "10"]}`, false, rpctypes.JSONRPCIntID(0)},
-		{`{"jsonrpc": "2.0", "method": "c", "id": 1, "params": ["a", "10"]}`, false, rpctypes.JSONRPCIntID(1)},
-		{`{"jsonrpc": "2.0", "method": "c", "id": 1.3, "params": ["a", "10"]}`, false, rpctypes.JSONRPCIntID(1)},
-		{`{"jsonrpc": "2.0", "method": "c", "id": -1, "params": ["a", "10"]}`, false, rpctypes.JSONRPCIntID(-1)},
+		{`{"jsonrpc": "2.0", "method": "c", "id": "0", "params": ["a", "10"]}`, false, `"0"`},
+		{`{"jsonrpc": "2.0", "method": "c", "id": "abc", "params": ["a", "10"]}`, false, `"abc"`},
+		{`{"jsonrpc": "2.0", "method": "c", "id": 0, "params": ["a", "10"]}`, false, `0`},
+		{`{"jsonrpc": "2.0", "method": "c", "id": 1, "params": ["a", "10"]}`, false, `1`},
+		{`{"jsonrpc": "2.0", "method": "c", "id": -1, "params": ["a", "10"]}`, false, `-1`},
 
 		// bad id
-		{`{"jsonrpc": "2.0", "method": "c", "id": {}, "params": ["a", "10"]}`, true, nil},
-		{`{"jsonrpc": "2.0", "method": "c", "id": [], "params": ["a", "10"]}`, true, nil},
+		{`{"jsonrpc": "2.0", "method": "c", "id": {}, "params": ["a", "10"]}`, true, ""},  // object
+		{`{"jsonrpc": "2.0", "method": "c", "id": [], "params": ["a", "10"]}`, true, ""},  // array
+		{`{"jsonrpc": "2.0", "method": "c", "id": 1.3, "params": ["a", "10"]}`, true, ""}, // fractional
 	}
 
 	for i, tt := range tests {
@@ -123,7 +123,7 @@ func TestJSONRPCID(t *testing.T) {
 		assert.NoError(t, err, "#%d: expecting successful parsing of an RPCResponse:\nblob: %s", i, blob)
 		if !tt.wantErr {
 			assert.NotEqual(t, recv, new(rpctypes.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
-			assert.Equal(t, tt.expectedID, recv.ID, "#%d: expected ID not matched in RPCResponse", i)
+			assert.Equal(t, tt.expectedID, recv.ID(), "#%d: expected ID not matched in RPCResponse", i)
 			assert.Nil(t, recv.Error, "#%d: not expecting an error", i)
 		} else {
 			assert.True(t, recv.Error.Code < 0, "#%d: not expecting a positive JSONRPC code", i)

--- a/rpc/jsonrpc/server/http_server_test.go
+++ b/rpc/jsonrpc/server/http_server_test.go
@@ -125,7 +125,7 @@ func TestServeTLS(t *testing.T) {
 }
 
 func TestWriteRPCResponse(t *testing.T) {
-	req := rpctypes.RPCRequest{ID: rpctypes.JSONRPCIntID(-1)}
+	req := rpctypes.NewRequest(-1)
 
 	// one argument
 	w := httptest.NewRecorder()
@@ -160,7 +160,7 @@ func TestWriteRPCResponse(t *testing.T) {
 func TestWriteHTTPResponse(t *testing.T) {
 	w := httptest.NewRecorder()
 	logger := log.NewNopLogger()
-	req := rpctypes.RPCRequest{ID: rpctypes.JSONRPCIntID(-1)}
+	req := rpctypes.NewRequest(-1)
 	writeHTTPResponse(w, logger, req.MakeErrorf(rpctypes.CodeInternalError, "foo"))
 	resp := w.Result()
 	body, err := io.ReadAll(resp.Body)

--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -16,7 +16,7 @@ import (
 
 // uriReqID is a placeholder ID used for GET requests, which do not receive a
 // JSON-RPC request ID from the caller.
-var uriReqID = rpctypes.JSONRPCIntID(-1)
+const uriReqID = -1
 
 // convert from a function name to the http handler
 func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWriter, *http.Request) {
@@ -31,7 +31,7 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 			fmt.Fprintln(w, err.Error())
 			return
 		}
-		jreq := rpctypes.RPCRequest{ID: uriReqID}
+		jreq := rpctypes.NewRequest(uriReqID)
 		outs := rpcFunc.f.Call(args)
 
 		logger.Debug("HTTPRestRPC", "method", req.URL.Path, "args", args, "returns", outs)

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -274,7 +274,7 @@ func (wsc *wsConnection) readRoutine(ctx context.Context) {
 			if !ok {
 				err = fmt.Errorf("WSJSONRPC: %v", r)
 			}
-			req := rpctypes.RPCRequest{ID: uriReqID}
+			req := rpctypes.NewRequest(uriReqID)
 			wsc.Logger.Error("Panic in WSJSONRPC handler", "err", err, "stack", string(debug.Stack()))
 			if err := wsc.WriteRPCResponse(writeCtx,
 				req.MakeErrorf(rpctypes.CodeInternalError, "Panic in handler: %v", err)); err != nil {
@@ -325,7 +325,7 @@ func (wsc *wsConnection) readRoutine(ctx context.Context) {
 
 			// A Notification is a Request object without an "id" member.
 			// The Server MUST NOT reply to a Notification, including those that are within a batch request.
-			if request.ID == nil {
+			if request.IsNotification() {
 				wsc.Logger.Debug(
 					"WSJSONRPC received a notification, skipping... (please send a non-empty ID if you want to call a method)",
 					"req", request,

--- a/rpc/jsonrpc/server/ws_handler_test.go
+++ b/rpc/jsonrpc/server/ws_handler_test.go
@@ -32,14 +32,9 @@ func TestWebsocketManagerHandler(t *testing.T) {
 	}
 
 	// check basic functionality works
-	req, err := rpctypes.ParamsToRequest(
-		rpctypes.JSONRPCStringID("TestWebsocketManager"),
-		"c",
-		map[string]interface{}{"s": "a", "i": 10},
-	)
-	require.NoError(t, err)
-	err = c.WriteJSON(req)
-	require.NoError(t, err)
+	req := rpctypes.NewRequest(1001)
+	require.NoError(t, req.SetMethodAndParams("c", map[string]interface{}{"s": "a", "i": 10}))
+	require.NoError(t, c.WriteJSON(req))
 
 	var resp rpctypes.RPCResponse
 	err = c.ReadJSON(&resp)


### PR DESCRIPTION
Replace the ID wrapper interface with plain JSON. Internally, the client
libraries use only integer IDs, and the server does not care about the ID
structure apart from checking its validity.

Basic structure of this change:

- Remove the jsonrpcid interface and its helpers.
- Unexport the ID field of request and response.
- Add helpers for constructing requests and responses.
- Fix up usage and tests.
