### PR TITLE
types: add string format to 64-bit integer JSON fields

### DIFF
--- a/rpc/coretypes/responses.go
+++ b/rpc/coretypes/responses.go
@@ -208,7 +208,7 @@ type ResultValidators struct {
 
 // ConsensusParams for given height
 type ResultConsensusParams struct {
-	BlockHeight     int64                 `json:"block_height"`
+	BlockHeight     int64                 `json:"block_height,string"`
 	ConsensusParams types.ConsensusParams `json:"consensus_params"`
 }
 

--- a/types/block_meta.go
+++ b/types/block_meta.go
@@ -11,9 +11,9 @@ import (
 // BlockMeta contains meta information.
 type BlockMeta struct {
 	BlockID   BlockID `json:"block_id"`
-	BlockSize int     `json:"block_size"`
+	BlockSize int     `json:"block_size,string"`
 	Header    Header  `json:"header"`
-	NumTxs    int     `json:"num_txs"`
+	NumTxs    int     `json:"num_txs,string"`
 }
 
 // NewBlockMeta returns a new BlockMeta.

--- a/types/events.go
+++ b/types/events.go
@@ -124,7 +124,7 @@ func (EventDataNewBlock) TypeTag() string { return "tendermint/event/NewBlock" }
 type EventDataNewBlockHeader struct {
 	Header Header `json:"header"`
 
-	NumTxs           int64                   `json:"num_txs"` // Number of txs in a block
+	NumTxs           int64                   `json:"num_txs,string"` // Number of txs in a block
 	ResultBeginBlock abci.ResponseBeginBlock `json:"result_begin_block"`
 	ResultEndBlock   abci.ResponseEndBlock   `json:"result_end_block"`
 }
@@ -135,7 +135,7 @@ func (EventDataNewBlockHeader) TypeTag() string { return "tendermint/event/NewBl
 type EventDataNewEvidence struct {
 	Evidence Evidence `json:"evidence"`
 
-	Height int64 `json:"height"`
+	Height int64 `json:"height,string"`
 }
 
 // TypeTag implements the required method of jsontypes.Tagged.
@@ -151,7 +151,7 @@ func (EventDataTx) TypeTag() string { return "tendermint/event/Tx" }
 
 // NOTE: This goes into the replay WAL
 type EventDataRoundState struct {
-	Height int64  `json:"height"`
+	Height int64  `json:"height,string"`
 	Round  int32  `json:"round"`
 	Step   string `json:"step"`
 }
@@ -165,7 +165,7 @@ type ValidatorInfo struct {
 }
 
 type EventDataNewRound struct {
-	Height int64  `json:"height"`
+	Height int64  `json:"height,string"`
 	Round  int32  `json:"round"`
 	Step   string `json:"step"`
 
@@ -176,7 +176,7 @@ type EventDataNewRound struct {
 func (EventDataNewRound) TypeTag() string { return "tendermint/event/NewRound" }
 
 type EventDataCompleteProposal struct {
-	Height int64  `json:"height"`
+	Height int64  `json:"height,string"`
 	Round  int32  `json:"round"`
 	Step   string `json:"step"`
 
@@ -209,7 +209,7 @@ func (EventDataValidatorSetUpdates) TypeTag() string { return "tendermint/event/
 // height when the node state sync mechanism changes.
 type EventDataBlockSyncStatus struct {
 	Complete bool  `json:"complete"`
-	Height   int64 `json:"height"`
+	Height   int64 `json:"height,string"`
 }
 
 // TypeTag implements the required method of jsontypes.Tagged.
@@ -219,7 +219,7 @@ func (EventDataBlockSyncStatus) TypeTag() string { return "tendermint/event/Fast
 // height when the node state sync mechanism changes.
 type EventDataStateSyncStatus struct {
 	Complete bool  `json:"complete"`
-	Height   int64 `json:"height"`
+	Height   int64 `json:"height,string"`
 }
 
 // TypeTag implements the required method of jsontypes.Tagged.


### PR DESCRIPTION
This picks up a few remaining cases that I missed during my previous round of
adding these tags.
