### PR TITLE
Remove master from the docs site version config.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -33,10 +33,6 @@ module.exports = {
       {
         "label": "v0.35",
         "key": "v0.35"
-      },
-      {
-        "label": "master",
-        "key": "master"
       }
     ],
     topbar: {

--- a/docs/versions
+++ b/docs/versions
@@ -1,4 +1,3 @@
-master                  master
 v0.33.x                 v0.33
 v0.34.x                 v0.34
 v0.35.x                 v0.35


### PR DESCRIPTION
~We might want to do this for v0.33 also.~

Per the below we'll keep v0.33 for now. 