### PR TITLE
docs: fix RPC output examples for GET queries

### DIFF
--- a/docs/app-dev/getting-started.md
+++ b/docs/app-dev/getting-started.md
@@ -96,25 +96,21 @@ like:
 
 ```json
 {
-  "jsonrpc": "2.0",
-  "id": "",
-  "result": {
-    "check_tx": {},
-    "deliver_tx": {
-      "tags": [
-        {
-          "key": "YXBwLmNyZWF0b3I=",
-          "value": "amFl"
-        },
-        {
-          "key": "YXBwLmtleQ==",
-          "value": "YWJjZA=="
-        }
-      ]
-    },
-    "hash": "9DF66553F98DE3C26E3C3317A3E4CED54F714E39",
-    "height": 14
-  }
+  "check_tx": { ... },
+  "deliver_tx": {
+    "tags": [
+      {
+        "key": "YXBwLmNyZWF0b3I=",
+        "value": "amFl"
+      },
+      {
+        "key": "YXBwLmtleQ==",
+        "value": "YWJjZA=="
+      }
+    ]
+  },
+  "hash": "9DF66553F98DE3C26E3C3317A3E4CED54F714E39",
+  "height": 14
 }
 ```
 
@@ -129,15 +125,11 @@ The result should look like:
 
 ```json
 {
-  "jsonrpc": "2.0",
-  "id": "",
-  "result": {
-    "response": {
-      "log": "exists",
-      "index": "-1",
-      "key": "YWJjZA==",
-      "value": "YWJjZA=="
-    }
+  "response": {
+    "log": "exists",
+    "index": "-1",
+    "key": "YWJjZA==",
+    "value": "YWJjZA=="
   }
 }
 ```

