### PR TITLE
update abci cli test output

### DIFF
--- a/abci/tests/test_cli/ex1.abci.out
+++ b/abci/tests/test_cli/ex1.abci.out
@@ -12,7 +12,7 @@
 -> code: OK
 -> data.hex: 0x0000000000000000
 
-> deliver_tx "abc"
+> finalize_block "abc"
 -> code: OK
 
 > info 
@@ -33,12 +33,14 @@
 -> value: abc
 -> value.hex: 616263
 
-> deliver_tx "def=xyz"
+> finalize_block "def=xyz" "ghi=123"
+-> code: OK
+> finalize_block "def=xyz" "ghi=123"
 -> code: OK
 
 > commit 
 -> code: OK
--> data.hex: 0x0400000000000000
+-> data.hex: 0x0600000000000000
 
 > query "def"
 -> code: OK

--- a/abci/tests/test_cli/ex2.abci.out
+++ b/abci/tests/test_cli/ex2.abci.out
@@ -4,20 +4,20 @@
 > check_tx 0xff
 -> code: OK
 
-> deliver_tx 0x00
+> finalize_block 0x00
 -> code: OK
 
 > check_tx 0x00
 -> code: OK
 
-> deliver_tx 0x01
+> finalize_block 0x01
 -> code: OK
 
-> deliver_tx 0x04
+> finalize_block 0x04
 -> code: OK
 
 > info 
 -> code: OK
--> data: {"hashes":0,"txs":3}
--> data.hex: 0x7B22686173686573223A302C22747873223A337D
+-> data: {"size":3}
+-> data.hex: 0x7B2273697A65223A337D
 


### PR DESCRIPTION
the `abci/tests/test_cli/test.sh` test that runs during CI relies on the contents of this file matching the output of the commands that it runs. This PR updates the contents of the output files to contain the output for using `finalize_block`

related to: #7658 