### PR TITLE
Revert "Remove master from versions and copy it from the latest."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,9 +222,7 @@ build-docs:
 		mkdir -p ~/output/$${path_prefix} ; \
 		cp -r .vuepress/dist/* ~/output/$${path_prefix}/ ; \
 		cp ~/output/$${path_prefix}/index.html ~/output ; \
-	done < versions ; \
-	mkdir -p ~/output/master ; \
-	cp -r .vuepress/dist/* ~/output/master/
+	done < versions ;
 .PHONY: build-docs
 
 ###############################################################################
@@ -331,3 +329,4 @@ split-test-packages:$(BUILDDIR)/packages.txt
 	split -d -n l/$(NUM_SPLIT) $< $<.
 test-group-%:split-test-packages
 	cat $(BUILDDIR)/packages.txt.$* | xargs go test -mod=readonly -timeout=5m -race -coverprofile=$(BUILDDIR)/$*.profile.out
+

--- a/docs/versions
+++ b/docs/versions
@@ -1,3 +1,4 @@
+master                  master
 v0.33.x                 v0.33
 v0.34.x                 v0.34
 v0.35.x                 v0.35


### PR DESCRIPTION
This reverts commit f939f962b19d87e7f23ec912e388ac9165fb1ff4.

A lot of inbound links are still broken, so we will need to find a different
approach to suppressing unreleased docs.

Updates #8052.