### PR TITLE
ADR: synchronize PBTS ADR with spec

### DIFF
--- a/docs/architecture/adr-071-proposer-based-timestamps.md
+++ b/docs/architecture/adr-071-proposer-based-timestamps.md
@@ -151,8 +151,8 @@ type ConsensusParams struct {
 
 ```go
 type SynchronyParams struct {
-	MessageDelay  time.Duration `json:"message_delay"`
-	Precision time.Duration `json:"precision"`
+	MessageDelay time.Duration `json:"message_delay"`
+	Precision    time.Duration `json:"precision"`
 }
 ```
 

--- a/docs/architecture/adr-071-proposer-based-timestamps.md
+++ b/docs/architecture/adr-071-proposer-based-timestamps.md
@@ -150,8 +150,8 @@ type ConsensusParams struct {
 ```
 
 ```go
-type TimestampParams struct {
-	MsgDelay  time.Duration `json:"msg_delay"`
+type SynchronyParams struct {
+	MessageDelay  time.Duration `json:"message_delay"`
 	Precision time.Duration `json:"precision"`
 }
 ```

--- a/docs/architecture/adr-071-proposer-based-timestamps.md
+++ b/docs/architecture/adr-071-proposer-based-timestamps.md
@@ -133,7 +133,7 @@ These parameters are `PRECISION`, and `MSGDELAY`.
 The `PRECISION` and `MSGDELAY` parameters are used to determine if the proposed timestamp is acceptable.
 A validator will only Prevote a proposal if the proposal timestamp is considered `timely`.
 A proposal timestamp is considered `timely` if it is within `PRECISION` and `MSGDELAY` of the Unix time known to the validator.
-More specifically, a proposal timestamp is `timely` if `proposalTimestamp - PRECISION <= validatorLocalTime <= proposalTimestamp + PRECISION + MSGDELAY`.
+More specifically, a proposal timestamp is `timely` if `proposalTimestamp - PRECISION ≤ validatorLocalTime ≤ proposalTimestamp + PRECISION + MSGDELAY`.
 
 Because the `PRECISION` and `MSGDELAY` parameters must be the same across all validators, they will be added to the [consensus parameters](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/types/params.proto#L13) as [durations](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration).
 

--- a/docs/architecture/adr-071-proposer-based-timestamps.md
+++ b/docs/architecture/adr-071-proposer-based-timestamps.md
@@ -2,12 +2,13 @@
 
 ## Changelog
 
- - July 15 2021: Created by @williambanfield 
+ - July 15 2021: Created by @williambanfield
  - Aug 4 2021: Draft completed by @williambanfield
  - Aug 5 2021: Draft updated to include data structure changes by @williambanfield
  - Aug 20 2021: Language edits completed by @williambanfield
  - Oct 25 2021: Update the ADR to match updated spec from @cason by @williambanfield
  - Nov 10 2021: Additional language updates by @williambanfield per feedback from @cason
+ - Feb 2 2022: Synchronize logic for timely with latest version of the spec by @williambanfield
 
 ## Status
 
@@ -22,7 +23,7 @@ The timestamp it sends is either the validator's current known Unix time or one 
 When a block is produced, the proposer chooses the block timestamp as the weighted median of the times in all of the `Precommit` messages the proposer received.
 The weighting is proportional to the amount of voting power, or stake, a validator has on the network.
 This mechanism for producing timestamps is both deterministic and byzantine fault tolerant.
- 
+
 This current mechanism for producing timestamps has a few drawbacks.
 Validators do not have to agree at all on how close the selected block timestamp is to their own currently known Unix time.
 Additionally, any amount of voting power `>1/3` may directly control the block timestamp.
@@ -30,16 +31,16 @@ As a result, it is quite possible that the timestamp is not particularly meaning
 
 These drawbacks present issues in the Tendermint protocol.
 Timestamps are used by light clients to verify blocks.
-Light clients rely on correspondence between their own currently known Unix time and the block timestamp to verify blocks they see; 
+Light clients rely on correspondence between their own currently known Unix time and the block timestamp to verify blocks they see;
 However, their currently known Unix time may be greatly divergent from the block timestamp as a result of the limitations of `BFTTime`.
 
 The proposer-based timestamps specification suggests an alternative approach for producing block timestamps that remedies these issues.
 Proposer-based timestamps alter the current mechanism for producing block timestamps in two main ways:
 
 1. The block proposer is amended to offer up its currently known Unix time as the timestamp for the next block instead of the `BFTTime`.
-1. Correct validators only approve the proposed block timestamp if it is close enough to their own currently known Unix time. 
+1. Correct validators only approve the proposed block timestamp if it is close enough to their own currently known Unix time.
 
-The result of these changes is a more meaningful timestamp that cannot be controlled by `<= 2/3` of the validator voting power. 
+The result of these changes is a more meaningful timestamp that cannot be controlled by `<= 2/3` of the validator voting power.
 This document outlines the necessary code changes in Tendermint to implement the corresponding [proposer-based timestamps specification](https://github.com/tendermint/spec/tree/master/spec/consensus/proposer-based-timestamp).
 
 ## Alternative Approaches
@@ -53,7 +54,7 @@ An alternate approach is to remove timestamps altogether from the block protocol
 `BFTTime` is deterministic but may be arbitrarily inaccurate.
 However, having a reliable source of time is quite useful for applications and protocols built on top of a blockchain.
 
-We therefore decided not to remove the timestamp. 
+We therefore decided not to remove the timestamp.
 Applications often wish for some transactions to occur on a certain day, on a regular period, or after some time following a different event.
 All of these require some meaningful representation of agreed upon time.
 The following protocols and application features require a reliable source of time:
@@ -62,8 +63,8 @@ The following protocols and application features require a reliable source of ti
 * Unbonding of staked assets in the Cosmos Hub [occurs after a period of 21 days](https://github.com/cosmos/governance/blob/ce75de4019b0129f6efcbb0e752cd2cc9e6136d3/params-change/Staking.md#unbondingtime).
 * IBC packets can use either a [timestamp or a height to timeout packet delivery](https://docs.cosmos.network/v0.43/ibc/overview.html#acknowledgements).
 
-Finally, inflation distribution in the Cosmos Hub uses an approximation of time to calculate an annual percentage rate. 
-This approximation of time is calculated using [block heights with an estimated number of blocks produced in a year](https://github.com/cosmos/governance/blob/master/params-change/Mint.md#blocksperyear). 
+Finally, inflation distribution in the Cosmos Hub uses an approximation of time to calculate an annual percentage rate.
+This approximation of time is calculated using [block heights with an estimated number of blocks produced in a year](https://github.com/cosmos/governance/blob/master/params-change/Mint.md#blocksperyear).
 Proposer-based timestamps will allow this inflation calculation to use a more meaningful and accurate source of time.
 
 
@@ -84,7 +85,7 @@ These changes will be to the following components:
 
 ### Changes to `CommitSig`
 
-The [CommitSig](https://github.com/tendermint/tendermint/blob/a419f4df76fe4aed668a6c74696deabb9fe73211/types/block.go#L604) struct currently contains a timestamp. 
+The [CommitSig](https://github.com/tendermint/tendermint/blob/a419f4df76fe4aed668a6c74696deabb9fe73211/types/block.go#L604) struct currently contains a timestamp.
 This timestamp is the current Unix time known to the validator when it issued a `Precommit` for the block.
 This timestamp is no longer used and will be removed in this change.
 
@@ -106,7 +107,7 @@ This struct currently contains a timestamp.
 This timestamp is set using the [voteTime](https://github.com/tendermint/tendermint/blob/e8013281281985e3ada7819f42502b09623d24a0/internal/consensus/state.go#L2241) function and therefore vote times correspond to the current Unix time known to the validator.
 For precommits, this timestamp is used to construct the [CommitSig that is included in the block in the LastCommit](https://github.com/tendermint/tendermint/blob/e8013281281985e3ada7819f42502b09623d24a0/types/block.go#L754) field.
 For prevotes, this field is currently unused.
-Proposer-based timestamps will use the timestamp that the proposer sets into the block and will therefore no longer require that a timestamp be included in the vote messages. 
+Proposer-based timestamps will use the timestamp that the proposer sets into the block and will therefore no longer require that a timestamp be included in the vote messages.
 This timestamp is therefore no longer useful and will be dropped.
 
 `Vote` will be updated as follows:
@@ -115,7 +116,7 @@ This timestamp is therefore no longer useful and will be dropped.
 type Vote struct {
 	Type             tmproto.SignedMsgType `json:"type"`
 	Height           int64                 `json:"height"`
-	Round            int32                 `json:"round"`    
+	Round            int32                 `json:"round"`   
 	BlockID          BlockID               `json:"block_id"` // zero if vote is nil.
 --	Timestamp        time.Time             `json:"timestamp"`
 	ValidatorAddress Address               `json:"validator_address"`
@@ -127,24 +128,16 @@ type Vote struct {
 ### New consensus parameters
 
 The proposer-based timestamp specification includes multiple new parameters that must be the same among all validators.
-These parameters are `PRECISION`, `MSGDELAY`, and `ACCURACY`.
+These parameters are `PRECISION`, and `MSGDELAY`.
 
 The `PRECISION` and `MSGDELAY` parameters are used to determine if the proposed timestamp is acceptable.
 A validator will only Prevote a proposal if the proposal timestamp is considered `timely`.
 A proposal timestamp is considered `timely` if it is within `PRECISION` and `MSGDELAY` of the Unix time known to the validator.
-More specifically, a proposal timestamp is `timely` if `validatorLocalTime - PRECISION < proposalTime < validatorLocalTime + PRECISION + MSGDELAY`. 
+More specifically, a proposal timestamp is `timely` if `proposalTimestamp - PRECISION <= validatorLocalTime <= proposalTimestamp + PRECISION + MSGDELAY`.
 
 Because the `PRECISION` and `MSGDELAY` parameters must be the same across all validators, they will be added to the [consensus parameters](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/types/params.proto#L13) as [durations](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration).
 
-The proposer-based timestamp specification also includes a [new ACCURACY parameter](https://github.com/tendermint/spec/blob/master/spec/consensus/proposer-based-timestamp/pbts-sysmodel_001_draft.md#pbts-clocksync-external0).
-Intuitively, `ACCURACY` represents the difference between the ‘real’ time and the currently known time of correct validators.
-The currently known Unix time of any validator is always somewhat different from real time.
-`ACCURACY` is the largest such difference between each validator's time and real time taken as an absolute value. 
-This is not something a computer can determine on its own and must be specified as an estimate by community running a Tendermint-based chain.
-It is used in the new algorithm to [calculate a timeout for the propose step](https://github.com/tendermint/spec/blob/master/spec/consensus/proposer-based-timestamp/pbts-algorithm_001_draft.md#pbts-alg-startround0).
-`ACCURACY` is assumed to be the same across all validators and therefore should be included as a consensus parameter.
-
-The consensus will be updated to include this `Timestamp` field as follows:
+The consensus parameters will be updated to include this `Synchrony` field as follows:
 
 ```diff
 type ConsensusParams struct {
@@ -152,15 +145,14 @@ type ConsensusParams struct {
 	Evidence  EvidenceParams  `json:"evidence"`
 	Validator ValidatorParams `json:"validator"`
 	Version   VersionParams   `json:"version"`
-++	Timestamp TimestampParams `json:"timestamp"`
+++	Synchrony SynchronyParams `json:"synchrony"`
 }
 ```
 
 ```go
 type TimestampParams struct {
-	Accuracy  time.Duration `json:"accuracy"`
-	Precision time.Duration `json:"precision"`
 	MsgDelay  time.Duration `json:"msg_delay"`
+	Precision time.Duration `json:"precision"`
 }
 ```
 
@@ -183,7 +175,7 @@ The proposer will also set this same timestamp into the `Timestamp` field of the
 
 If a proposer is re-proposing a block that has previously received a polka on the network, then the proposer does not update the `Header.Timestamp` of that block.
 Instead, the proposer simply re-proposes the exact same block.
-This way, the proposed block has the exact same block ID as the previously proposed block and the validators that have already received that block do not need to attempt to receive it again. 
+This way, the proposed block has the exact same block ID as the previously proposed block and the validators that have already received that block do not need to attempt to receive it again.
 
 The proposer will set the re-proposed block's `Header.Timestamp` as the `Proposal` message's `Timestamp`.
 
@@ -192,42 +184,23 @@ The proposer will set the re-proposed block's `Header.Timestamp` as the `Proposa
 Block timestamps must be monotonically increasing.
 In `BFTTime`, if a validator’s clock was behind, the [validator added 1 millisecond to the previous block’s time and used that in its vote messages](https://github.com/tendermint/tendermint/blob/e8013281281985e3ada7819f42502b09623d24a0/internal/consensus/state.go#L2246).
 A goal of adding proposer-based timestamps is to enforce some degree of clock synchronization, so having a mechanism that completely ignores the Unix time of the validator time no longer works.
-
 Validator clocks will not be perfectly in sync.
 Therefore, the proposer’s current known Unix time may be less than the previous block's `Header.Time`.
 If the proposer’s current known Unix time is less than the previous block's `Header.Time`, the proposer will sleep until its known Unix time exceeds it.
 
 This change will require amending the [defaultDecideProposal](https://github.com/tendermint/tendermint/blob/822893615564cb20b002dd5cf3b42b8d364cb7d9/internal/consensus/state.go#L1180) method.
 This method should now schedule a timeout that fires when the proposer’s time is greater than the previous block's `Header.Time`.
-When the timeout fires, the proposer will finally issue the `Proposal` message. 
-
-#### Changes to the propose step timeout
-
-Currently, a validator waiting for a proposal will proceed past the propose step if the configured propose timeout is reached and no proposal is seen.
-Proposer-based timestamps requires changing this timeout logic.
-
-The proposer will now wait until its current known Unix time exceeds the previous block's `Header.Time` to propose a block.
-The validators must now take this and some other factors into account when deciding when to timeout the propose step.
-Specifically, the propose step timeout must also take into account potential inaccuracy in the validator’s clock and in the clock of the proposer.
-Additionally, there may be a delay communicating the proposal message from the proposer to the other validators. 
-
-Therefore, validators waiting for a proposal must wait until after the previous block's `Header.Time` before timing out.
-To account for possible inaccuracy in its own clock, inaccuracy in the proposer’s clock, and message delay, validators waiting for a proposal will wait until the previous block's `Header.Time + 2*ACCURACY + MSGDELAY`.
- The spec defines this as `waitingTime`.
- 
-The [propose step’s timeout is set in enterPropose](https://github.com/tendermint/tendermint/blob/822893615564cb20b002dd5cf3b42b8d364cb7d9/internal/consensus/state.go#L1108) in `state.go`. 
-`enterPropose` will be changed to calculate waiting time using the new consensus parameters.
-The timeout in `enterPropose` will then be set as the maximum of `waitingTime` and the [configured proposal step timeout](https://github.com/tendermint/tendermint/blob/dc7c212c41a360bfe6eb38a6dd8c709bbc39aae7/config/config.go#L1013).
+When the timeout fires, the proposer will finally issue the `Proposal` message.
 
 ### Changes to proposal validation rules
 
-The rules for validating a proposed block will be modification to implement proposer-based timestamps.
+The rules for validating a proposed block will be modified to implement proposer-based timestamps.
 We will change the validation logic to ensure that a proposal is `timely`.
 
 Per the proposer-based timestamps spec, `timely` only needs to be checked if a block has not received a +2/3 majority of `Prevotes` in a round.
 If a block previously received a +2/3 majority of prevotes in a previous round, then +2/3 of the voting power considered the block's timestamp near enough to their own currently known Unix time in that round.
 
-The validation logic will be updated to check `timely` for blocks that did not previously receive +2/3 prevotes in a round. 
+The validation logic will be updated to check `timely` for blocks that did not previously receive +2/3 prevotes in a round.
 Receiving +2/3 prevotes in a round is frequently referred to as a 'polka' and we will use this term for simplicity.
 
 #### Current timestamp validation logic
@@ -250,14 +223,14 @@ This takes place in the [VerifyCommit function](https://github.com/tendermint/te
 `BFTTime` validation is no longer applicable and will be removed.
 This means that validators will no longer check that the block timestamp is a weighted median of `LastCommit` timestamps.
 Specifically, we will remove the call to [MedianTime in the validateBlock function](https://github.com/tendermint/tendermint/blob/4db71da68e82d5cb732b235eeb2fd69d62114b45/state/validation.go#L117).
-The `MedianTime` function can be completely removed. 
+The `MedianTime` function can be completely removed.
 
 Since `CommitSig`s will no longer contain a timestamp, the validator authenticating a commit will no longer include the `CommitSig` timestamp in the hash of fields it builds to check against the cryptographic signature.
 
 #### Timestamp validation when a block has not received a polka
 
 The [POLRound](https://github.com/tendermint/tendermint/blob/68ca65f5d79905abd55ea999536b1a3685f9f19d/types/proposal.go#L29) in the `Proposal` message indicates which round the block received a polka.
-A negative value in the `POLRound` field indicates that the block has not previously been proposed on the network. 
+A negative value in the `POLRound` field indicates that the block has not previously been proposed on the network.
 Therefore the validation logic will check for timely when `POLRound < 0`.
 
 When a validator receives a `Proposal` message, the validator will check that the `Proposal.Timestamp` is at most `PRECISION` greater than the current Unix time known to the validator, and at minimum `PRECISION + MSGDELAY` less than the current Unix time known to the validator.
@@ -281,7 +254,7 @@ Validators already check that +2/3 prevotes were seen in `POLRound`, so this doe
 A validator will also check that the proposed timestamp is greater than the timestamp of the block for the previous height.
 If the timestamp is not greater than the previous block's timestamp, the block will not be considered valid, which is the same as the current logic.
 
-Additionally, this validation logic can be updated to check that the `Proposal.Timestamp` matches the `Header.Timestamp` of the proposed block, but it is less relevant since checking that votes were received is sufficient to ensure the block timestamp is correct. 
+Additionally, this validation logic can be updated to check that the `Proposal.Timestamp` matches the `Header.Timestamp` of the proposed block, but it is less relevant since checking that votes were received is sufficient to ensure the block timestamp is correct.
 
 ### Changes to the prevote step
 
@@ -289,7 +262,7 @@ Currently, a validator will prevote a proposal in one of three cases:
 
 * Case 1:  Validator has no locked block and receives a valid proposal.
 * Case 2:  Validator has a locked block and receives a valid proposal matching its locked block.
-* Case 3:  Validator has a locked block, sees a valid proposal not matching its locked block but sees +⅔ prevotes for the proposal’s block, either in the current round or in a round greater than or equal to the round in which it locked its locked block. 
+* Case 3:  Validator has a locked block, sees a valid proposal not matching its locked block but sees +2/3 prevotes for the proposal’s block, either in the current round or in a round greater than or equal to the round in which it locked its locked block.
 
 The only change we will make to the prevote step is to what a validator considers a valid proposal as detailed above.
 


### PR DESCRIPTION
closes: #7758 

This change performs the following:
* Removes the description of the non-proposers waiting
* Removes descriptions of the `Accuracy` parameter that no longer exists
* Corrects the inequality to properly reflect the `timely` check.
* Renames the consensus params to `SynchronyParams`
* Minor cosmetic fixes.