### PR TITLE
Restore building docs for master on docs.tendermint.com.

### DIFF
--- a/docs/versions
+++ b/docs/versions
@@ -1,3 +1,4 @@
+master                  master
 v0.33.x                 v0.33
 v0.34.x                 v0.34
 v0.35.x                 v0.35


### PR DESCRIPTION
There are a lot of existing links to the master section of the site, and my
attempts to get a redirector working have so far not succeeded. While it still
makes sense to not publish docs for unreleased code, a 404 is almost certainly
more disruptive than seeing docs for unreleased stuff.

This includes the docs in the build again, but does not add them back to the
selector menu. That allows URLs to resolve but encourages folks to use the
released versions when they have a choice.

I left the redirect for the RPC link in place, since that's still useful.

Updates #7935.