### PR TITLE
service: add NopService and use for PexReactor

### DIFF
--- a/libs/service/service.go
+++ b/libs/service/service.go
@@ -14,6 +14,11 @@ var (
 	errAlreadyStopped = errors.New("already stopped")
 )
 
+var (
+	_ Service = (*BaseService)(nil)
+	_ Service = (*NopService)(nil)
+)
+
 // Service defines a service that can be started, stopped, and reset.
 type Service interface {
 	// Start is called to start the service, which should run until
@@ -84,6 +89,12 @@ type BaseService struct {
 	// The "subclass" of BaseService
 	impl Implementation
 }
+
+type NopService struct{}
+
+func (NopService) Start(_ context.Context) error { return nil }
+func (NopService) IsRunning() bool               { return true }
+func (NopService) Wait()                         {}
 
 // NewBaseService creates a new BaseService.
 func NewBaseService(logger log.Logger, name string, impl Implementation) *BaseService {

--- a/node/node.go
+++ b/node/node.go
@@ -357,7 +357,7 @@ func makeNode(
 		return nil, combineCloseError(err, makeCloser(closers))
 	}
 
-	var pexReactor service.Service
+	var pexReactor service.Service = service.NopService{}
 	if cfg.P2P.PexReactor {
 		pexReactor, err = pex.NewReactor(ctx, logger, peerManager, router.OpenChannel, peerManager.Subscribe(ctx))
 		if err != nil {


### PR DESCRIPTION
closes: #8088 

This change allows the `service.Service` list in `node.go` to start Nop versions of the listed services. An alternate approach would be to build the services list up throughout the course of the `makeNode` function and assign it to the field in the node at the end instead of using a literal of the list. I somewhat like the aesthetics of the literal, but am happy to change to the appending style if this seems off.