### PR TITLE
light: remove legacy timeout scheme

### DIFF
--- a/light/client.go
+++ b/light/client.go
@@ -52,8 +52,6 @@ const (
 
 	// 10s is sufficient for most networks.
 	defaultMaxBlockLag = 10 * time.Second
-
-	defaultProviderTimeout = 10 * time.Second
 )
 
 // Option sets a parameter for the light client.
@@ -113,12 +111,6 @@ func MaxBlockLag(d time.Duration) Option {
 	return func(c *Client) { c.maxBlockLag = d }
 }
 
-// Provider timeout is the maximum time that the light client will wait for a
-// provider to respond with a light block.
-func ProviderTimeout(d time.Duration) Option {
-	return func(c *Client) { c.providerTimeout = d }
-}
-
 // Client represents a light client, connected to a single chain, which gets
 // light blocks from a primary provider, verifies them either sequentially or by
 // skipping some and stores them in a trusted store (usually, a local FS).
@@ -131,7 +123,6 @@ type Client struct {
 	trustLevel       tmmath.Fraction
 	maxClockDrift    time.Duration
 	maxBlockLag      time.Duration
-	providerTimeout  time.Duration
 
 	// Mutex for locking during changes of the light clients providers
 	providerMutex sync.Mutex
@@ -203,7 +194,6 @@ func NewClient(
 		trustLevel:       DefaultTrustLevel,
 		maxClockDrift:    defaultMaxClockDrift,
 		maxBlockLag:      defaultMaxBlockLag,
-		providerTimeout:  defaultProviderTimeout,
 		pruningSize:      defaultPruningSize,
 		logger:           log.NewNopLogger(),
 	}
@@ -696,9 +686,7 @@ func (c *Client) verifySkipping(
 			if depth == len(blockCache)-1 {
 				// schedule what the next height we need to fetch is
 				pivotHeight := c.schedule(verifiedBlock.Height, blockCache[depth].Height)
-				subCtx, cancel := context.WithTimeout(ctx, c.providerTimeout)
-				defer cancel()
-				interimBlock, providerErr := c.getLightBlock(subCtx, source, pivotHeight)
+				interimBlock, providerErr := c.getLightBlock(ctx, source, pivotHeight)
 				if providerErr != nil {
 					return nil, ErrVerificationFailed{From: verifiedBlock.Height, To: pivotHeight, Reason: providerErr}
 				}
@@ -963,10 +951,8 @@ func (c *Client) lightBlockFromPrimary(ctx context.Context, height int64) (*type
 }
 
 func (c *Client) getLightBlock(ctx context.Context, p provider.Provider, height int64) (*types.LightBlock, error) {
-	subCtx, cancel := context.WithTimeout(ctx, c.providerTimeout)
-	defer cancel()
-	l, err := p.LightBlock(subCtx, height)
-	if err == context.DeadlineExceeded || ctx.Err() != nil {
+	l, err := p.LightBlock(ctx, height)
+	if ctx.Err() != nil {
 		return nil, provider.ErrNoResponse
 	}
 	return l, err
@@ -1015,15 +1001,15 @@ func (c *Client) findNewPrimary(ctx context.Context, height int64, remove bool) 
 		wg                sync.WaitGroup
 	)
 
-	// send out a light block request to all witnesses
-	subctx, cancel := context.WithTimeout(ctx, c.providerTimeout)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	// send out a light block request to all witnesses
 	for index := range c.witnesses {
 		wg.Add(1)
 		go func(witnessIndex int, witnessResponsesC chan witnessResponse) {
 			defer wg.Done()
 
-			lb, err := c.witnesses[witnessIndex].LightBlock(subctx, height)
+			lb, err := c.witnesses[witnessIndex].LightBlock(ctx, height)
 			select {
 			case witnessResponsesC <- witnessResponse{lb, witnessIndex, err}:
 			case <-ctx.Done():


### PR DESCRIPTION
Contexts should be enough for callers to specify timeouts moving forward.

This should resolve #7774