### PR TITLE
docs: remove unnecessary os.Exit calls at the end of main

### DIFF
--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -384,7 +384,6 @@ func main() {
  c := make(chan os.Signal, 1)
  signal.Notify(c, os.Interrupt, syscall.SIGTERM)
  <-c
- os.Exit(0)
 }
 ```
 
@@ -425,7 +424,6 @@ defer server.Stop()
 c := make(chan os.Signal, 1)
 signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 <-c
-os.Exit(0)
 ```
 
 ## 1.5 Getting Up and Running


### PR DESCRIPTION
The main function defers some things that do not run in the "normal" exit case
because we call os.Exit(0) explicitly. Since falling off the end of main does
the same thing, and also permits defers to run, let's do that.

Fixes #7852.