### PR TITLE
Fix govet errors for %w use in test errors.

### DIFF
--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -212,7 +212,7 @@ func TestMempoolRmBadTx(t *testing.T) {
 			checkTxRespCh <- struct{}{}
 		}, mempool.TxInfo{})
 		if err != nil {
-			t.Errorf("error after CheckTx: %w", err)
+			t.Errorf("error after CheckTx: %v", err)
 			return
 		}
 

--- a/internal/libs/queue/queue_test.go
+++ b/internal/libs/queue/queue_test.go
@@ -167,7 +167,7 @@ func TestWait(t *testing.T) {
 			defer close(done)
 			got, err := q.Wait(ctx)
 			if err != nil {
-				t.Errorf("Wait: unexpected error: %w", err)
+				t.Errorf("Wait: unexpected error: %v", err)
 			} else if got != input {
 				t.Errorf("Wait: got %q, want %q", got, input)
 			}

--- a/internal/p2p/conn/secret_connection_test.go
+++ b/internal/p2p/conn/secret_connection_test.go
@@ -126,7 +126,7 @@ func TestSecretConnectionReadWrite(t *testing.T) {
 			nodePrvKey := ed25519.GenPrivKey()
 			nodeSecretConn, err := MakeSecretConnection(nodeConn, nodePrvKey)
 			if err != nil {
-				t.Errorf("failed to establish SecretConnection for node: %w", err)
+				t.Errorf("failed to establish SecretConnection for node: %v", err)
 				return nil, true, err
 			}
 			// In parallel, handle some reads and writes.
@@ -136,7 +136,7 @@ func TestSecretConnectionReadWrite(t *testing.T) {
 					for _, nodeWrite := range nodeWrites {
 						n, err := nodeSecretConn.Write([]byte(nodeWrite))
 						if err != nil {
-							t.Errorf("failed to write to nodeSecretConn: %w", err)
+							t.Errorf("failed to write to nodeSecretConn: %v", err)
 							return nil, true, err
 						}
 						if n != len(nodeWrite) {
@@ -163,7 +163,7 @@ func TestSecretConnectionReadWrite(t *testing.T) {
 							}
 							return nil, false, nil
 						} else if err != nil {
-							t.Errorf("failed to read from nodeSecretConn: %w", err)
+							t.Errorf("failed to read from nodeSecretConn: %v", err)
 							return nil, true, err
 						}
 						*nodeReads = append(*nodeReads, string(readBuffer[:n]))
@@ -288,7 +288,7 @@ func writeLots(t *testing.T, wg *sync.WaitGroup, conn io.Writer, txt string, n i
 	for i := 0; i < n; i++ {
 		_, err := conn.Write([]byte(txt))
 		if err != nil {
-			t.Errorf("failed to write to fooSecConn: %w", err)
+			t.Errorf("failed to write to fooSecConn: %v", err)
 			return
 		}
 	}
@@ -343,7 +343,7 @@ func makeSecretConnPair(tb testing.TB) (fooSecConn, barSecConn *SecretConnection
 		func(_ int) (val interface{}, abort bool, err error) {
 			fooSecConn, err = MakeSecretConnection(fooConn, fooPrvKey)
 			if err != nil {
-				tb.Errorf("failed to establish SecretConnection for foo: %w", err)
+				tb.Errorf("failed to establish SecretConnection for foo: %v", err)
 				return nil, true, err
 			}
 			remotePubBytes := fooSecConn.RemotePubKey()
@@ -358,7 +358,7 @@ func makeSecretConnPair(tb testing.TB) (fooSecConn, barSecConn *SecretConnection
 		func(_ int) (val interface{}, abort bool, err error) {
 			barSecConn, err = MakeSecretConnection(barConn, barPrvKey)
 			if barSecConn == nil {
-				tb.Errorf("failed to establish SecretConnection for bar: %w", err)
+				tb.Errorf("failed to establish SecretConnection for bar: %v", err)
 				return nil, true, err
 			}
 			remotePubBytes := barSecConn.RemotePubKey()
@@ -405,7 +405,7 @@ func BenchmarkWriteSecretConnection(b *testing.B) {
 			if err == io.EOF {
 				return
 			} else if err != nil {
-				b.Errorf("failed to read from barSecConn: %w", err)
+				b.Errorf("failed to read from barSecConn: %v", err)
 				return
 			}
 		}
@@ -416,7 +416,7 @@ func BenchmarkWriteSecretConnection(b *testing.B) {
 		idx := mrand.Intn(len(fooWriteBytes))
 		_, err := fooSecConn.Write(fooWriteBytes[idx])
 		if err != nil {
-			b.Errorf("failed to write to fooSecConn: %w", err)
+			b.Errorf("failed to write to fooSecConn: %v", err)
 			return
 		}
 	}

--- a/internal/pubsub/query/syntax/syntax_test.go
+++ b/internal/pubsub/query/syntax/syntax_test.go
@@ -55,7 +55,7 @@ func TestScanner(t *testing.T) {
 			got = append(got, s.Token())
 		}
 		if err := s.Err(); err != io.EOF {
-			t.Errorf("Next: unexpected error: %w", err)
+			t.Errorf("Next: unexpected error: %v", err)
 		}
 
 		if !reflect.DeepEqual(got, test.want) {

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -493,7 +493,7 @@ func TestVoteSet_MakeCommit(t *testing.T) {
 
 	// Ensure that Commit is good.
 	if err := commit.ValidateBasic(); err != nil {
-		t.Errorf("error in Commit.ValidateBasic(): %w", err)
+		t.Errorf("error in Commit.ValidateBasic(): %v", err)
 	}
 }
 


### PR DESCRIPTION
The %w syntax is a fmt.Errorf thing, not supported by the testing package.
