### PR TITLE
node: nodes should fetch state on startup

### DIFF
--- a/internal/blocksync/reactor_test.go
+++ b/internal/blocksync/reactor_test.go
@@ -176,7 +176,7 @@ func (rts *reactorTestSuite) addNode(
 	rts.reactors[nodeID], err = NewReactor(
 		ctx,
 		rts.logger.With("nodeID", nodeID),
-		state.Copy(),
+		stateStore,
 		blockExec,
 		blockStore,
 		nil,

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -94,7 +94,8 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 
 			// Make State
 			blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool, blockStore)
-			cs := NewState(ctx, logger, thisConfig.Consensus, stateStore, blockExec, blockStore, mempool, evpool)
+			cs, err := NewState(ctx, logger, thisConfig.Consensus, stateStore, blockExec, blockStore, mempool, evpool)
+			require.NoError(t, err)
 			// set private validator
 			pv := privVals[i]
 			cs.SetPrivValidator(ctx, pv)
@@ -104,7 +105,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			require.NoError(t, err)
 			cs.SetEventBus(eventBus)
 			evpool.SetEventBus(eventBus)
-
 			cs.SetTimeoutTicker(tickerFunc())
 
 			states[i] = cs
@@ -237,8 +237,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	}
 
 	for _, reactor := range rts.reactors {
-		state := reactor.state.GetState()
-		reactor.SwitchToConsensus(ctx, state, false)
+		reactor.SwitchToConsensus(ctx, reactor.state.GetState(), false)
 	}
 
 	// Evidence should be submitted and committed at the third height but
@@ -247,20 +246,26 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 
 	var wg sync.WaitGroup
 	i := 0
+	subctx, subcancel := context.WithCancel(ctx)
+	defer subcancel()
 	for _, sub := range rts.subs {
 		wg.Add(1)
 
 		go func(j int, s eventbus.Subscription) {
 			defer wg.Done()
 			for {
-				if ctx.Err() != nil {
+				if subctx.Err() != nil {
 					return
 				}
 
-				msg, err := s.Next(ctx)
-				assert.NoError(t, err)
+				msg, err := s.Next(subctx)
+				if subctx.Err() != nil {
+					return
+				}
+
 				if err != nil {
-					cancel()
+					t.Errorf("waiting for subscription: %v", err)
+					subcancel()
 					return
 				}
 
@@ -272,11 +277,17 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				}
 			}
 		}(i, sub)
-
 		i++
 	}
 
 	wg.Wait()
+
+	// don't run more assertions if we've encountered a timeout
+	select {
+	case <-subctx.Done():
+		t.Fatal("encountered timeout")
+	default:
+	}
 
 	pubkey, err := bzNodeState.privValidator.GetPubKey(ctx)
 	require.NoError(t, err)

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -111,7 +111,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		}()
 	}
 
-	rts := setup(ctx, t, nValidators, states, 100) // buffer must be large enough to not deadlock
+	rts := setup(ctx, t, nValidators, states, 512) // buffer must be large enough to not deadlock
 
 	var bzNodeID types.NodeID
 

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -82,7 +82,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				log.TestingLogger().With("module", "mempool"),
 				thisConfig.Mempool,
 				proxyAppConnMem,
-				0,
 			)
 			if thisConfig.Consensus.WaitForTxs() {
 				mempool.EnableTxsAvailable()
@@ -95,7 +94,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 
 			// Make State
 			blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool, blockStore)
