### PR TITLE
Revert "build(deps): Bump golangci/golangci-lint-action from 2.5.2 to 3.1.0 (#8026)"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: golangci/golangci-lint-action@v3.1.0
+      - uses: golangci/golangci-lint-action@v2.5.2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.42.1


### PR DESCRIPTION
This reverts commit e4dced243727da5db4190741aa49a816ced41ada.

Caused inconsistent results, likely due to a caching problem.