### PR TITLE
docs: Pin the RPC docs to v0.35 instead of master

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -45,8 +45,10 @@ module.exports = {
           title: 'Resources',
           children: [
             {
+              // TODO(creachadair): Figure out how to make this per-branch.
+              // See: https://github.com/tendermint/tendermint/issues/7908
               title: 'RPC',
-              path: 'https://docs.tendermint.com/master/rpc/',
+              path: 'https://docs.tendermint.com/v0.35/rpc/',
               static: true
             },
           ]


### PR DESCRIPTION
This is a temporary workaround for #7908.
