### PR TITLE
mempool: remove duplicate tx message from reactor logs

### DIFF
--- a/internal/mempool/reactor.go
+++ b/internal/mempool/reactor.go
@@ -163,7 +163,18 @@ func (r *Reactor) handleMempoolMessage(ctx context.Context, envelope *p2p.Envelo
 
 		for _, tx := range protoTxs {
 			if err := r.mempool.CheckTx(ctx, types.Tx(tx), nil, txInfo); err != nil {
-				logger.Error("checktx failed for tx", "tx", fmt.Sprintf("%X", types.Tx(tx).Hash()), "err", err)
+				if errors.Is(err, types.ErrTxInCache) {
+					// if the tx is in the cache,
+					// then we've been gossiped a
+					// Tx that we've already
+					// got. Gossip should be
+					// smarter, but it's not a
+					// problem.
+					continue
+				}
+				logger.Error("checktx failed for tx",
+					"tx", fmt.Sprintf("%X", types.Tx(tx).Hash()),
+					"err", err)
 			}
 		}
 


### PR DESCRIPTION
The incidence of this message increased a bunch in recent days because
we're returning this error in more cases now. There's no real need to
log it in any case, but particularly this one.