### PR TITLE
rpc: remove the placeholder RunState type.

### DIFF
--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -105,12 +105,12 @@ func NewClient(logger log.Logger, next rpcclient.Client, lc LightClient, opts ..
 }
 
 func (c *Client) OnStart(ctx context.Context) error {
-	if !c.next.IsRunning() {
-		nctx, ncancel := context.WithCancel(ctx)
-		c.closers = append(c.closers, ncancel)
-		return c.next.Start(nctx)
+	nctx, ncancel := context.WithCancel(ctx)
+	if err := c.next.Start(nctx); err != nil {
+		ncancel()
+		return err
 	}
-
+	c.closers = append(c.closers, ncancel)
 	go func() {
 		defer close(c.quitCh)
 		c.Wait()

--- a/rpc/client/helpers.go
+++ b/rpc/client/helpers.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
-	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -83,70 +81,4 @@ func WaitForOneEvent(c EventsClient, eventValue string, timeout time.Duration) (
 	case <-ctx.Done():
 		return nil, errors.New("timed out waiting for event")
 	}
-}
-
-var (
-	// ErrClientRunning is returned by Start when the client is already running.
-	ErrClientRunning = errors.New("client already running")
-
-	// ErrClientNotRunning is returned by Stop when the client is not running.
-	ErrClientNotRunning = errors.New("client is not running")
-)
-
-// RunState is a helper that a client implementation can embed to implement
-// common plumbing for keeping track of run state and logging.
-//
-// TODO(creachadair): This type is a temporary measure, and will be removed.
-// See the discussion on #6971.
-type RunState struct {
-	Logger log.Logger
-
-	mu        sync.Mutex
-	name      string
-	isRunning bool
-}
-
-// NewRunState returns a new unstarted run state tracker with the given logging
-// label and log sink. If logger == nil, a no-op logger is provided by default.
-func NewRunState(name string, logger log.Logger) *RunState {
-	if logger == nil {
-		logger = log.NewNopLogger()
-	}
-	return &RunState{
-		name:   name,
-		Logger: logger,
-	}
-}
-
-// Start sets the state to running, or reports an error.
-func (r *RunState) Start(context.Context) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.isRunning {
-		r.Logger.Error("not starting client, it is already started", "client", r.name)
-		return ErrClientRunning
-	}
-	r.Logger.Info("starting client", "client", r.name)
-	r.isRunning = true
-	return nil
-}
-
-// Stop sets the state to not running, or reports an error.
-func (r *RunState) Stop() error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if !r.isRunning {
-		r.Logger.Error("not stopping client; it is already stopped", "client", r.name)
-		return ErrClientNotRunning
-	}
-	r.Logger.Info("stopping client", "client", r.name)
-	r.isRunning = false
-	return nil
-}
-
-// IsRunning reports whether the state is running.
-func (r *RunState) IsRunning() bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.isRunning
 }

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -32,13 +32,9 @@ import (
 
 // Client describes the interface of Tendermint RPC client implementations.
 type Client interface {
-	// These methods define the operational structure of the client.
-
-	// Start the client. Start must report an error if the client is running.
+	// Start the client, which will run until the context terminates.
+	// An error from Start indicates the client could not start.
 	Start(context.Context) error
-
-	// IsRunning reports whether the client is running.
-	IsRunning() bool
 
 	// These embedded interfaces define the callable methods of the service.
 	ABCIClient

--- a/rpc/client/mocks/client.go
+++ b/rpc/client/mocks/client.go
@@ -526,20 +526,6 @@ func (_m *Client) Health(_a0 context.Context) (*coretypes.ResultHealth, error) {
 	return r0, r1
 }
 
-// IsRunning provides a mock function with given fields:
-func (_m *Client) IsRunning() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
 // NetInfo provides a mock function with given fields: _a0
 func (_m *Client) NetInfo(_a0 context.Context) (*coretypes.ResultNetInfo, error) {
 	ret := _m.Called(_a0)

--- a/rpc/jsonrpc/client/ws_client.go
+++ b/rpc/jsonrpc/client/ws_client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gorilla/websocket"
 	metrics "github.com/rcrowley/go-metrics"
 
-	tmclient "github.com/tendermint/tendermint/rpc/client"
+	"github.com/tendermint/tendermint/libs/log"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
@@ -38,8 +38,8 @@ var defaultWSOptions = wsOptions{
 //
 // WSClient is safe for concurrent use by multiple goroutines.
 type WSClient struct { // nolint: maligned
-	*tmclient.RunState
-	conn *websocket.Conn
+	Logger log.Logger
+	conn   *websocket.Conn
 
 	Address  string // IP:PORT or /path/to/socket
 	Endpoint string // /websocket/url/endpoint
@@ -105,7 +105,7 @@ func NewWS(remoteAddr, endpoint string) (*WSClient, error) {
 	}
 
 	c := &WSClient{
-		RunState:             tmclient.NewRunState("WSClient", nil),
+		Logger:               log.NewNopLogger(),
 		Address:              parsedURL.GetTrimmedHostWithPath(),
 		Dialer:               dialFn,
 		Endpoint:             endpoint,
@@ -134,13 +134,11 @@ func (c *WSClient) String() string {
 	return fmt.Sprintf("WSClient{%s (%s)}", c.Address, c.Endpoint)
 }
 
-// Start dials the specified service address and starts the I/O routines.
+// Start dials the specified service address and starts the I/O routines.  The
+// service routines run until ctx terminates. To wait for the client to exit
+// after ctx ends, call Stop.
 func (c *WSClient) Start(ctx context.Context) error {
-	if err := c.RunState.Start(ctx); err != nil {
-		return err
-	}
-	err := c.dial()
-	if err != nil {
+	if err := c.dial(); err != nil {
 		return err
 	}
 
@@ -160,17 +158,15 @@ func (c *WSClient) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop shuts down the client.
+// Stop blocks until the client is shut down and returns nil.
+//
+// TODO(creachadair): This method exists for compatibility with the original
+// service plumbing. Give it a better name (e.g., Wait).
 func (c *WSClient) Stop() error {
-	if err := c.RunState.Stop(); err != nil {
-		return err
-	}
-
 	// only close user-facing channels when we can't write to them
 	c.wg.Wait()
 	c.PingPongLatencyTimer.Stop()
 	close(c.ResponsesCh)
-
 	return nil
 }
 
@@ -181,9 +177,9 @@ func (c *WSClient) IsReconnecting() bool {
 	return c.reconnecting
 }
 
-// IsActive returns true if the client is running and not reconnecting.
+// IsActive returns true if the client is not reconnecting.
 func (c *WSClient) IsActive() bool {
-	return c.IsRunning() && !c.IsReconnecting()
+	return !c.IsReconnecting()
 }
 
 // Send the given RPC request to the server. Results will be available on

--- a/rpc/jsonrpc/client/ws_client.go
+++ b/rpc/jsonrpc/client/ws_client.go
@@ -177,11 +177,6 @@ func (c *WSClient) IsReconnecting() bool {
 	return c.reconnecting
 }
 
-// IsActive returns true if the client is not reconnecting.
-func (c *WSClient) IsActive() bool {
-	return !c.IsReconnecting()
-}
-
 // Send the given RPC request to the server. Results will be available on
 // ResponsesCh, errors, if any, on ErrorsCh. Will block until send succeeds or
 // ctx.Done is closed.


### PR DESCRIPTION
I added the RunState type in #6971 to disconnect clients from the service
plumbing, which they do not need. Now that we have more complete context
plumbing, the lifecycle of a client no longer depends on this type: It serves
as a carrier for a logger, and a Boolean flag for "running" status, neither of
which is used outside of tests.

Logging in particular is defaulted to a no-op logger in all production use.
Arguably we could just remove the logging calls, since they are never invoked
except in tests. To defer the question of whether we should do that or make the
logging go somewhere more productive, I've preserved the existing use here.

Remove use of the IsRunning method that was provided by the RunState, and use
the Start method and context to govern client lifecycle.

Remove the one test that exercised "unstarted" clients. I would like to remove
that method entirely, but that will require updating the constructors for all
the client types to plumb a context and possibly other options. I have deferred
that for now.