-			cs := NewState(ctx, logger, thisConfig.Consensus, state, blockExec, blockStore, mempool, evpool)
+			cs := NewState(ctx, logger, thisConfig.Consensus, stateStore, blockExec, blockStore, mempool, evpool)
 			// set private validator
 			pv := privVals[i]
 			cs.SetPrivValidator(ctx, pv)

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -469,7 +469,6 @@ func newStateWithConfigAndBlockStore(
 		logger.With("module", "mempool"),
 		thisConfig.Mempool,
 		proxyAppConnMem,
-		0,
 	)
 
 	if thisConfig.Consensus.WaitForTxs() {
@@ -487,7 +486,7 @@ func newStateWithConfigAndBlockStore(
 	cs := NewState(ctx,
 		logger.With("module", "consensus"),
 		thisConfig.Consensus,
-		state,
+		stateStore,
 		blockExec,
 		blockStore,
 		mempool,

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -483,7 +483,7 @@ func newStateWithConfigAndBlockStore(
 	require.NoError(t, stateStore.Save(state))
 
 	blockExec := sm.NewBlockExecutor(stateStore, logger, proxyAppConnCon, mempool, evpool, blockStore)
-	cs := NewState(ctx,
+	cs, err := NewState(ctx,
 		logger.With("module", "consensus"),
 		thisConfig.Consensus,
 		stateStore,
@@ -492,6 +492,10 @@ func newStateWithConfigAndBlockStore(
 		mempool,
 		evpool,
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cs.SetPrivValidator(ctx, pv)
 
 	eventBus := eventbus.NewDefault(logger.With("module", "events"))

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -505,8 +505,9 @@ func TestReactorWithEvidence(t *testing.T) {
 
 		blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool, blockStore)
 
-		cs := NewState(ctx, logger.With("validator", i, "module", "consensus"),
+		cs, err := NewState(ctx, logger.With("validator", i, "module", "consensus"),
 			thisConfig.Consensus, stateStore, blockExec, blockStore, mempool, evpool2)
+		require.NoError(t, err)
 		cs.SetPrivValidator(ctx, pv)
 
 		eventBus := eventbus.NewDefault(log.TestingLogger().With("module", "events"))

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -483,7 +483,6 @@ func TestReactorWithEvidence(t *testing.T) {
 			log.TestingLogger().With("module", "mempool"),
 			thisConfig.Mempool,
 			proxyAppConnMem,
-			0,
 		)
 
 		if thisConfig.Consensus.WaitForTxs() {
@@ -507,7 +506,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool, blockStore)
 
 		cs := NewState(ctx, logger.With("validator", i, "module", "consensus"),
-			thisConfig.Consensus, state, blockExec, blockStore, mempool, evpool2)
+			thisConfig.Consensus, stateStore, blockExec, blockStore, mempool, evpool2)
 		cs.SetPrivValidator(ctx, pv)
 
 		eventBus := eventbus.NewDefault(log.TestingLogger().With("module", "events"))

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -461,6 +461,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		stateStore := sm.NewStore(stateDB)
 		state, err := sm.MakeGenesisState(genDoc)
 		require.NoError(t, err)
+		require.NoError(t, stateStore.Save(state))
 		thisConfig, err := ResetConfig(t.TempDir(), fmt.Sprintf("%s_%d", testName, i))
 		require.NoError(t, err)
 

--- a/internal/consensus/replay_file.go
+++ b/internal/consensus/replay_file.go
@@ -84,7 +84,7 @@ func (cs *State) ReplayFile(ctx context.Context, file string, console bool) erro
 		return err
 	}
 
-	pb := newPlayback(file, fp, cs, cs.state.Copy())
+	pb := newPlayback(file, fp, cs, cs.stateStore)
 	defer pb.fp.Close()
 
 	var nextN int // apply N msgs in a row
@@ -126,17 +126,17 @@ type playback struct {
 	count int // how many lines/msgs into the file are we
 
 	// replays can be reset to beginning
-	fileName     string   // so we can close/reopen the file
-	genesisState sm.State // so the replay session knows where to restart from
+	fileName   string // so we can close/reopen the file
+	stateStore sm.Store
 }
 
-func newPlayback(fileName string, fp *os.File, cs *State, genState sm.State) *playback {
+func newPlayback(fileName string, fp *os.File, cs *State, store sm.Store) *playback {
 	return &playback{
-		cs:           cs,
-		fp:           fp,
-		fileName:     fileName,
-		genesisState: genState,
-		dec:          NewWALDecoder(fp),
+		cs:         cs,
+		fp:         fp,
+		fileName:   fileName,
+		stateStore: store,
+		dec:        NewWALDecoder(fp),
 	}
 }
 
@@ -145,7 +145,7 @@ func (pb *playback) replayReset(ctx context.Context, count int, newStepSub event
 	pb.cs.Stop()
 	pb.cs.Wait()
 
-	newCS := NewState(ctx, pb.cs.logger, pb.cs.config, pb.genesisState.Copy(), pb.cs.blockExec,
+	newCS := NewState(ctx, pb.cs.logger, pb.cs.config, pb.stateStore, pb.cs.blockExec,
 		pb.cs.blockStore, pb.cs.txNotifier, pb.cs.evpool)
 	newCS.SetEventBus(pb.cs.eventBus)
 	newCS.startForReplay()
@@ -345,7 +345,7 @@ func newConsensusStateForReplay(
 	mempool, evpool := emptyMempool{}, sm.EmptyEvidencePool{}
 	blockExec := sm.NewBlockExecutor(stateStore, logger, proxyApp.Consensus(), mempool, evpool, blockStore)
 
-	consensusState := NewState(ctx, logger, csConfig, state.Copy(), blockExec,
+	consensusState := NewState(ctx, logger, csConfig, stateStore, blockExec,
 		blockStore, mempool, evpool)
 
 	consensusState.SetEventBus(eventBus)

--- a/internal/consensus/replay_file.go
+++ b/internal/consensus/replay_file.go
@@ -145,8 +145,11 @@ func (pb *playback) replayReset(ctx context.Context, count int, newStepSub event
 	pb.cs.Stop()
 	pb.cs.Wait()
 
-	newCS := NewState(ctx, pb.cs.logger, pb.cs.config, pb.stateStore, pb.cs.blockExec,
+	newCS, err := NewState(ctx, pb.cs.logger, pb.cs.config, pb.stateStore, pb.cs.blockExec,
 		pb.cs.blockStore, pb.cs.txNotifier, pb.cs.evpool)
+	if err != nil {
+		return err
+	}
 	newCS.SetEventBus(pb.cs.eventBus)
 	newCS.startForReplay()
 
@@ -345,9 +348,11 @@ func newConsensusStateForReplay(
 	mempool, evpool := emptyMempool{}, sm.EmptyEvidencePool{}
 	blockExec := sm.NewBlockExecutor(stateStore, logger, proxyApp.Consensus(), mempool, evpool, blockStore)
 
-	consensusState := NewState(ctx, logger, csConfig, stateStore, blockExec,
+	consensusState, err := NewState(ctx, logger, csConfig, stateStore, blockExec,
 		blockStore, mempool, evpool)
-
+	if err != nil {
+		return nil, err
+	}
 	consensusState.SetEventBus(eventBus)
 	return consensusState, nil
 }

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -217,6 +217,11 @@ func NewState(
 		onStopCh:         make(chan *cstypes.RoundState),
 	}
 
+	// set function defaults (may be overwritten before calling Start)
+	cs.decideProposal = cs.defaultDecideProposal
+	cs.doPrevote = cs.defaultDoPrevote
+	cs.setProposal = cs.defaultSetProposal
+
 	state, err := cs.stateStore.Load()
 	if err != nil {
 		return nil, fmt.Errorf("loading state: %w", err)
@@ -228,11 +233,6 @@ func NewState(
 	}
 
 	cs.updateToState(ctx, state)
-
-	// set function defaults (may be overwritten before calling Start)
-	cs.decideProposal = cs.defaultDecideProposal
-	cs.doPrevote = cs.defaultDoPrevote
-	cs.setProposal = cs.defaultSetProposal
 
 	// NOTE: we do not call scheduleRound0 yet, we do that upon Start()
 	cs.BaseService = *service.NewBaseService(logger, "State", cs)

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -362,7 +362,7 @@ func (cs *State) LoadCommit(height int64) *types.Commit {
 func (cs *State) OnStart(ctx context.Context) error {
 	state, err := cs.stateStore.Load()
 	if err != nil {
-		return err
+		return fmt.Errorf("loading state: %w", err)
 	}
 
 	// We have no votes, so reconstruct LastCommit from SeenCommit.

--- a/internal/consensus/wal_generator.go
+++ b/internal/consensus/wal_generator.go
@@ -83,7 +83,7 @@ func WALGenerateNBlocks(ctx context.Context, t *testing.T, logger log.Logger, wr
 	mempool := emptyMempool{}
 	evpool := sm.EmptyEvidencePool{}
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, blockStore)
-	consensusState := NewState(ctx, logger, cfg.Consensus, state.Copy(), blockExec, blockStore, mempool, evpool)
+	consensusState := NewState(ctx, logger, cfg.Consensus, stateStore, blockExec, blockStore, mempool, evpool)
 	consensusState.SetEventBus(eventBus)
 	if privValidator != nil && privValidator != (*privval.FilePV)(nil) {
 		consensusState.SetPrivValidator(ctx, privValidator)

--- a/internal/consensus/wal_generator.go
+++ b/internal/consensus/wal_generator.go
@@ -83,7 +83,11 @@ func WALGenerateNBlocks(ctx context.Context, t *testing.T, logger log.Logger, wr
 	mempool := emptyMempool{}
 	evpool := sm.EmptyEvidencePool{}
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, blockStore)
-	consensusState := NewState(ctx, logger, cfg.Consensus, stateStore, blockExec, blockStore, mempool, evpool)
+	consensusState, err := NewState(ctx, logger, cfg.Consensus, stateStore, blockExec, blockStore, mempool, evpool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	consensusState.SetEventBus(eventBus)
 	if privValidator != nil && privValidator != (*privval.FilePV)(nil) {
 		consensusState.SetPrivValidator(ctx, privValidator)

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -94,7 +94,6 @@ func NewTxMempool(
 	logger log.Logger,
 	cfg *config.MempoolConfig,
 	proxyAppConn proxy.AppConnMempool,
-	height int64,
 	options ...TxMempoolOption,
 ) *TxMempool {
 
@@ -102,7 +101,7 @@ func NewTxMempool(
 		logger:        logger,
 		config:        cfg,
 		proxyAppConn:  proxyAppConn,
-		height:        height,
+		height:        -1,
 		cache:         NopTxCache{},
 		metrics:       NopMetrics(),
 		txStore:       NewTxStore(),

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -95,7 +95,7 @@ func setup(ctx context.Context, t testing.TB, cacheSize int, options ...TxMempoo
 		appConnMem.Wait()
 	})
 
-	return NewTxMempool(logger.With("test", t.Name()), cfg.Mempool, appConnMem, 0, options...)
+	return NewTxMempool(logger.With("test", t.Name()), cfg.Mempool, appConnMem, options...)
 }
 
 func checkTxs(ctx context.Context, t *testing.T, txmp *TxMempool, numTxs int, peerID uint16) []testTx {

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -253,7 +253,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 	}
 
 	// Lock mempool, commit app state, update mempoool.
-	appHash, retainHeight, err := blockExec.Commit(ctx, block, state, abciResponses.FinalizeBlock.Txs)
+	appHash, retainHeight, err := blockExec.Commit(ctx, state, block, abciResponses.FinalizeBlock.Txs)
 	if err != nil {
 		return state, fmt.Errorf("commit failed for application: %w", err)
 	}
@@ -324,8 +324,8 @@ func (blockExec *BlockExecutor) VerifyVoteExtension(ctx context.Context, vote *t
 // state before new txs are run in the mempool, lest they be invalid.
 func (blockExec *BlockExecutor) Commit(
 	ctx context.Context,
-	block *types.Block,
 	state State,
+	block *types.Block,
 	deliverTxResponses []*abci.ResponseDeliverTx,
 ) ([]byte, int64, error) {
 	blockExec.mempool.Lock()

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -253,7 +253,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 	}
 
 	// Lock mempool, commit app state, update mempoool.
-	appHash, retainHeight, err := blockExec.Commit(ctx, block, abciResponses.FinalizeBlock.Txs)
+	appHash, retainHeight, err := blockExec.Commit(ctx, block, state, abciResponses.FinalizeBlock.Txs)
 	if err != nil {
 		return state, fmt.Errorf("commit failed for application: %w", err)
 	}
@@ -325,6 +325,7 @@ func (blockExec *BlockExecutor) VerifyVoteExtension(ctx context.Context, vote *t
 func (blockExec *BlockExecutor) Commit(
 	ctx context.Context,
 	block *types.Block,
+	state State,
 	deliverTxResponses []*abci.ResponseDeliverTx,
 ) ([]byte, int64, error) {
 	blockExec.mempool.Lock()
@@ -359,8 +360,8 @@ func (blockExec *BlockExecutor) Commit(
 		block.Height,
 		block.Txs,
 		deliverTxResponses,
-		TxPreCheck(blockExec.store),
-		TxPostCheck(blockExec.store),
+		TxPreCheckForState(state),
+		TxPostCheckForState(state),
 	)
 
 	return res.Data, res.RetainHeight, err

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -253,7 +253,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 	}
 
 	// Lock mempool, commit app state, update mempoool.
-	appHash, retainHeight, err := blockExec.Commit(ctx, state, block, abciResponses.FinalizeBlock.Txs)
+	appHash, retainHeight, err := blockExec.Commit(ctx, block, abciResponses.FinalizeBlock.Txs)
 	if err != nil {
 		return state, fmt.Errorf("commit failed for application: %w", err)
 	}
@@ -324,7 +324,6 @@ func (blockExec *BlockExecutor) VerifyVoteExtension(ctx context.Context, vote *t
 // state before new txs are run in the mempool, lest they be invalid.
 func (blockExec *BlockExecutor) Commit(
 	ctx context.Context,
-	state State,
 	block *types.Block,
 	deliverTxResponses []*abci.ResponseDeliverTx,
 ) ([]byte, int64, error) {
@@ -360,8 +359,8 @@ func (blockExec *BlockExecutor) Commit(
 		block.Height,
 		block.Txs,
 		deliverTxResponses,
-		TxPreCheck(state),
-		TxPostCheck(state),
+		TxPreCheck(blockExec.store),
+		TxPostCheck(blockExec.store),
 	)
 
 	return res.Data, res.RetainHeight, err

--- a/internal/state/tx_filter.go
+++ b/internal/state/tx_filter.go
@@ -53,12 +53,20 @@ func TxPreCheck(store Store) mempool.PreCheckFunc {
 		if err != nil {
 			return err
 		}
+
+		return TxPreCheckForState(state)(tx)
+	}
+}
+
+func TxPreCheckForState(state State) mempool.PreCheckFunc {
+	return func(tx types.Tx) error {
 		maxDataBytes := types.MaxDataBytesNoEvidence(
 			state.ConsensusParams.Block.MaxBytes,
 			state.Validators.Size(),
 		)
 		return mempool.PreCheckMaxBytes(maxDataBytes)(tx)
 	}
+
 }
 
 // TxPostCheck returns a function to filter transactions after processing.
@@ -71,6 +79,12 @@ func TxPostCheck(store Store) mempool.PostCheckFunc {
 		if err != nil {
 			return err
 		}
+		return mempool.PostCheckMaxGas(state.ConsensusParams.Block.MaxGas)(tx, resp)
+	}
+}
+
+func TxPostCheckForState(state State) mempool.PostCheckFunc {
+	return func(tx types.Tx, resp *abci.ResponseCheckTx) error {
 		return mempool.PostCheckMaxGas(state.ConsensusParams.Block.MaxGas)(tx, resp)
 	}
 }

--- a/internal/state/tx_filter.go
+++ b/internal/state/tx_filter.go
@@ -1,22 +1,66 @@
 package state
 
 import (
+	"sync"
+	"time"
+
+	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/types"
 )
 
+func cachingStateFetcher(store Store) func() (State, error) {
+	var (
+		last  time.Time
+		mutex = &sync.Mutex{}
+		ttl   time.Duration
+		cache State
+		err   error
+	)
+
+	return func() (State, error) {
+		mutex.Lock()
+		defer mutex.Unlock()
+
+		if cache.ChainID == "" { // is nil
+			cache, err = store.Load()
+			if err != nil {
+				return State{}, err
+			}
+			last = time.Now()
+			ttl = 100*time.Millisecond + (cache.LastBlockTime.Add(last) * 2)
+		}
+
+	}
+
+}
+
 // TxPreCheck returns a function to filter transactions before processing.
 // The function limits the size of a transaction to the block's maximum data size.
-func TxPreCheck(state State) mempool.PreCheckFunc {
-	maxDataBytes := types.MaxDataBytesNoEvidence(
-		state.ConsensusParams.Block.MaxBytes,
-		state.Validators.Size(),
-	)
-	return mempool.PreCheckMaxBytes(maxDataBytes)
+func TxPreCheck(store Store) mempool.PreCheckFunc {
+	return func(tx types.Tx) error {
+		// TODO: this should probably be cached at some level.
+		state, err := store.Load()
+		if err != nil {
+			return err
+		}
+		maxDataBytes := types.MaxDataBytesNoEvidence(
+			state.ConsensusParams.Block.MaxBytes,
+			state.Validators.Size(),
+		)
+		return mempool.PreCheckMaxBytes(maxDataBytes)(tx)
+	}
 }
 
 // TxPostCheck returns a function to filter transactions after processing.
 // The function limits the gas wanted by a transaction to the block's maximum total gas.
-func TxPostCheck(state State) mempool.PostCheckFunc {
-	return mempool.PostCheckMaxGas(state.ConsensusParams.Block.MaxGas)
+func TxPostCheck(store Store) mempool.PostCheckFunc {
+	return func(tx types.Tx, resp *abci.ResponseCheckTx) error {
+		// TODO: this should probably be cached at some level.
+		state, err := store.Load()
+		if err != nil {
+			return err
+		}
+		return mempool.PostCheckMaxGas(state.ConsensusParams.Block.MaxGas)(tx, resp)
+	}
 }

--- a/internal/state/tx_filter_test.go
+++ b/internal/state/tx_filter_test.go
@@ -31,7 +31,7 @@ func TestTxFilter(t *testing.T) {
 		state, err := sm.MakeGenesisState(genDoc)
 		require.NoError(t, err)
 
-		f := sm.TxPreCheck(state)
+		f := sm.TxPreCheckForState(state)
 		if tc.isErr {
 			assert.NotNil(t, f(tc.tx), "#%v", i)
 		} else {

--- a/node/node.go
+++ b/node/node.go
@@ -272,7 +272,7 @@ func makeNode(
 	}
 
 	mpReactor, mp, err := createMempoolReactor(ctx,
-		cfg, proxyApp, state, nodeMetrics.mempool, peerManager, router, logger,
+		cfg, proxyApp, stateStore, nodeMetrics.mempool, peerManager, router, logger,
 	)
 	if err != nil {
 		return nil, combineCloseError(err, makeCloser(closers))

--- a/node/node.go
+++ b/node/node.go
@@ -142,7 +142,6 @@ func makeNode(
 	genDoc, err := genesisDocProvider()
 	if err != nil {
 		return nil, combineCloseError(err, makeCloser(closers))
-		state
 	}
 
 	err = genDoc.ValidateAndComplete()

--- a/node/node.go
+++ b/node/node.go
@@ -142,6 +142,7 @@ func makeNode(
 	genDoc, err := genesisDocProvider()
 	if err != nil {
 		return nil, combineCloseError(err, makeCloser(closers))
+		state
 	}
 
 	err = genDoc.ValidateAndComplete()
@@ -279,7 +280,7 @@ func makeNode(
 	}
 
 	evReactor, evPool, err := createEvidenceReactor(ctx,
-		cfg, dbProvider, stateDB, blockStore, peerManager, router, logger, nodeMetrics.evidence, eventBus,
+		cfg, dbProvider, stateStore, blockStore, peerManager, router, logger, nodeMetrics.evidence, eventBus,
 	)
 	if err != nil {
 		return nil, combineCloseError(err, makeCloser(closers))
@@ -297,7 +298,7 @@ func makeNode(
 	)
 
 	csReactor, csState, err := createConsensusReactor(ctx,
-		cfg, state, blockExec, blockStore, mp, evPool,
+		cfg, stateStore, blockExec, blockStore, mp, evPool,
 		privValidator, nodeMetrics.consensus, stateSync || blockSync, eventBus,
 		peerManager, router, logger,
 	)
@@ -309,7 +310,7 @@ func makeNode(
 	// doing a state sync first.
 	bcReactor, err := blocksync.NewReactor(ctx,
 		logger.With("module", "blockchain"),
-		state.Copy(),
+		stateStore,
 		blockExec,
 		blockStore,
 		csReactor,

--- a/node/node.go
+++ b/node/node.go
@@ -745,7 +745,9 @@ func loadStateFromDBOrGenesisDocProvider(stateStore sm.Store, genDoc *types.Gene
 			return sm.State{}, err
 		}
 
-		stateStore.Save(state)
+		if err := stateStore.Save(state); err != nil {
+			return sm.State{}, err
+		}
 	}
 
 	return state, nil

--- a/node/node.go
+++ b/node/node.go
@@ -730,10 +730,7 @@ func defaultMetricsProvider(cfg *config.InstrumentationConfig) metricsProvider {
 // loadStateFromDBOrGenesisDocProvider attempts to load the state from the
 // database, or creates one using the given genesisDocProvider. On success this also
 // returns the genesis doc loaded through the given provider.
-func loadStateFromDBOrGenesisDocProvider(
-	stateStore sm.Store,
-	genDoc *types.GenesisDoc,
-) (sm.State, error) {
+func loadStateFromDBOrGenesisDocProvider(stateStore sm.Store, genDoc *types.GenesisDoc) (sm.State, error) {
 
 	// 1. Attempt to load state form the database
 	state, err := stateStore.Load()
@@ -747,6 +744,8 @@ func loadStateFromDBOrGenesisDocProvider(
 		if err != nil {
 			return sm.State{}, err
 		}
+
+		stateStore.Save(state)
 	}
 
 	return state, nil

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -292,7 +292,6 @@ func TestCreateProposalBlock(t *testing.T) {
 		logger.With("module", "mempool"),
 		cfg.Mempool,
 		proxyApp.Mempool(),
-		state.LastBlockHeight,
 	)
 
 	// Make EvidencePool
@@ -392,7 +391,6 @@ func TestMaxTxsProposalBlockSize(t *testing.T) {
 		logger.With("module", "mempool"),
 		cfg.Mempool,
 		proxyApp.Mempool(),
-		state.LastBlockHeight,
 	)
 
 	// fill the mempool with one txs just below the maximum size
@@ -457,7 +455,6 @@ func TestMaxProposalBlockSize(t *testing.T) {
 		logger.With("module", "mempool"),
 		cfg.Mempool,
 		proxyApp.Mempool(),
-		state.LastBlockHeight,
 	)
 
 	// fill the mempool with one txs just below the maximum size

--- a/node/setup.go
+++ b/node/setup.go
@@ -185,8 +185,8 @@ func createMempoolReactor(
 		cfg.Mempool,
 		proxyApp.Mempool(),
 		mempool.WithMetrics(memplMetrics),
-		mempool.WithPreCheck(sm.TxPreCheck(store)),
-		mempool.WithPostCheck(sm.TxPostCheck(store)),
+		mempool.WithPreCheck(sm.TxPreCheckFromStore(store)),
+		mempool.WithPostCheck(sm.TxPostCheckFromStore(store)),
 	)
 
 	reactor, err := mempool.NewReactor(
@@ -213,7 +213,7 @@ func createEvidenceReactor(
 	ctx context.Context,
 	cfg *config.Config,
 	dbProvider config.DBProvider,
-	stateDB dbm.DB,
+	store sm.Store,
 	blockStore *store.BlockStore,
 	peerManager *p2p.PeerManager,
 	router *p2p.Router,
@@ -228,7 +228,7 @@ func createEvidenceReactor(
 
 	logger = logger.With("module", "evidence")
 
-	evidencePool, err := evidence.NewPool(logger, evidenceDB, sm.NewStore(stateDB), blockStore, metrics)
+	evidencePool, err := evidence.NewPool(logger, evidenceDB, store, blockStore, metrics)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating evidence pool: %w", err)
 	}
@@ -252,7 +252,7 @@ func createEvidenceReactor(
 func createConsensusReactor(
 	ctx context.Context,
 	cfg *config.Config,
-	state sm.State,
+	store sm.Store,
 	blockExec *sm.BlockExecutor,
 	blockStore sm.BlockStore,
 	mp mempool.Mempool,
@@ -270,7 +270,7 @@ func createConsensusReactor(
 	consensusState := consensus.NewState(ctx,
 		logger,
 		cfg.Consensus,
-		state.Copy(),
+		store,
 		blockExec,
 		blockStore,
 		mp,

--- a/node/setup.go
+++ b/node/setup.go
@@ -267,7 +267,7 @@ func createConsensusReactor(
 ) (*consensus.Reactor, *consensus.State, error) {
 	logger = logger.With("module", "consensus")
 
-	consensusState := consensus.NewState(ctx,
+	consensusState, err := consensus.NewState(ctx,
 		logger,
 		cfg.Consensus,
 		store,
@@ -277,6 +277,9 @@ func createConsensusReactor(
 		evidencePool,
 		consensus.StateMetrics(csMetrics),
 	)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	if privValidator != nil && cfg.Mode == config.ModeValidator {
 		consensusState.SetPrivValidator(ctx, privValidator)

--- a/node/setup.go
+++ b/node/setup.go
@@ -172,7 +172,7 @@ func createMempoolReactor(
 	ctx context.Context,
 	cfg *config.Config,
 	proxyApp proxy.AppConns,
-	state sm.State,
+	store sm.Store,
 	memplMetrics *mempool.Metrics,
 	peerManager *p2p.PeerManager,
 	router *p2p.Router,
@@ -184,10 +184,9 @@ func createMempoolReactor(
 		logger,
 		cfg.Mempool,
 		proxyApp.Mempool(),
-		state.LastBlockHeight,
 		mempool.WithMetrics(memplMetrics),
-		mempool.WithPreCheck(sm.TxPreCheck(state)),
-		mempool.WithPostCheck(sm.TxPostCheck(state)),
+		mempool.WithPreCheck(sm.TxPreCheck(store)),
+		mempool.WithPostCheck(sm.TxPostCheck(store)),
 	)
 
 	reactor, err := mempool.NewReactor(

--- a/test/fuzz/mempool/checktx.go
+++ b/test/fuzz/mempool/checktx.go
@@ -31,7 +31,6 @@ func init() {
 				log.NewNopLogger(),
 				cfg,
 				appConnMem,
-				0,
 			)
 
 		}


### PR DESCRIPTION
This is in persuit of #6777, but sort of backs into the solution, by
removing the construction-time dependency on a state object and uses
the state store and reorganizes reactor construction to interact with
the during startup.