### PR TITLE
docs: Pin the RPC docs to v0.35 instead of master (#7909)

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -43,8 +43,10 @@ module.exports = {
               path: '/DEV_SESSIONS.html'
             },
             {
+              // TODO(creachadair): Figure out how to make this per-branch.
+              // See: https://github.com/tendermint/tendermint/issues/7908
               title: 'RPC',
-              path: 'https://docs.tendermint.com/master/rpc/',
+              path: 'https://docs.tendermint.com/v0.35/rpc/',
               static: true
             },
           ]


### PR DESCRIPTION
A manual cherry-pick of 3b20931da335fe9bbe707adc37313bccbe613192.