### PR TITLE
consensus: validator set changes test cleanup

### DIFF
--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -397,8 +397,12 @@ func TestReactorBasic(t *testing.T) {
 	if err := ctx.Err(); errors.Is(err, context.DeadlineExceeded) {
 		t.Fatal("encountered timeout")
 	}
-	if err := <-errCh; err != nil {
-		t.Fatal(err)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	default:
 	}
 
 	errCh = make(chan error, len(rts.blocksyncSubs))
@@ -427,8 +431,13 @@ func TestReactorBasic(t *testing.T) {
 	if err := ctx.Err(); errors.Is(err, context.DeadlineExceeded) {
 		t.Fatal("encountered timeout")
 	}
-	if err := <-errCh; err != nil {
-		t.Fatal(err)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	default:
 	}
 }
 

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -188,6 +188,7 @@ func waitForAndValidateBlock(
 
 	ctx, cancel := context.WithCancel(bctx)
 	defer cancel()
+
 	fn := func(j int) {
 		msg, err := blocksSubs[j].Next(ctx)
 		switch {
@@ -196,8 +197,8 @@ func waitForAndValidateBlock(
 		case errors.Is(err, context.Canceled):
 			return
 		case err != nil:
-			t.Fatalf("problem waiting for %d subscription: %v", j, err)
 			cancel() // terminate other workers
+			require.NoError(t, err)
 			return
 		}
 
@@ -252,8 +253,8 @@ func waitForAndValidateBlockWithTx(
 			case errors.Is(err, context.Canceled):
 				return
 			case err != nil:
-				t.Fatalf("problem waiting for %d subscription: %v", j, err)
 				cancel() // terminate other workers
+				t.Fatalf("problem waiting for %d subscription: %v", j, err)
 				return
 			}
 
@@ -312,8 +313,8 @@ func waitForBlockWithUpdatedValsAndValidateIt(
 			case errors.Is(err, context.Canceled):
 				return
 			case err != nil:
-				t.Fatalf("problem waiting for %d subscription: %v", j, err)
 				cancel() // terminate other workers
+				t.Fatalf("problem waiting for %d subscription: %v", j, err)
 				return
 			}
 


### PR DESCRIPTION
This is mostly an extremely small change where I double a somewhat
arbitrarly set timeout from 1m to 2m for an entire test. When I put
these timeouts in the test, they were arbitrary based on my local
performance (which is quite fact,) and I expected that they'd need to
be tweaked in the future.

A big chunk of this PR is reworking a collection of helper functions
that produce somewhat intractable messages when a test fails, so that
the error messages take up less vertical space, hopefully without
losing any debugability.