--- a/docs/tendermint-core/subscription.md
+++ b/docs/tendermint-core/subscription.md
@@ -22,12 +22,12 @@ method via Websocket along with a valid query.
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "method": "subscribe",
-    "id": 0,
-    "params": {
-        "query": "tm.event='NewBlock'"
-    }
+  "jsonrpc": "2.0",
+  "method": "subscribe",
+  "id": 0,
+  "params": {
+    "query": "tm.event='NewBlock'"
+  }
 }
 ```
 
@@ -50,26 +50,26 @@ Response:
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "id": 0,
-    "result": {
-        "query": "tm.event='ValidatorSetUpdates'",
-        "data": {
-            "type": "tendermint/event/ValidatorSetUpdates",
-            "value": {
-              "validator_updates": [
-                {
-                  "address": "09EAD022FD25DE3A02E64B0FE9610B1417183EE4",
-                  "pub_key": {
-                    "type": "tendermint/PubKeyEd25519",
-                    "value": "ww0z4WaZ0Xg+YI10w43wTWbBmM3dpVza4mmSQYsd0ck="
-                  },
-                  "voting_power": "10",
-                  "proposer_priority": "0"
-                }
-              ]
-            }
-        }
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "query": "tm.event='ValidatorSetUpdates'",
+    "data": {
+      "type": "tendermint/event/ValidatorSetUpdates",
+      "value": {
+        "validator_updates": [
+          {
+            "address": "09EAD022FD25DE3A02E64B0FE9610B1417183EE4",
+            "pub_key": {
+              "type": "tendermint/PubKeyEd25519",
+              "value": "ww0z4WaZ0Xg+YI10w43wTWbBmM3dpVza4mmSQYsd0ck="
+            },
+            "voting_power": "10",
+            "proposer_priority": "0"
+          }
+        ]
+      }
     }
+  }
 }
 ```

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -47,8 +47,8 @@ definition](https://github.com/tendermint/tendermint/blob/master/types/genesis.g
 - `chain_id`: ID of the blockchain. **This must be unique for
   every blockchain.** If your testnet blockchains do not have unique
   chain IDs, you will have a bad time. The ChainID must be less than 50 symbols.
-- `initial_height`: Height at which Tendermint should begin at. If a blockchain is conducting a network upgrade, 
-    starting from the stopped height brings uniqueness to previous heights. 
+- `initial_height`: Height at which Tendermint should begin at. If a blockchain is conducting a network upgrade,
+    starting from the stopped height brings uniqueness to previous heights.
 - `consensus_params` [spec](https://github.com/tendermint/spec/blob/master/spec/core/state.md#consensusparams)
     - `block`
         - `max_bytes`: Max block size, in bytes.

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -47,7 +47,7 @@ definition](https://github.com/tendermint/tendermint/blob/master/types/genesis.g
 - `chain_id`: ID of the blockchain. **This must be unique for
   every blockchain.** If your testnet blockchains do not have unique
   chain IDs, you will have a bad time. The ChainID must be less than 50 symbols.
-- `initial_height`: Height at which Tendermint should begin at. If a blockchain is conducting a network upgrade,
+- `initial_height`: Height at which Tendermint should begin. If a blockchain is conducting a network upgrade,
     starting from the stopped height brings uniqueness to previous heights.
 - `consensus_params` [spec](https://github.com/tendermint/spec/blob/master/spec/core/state.md#consensusparams)
     - `block`

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -23,7 +23,7 @@ yourself with the syntax.
 By following along with this guide, you'll create a Tendermint Core project
 called kvstore, a (very) simple distributed BFT key-value store.
 
-> Note: please use a released version of Tendermint with this guide. The guides will work with the latest version. Please, do not use master. 
+> Note: please use a released version of Tendermint with this guide. The guides will work with the latest version. Please, do not use master.
 
 ## Built-in app vs external app
 
@@ -57,7 +57,7 @@ go mod init github.com/<github_username>/<repo_name>
 
 Inside the example directory create a `main.go` file with the following content:
 
-> Note: there is no need to clone or fork Tendermint in this tutorial. 
+> Note: there is no need to clone or fork Tendermint in this tutorial.
 
 ```go
 package main
@@ -642,16 +642,13 @@ Now open another tab in your terminal and try sending a transaction:
 ```bash
 $ curl -s 'localhost:26657/broadcast_tx_commit?tx="tendermint=rocks"'
 {
-  "jsonrpc": "2.0",
-  "id": "",
-  "result": {
-    "check_tx": {
-      "gasWanted": "1"
-    },
-    "deliver_tx": {},
-    "hash": "1B3C5A1093DB952C331B1749A21DCCBB0F6C7F4E0055CD04D16346472FC60EC6",
-    "height": "128"
-  }
+  "check_tx": {
+    "gasWanted": "1",
+    ...
+  },
+  "deliver_tx": { ... },
+  "hash": "1B3C5A1093DB952C331B1749A21DCCBB0F6C7F4E0055CD04D16346472FC60EC6",
+  "height": "128"
 }
 ```
 
@@ -662,14 +659,16 @@ Now let's check if the given key now exists and its value:
 ```json
 $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 {
-  "jsonrpc": "2.0",
-  "id": "",
-  "result": {
-    "response": {
-      "log": "exists",
-      "key": "dGVuZGVybWludA==",
-      "value": "cm9ja3M="
-    }
+  "response": {
+    "code": 0,
+    "log": "exists",
+    "info": "",
+    "index": "0",
+    "key": "dGVuZGVybWludA==",
+    "value": "cm9ja3M=",
+    "proofOps": null,
+    "height": "6",
+    "codespace": ""
   }
 }
 ```

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -526,17 +526,15 @@ I[2019-07-16|18:26:20.330] Accepted a new connection
 Now open another tab in your terminal and try sending a transaction:
 
 ```json
-curl -s 'localhost:26657/broadcast_tx_commit?tx="tendermint=rocks"'
+$ curl -s 'localhost:26657/broadcast_tx_commit?tx="tendermint=rocks"'
 {
-  "jsonrpc": "2.0",
-  "id": "",
-  "result": {
-    "check_tx": {
-      "gasWanted": "1"
-    },
-    "deliver_tx": {},
-    "hash": "CDD3C6DFA0A08CAEDF546F9938A2EEC232209C24AA0E4201194E0AFB78A2C2BB",
-    "height": "33"
+  "check_tx": {
+    "gasWanted": "1",
+    ...
+  },
+  "deliver_tx": { ... },
+  "hash": "CDD3C6DFA0A08CAEDF546F9938A2EEC232209C24AA0E4201194E0AFB78A2C2BB",
+  "height": "33"
 }
 ```
 
@@ -545,16 +543,18 @@ Response should contain the height where this transaction was committed.
 Now let's check if the given key now exists and its value:
 
 ```json
-curl -s 'localhost:26657/abci_query?data="tendermint"'
+$ curl -s 'localhost:26657/abci_query?data="tendermint"'
 {
-  "jsonrpc": "2.0",
-  "id": "",
-  "result": {
-    "response": {
-      "log": "exists",
-      "key": "dGVuZGVybWludA==",
-      "value": "cm9ja3My"
-    }
+  "response": {
+    "code": 0,
+    "log": "exists",
+    "info": "",
+    "index": "0",
+    "key": "dGVuZGVybWludA==",
+    "value": "cm9ja3M=",
+    "proofOps": null,
+    "height": "6",
+    "codespace": ""
   }
 }
 ```


### PR DESCRIPTION
Remove JSON-RPC wrappers from GET output, since they are no longer printed.
Also format examples with jq so they look a little neater.

Fixes #7779.