### PR TITLE
docs: point docs/master to the same content as the latest release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,9 @@ build-docs:
 		mkdir -p ~/output/$${path_prefix} ; \
 		cp -r .vuepress/dist/* ~/output/$${path_prefix}/ ; \
 		cp ~/output/$${path_prefix}/index.html ~/output ; \
-	done < versions ;
+	done < versions ; \
+	mkdir -p ~/output/master ; \
+	cp -r .vuepress/dist/* ~/output/master/
 .PHONY: build-docs
 
 ###############################################################################
@@ -329,4 +331,3 @@ split-test-packages:$(BUILDDIR)/packages.txt
 	split -d -n l/$(NUM_SPLIT) $< $<.
 test-group-%:split-test-packages
 	cat $(BUILDDIR)/packages.txt.$* | xargs go test -mod=readonly -timeout=5m -race -coverprofile=$(BUILDDIR)/$*.profile.out
-

--- a/docs/versions
+++ b/docs/versions
@@ -1,4 +1,3 @@
-master                  master
 v0.33.x                 v0.33
 v0.34.x                 v0.34
 v0.35.x                 v0.35


### PR DESCRIPTION
We originally tried to disable building docs for the master branch, but a lot of existing links pointed to that, so we reverted that change.

This is a different tactic, suggested by @cmwaters, where we point docs/master to the same data as the latest (default) release branch (the one listed "last" in the `versions` file).
