### PR TITLE
optimize State.receiveRoutine

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -876,8 +876,6 @@ func (cs *State) receiveRoutine(ctx context.Context, maxSteps int) {
 			}
 		}
 
-		rs := cs.RoundState
-
 		select {
 		case <-cs.txNotifier.TxsAvailable():
 			cs.handleTxsAvailable(ctx)
@@ -910,7 +908,7 @@ func (cs *State) receiveRoutine(ctx context.Context, maxSteps int) {
 
 			// if the timeout is relevant to the rs
 			// go to the next step
-			cs.handleTimeout(ctx, ti, rs)
+			cs.handleTimeout(ctx, ti, cs.RoundState)
 
 		case <-ctx.Done():
 			onExit(cs)

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -865,6 +865,8 @@ func (cs *State) receiveRoutine(ctx context.Context, maxSteps int) {
 		}
 	}()
 
+	var mi msgInfo
+
 	for {
 		if maxSteps > 0 {
 			if cs.nSteps >= maxSteps {
@@ -875,7 +877,6 @@ func (cs *State) receiveRoutine(ctx context.Context, maxSteps int) {
 		}
 
 		rs := cs.RoundState
-		var mi msgInfo
 
 		select {
 		case <-cs.txNotifier.TxsAvailable():


### PR DESCRIPTION
`mi` is always updated with the value received from channel, no need to allocate a new variable for each loop.

`rs` variable is not needed.