### PR TITLE
docs: remove spec section from v0.35 docs

### DIFF
--- a/docs/post.sh
+++ b/docs/post.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 rm -rf ./.vuepress/public/rpc
-rm -rf ./spec

--- a/docs/pre.sh
+++ b/docs/pre.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 cp -a ../rpc/openapi/ .vuepress/public/rpc/
-git clone https://github.com/tendermint/spec.git specRepo && cp -r specRepo/spec . && rm -rf specRepo


### PR DESCRIPTION
Previously we cloned the spec repository and attached the markdown files to the docs site we host. This PR removes the spec section because:
1. It refers to the master version of the spec and thus could lead to confusion
2. Users should first rely on the externally facing documentation provided and only when necessary referto the more technical spec which they can see in github


