### PR TITLE
statesync: avoid compounding retry logic for fetching consensus parameters

### DIFF
--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -588,7 +588,7 @@ func TestReactor_StateProviderP2P(t *testing.T) {
 	require.NoError(t, err)
 	rts.reactor.syncer.stateProvider = rts.reactor.stateProvider
 
-	actx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	actx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
 	appHash, err := rts.reactor.stateProvider.AppHash(actx, 5)

--- a/internal/statesync/stateprovider.go
+++ b/internal/statesync/stateprovider.go
@@ -355,7 +355,7 @@ func (s *stateProviderP2P) addProvider(p lightprovider.Provider) {
 // until one is returned.
 //
 // It attempts to send requests to all witnesses in parallel, but if
-// non responds it will retry them all sometime later until it
+// none responds it will retry them all sometime later until it
 // receives some response. This operation will block until it receives
 // a response or the context is canceled.
 func (s *stateProviderP2P) consensusParams(ctx context.Context, height int64) (param types.ConsensusParams, err error) {


### PR DESCRIPTION
We're waiting between trying witnesses (which shouldn't be neccessary
because the witnesses shouldn't depend on each other,) and also
between *attempts*, and really the outer sleep should be enough.