### PR TITLE
pubsub: check for termination in UnsubscribeAll

### DIFF
--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -281,6 +281,9 @@ func (s *Server) UnsubscribeAll(ctx context.Context, clientID string) error {
 	s.subs.Lock()
 	defer s.subs.Unlock()
 
+	if s.subs.index == nil {
+		return ErrServerStopped
+	}
 	evict := s.subs.index.findClientID(clientID)
 	if len(evict) == 0 {
 		return ErrSubscriptionNotFound


### PR DESCRIPTION
This check was correctly handled in Unsubscribe, but not UnsubscribeAll.
