### PR TITLE
node: excise node handle within rpc env

### DIFF
--- a/internal/rpc/core/env.go
+++ b/internal/rpc/core/env.go
@@ -57,12 +57,6 @@ type consensusState interface {
 	GetRoundStateSimpleJSON() ([]byte, error)
 }
 
-type transport interface {
-	Listeners() []string
-	IsListening() bool
-	NodeInfo() types.NodeInfo
-}
-
 type peerManager interface {
 	Peers() []types.NodeID
 	Addresses(types.NodeID) []p2p.NodeAddress
@@ -84,8 +78,9 @@ type Environment struct {
 	ConsensusReactor *consensus.Reactor
 	BlockSyncReactor *blocksync.Reactor
 
-	// Legacy p2p stack
-	P2PTransport transport
+	IsListening bool
+	Listeners   []string
+	NodeInfo    types.NodeInfo
 
 	// interfaces for new p2p interfaces
 	PeerManager peerManager
@@ -224,6 +219,10 @@ func (env *Environment) latestUncommittedHeight() int64 {
 func (env *Environment) StartService(ctx context.Context, conf *config.Config) ([]net.Listener, error) {
 	if err := env.InitGenesisChunks(); err != nil {
 		return nil, err
+	}
+
+	env.Listeners = []string{
+		fmt.Sprintf("Listener(@%v)", conf.P2P.ExternalAddress),
 	}
 
 	listenAddrs := strings.SplitAndTrimEmpty(conf.RPC.ListenAddress, ",", " ")

--- a/internal/rpc/core/net.go
+++ b/internal/rpc/core/net.go
@@ -27,8 +27,8 @@ func (env *Environment) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, 
 	}
 
 	return &coretypes.ResultNetInfo{
-		Listening: env.P2PTransport.IsListening(),
-		Listeners: env.P2PTransport.Listeners(),
+		Listening: env.IsListening,
+		Listeners: env.Listeners,
 		NPeers:    len(peers),
 		Peers:     peers,
 	}, nil

--- a/internal/rpc/core/status.go
+++ b/internal/rpc/core/status.go
@@ -66,7 +66,7 @@ func (env *Environment) Status(ctx context.Context) (*coretypes.ResultStatus, er
 	}
 
 	result := &coretypes.ResultStatus{
-		NodeInfo:        env.P2PTransport.NodeInfo(),
+		NodeInfo:        env.NodeInfo,
 		ApplicationInfo: applicationInfo,
 		SyncInfo: coretypes.SyncInfo{
 			LatestBlockHash:     latestBlockHash,


### PR DESCRIPTION
This is another small (and perhaps unintuitive) cut toward #6777, to
make the dependency on `types.NodeInfo` a start-time rather than
construction-time requirement.