### PR TITLE
Update absolute links in v0.33.x to reference that branch.

### DIFF
--- a/docs/app-dev/abci-cli.md
+++ b/docs/app-dev/abci-cli.md
@@ -66,7 +66,7 @@ as `abci-cli` above. The kvstore just stores transactions in a merkle
 tree.
 
 Its code can be found
-[here](https://github.com/tendermint/tendermint/blob/master/abci/cmd/abci-cli/abci-cli.go)
+[here](https://github.com/tendermint/tendermint/blob/v0.33.x/abci/cmd/abci-cli/abci-cli.go)
 and looks like:
 
 ```
@@ -223,7 +223,7 @@ Now that we've got the hang of it, let's try another application, the
 "counter" app.
 
 Like the kvstore app, its code can be found
-[here](https://github.com/tendermint/tendermint/blob/master/abci/cmd/abci-cli/abci-cli.go)
+[here](https://github.com/tendermint/tendermint/blob/v0.33.x/abci/cmd/abci-cli/abci-cli.go)
 and looks like:
 
 ```

--- a/docs/networks/docker-compose.md
+++ b/docs/networks/docker-compose.md
@@ -84,7 +84,7 @@ rm -rf ./build/node*
 
 ## Configuring abci containers
 
-To use your own abci applications with 4-node setup edit the [docker-compose.yaml](https://github.com/tendermint/tendermint/blob/master/docker-compose.yml) file and add image to your abci application.
+To use your own abci applications with 4-node setup edit the [docker-compose.yaml](https://github.com/tendermint/tendermint/blob/v0.33.x/docker-compose.yml) file and add image to your abci application.
 
 ```
  abci0:
@@ -133,7 +133,7 @@ To use your own abci applications with 4-node setup edit the [docker-compose.yam
 
 ```
 
-Override the [command](https://github.com/tendermint/tendermint/blob/master/networks/local/localnode/Dockerfile#L12) in each node to connect to it's abci.
+Override the [command](https://github.com/tendermint/tendermint/blob/v0.33.x/networks/local/localnode/Dockerfile#L12) in each node to connect to it's abci.
 
 ```
   node0:
@@ -152,7 +152,7 @@ Override the [command](https://github.com/tendermint/tendermint/blob/master/netw
         ipv4_address: 192.167.10.2
 ```
 
-Similarly do for node1, node2 and node3 then [run testnet](https://github.com/tendermint/tendermint/blob/master/docs/networks/docker-compose.md#run-a-testnet)
+Similarly do for node1, node2 and node3 then [run testnet](https://github.com/tendermint/tendermint/blob/v0.33.x/docs/networks/docker-compose.md#run-a-testnet)
 
 ## Logging
 

--- a/docs/tendermint-core/how-to-read-logs.md
+++ b/docs/tendermint-core/how-to-read-logs.md
@@ -118,7 +118,7 @@ little overview what they do.
 - `abci-client` As mentioned in [Application Development Guide](../app-dev/app-development.md), Tendermint acts as an ABCI
   client with respect to the application and maintains 3 connections:
   mempool, consensus and query. The code used by Tendermint Core can
-  be found [here](https://github.com/tendermint/tendermint/tree/master/abci/client).
+  be found [here](https://github.com/tendermint/tendermint/blob/v0.33.x/abci/client).
 - `blockchain` Provides storage, pool (a group of peers), and reactor
   for both storing and exchanging blocks between peers.
 - `consensus` The heart of Tendermint core, which is the
@@ -128,17 +128,17 @@ little overview what they do.
   from a crash.
 - `events` Simple event notification system. The list of events can be
   found
-  [here](https://github.com/tendermint/tendermint/blob/master/types/events.go).
+  [here](https://github.com/tendermint/tendermint/blob/v0.33.x/types/events.go).
   You can subscribe to them by calling `subscribe` RPC method. Refer
   to [RPC docs](./rpc.md) for additional information.
 - `mempool` Mempool module handles all incoming transactions, whenever
   they are coming from peers or the application.
 - `p2p` Provides an abstraction around peer-to-peer communication. For
   more details, please check out the
-  [README](https://github.com/tendermint/tendermint/blob/master/p2p/README.md).
+  [README](https://github.com/tendermint/tendermint/blob/v0.33.x/p2p/README.md).
 - `rpc` [Tendermint's RPC](./rpc.md).
 - `rpc-server` RPC server. For implementation details, please read the
-  [doc.go](https://github.com/tendermint/tendermint/blob/master/rpc/lib/doc.go).
+  [doc.go](https://github.com/tendermint/tendermint/blob/v0.33.x/rpc/lib/doc.go).
 - `state` Represents the latest state and execution submodule, which
   executes blocks against the application.
 - `types` A collection of the publicly exposed types and methods to

--- a/docs/tendermint-core/rpc.md
+++ b/docs/tendermint-core/rpc.md
@@ -8,4 +8,4 @@ The RPC documentation is hosted here:
 
 - [https://docs.tendermint.com/master/rpc/](https://docs.tendermint.com/master/rpc/)
 
-To update the documentation, edit the relevant `godoc` comments in the [rpc/core directory](https://github.com/tendermint/tendermint/tree/master/rpc/core).
+To update the documentation, edit the relevant `godoc` comments in the [rpc/core directory](https://github.com/tendermint/tendermint/blob/v0.33.x/rpc/core).

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -552,7 +552,7 @@ library will deny making connections to peers with the same IP address.
 ### Upgrading
 
 See the
-[UPGRADING.md](https://github.com/tendermint/tendermint/blob/master/UPGRADING.md)
+[UPGRADING.md](https://github.com/tendermint/tendermint/blob/v0.33.x/UPGRADING.md)
 guide. You may need to reset your chain between major breaking releases.
 Although, we expect Tendermint to have fewer breaking releases in the future
 (especially after 1.0 release).


### PR DESCRIPTION
Updates #7675.

Repro:

    linkpatch -recur -target v0.33.x -skip-path docs/README.md,docs/DOCS_README.md \
      -skip-match 'docs/architecture/' docs
