### PR TITLE
Silence a staticcheck warning.

### DIFF
--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tendermint/tendermint/internal/jsontypes"
 
 	// necessary for Bitcoin address format
-	"golang.org/x/crypto/ripemd160" // nolint
+	"golang.org/x/crypto/ripemd160" //nolint:staticcheck
 )
 
 //-------------------------------------


### PR DESCRIPTION
There was a nolint directive on this deprecated import, which golangci-lint
complains about being unnecessary. However, removing it angers staticcheck,
which enforces deprecation warnings.

Use the right syntax to make both equally unhappy.
