### PR TITLE
libs/cli: clean up package

### DIFF
--- a/cmd/tendermint/commands/completion.go
+++ b/cmd/tendermint/commands/completion.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCompletionCmd returns a cobra.Command that generates bash and zsh
+// completion scripts for the given root command. If hidden is true, the
+// command will not show up in the root command's list of available commands.
+func NewCompletionCmd(rootCmd *cobra.Command, hidden bool) *cobra.Command {
+	flagZsh := "zsh"
+	cmd := &cobra.Command{
+		Use:   "completion",
+		Short: "Generate shell completion scripts",
+		Long: fmt.Sprintf(`Generate Bash and Zsh completion scripts and print them to STDOUT.
+
+Once saved to file, a completion script can be loaded in the shell's
+current session as shown:
+
+   $ . <(%s completion)
+
+To configure your bash shell to load completions for each session add to
+your $HOME/.bashrc or $HOME/.profile the following instruction:
+
+   . <(%s completion)
+`, rootCmd.Use, rootCmd.Use),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			zsh, err := cmd.Flags().GetBool(flagZsh)
+			if err != nil {
+				return err
+			}
+			if zsh {
+				return rootCmd.GenZshCompletion(cmd.OutOrStdout())
+			}
+			return rootCmd.GenBashCompletion(cmd.OutOrStdout())
+		},
+		Hidden: hidden,
+		Args:   cobra.NoArgs,
+	}
+
+	cmd.Flags().Bool(flagZsh, false, "Generate Zsh completion script")
+
+	return cmd
+}

--- a/cmd/tendermint/commands/root_test.go
+++ b/cmd/tendermint/commands/root_test.go
@@ -17,6 +17,17 @@ import (
 	tmos "github.com/tendermint/tendermint/libs/os"
 )
 
