### PR TITLE
proxy: fix endblock metric

### DIFF
--- a/internal/proxy/app_conn.go
+++ b/internal/proxy/app_conn.go
@@ -105,7 +105,7 @@ func (app *appConnConsensus) EndBlockSync(
 	ctx context.Context,
 	req types.RequestEndBlock,
 ) (*types.ResponseEndBlock, error) {
-	defer addTimeSample(app.metrics.MethodTiming.With("method", "deliver_tx", "type", "sync"))()
+	defer addTimeSample(app.metrics.MethodTiming.With("method", "end_block", "type", "sync"))()
 	return app.appConn.EndBlockSync(ctx, req)
 }
 


### PR DESCRIPTION
Noticed this issue while working on the abci buffer problem. Merging here so that the fix can be part of v0.35.2