### PR TITLE
rpc: fix layout of endpoint list

### DIFF
--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"net/http"
 	"reflect"
-	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/tendermint/tendermint/libs/log"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
@@ -222,40 +223,51 @@ func (z *int64String) UnmarshalText(data []byte) error {
 
 // writes a list of available rpc endpoints as an html page
 func writeListOfEndpoints(w http.ResponseWriter, r *http.Request, funcMap map[string]*RPCFunc) {
-	noArgNames := []string{}
-	argNames := []string{}
-	for name, funcData := range funcMap {
-		if len(funcData.args) == 0 {
-			noArgNames = append(noArgNames, name)
+	hasArgs := make(map[string]string)
+	noArgs := make(map[string]string)
+	for name, rf := range funcMap {
+		base := fmt.Sprintf("//%s/%s", r.Host, name)
+		// N.B. Check argNames, not args, since the type list includes the type
+		// of the leading context argument.
+		if len(rf.argNames) == 0 {
+			noArgs[name] = base
 		} else {
-			argNames = append(argNames, name)
-		}
-	}
-	sort.Strings(noArgNames)
-	sort.Strings(argNames)
-	buf := new(bytes.Buffer)
-	buf.WriteString("<html><body>")
-	buf.WriteString("<br>Available endpoints:<br>")
-
-	for _, name := range noArgNames {
-		link := fmt.Sprintf("//%s/%s", r.Host, name)
-		buf.WriteString(fmt.Sprintf("<a href=\"%s\">%s</a></br>", link, link))
-	}
-
-	buf.WriteString("<br>Endpoints that require arguments:<br>")
-	for _, name := range argNames {
-		link := fmt.Sprintf("//%s/%s?", r.Host, name)
-		funcData := funcMap[name]
-		for i, argName := range funcData.argNames {
-			link += argName + "=_"
-			if i < len(funcData.argNames)-1 {
-				link += "&"
+			query := append([]string(nil), rf.argNames...)
+			for i, arg := range query {
+				query[i] = arg + "=_"
 			}
+			hasArgs[name] = base + "?" + strings.Join(query, "&")
 		}
-		buf.WriteString(fmt.Sprintf("<a href=\"%s\">%s</a></br>", link, link))
 	}
-	buf.WriteString("</body></html>")
 	w.Header().Set("Content-Type", "text/html")
-	w.WriteHeader(200)
-	w.Write(buf.Bytes()) // nolint: errcheck
+	listOfEndpoints.Execute(w, map[string]map[string]string{
+		"NoArgs":  noArgs,
+		"HasArgs": hasArgs,
+	})
 }
+
+var listOfEndpoints = template.Must(template.New("list").Parse(`<html>
+<head><title>List of RPC Endpoints</title></head>
+<body>
+
+<h1>Available RPC endpoints:</h1>
+
+{{if .NoArgs}}
+<hr />
+<h2>Endpoints with no arguments:</h2>
+
+<ul>
+{{range $link := .NoArgs}}  <li><a href="{{$link}}">{{$link}}</a></li>
+{{end -}}
+</ul>{{end}}
+
+{{if .HasArgs}}
+<hr />
+<h2>Endpoints that require arguments:</h2>
+
+<ul>
+{{range $link := .HasArgs}}  <li><a href="{{$link}}">{{$link}}</a></li>
+{{end -}}
+</ul>{{end}}
+
+</body></html>`))

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -240,7 +240,7 @@ func writeListOfEndpoints(w http.ResponseWriter, r *http.Request, funcMap map[st
 		}
 	}
 	w.Header().Set("Content-Type", "text/html")
-	listOfEndpoints.Execute(w, map[string]map[string]string{
+	_ = listOfEndpoints.Execute(w, map[string]map[string]string{
 		"NoArgs":  noArgs,
 		"HasArgs": hasArgs,
 	})


### PR DESCRIPTION
The output of the default endpoint-list query was not correctly segregating
methods with and without arguments. Fix this, and also clean up the output to
be easier to read (both in code and in generated source).

Fixes #3618.

Results:

```html
<html>
<head><title>List of RPC Endpoints</title></head>
<body>

<h1>Available RPC endpoints:</h1>


<hr />
<h2>Endpoints with no arguments:</h2>

<ul>
  <li><a href="//localhost:26657/abci_info">//localhost:26657/abci_info</a></li>
  <li><a href="//localhost:26657/consensus_state">//localhost:26657/consensus_state</a></li>
  <li><a href="//localhost:26657/dump_consensus_state">//localhost:26657/dump_consensus_state</a></li>
  <li><a href="//localhost:26657/genesis">//localhost:26657/genesis</a></li>
  <li><a href="//localhost:26657/health">//localhost:26657/health</a></li>
  <li><a href="//localhost:26657/net_info">//localhost:26657/net_info</a></li>
  <li><a href="//localhost:26657/num_unconfirmed_txs">//localhost:26657/num_unconfirmed_txs</a></li>
  <li><a href="//localhost:26657/status">//localhost:26657/status</a></li>
  <li><a href="//localhost:26657/unsubscribe_all">//localhost:26657/unsubscribe_all</a></li>
</ul>


<hr />
<h2>Endpoints that require arguments:</h2>

<ul>
  <li><a href="//localhost:26657/abci_query?path=_&amp;data=_&amp;height=_&amp;prove=_">//localhost:26657/abci_query?path=_&amp;data=_&amp;height=_&amp;prove=_</a></li>
  <li><a href="//localhost:26657/block?height=_">//localhost:26657/block?height=_</a></li>
  <li><a href="//localhost:26657/block_by_hash?hash=_">//localhost:26657/block_by_hash?hash=_</a></li>
  <li><a href="//localhost:26657/block_results?height=_">//localhost:26657/block_results?height=_</a></li>
  <li><a href="//localhost:26657/block_search?query=_&amp;page=_&amp;per_page=_&amp;order_by=_">//localhost:26657/block_search?query=_&amp;page=_&amp;per_page=_&amp;order_by=_</a></li>
  <li><a href="//localhost:26657/blockchain?minHeight=_&amp;maxHeight=_">//localhost:26657/blockchain?minHeight=_&amp;maxHeight=_</a></li>
  <li><a href="//localhost:26657/broadcast_evidence?evidence=_">//localhost:26657/broadcast_evidence?evidence=_</a></li>
  <li><a href="//localhost:26657/broadcast_tx_async?tx=_">//localhost:26657/broadcast_tx_async?tx=_</a></li>
  <li><a href="//localhost:26657/broadcast_tx_commit?tx=_">//localhost:26657/broadcast_tx_commit?tx=_</a></li>
  <li><a href="//localhost:26657/broadcast_tx_sync?tx=_">//localhost:26657/broadcast_tx_sync?tx=_</a></li>
  <li><a href="//localhost:26657/check_tx?tx=_">//localhost:26657/check_tx?tx=_</a></li>
  <li><a href="//localhost:26657/commit?height=_">//localhost:26657/commit?height=_</a></li>
  <li><a href="//localhost:26657/consensus_params?height=_">//localhost:26657/consensus_params?height=_</a></li>
  <li><a href="//localhost:26657/genesis_chunked?chunk=_">//localhost:26657/genesis_chunked?chunk=_</a></li>
  <li><a href="//localhost:26657/header?height=_">//localhost:26657/header?height=_</a></li>
  <li><a href="//localhost:26657/header_by_hash?hash=_">//localhost:26657/header_by_hash?hash=_</a></li>
  <li><a href="//localhost:26657/remove_tx?txkey=_">//localhost:26657/remove_tx?txkey=_</a></li>
  <li><a href="//localhost:26657/subscribe?query=_">//localhost:26657/subscribe?query=_</a></li>
  <li><a href="//localhost:26657/tx?hash=_&amp;prove=_">//localhost:26657/tx?hash=_&amp;prove=_</a></li>
  <li><a href="//localhost:26657/tx_search?query=_&amp;prove=_&amp;page=_&amp;per_page=_&amp;order_by=_">//localhost:26657/tx_search?query=_&amp;prove=_&amp;page=_&amp;per_page=_&amp;order_by=_</a></li>
  <li><a href="//localhost:26657/unconfirmed_txs?page=_&amp;per_page=_">//localhost:26657/unconfirmed_txs?page=_&amp;per_page=_</a></li>
  <li><a href="//localhost:26657/unsubscribe?query=_">//localhost:26657/unsubscribe?query=_</a></li>
  <li><a href="//localhost:26657/validators?height=_&amp;page=_&amp;per_page=_">//localhost:26657/validators?height=_&amp;page=_&amp;per_page=_</a></li>
</ul>

</body></html>
```