### PR TITLE
Update absolute links in v0.35.x to reference that branch.

### DIFF
--- a/docs/app-dev/abci-cli.md
+++ b/docs/app-dev/abci-cli.md
@@ -62,7 +62,7 @@ as `abci-cli` above. The kvstore just stores transactions in a merkle
 tree.
 
 Its code can be found
-[here](https://github.com/tendermint/tendermint/blob/master/abci/cmd/abci-cli/abci-cli.go)
+[here](https://github.com/tendermint/tendermint/blob/v0.35.x/abci/cmd/abci-cli/abci-cli.go)
 and looks like:
 
 ```go

--- a/docs/networks/docker-compose.md
+++ b/docs/networks/docker-compose.md
@@ -101,7 +101,7 @@ rm -rf ./build/node*
 
 ## Configuring ABCI containers
 
-To use your own ABCI applications with 4-node setup edit the [docker-compose.yaml](https://github.com/tendermint/tendermint/blob/master/docker-compose.yml) file and add image to your ABCI application.
+To use your own ABCI applications with 4-node setup edit the [docker-compose.yaml](https://github.com/tendermint/tendermint/blob/v0.35.x/docker-compose.yml) file and add image to your ABCI application.
 
 ```yml
  abci0:
@@ -150,7 +150,7 @@ To use your own ABCI applications with 4-node setup edit the [docker-compose.yam
 
 ```
 
-Override the [command](https://github.com/tendermint/tendermint/blob/master/networks/local/localnode/Dockerfile#L12) in each node to connect to it's ABCI.
+Override the [command](https://github.com/tendermint/tendermint/blob/v0.35.x/networks/local/localnode/Dockerfile#L12) in each node to connect to it's ABCI.
 
 ```yml
   node0:

--- a/docs/nodes/logging.md
+++ b/docs/nodes/logging.md
@@ -35,7 +35,7 @@ little overview what they do.
 - `abci-client` As mentioned in [Application Architecture Guide](../app-dev/app-architecture.md), Tendermint acts as an ABCI
   client with respect to the application and maintains 3 connections:
   mempool, consensus and query. The code used by Tendermint Core can
-  be found [here](https://github.com/tendermint/tendermint/tree/master/abci/client).
+  be found [here](https://github.com/tendermint/tendermint/blob/v0.35.x/abci/client).
 - `blockchain` Provides storage, pool (a group of peers), and reactor
   for both storing and exchanging blocks between peers.
 - `consensus` The heart of Tendermint core, which is the
@@ -43,7 +43,7 @@ little overview what they do.
   "submodules": `wal` (write-ahead logging) for ensuring data
   integrity and `replay` to replay blocks and messages on recovery
   from a crash.
-  [here](https://github.com/tendermint/tendermint/blob/master/types/events.go).
+  [here](https://github.com/tendermint/tendermint/blob/v0.35.x/types/events.go).
   You can subscribe to them by calling `subscribe` RPC method. Refer
   to [RPC docs](../tendermint-core/rpc.md) for additional information.
 - `mempool` Mempool module handles all incoming transactions, whenever
@@ -52,7 +52,7 @@ little overview what they do.
   more details, please check out the
   [README](https://github.com/tendermint/spec/tree/master/spec/p2p).
 - `rpc-server` RPC server. For implementation details, please read the
-  [doc.go](https://github.com/tendermint/tendermint/blob/master/rpc/jsonrpc/doc.go).
+  [doc.go](https://github.com/tendermint/tendermint/blob/v0.35.x/rpc/jsonrpc/doc.go).
 - `state` Represents the latest state and execution submodule, which
   executes blocks against the application.
 - `statesync` Provides a way to quickly sync a node with pruned history.

--- a/docs/tendermint-core/rpc.md
+++ b/docs/tendermint-core/rpc.md
@@ -8,7 +8,7 @@ The RPC documentation is hosted here:
 
 - [https://docs.tendermint.com/master/rpc/](https://docs.tendermint.com/master/rpc/)
 
-To update the documentation, edit the relevant `godoc` comments in the [rpc directory](https://github.com/tendermint/tendermint/tree/master/rpc).
+To update the documentation, edit the relevant `godoc` comments in the [rpc directory](https://github.com/tendermint/tendermint/blob/v0.35.x/rpc).
 
 If you are using Tendermint in-process, you will need to set the version to be displayed in the RPC.
 

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -579,7 +579,7 @@ library will deny making connections to peers with the same IP address.
 ### Upgrading
 
 See the
-[UPGRADING.md](https://github.com/tendermint/tendermint/blob/master/UPGRADING.md)
+[UPGRADING.md](https://github.com/tendermint/tendermint/blob/v0.35.x/UPGRADING.md)
 guide. You may need to reset your chain between major breaking releases.
 Although, we expect Tendermint to have fewer breaking releases in the future
 (especially after 1.0 release).


### PR DESCRIPTION
Updates #7675.

Repro:

    linkpatch -recur -target v0.35.x -skip-path docs/README.md,docs/DOCS_README.md \
      -skip-match 'docs/(rfc|architecture)/' docs
