### PR TITLE
docs: fix broken markdown links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ To get started quickly with an example application, see the [quick start guide](
 To learn about application development on Tendermint, see the [Application Blockchain Interface](https://github.com/tendermint/spec/tree/master/spec/abci).
 
 For more details on using Tendermint, see the respective documentation for
-[Tendermint Core](tendermint-core/), [benchmarking and monitoring](tools/), and [network deployments](networks/).
+[Tendermint Core](tendermint-core/), [benchmarking and monitoring](tools/), and [network deployments](nodes/).
 
 To find out about the Tendermint ecosystem you can go [here](https://github.com/tendermint/awesome#ecosystem). If you are a project that is using Tendermint you are welcome to make a PR to add your project to the list.
 

--- a/docs/architecture/adr-001-logging.md
+++ b/docs/architecture/adr-001-logging.md
@@ -213,4 +213,4 @@ type Logger interface {
 }
 ```
 
-See [The Hunt for a Logger Interface](https://go-talks.appspot.com/github.com/ChrisHines/talks/structured-logging/structured-logging.slide). The advantage is greater composability (check out how go-kit defines colored logging or log-leveled logging on top of this interface https://github.com/go-kit/kit/tree/master/log).
+See [The Hunt for a Logger Interface](https://web.archive.org/web/20210902161539/https://go-talks.appspot.com/github.com/ChrisHines/talks/structured-logging/structured-logging.slide#1). The advantage is greater composability (check out how go-kit defines colored logging or log-leveled logging on top of this interface https://github.com/go-kit/kit/tree/master/log).

--- a/docs/architecture/adr-044-lite-client-with-weak-subjectivity.md
+++ b/docs/architecture/adr-044-lite-client-with-weak-subjectivity.md
@@ -84,7 +84,7 @@ The linear verification algorithm requires downloading all headers
 between the `TrustHeight` and the `LatestHeight`. The lite client downloads the
 full header for the provided `TrustHeight` and then proceeds to download `N+1`
 headers and applies the [Tendermint validation
-rules](https://docs.tendermint.com/master/spec/blockchain/blockchain.html#validation)
+rules](https://docs.tendermint.com/master/spec/light-client/verification/)
 to each block.
 
 ### Bisecting Verification

--- a/docs/architecture/adr-069-flexible-node-intitalization.md
+++ b/docs/architecture/adr-069-flexible-node-intitalization.md
@@ -252,11 +252,6 @@ N/A
 
 ## References
 
-- [this
-  branch](https://github.com/tendermint/tendermint/tree/tychoish/scratch-node-minimize)
-  contains experimental work in the implementation of the node package
-  to unwind some of the hard dependencies between components.
-
 - [the component
   graph](https://peter.bourgon.org/go-for-industrial-programming/#the-component-graph)
   as a framing for internal service construction.

--- a/docs/architecture/adr-073-libp2p.md
+++ b/docs/architecture/adr-073-libp2p.md
@@ -232,4 +232,4 @@ the implementation timeline.
 
 [adr61]: ./adr-061-p2p-refactor-scope.md
 [adr62]: ./adr-062-p2p-architecture.md
-[rfc]: ../rfc/rfc-000-p2p.rst
+[rfc]: ../rfc/rfc-000-p2p-roadmap.rst

--- a/docs/architecture/adr-078-nonzero-genesis.md
+++ b/docs/architecture/adr-078-nonzero-genesis.md
@@ -15,7 +15,7 @@
 ## Context
 
 The recommended upgrade path for block protocol-breaking upgrades is currently to hard fork the
-chain (see e.g. [`cosmoshub-3` upgrade](https://blog.cosmos.network/cosmos-hub-3-upgrade-announcement-39c9da941aee)).
+chain (see e.g. [`cosmoshub-3` upgrade](https://blog.cosmos.network/cosmos-hub-3-upgrade-announcement-39c9da941aee).
 This is done by halting all validators at a predetermined height, exporting the application
 state via application-specific tooling, and creating an entirely new chain using the exported
 application state.

--- a/docs/nodes/running-in-production.md
+++ b/docs/nodes/running-in-production.md
@@ -83,7 +83,7 @@ for more information.
 Rate-limiting and authentication are another key aspects to help protect
 against DOS attacks. Validators are supposed to use external tools like
 [NGINX](https://www.nginx.com/blog/rate-limiting-nginx/) or
-[traefik](https://docs.traefik.io/middlewares/ratelimit/)
+[traefik](https://doc.traefik.io/traefik/middlewares/http/ratelimit/)
 to achieve the same things.
 
 ## Debugging Tendermint

--- a/docs/tendermint-core/rpc.md
+++ b/docs/tendermint-core/rpc.md
@@ -8,13 +8,13 @@ The RPC documentation is hosted here:
 
 - [https://docs.tendermint.com/master/rpc/](https://docs.tendermint.com/master/rpc/)
 
-To update the documentation, edit the relevant `godoc` comments in the [rpc/core directory](https://github.com/tendermint/tendermint/tree/master/rpc/core).
+To update the documentation, edit the relevant `godoc` comments in the [rpc directory](https://github.com/tendermint/tendermint/tree/master/rpc).
 
 If you are using Tendermint in-process, you will need to set the version to be displayed in the RPC.
 
 If you are using a makefile with your go project, this can be done by using sed and `ldflags`.
 
-Example: 
+Example:
 
 ```
 VERSION := $(shell go list -m github.com/tendermint/tendermint | sed 's:.* ::')


### PR DESCRIPTION
For most cases I was able to find a new target. In one case the branch was
deleted, so I removed the link.

Updates #7675.

### Repro

```sh
find docs -type f -name '*.md' -print0 | \
  xargs -0 -n1 -t docker run -v ${PWD}:/tmp:ro --rm -i --workdir /tmp \
    -a stderr -a stdout ghcr.io/tcort/markdown-link-check:stable |& \
  grep -A1 -E '(FILE|ERROR):'
```