### PR TITLE
indexer: skip Docker tests when Docker is not available

### DIFF
--- a/internal/state/indexer/indexer_service_test.go
+++ b/internal/state/indexer/indexer_service_test.go
@@ -137,6 +137,9 @@ func setupDB(t *testing.T) (*dockertest.Pool, error) {
 	t.Helper()
 	pool, err := dockertest.NewPool(os.Getenv("DOCKER_URL"))
 	assert.NoError(t, err)
+	if _, err := pool.Client.Info(); err != nil {
+		t.Skipf("WARNING: Docker is not available: %v [skipping this test]", err)
+	}
 
 	resource, err = pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "postgres",

--- a/internal/state/indexer/sink/psql/psql_test.go
+++ b/internal/state/indexer/sink/psql/psql_test.go
@@ -52,12 +52,19 @@ const (
 func TestMain(m *testing.M) {
 	flag.Parse()
 
-	// Set up docker and start a container running PostgreSQL.
+	// Set up docker.
 	pool, err := dockertest.NewPool(os.Getenv("DOCKER_URL"))
 	if err != nil {
 		log.Fatalf("Creating docker pool: %v", err)
 	}
 
+	// If docker is unavailable, log and exit without reporting failure.
+	if _, err := pool.Client.Info(); err != nil {
+		log.Printf("WARNING: Docker is not available: %v [skipping this test]", err)
+		return
+	}
+
+	// Start a container running PostgreSQL.
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "postgres",
 		Tag:        "13",


### PR DESCRIPTION
To simplify local testing, do not report failures for tests that require Docker
when Docker is not avaliable. Instead, log a warning and skip the tests.
This has no effect in CI, where Docker is installed.
