### PR TITLE
(WIP) docs: an attempt to fix version-specific links

### DIFF
--- a/docs/app-dev/abci-cli.md
+++ b/docs/app-dev/abci-cli.md
@@ -61,9 +61,8 @@ We'll start a kvstore application, which was installed at the same time
 as `abci-cli` above. The kvstore just stores transactions in a merkle
 tree.
 
-Its code can be found
-[here](https://github.com/tendermint/tendermint/blob/master/abci/cmd/abci-cli/abci-cli.go)
-and looks like:
+Its code can be found [here](../../abci/cmd/abci-cli/abci-cli.go) and looks
+like:
 
 ```go
 func cmdKVStore(cmd *cobra.Command, args []string) error {
@@ -136,10 +135,9 @@ application's socket server, send the given ABCI message, and wait for a
 response.
 
 The server may be generic for a particular language, and we provide a
-[reference implementation in
-Golang](https://github.com/tendermint/tendermint/tree/master/abci/server). See the
-[list of other ABCI implementations](https://github.com/tendermint/awesome#ecosystem) for servers in
-other languages.
+[reference implementation in Golang](../../abci/server). See the [list of other
+ABCI implementations](https://github.com/tendermint/awesome#ecosystem) for
+servers in other languages.
 
 The handler is specific to the application, and may be arbitrary, so
 long as it is deterministic and conforms to the ABCI interface

--- a/docs/app-dev/app-architecture.md
+++ b/docs/app-dev/app-architecture.md
@@ -55,6 +55,6 @@ Tendermint.
 See the following for more extensive documentation:
 
 - [Interchain Standard for the Light-Client REST API](https://github.com/cosmos/cosmos-sdk/pull/1028)
-- [Tendermint RPC Docs](https://docs.tendermint.com/master/rpc/)
+- [Tendermint RPC Docs](./rpc/)
 - [Tendermint in Production](../tendermint-core/running-in-production.md)
 - [ABCI spec](https://github.com/tendermint/spec/tree/95cf253b6df623066ff7cd4074a94e7a3f147c7a/spec/abci)

--- a/docs/app-dev/indexing-transactions.md
+++ b/docs/app-dev/indexing-transactions.md
@@ -14,8 +14,7 @@ the block itself is never stored.
 
 Each event contains a type and a list of attributes, which are key-value pairs
 denoting something about what happened during the method's execution. For more
-details on `Events`, see the
-[ABCI](https://github.com/tendermint/spec/blob/master/spec/abci/abci.md#events)
+details on `Events`, see the [ABCI](../../spec/abci/abci.md#events)
 documentation.
 
 An `Event` has a composite key associated with it. A `compositeKey` is
@@ -146,8 +145,8 @@ You can query for a paginated set of transaction by their events by calling the
 curl "localhost:26657/tx_search?query=\"message.sender='cosmos1...'\"&prove=true"
 ```
 
-Check out [API docs](https://docs.tendermint.com/master/rpc/#/Info/tx_search)
-for more information on query syntax and other options.
+Check out [API docs](./rpc/#/Info/tx_search) for more information on query
+syntax and other options.
 
 ## Subscribing to Transactions
 
@@ -165,8 +164,8 @@ a query to `/subscribe` RPC endpoint.
 }
 ```
 
-Check out [API docs](https://docs.tendermint.com/master/rpc/#subscribe) for more information
-on query syntax and other options.
+Check out [API docs](./rpc/#subscribe) for more information on query syntax and
+other options.
 
 ## Querying Blocks Events
 
@@ -177,5 +176,5 @@ You can query for a paginated set of blocks by their events by calling the
 curl "localhost:26657/block_search?query=\"block.height > 10 AND val_set.num_changed > 0\""
 ```
 
-Check out [API docs](https://docs.tendermint.com/master/rpc/#/Info/block_search)
-for more information on query syntax and other options.
+Check out [API docs](./rpc/#/Info/block_search) for more information on query
+syntax and other options.

--- a/docs/introduction/what-is-tendermint.md
+++ b/docs/introduction/what-is-tendermint.md
@@ -68,10 +68,10 @@ Tendermint is in essence similar software, but with two key differences:
 
 - It is Byzantine Fault Tolerant, meaning it can only tolerate up to a
   1/3 of failures, but those failures can include arbitrary behaviour -
-  including hacking and malicious attacks. 
-- It does not specify a particular application, like a fancy key-value 
-  store. Instead, it focuses on arbitrary state machine replication, 
-  so developers can build the application logic that's right for them, 
+  including hacking and malicious attacks.
+- It does not specify a particular application, like a fancy key-value
+  store. Instead, it focuses on arbitrary state machine replication,
+  so developers can build the application logic that's right for them,
   from key-value store to cryptocurrency to e-voting platform and beyond.
 
 ### Bitcoin, Ethereum, etc
@@ -119,10 +119,8 @@ consensus engine, and provides a particular application state.
 
 ## ABCI Overview
 
-The [Application BlockChain Interface
-(ABCI)](https://github.com/tendermint/tendermint/tree/master/abci)
-allows for Byzantine Fault Tolerant replication of applications
-written in any programming language.
+The [Application BlockChain Interface (ABCI)](../../abci) allows for Byzantine
+Fault Tolerant replication of applications written in any programming language.
 
 ### Motivation
 
@@ -188,7 +186,7 @@ core to the application. The application replies with corresponding
 response messages.
 
 The messages are specified here: [ABCI Message
-Types](https://github.com/tendermint/tendermint/blob/master/abci/README.md#message-types).
+Types](../../abci/README.md#message-types).
 
 The **DeliverTx** message is the work horse of the application. Each
 transaction in the blockchain is delivered with this message. The

--- a/docs/nodes/logging.md
+++ b/docs/nodes/logging.md
@@ -33,9 +33,9 @@ Here is the list of modules you may encounter in Tendermint's log and a
 little overview what they do.
 
 - `abci-client` As mentioned in [Application Architecture Guide](../app-dev/app-architecture.md), Tendermint acts as an ABCI
-  client with respect to the application and maintains 3 connections:
-  mempool, consensus and query. The code used by Tendermint Core can
-  be found [here](https://github.com/tendermint/tendermint/tree/master/abci/client).
+  client with respect to the application and maintains 3 connections: mempool,
+  consensus and query. The code used by Tendermint Core can be found
+  [here](../../abci/client).
 - `blockchain` Provides storage, pool (a group of peers), and reactor
   for both storing and exchanging blocks between peers.
 - `consensus` The heart of Tendermint core, which is the
@@ -43,16 +43,16 @@ little overview what they do.
   "submodules": `wal` (write-ahead logging) for ensuring data
   integrity and `replay` to replay blocks and messages on recovery
   from a crash.
-  [here](https://github.com/tendermint/tendermint/blob/master/types/events.go).
+  [here](../../types/events.go).
   You can subscribe to them by calling `subscribe` RPC method. Refer
   to [RPC docs](../tendermint-core/rpc.md) for additional information.
 - `mempool` Mempool module handles all incoming transactions, whenever
   they are coming from peers or the application.
 - `p2p` Provides an abstraction around peer-to-peer communication. For
   more details, please check out the
-  [README](https://github.com/tendermint/spec/tree/master/spec/p2p).
+  [README](../../spec/p2p).
 - `rpc-server` RPC server. For implementation details, please read the
-  [doc.go](https://github.com/tendermint/tendermint/blob/master/rpc/jsonrpc/doc.go).
+  [doc.go](../../rpc/jsonrpc/doc.go).
 - `state` Represents the latest state and execution submodule, which
   executes blocks against the application.
 - `statesync` Provides a way to quickly sync a node with pruned history.
@@ -116,11 +116,10 @@ I[10-04|13:54:30.391] Starting RPC HTTP server on tcp socket 0.0.0.0:26657 modul
 I[10-04|13:54:30.392] Started node                                 module=main nodeInfo="NodeInfo{id: DF22D7C92C91082324A1312F092AA1DA197FA598DBBFB6526E, moniker: anonymous, network: test-chain-3MNw2N [remote , listen 10.0.2.15:26656], version: 0.11.0-10f361fc ([wire_version=0.6.2 p2p_version=0.5.0 consensus_version=v1/0.2.2 rpc_version=0.7.0/3 tx_index=on rpc_addr=tcp://0.0.0.0:26657])}"
 ```
 
-Next follows a standard block creation cycle, where we enter a new
-round, propose a block, receive more than 2/3 of prevotes, then
-precommits and finally have a chance to commit a block. For details,
-please refer to [Byzantine Consensus
-Algorithm](https://github.com/tendermint/spec/blob/master/spec/consensus/consensus.md).
+Next follows a standard block creation cycle, where we enter a new round,
+propose a block, receive more than 2/3 of prevotes, then precommits and finally
+have a chance to commit a block. For details, please refer to [Byzantine
+Consensus Algorithm](../../spec/consensus/consensus.md).
 
 ```sh
 I[10-04|13:54:30.393] enterNewRound(91/0). Current: 91/0/RoundStepNewHeight module=consensus

--- a/docs/nodes/running-in-production.md
+++ b/docs/nodes/running-in-production.md
@@ -77,8 +77,7 @@ mechanisms.
 ### RPC
 
 Endpoints returning multiple entries are limited by default to return 30
-elements (100 max). See the [RPC Documentation](https://docs.tendermint.com/master/rpc/)
-for more information.
+elements (100 max). See the [RPC Documentation](./rpc/) for more information.
 
 Rate-limiting and authentication are another key aspects to help protect
 against DOS attacks. Validators are supposed to use external tools like

--- a/docs/tendermint-core/consensus/README.md
+++ b/docs/tendermint-core/consensus/README.md
@@ -23,10 +23,10 @@ explained in a forthcoming document.
 For efficiency reasons, validators in Tendermint consensus protocol do not agree directly on the
 block as the block size is big, i.e., they don't embed the block inside `Proposal` and
 `VoteMessage`. Instead, they reach agreement on the `BlockID` (see `BlockID` definition in
-[Blockchain](https://github.com/tendermint/spec/blob/master/spec/core/data_structures.md#blockid) section)
-that uniquely identifies each block. The block itself is
-disseminated to validator processes using peer-to-peer gossiping protocol. It starts by having a
-proposer first splitting a block into a number of block parts, that are then gossiped between
+[Blockchain](../../spec/core/data_structures.md#blockid) section) that uniquely
+identifies each block. The block itself is disseminated to validator processes
+using peer-to-peer gossiping protocol. It starts by having a proposer first
+splitting a block into a number of block parts, that are then gossiped between
 processes using `BlockPartMessage`.
 
 Validators in Tendermint communicate by peer-to-peer gossiping protocol. Each validator is connected

--- a/docs/tendermint-core/evidence/README.md
+++ b/docs/tendermint-core/evidence/README.md
@@ -5,7 +5,7 @@ parent:
   order: 3
 ---
 
-Evidence is used to identify validators who have or are acting malicious. There are multiple types of evidence, to read more on the evidence types please see [Evidence Types](https://docs.tendermint.com/master/spec/core/data_structures.html#evidence).
+Evidence is used to identify validators who have or are acting malicious. There are multiple types of evidence, to read more on the evidence types please see [Evidence Types](./spec/core/data_structures.html#evidence).
 
 The evidence reactor works similar to the mempool reactor. When evidence is observed, it is sent to all the peers in a repetitive manner. This ensures evidence is sent to as many people as possible to avoid sensoring. After evidence is received by peers and committed in a block it is pruned from the evidence module.
 

--- a/docs/tendermint-core/rpc.md
+++ b/docs/tendermint-core/rpc.md
@@ -4,9 +4,7 @@ order: 9
 
 # RPC
 
-The RPC documentation is hosted here:
-
-- [https://docs.tendermint.com/master/rpc/](https://docs.tendermint.com/master/rpc/)
+The RPC documentation is hosted [here](./rpc/).
 
 To update the documentation, edit the relevant `godoc` comments in the [rpc/core directory](https://github.com/tendermint/tendermint/tree/master/rpc/core).
 
@@ -14,7 +12,7 @@ If you are using Tendermint in-process, you will need to set the version to be d
 
 If you are using a makefile with your go project, this can be done by using sed and `ldflags`.
 
-Example: 
+Example:
 
 ```
 VERSION := $(shell go list -m github.com/tendermint/tendermint | sed 's:.* ::')

--- a/docs/tendermint-core/state-sync/README.md
+++ b/docs/tendermint-core/state-sync/README.md
@@ -7,7 +7,7 @@ parent:
 
 
 State sync allows new nodes to rapidly bootstrap and join the network by discovering, fetching,
-and restoring state machine snapshots. For more information, see the [state sync ABCI section](https://docs.tendermint.com/master/spec/abci/abci.html#state-sync)).
+and restoring state machine snapshots. For more information, see the [state sync ABCI section](./spec/abci/abci.html#state-sync)).
 
 The state sync reactor has two main responsibilities:
 
@@ -21,7 +21,7 @@ The state sync process for bootstrapping a new node is described in detail in th
 above. While technically part of the reactor (see `statesync/syncer.go` and related components),
 this document will only cover the P2P reactor component.
 
-For details on the ABCI methods and data types, see the [ABCI documentation](https://docs.tendermint.com/master/spec/abci/).
+For details on the ABCI methods and data types, see the [ABCI documentation](./spec/abci/).
 
 Information on how to configure state sync is located in the [nodes section](../../nodes/state-sync.md)
 

--- a/docs/tendermint-core/subscription.md
+++ b/docs/tendermint-core/subscription.md
@@ -31,8 +31,8 @@ method via Websocket along with a valid query.
 }
 ```
 
-Check out [API docs](https://docs.tendermint.com/master/rpc/) for
-more information on query syntax and other options.
+Check out [API docs](./rpc/) for more information on query syntax and other
+options.
 
 You can also use tags, given you had included them into DeliverTx
 response, to query transaction results. See [Indexing
@@ -40,11 +40,10 @@ transactions](../app-dev/indexing-transactions.md) for details.
 
 ## ValidatorSetUpdates
 
-When validator set changes, ValidatorSetUpdates event is published. The
-event carries a list of pubkey/power pairs. The list is the same
-Tendermint receives from ABCI application (see [EndBlock
-section](https://github.com/tendermint/spec/blob/master/spec/abci/abci.md#endblock) in
-the ABCI spec).
+When validator set changes, ValidatorSetUpdates event is published. The event
+carries a list of pubkey/power pairs. The list is the same Tendermint receives
+from ABCI application (see [EndBlock
+section](../../spec/abci/abci.md#endblock) in the ABCI spec).
 
 Response:
 

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -37,9 +37,8 @@ tendermint testnet --help
 
 ### Genesis
 
-The `genesis.json` file in `$TMHOME/config/` defines the initial
-TendermintCore state upon genesis of the blockchain ([see
-definition](https://github.com/tendermint/tendermint/blob/master/types/genesis.go)).
+The `genesis.json` file in `$TMHOME/config/` defines the initial TendermintCore
+state upon genesis of the blockchain ([see definition](../../types/genesis.go)).
 
 #### Fields
 
@@ -47,9 +46,9 @@ definition](https://github.com/tendermint/tendermint/blob/master/types/genesis.g
 - `chain_id`: ID of the blockchain. **This must be unique for
   every blockchain.** If your testnet blockchains do not have unique
   chain IDs, you will have a bad time. The ChainID must be less than 50 symbols.
-- `initial_height`: Height at which Tendermint should begin at. If a blockchain is conducting a network upgrade, 
-    starting from the stopped height brings uniqueness to previous heights. 
-- `consensus_params` [spec](https://github.com/tendermint/spec/blob/master/spec/core/state.md#consensusparams)
+- `initial_height`: Height at which Tendermint should begin at. If a blockchain is conducting a network upgrade,
+    starting from the stopped height brings uniqueness to previous heights.
+- `consensus_params` [spec](../../spec/core/state.md#consensusparams)
     - `block`
         - `max_bytes`: Max block size, in bytes.
         - `max_gas`: Max gas per block.
@@ -181,7 +180,7 @@ endpoints. Some take no arguments (like `/status`), while others specify
 the argument name and use `_` as a placeholder.
 
 
-> TIP: Find the RPC Documentation [here](https://docs.tendermint.com/master/rpc/)
+> TIP: Find the RPC Documentation [here](./rpc/)
 
 ### Formatting
 
@@ -578,8 +577,6 @@ library will deny making connections to peers with the same IP address.
 
 ### Upgrading
 
-See the
-[UPGRADING.md](https://github.com/tendermint/tendermint/blob/master/UPGRADING.md)
-guide. You may need to reset your chain between major breaking releases.
-Although, we expect Tendermint to have fewer breaking releases in the future
-(especially after 1.0 release).
+See the [UPGRADING.md](../../UPGRADING.md) guide. You may need to reset your
+chain between major breaking releases.  Although, we expect Tendermint to have
+fewer breaking releases in the future (especially after 1.0 release).

--- a/docs/tools/debugging/README.md
+++ b/docs/tools/debugging/README.md
@@ -69,13 +69,13 @@ Tendermint includes an `inspect` command for querying Tendermint's state store a
 store over Tendermint RPC.
 
 When the Tendermint consensus engine detects inconsistent state, it will crash the
-entire Tendermint process. 
-While in this inconsistent state, a node running Tendermint's consensus engine will not start up. 
+entire Tendermint process.
+While in this inconsistent state, a node running Tendermint's consensus engine will not start up.
 The `inspect` command runs only a subset of Tendermint's RPC endpoints for querying the block store
-and state store. 
+and state store.
 `inspect` allows operators to query a read-only view of the stage.
 `inspect` does not run the consensus engine at all and can therefore be used to debug
-processes that have crashed due to inconsistent state. 
+processes that have crashed due to inconsistent state.
 
 
 To start the `inspect` process, run
@@ -85,7 +85,7 @@ tendermint inspect
 
 ### RPC endpoints
 The list of available RPC endpoints can be found by making a request to the RPC port.
-For an `inspect` process running on `127.0.0.1:26657`, navigate your browser to 
+For an `inspect` process running on `127.0.0.1:26657`, navigate your browser to
 `http://127.0.0.1:26657/` to retrieve the list of enabled RPC endpoints.
 
-Additional information on the Tendermint RPC endpoints can be found in the [rpc documentation](https://docs.tendermint.com/master/rpc).
+Additional information on the Tendermint RPC endpoints can be found in the [rpc documentation](./rpc).

--- a/docs/tools/debugging/pro.md
+++ b/docs/tools/debugging/pro.md
@@ -46,7 +46,7 @@ To ease the burden of collecting different pieces of data Tendermint Core (since
 tendermint debug kill <pid> </path/to/out.zip> — home=</path/to/app.d>
 ```
 
-Here’s the official documentation page — <https://docs.tendermint.com/master/tools/debugging>
+Here’s the [official documentation page](./tools/debugging).
 
 If you’re using a process supervisor, like systemd, it will restart the Tendermint automatically. We strongly advise you to have one in production. If not, you will need to restart the node by hand.
 
@@ -66,19 +66,19 @@ At this point, depending on how severe the degradation is, you may want to resta
 
 ## Tendermint Inspect
 
-What if the Tendermint node will not start up due to inconsistent consensus state? 
+What if the Tendermint node will not start up due to inconsistent consensus state?
 
-When a node running the Tendermint consensus engine detects an inconsistent state 
-it will crash the entire Tendermint process. 
+When a node running the Tendermint consensus engine detects an inconsistent state
+it will crash the entire Tendermint process.
 The Tendermint consensus engine cannot be run in this inconsistent state and the so node
 will fail to start up as a result.
 The Tendermint RPC server can provide valuable information for debugging in this situation.
-The Tendermint `inspect` command will run a subset of the Tendermint RPC server 
+The Tendermint `inspect` command will run a subset of the Tendermint RPC server
 that is useful for debugging inconsistent state.
 
 ### Running inspect
 
-Start up the `inspect` tool on the machine where Tendermint crashed using: 
+Start up the `inspect` tool on the machine where Tendermint crashed using:
 ```bash
 tendermint inspect --home=</path/to/app.d>
 ```
@@ -90,7 +90,7 @@ tendermint inspect --home=</path/to/app.d>
 
 With the `inspect` server running, you can access RPC endpoints that are critically important
 for debugging.
-Calling the `/status`, `/consensus_state` and `/dump_consensus_state` RPC endpoint 
+Calling the `/status`, `/consensus_state` and `/dump_consensus_state` RPC endpoint
 will return useful information about the Tendermint consensus state.
 
 ## Outro

--- a/docs/tools/docker-compose.md
+++ b/docs/tools/docker-compose.md
@@ -101,7 +101,7 @@ rm -rf ./build/node*
 
 ## Configuring ABCI containers
 
-To use your own ABCI applications with 4-node setup edit the [docker-compose.yaml](https://github.com/tendermint/tendermint/blob/master/docker-compose.yml) file and add image to your ABCI application.
+To use your own ABCI applications with 4-node setup edit the [docker-compose.yaml](../../docker-compose.yml) file and add image to your ABCI application.
 
 ```yml
  abci0:
@@ -150,7 +150,7 @@ To use your own ABCI applications with 4-node setup edit the [docker-compose.yam
 
 ```
 
-Override the [command](https://github.com/tendermint/tendermint/blob/master/networks/local/localnode/Dockerfile#L12) in each node to connect to it's ABCI.
+Override the [command](../../networks/local/localnode/Dockerfile#L12) in each node to connect to it's ABCI.
 
 ```yml
   node0:

--- a/docs/tools/terraform-and-ansible.md
+++ b/docs/tools/terraform-and-ansible.md
@@ -13,10 +13,9 @@ testnets on those servers.
 
 ## Install
 
-NOTE: see the [integration bash
-script](https://github.com/tendermint/tendermint/blob/master/networks/remote/integration.sh)
-that can be run on a fresh DO droplet and will automatically spin up a 4
-node testnet. The script more or less does everything described below.
+NOTE: see the [integration bash script](../../networks/remote/integration.sh)
+that can be run on a fresh DO droplet and will automatically spin up a 4 node
+testnet. The script more or less does everything described below.
 
 - Install [Terraform](https://www.terraform.io/downloads.html) and
   [Ansible](http://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
@@ -57,11 +56,10 @@ With the droplets created and running, let's setup Ansible.
 
 ## Ansible
 
-The playbooks in [the ansible
-directory](https://github.com/tendermint/tendermint/tree/master/networks/remote/ansible)
-run ansible roles to configure the sentry node architecture. You must
-switch to this directory to run ansible
-(`cd $GOPATH/src/github.com/tendermint/tendermint/networks/remote/ansible`).
+The playbooks in [the ansible directory](../../networks/remote/ansible) run
+ansible roles to configure the sentry node architecture. You must switch to
+this directory to run ansible (`cd
+$GOPATH/src/github.com/tendermint/tendermint/networks/remote/ansible`).
 
 There are several roles that are self-explanatory:
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -23,7 +23,7 @@ yourself with the syntax.
 By following along with this guide, you'll create a Tendermint Core project
 called kvstore, a (very) simple distributed BFT key-value store.
 
-> Note: please use a released version of Tendermint with this guide. The guides will work with the latest version. Please, do not use master. 
+> Note: please use a released version of Tendermint with this guide. The guides will work with the latest version. Please, do not use master.
 
 ## Built-in app vs external app
 
@@ -57,7 +57,7 @@ go mod init github.com/<github_username>/<repo_name>
 
 Inside the example directory create a `main.go` file with the following content:
 
-> Note: there is no need to clone or fork Tendermint in this tutorial. 
+> Note: there is no need to clone or fork Tendermint in this tutorial.
 
 ```go
 package main
@@ -82,9 +82,8 @@ Hello, Tendermint Core
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/abci/types.proto).
-This allows Tendermint Core to run applications written in any programming
-language.
+file](../../proto/tendermint/abci/types.proto).  This allows Tendermint Core to
+run applications written in any programming language.
 
 Create a file called `app.go` with the following content:
 
@@ -211,8 +210,8 @@ Note that anything with non-zero code will be considered invalid (`-1`, `100`,
 etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
-have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
+have enough gas. To learn more about gas, check out [the
+specification](./spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -330,8 +329,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 }
 ```
 
-The complete specification can be found
-[here](https://docs.tendermint.com/master/spec/abci/).
+The complete specification can be found [here](./spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instance in the same process
 
@@ -609,7 +607,7 @@ go build
 To create a default configuration, nodeKey and private validator files, let's
 execute `tendermint init validator`. But before we do that, we will need to install
 Tendermint Core. Please refer to [the official
-guide](https://docs.tendermint.com/master/introduction/install.html). If you're
+guide](./introduction/install.html). If you're
 installing from source, don't forget to checkout the latest release (`git
 checkout vX.Y.Z`). Don't forget to check that the application uses the same
 major version.
@@ -682,4 +680,4 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/master/).
+deeper, read [the docs](./).

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -80,9 +80,8 @@ Hello, Tendermint Core
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/abci/types.proto).
-This allows Tendermint Core to run applications written in any programming
-language.
+file](../../proto/tendermint/abci/types.proto).  This allows Tendermint Core to
+run applications written in any programming language.
 
 Create a file called `app.go` with the following content:
 
@@ -209,8 +208,8 @@ Note that anything with non-zero code will be considered invalid (`-1`, `100`,
 etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
-have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
+have enough gas. To learn more about gas, check out [the
+specification](./spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -327,8 +326,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 }
 ```
 
-The complete specification can be found
-[here](https://docs.tendermint.com/master/spec/abci/).
+The complete specification can be found [here](./spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -465,12 +463,11 @@ go build
 ```
 
 To create a default configuration, nodeKey and private validator files, let's
-execute `tendermint init validator`. But before we do that, we will need to install
-Tendermint Core. Please refer to [the official
-guide](https://docs.tendermint.com/master/introduction/install.html). If you're
-installing from source, don't forget to checkout the latest release (`git
-checkout vX.Y.Z`). Don't forget to check that the application uses the same
-major version.
+execute `tendermint init validator`. But before we do that, we will need to
+install Tendermint Core. Please refer to [the official
+guide](./introduction/install.html). If you're installing from source, don't
+forget to checkout the latest release (`git checkout vX.Y.Z`). Don't forget to
+check that the application uses the same major version.
 
 ```bash
 rm -rf /tmp/example
@@ -484,7 +481,7 @@ I[2019-07-16|18:20:36.483] Generated config                             module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://docs.tendermint.com/master/tendermint-core/configuration.html).
+[here](./tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -567,4 +564,4 @@ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/master/).
+deeper, read [the docs](./).

--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -115,9 +115,8 @@ Hello world.
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/abci/types.proto).
-This allows Tendermint Core to run applications written in any programming
-language.
+file](../../proto/tendermint/abci/types.proto).  This allows Tendermint Core to
+run applications written in any programming language.
 
 ### 1.3.1 Compile .proto files
 
@@ -322,8 +321,8 @@ Note that anything with non-zero code will be considered invalid (`-1`, `100`,
 etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
-have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
+have enough gas. To learn more about gas, check out [the
+specification](./spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [JetBrains Xodus](https://github.com/JetBrains/xodus), which is a transactional schema-less embedded high-performance database written in Java.
@@ -466,8 +465,7 @@ public void query(RequestQuery req, StreamObserver<ResponseQuery> responseObserv
 }
 ```
 
-The complete specification can be found
-[here](https://docs.tendermint.com/master/spec/abci/).
+The complete specification can be found [here](./spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -560,7 +558,7 @@ I[2019-07-16|18:20:36.483] Generated config                             module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://docs.tendermint.com/master/tendermint-core/configuration.html).
+[here](./tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -626,6 +624,6 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/master/).
+deeper, read [the docs](./).
 
 The full source code of this example project can be found [here](https://github.com/climber73/tendermint-abci-grpc-java).

--- a/docs/tutorials/kotlin.md
+++ b/docs/tutorials/kotlin.md
@@ -115,9 +115,8 @@ Hello world.
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/abci/types.proto).
-This allows Tendermint Core to run applications written in any programming
-language.
+file](../../proto/tendermint/abci/types.proto).  This allows Tendermint Core to
+run applications written in any programming language.
 
 ### 1.3.1 Compile .proto files
 
@@ -313,8 +312,8 @@ Note that anything with non-zero code will be considered invalid (`-1`, `100`,
 etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
-have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
+have enough gas. To learn more about gas, check out [the
+specification](./spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [JetBrains Xodus](https://github.com/JetBrains/xodus), which is a transactional schema-less embedded high-performance database written in Java.
@@ -445,8 +444,7 @@ override fun query(req: RequestQuery, responseObserver: StreamObserver<ResponseQ
 }
 ```
 
-The complete specification can be found
-[here](https://docs.tendermint.com/master/spec/abci/).
+The complete specification can be found [here](./spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -534,7 +532,7 @@ I[2019-07-16|18:20:36.482] Generated config                             module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://docs.tendermint.com/master/tendermint-core/configuration.html).
+[here](./tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -600,6 +598,6 @@ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/master/).
+deeper, read [the docs](./).
 
 The full source code of this example project can be found [here](https://github.com/climber73/tendermint-abci-grpc-kotlin).

--- a/docs/versions
+++ b/docs/versions
@@ -1,4 +1,4 @@
-master                  master
+mjf/doclink             master
 v0.33.x                 v0.33
 v0.34.x                 v0.34
 v0.35.x                 v0.35


### PR DESCRIPTION
An attempt to mitigate #7675. Not ready to merge.

The essence of this change is to make the links that should track a release branch (notably in the tutorials and other files linked from docs.tendermint.com) point to the branch-specific version of the file rather than the `master` copy.

The fundamental problem, however, is that some of the URLs are interpreted by the docs site, and others by GitHub. They use different namespaces (e.g., https://github.com/tendermint/tendermint/blob/master vs. https://docs.tendermint.com/master), that point to different parts of the tree.

I think that making the URLs relative to the repo root should cover it, but I have to see what the docs generator does with them.