### PR TITLE
statesync: fix SyncAny test

### DIFF
--- a/internal/statesync/syncer_test.go
+++ b/internal/statesync/syncer_test.go
@@ -173,7 +173,7 @@ func TestSyncer_SyncAny(t *testing.T) {
 	// beginning. We also wait for a little while, to exercise the retry logic in fetchChunks().
 	connSnapshot.On("ApplySnapshotChunk", mock.Anything, abci.RequestApplySnapshotChunk{
 		Index: 2, Chunk: []byte{1, 1, 2},
-	}).Once().Run(func(args mock.Arguments) { time.Sleep(2 * time.Second) }).Return(
+	}).Once().Run(func(args mock.Arguments) { time.Sleep(1 * time.Second) }).Return(
 		&abci.ResponseApplySnapshotChunk{
 			Result:        abci.ResponseApplySnapshotChunk_RETRY_SNAPSHOT,
 			RefetchChunks: []uint32{1},


### PR DESCRIPTION
the perfectly 2-second sleep setup in line 176  let the `syncer.fetchChunks` has a small chance to refetch the chunk index1 
before the `syncer.applyChunks` returns the RETRY_SNAPSHOT error. it will let the fetchCtx be canceled and then make the goroutine cannot request the chunk.

the syncer.Sync might need a bit of refactor to tackle this case.

close #7644