+// writeConfigVals writes a toml file with the given values.
+// It returns an error if writing was impossible.
+func writeConfigVals(dir string, vals map[string]string) error {
+	data := ""
+	for k, v := range vals {
+		data += fmt.Sprintf("%s = \"%s\"\n", k, v)
+	}
+	cfile := filepath.Join(dir, "config.toml")
+	return os.WriteFile(cfile, []byte(data), 0600)
+}
+
 // clearConfig clears env vars, the given root dir, and resets viper.
 func clearConfig(t *testing.T, dir string) *cfg.Config {
 	t.Helper()
@@ -142,7 +153,7 @@ func TestRootConfig(t *testing.T) {
 
 			// write the non-defaults to a different path
 			// TODO: support writing sub configs so we can test that too
-			err = WriteConfigVals(configFilePath, cvals)
+			err = writeConfigVals(configFilePath, cvals)
 			require.NoError(t, err)
 
 			cmd := testRootCmd(conf)

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/tendermint/tendermint/cmd/tendermint/commands"
 	"github.com/tendermint/tendermint/cmd/tendermint/commands/debug"
 	"github.com/tendermint/tendermint/config"
-	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/node"
 )
@@ -44,7 +43,7 @@ func main() {
 		commands.MakeRollbackStateCommand(conf),
 		commands.MakeKeyMigrateCommand(conf, logger),
 		debug.DebugCmd,
-		cli.NewCompletionCmd(rcmd, true),
+		commands.NewCompletionCmd(rcmd, true),
 	)
 
 	// NOTE:

--- a/libs/cli/helper.go
+++ b/libs/cli/helper.go
@@ -1,29 +1,16 @@
 package cli
 
 import (
-	"bytes"
-	"fmt"
-	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
 
-// WriteConfigVals writes a toml file with the given values.
-// It returns an error if writing was impossible.
-func WriteConfigVals(dir string, vals map[string]string) error {
-	data := ""
-	for k, v := range vals {
-		data += fmt.Sprintf("%s = \"%s\"\n", k, v)
-	}
-	cfile := filepath.Join(dir, "config.toml")
-	return os.WriteFile(cfile, []byte(data), 0600)
-}
-
 // RunWithArgs executes the given command with the specified command line args
 // and environmental variables set. It returns any error returned from cmd.Execute()
-func RunWithArgs(cmd Executable, args []string, env map[string]string) error {
+//
+// This is only used in testing.
+func RunWithArgs(cmd *cobra.Command, args []string, env map[string]string) error {
 	oargs := os.Args
 	oenv := map[string]string{}
 	// defer returns the environment back to normal
@@ -47,84 +34,4 @@ func RunWithArgs(cmd Executable, args []string, env map[string]string) error {
 
 	// and finally run the command
 	return cmd.Execute()
-}
-
-// RunCaptureWithArgs executes the given command with the specified command
-// line args and environmental variables set. It returns string fields
-// representing output written to stdout and stderr, additionally any error
-// from cmd.Execute() is also returned
-func RunCaptureWithArgs(cmd Executable, args []string, env map[string]string) (stdout, stderr string, err error) {
-	oldout, olderr := os.Stdout, os.Stderr // keep backup of the real stdout
-	rOut, wOut, _ := os.Pipe()
-	rErr, wErr, _ := os.Pipe()
-	os.Stdout, os.Stderr = wOut, wErr
-	defer func() {
-		os.Stdout, os.Stderr = oldout, olderr // restoring the real stdout
-	}()
-
-	// copy the output in a separate goroutine so printing can't block indefinitely
-	copyStd := func(reader *os.File) *(chan string) {
-		stdC := make(chan string)
-		go func() {
-			var buf bytes.Buffer
-			// io.Copy will end when we call reader.Close() below
-			io.Copy(&buf, reader) //nolint:errcheck //ignore error
-			select {
-			case <-cmd.Context().Done():
-			case stdC <- buf.String():
-			}
-		}()
-		return &stdC
-	}
-	outC := copyStd(rOut)
-	errC := copyStd(rErr)
-
-	// now run the command
-	err = RunWithArgs(cmd, args, env)
-
-	// and grab the stdout to return
-	wOut.Close()
-	wErr.Close()
-	stdout = <-*outC
-	stderr = <-*errC
-	return stdout, stderr, err
-}
-
-// NewCompletionCmd returns a cobra.Command that generates bash and zsh
-// completion scripts for the given root command. If hidden is true, the
-// command will not show up in the root command's list of available commands.
-func NewCompletionCmd(rootCmd *cobra.Command, hidden bool) *cobra.Command {
-	flagZsh := "zsh"
-	cmd := &cobra.Command{
-		Use:   "completion",
-		Short: "Generate shell completion scripts",
-		Long: fmt.Sprintf(`Generate Bash and Zsh completion scripts and print them to STDOUT.
-
-Once saved to file, a completion script can be loaded in the shell's
-current session as shown:
-
-   $ . <(%s completion)
-
-To configure your bash shell to load completions for each session add to
-your $HOME/.bashrc or $HOME/.profile the following instruction:
-
-   . <(%s completion)
-`, rootCmd.Use, rootCmd.Use),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			zsh, err := cmd.Flags().GetBool(flagZsh)
-			if err != nil {
-				return err
-			}
-			if zsh {
-				return rootCmd.GenZshCompletion(cmd.OutOrStdout())
-			}
-			return rootCmd.GenBashCompletion(cmd.OutOrStdout())
-		},
-		Hidden: hidden,
-		Args:   cobra.NoArgs,
-	}
-
-	cmd.Flags().Bool(flagZsh, false, "Generate Zsh completion script")
-
-	return cmd
 }


### PR DESCRIPTION
This is a first stab at cleaninung up a package that I'd like to
delete as possible, but this avoids breaking the API (and callers in
the SDK) and just shaves off the unneccessary bits. In the future most
of these functions can and should move to `cmd/tendermint/commands` or
similar, and maybe we would consider breaking that in this release but
I think it's good to keep this patch clean of those details.