### PR TITLE
abci: use no-op loggers in the examples

### DIFF
--- a/abci/example/example_test.go
+++ b/abci/example/example_test.go
@@ -33,7 +33,7 @@ func TestKVStore(t *testing.T) {
 	defer cancel()
 	logger := log.NewNopLogger()
 
-	logger.Info("### Testing KVStore")
+	t.Log("### Testing KVStore")
 	testBulk(ctx, t, logger, kvstore.NewApplication())
 }
 
@@ -42,7 +42,7 @@ func TestBaseApp(t *testing.T) {
 	defer cancel()
 	logger := log.NewNopLogger()
 
-	logger.Info("### Testing BaseApp")
+	t.Log("### Testing BaseApp")
 	testBulk(ctx, t, logger, types.NewBaseApplication())
 }
 
@@ -52,7 +52,7 @@ func TestGRPC(t *testing.T) {
 
 	logger := log.NewNopLogger()
 
-	logger.Info("### Testing GRPC")
+	t.Log("### Testing GRPC")
 	testGRPCSync(ctx, t, logger, types.NewGRPCApplication(types.NewBaseApplication()))
 }
 

--- a/abci/example/example_test.go
+++ b/abci/example/example_test.go
@@ -31,7 +31,7 @@ func init() {
 func TestKVStore(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	logger.Info("### Testing KVStore")
 	testBulk(ctx, t, logger, kvstore.NewApplication())
@@ -40,7 +40,7 @@ func TestKVStore(t *testing.T) {
 func TestBaseApp(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	logger.Info("### Testing BaseApp")
 	testBulk(ctx, t, logger, types.NewBaseApplication())
@@ -50,7 +50,7 @@ func TestGRPC(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.NewTestingLogger(t)
+	logger := log.NewNopLogger()
 
 	logger.Info("### Testing GRPC")
 	testGRPCSync(ctx, t, logger, types.NewGRPCApplication(types.NewBaseApplication()))


### PR DESCRIPTION
This averts a rare but annoying log-after-test race condition.
