### PR TITLE
consensus: avoid persistent kvstore in tests

### DIFF
--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -885,8 +885,11 @@ func randConsensusNetWithPeers(
 
 		app := appFunc(logger, filepath.Join(cfg.DBDir(), fmt.Sprintf("%s_%d", testName, i)))
 		vals := types.TM2PB.ValidatorUpdates(state.Validators)
-		if _, ok := app.(*kvstore.PersistentKVStoreApplication); ok {
-			// simulate handshake, receive app version. If don't do this, replay test will fail
+		switch app.(type) {
+		// simulate handshake, receive app version. If don't do this, replay test will fail
+		case *kvstore.PersistentKVStoreApplication:
+			state.Version.Consensus.App = kvstore.ProtocolVersion
+		case *kvstore.Application:
 			state.Version.Consensus.App = kvstore.ProtocolVersion
 		}
 		app.InitChain(abci.RequestInitChain{Validators: vals})

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -973,10 +973,6 @@ func newEpehemeralKVStore(_ log.Logger, _ string) abci.Application {
 	return kvstore.NewApplication()
 }
 
-func newPersistentKVStore(logger log.Logger, dbDir string) abci.Application {
-	return kvstore.NewPersistentKVStoreApplication(logger, dbDir)
-}
-
 func signDataIsEqual(v1 *types.Vote, v2 *tmproto.Vote) bool {
 	if v1 == nil || v2 == nil {
 		return false

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -338,13 +337,13 @@ func setupSimulator(ctx context.Context, t *testing.T) *simulatorTestSuite {
 		nPeers,
 		"replay_test",
 		newMockTickerFunc(true),
-		newPersistentKVStore)
+		newEpehemeralKVStore)
 	sim.Config = cfg
+	defer func() { t.Cleanup(cleanup) }()
 
 	var err error
 	sim.GenesisState, err = sm.MakeGenesisState(genDoc)
 	require.NoError(t, err)
-	sim.CleanupFunc = cleanup
 
 	partSize := types.BlockPartSizeBytes
 
@@ -584,9 +583,6 @@ func setupSimulator(ctx context.Context, t *testing.T) *simulatorTestSuite {
 		sim.Chain = append(sim.Chain, css[0].blockStore.LoadBlock(int64(i)))
 		sim.Commits = append(sim.Commits, css[0].blockStore.LoadBlockCommit(int64(i)))
 	}
-	if sim.CleanupFunc != nil {
-		t.Cleanup(sim.CleanupFunc)
-	}
 
 	return sim
 }
@@ -743,19 +739,14 @@ func testHandshakeReplay(
 	)
 	latestAppHash := state.AppHash
 
-	// make a new client creator
-	kvstoreApp := kvstore.NewPersistentKVStoreApplication(logger,
-		filepath.Join(cfg.DBDir(), fmt.Sprintf("replay_test_%d_%d_a_r%d", nBlocks, mode, rand.Int())))
-	t.Cleanup(func() { require.NoError(t, kvstoreApp.Close()) })
-
 	eventBus := eventbus.NewDefault(logger)
 	require.NoError(t, eventBus.Start(ctx))
 
-	clientCreator2 := abciclient.NewLocalClient(logger, kvstoreApp)
+	client := abciclient.NewLocalClient(logger, kvstore.NewApplication())
 	if nBlocks > 0 {
 		// run nBlocks against a new client to build up the app state.
 		// use a throwaway tendermint state
-		proxyApp := proxy.New(clientCreator2, logger, proxy.NopMetrics())
+		proxyApp := proxy.New(client, logger, proxy.NopMetrics())
 		stateDB1 := dbm.NewMemDB()
 		stateStore := sm.NewStore(stateDB1)
 		err := stateStore.Save(genesisState)
@@ -776,7 +767,7 @@ func testHandshakeReplay(
 	genDoc, err := sm.MakeGenesisDocFromFile(cfg.GenesisFile())
 	require.NoError(t, err)
 	handshaker := NewHandshaker(logger, stateStore, state, store, eventBus, genDoc)
-	proxyApp := proxy.New(clientCreator2, logger, proxy.NopMetrics())
+	proxyApp := proxy.New(client, logger, proxy.NopMetrics())
 	require.NoError(t, proxyApp.Start(ctx), "Error starting proxy app connections")
 	require.True(t, proxyApp.IsRunning())
 	require.NotNil(t, proxyApp)
@@ -905,10 +896,7 @@ func buildTMStateFromChain(
 	t.Helper()
 
 	// run the whole chain against this client to build up the tendermint state
-	kvstoreApp := kvstore.NewPersistentKVStoreApplication(logger,
-		filepath.Join(cfg.DBDir(), fmt.Sprintf("replay_test_%d_%d_t", nBlocks, mode)))
-	defer kvstoreApp.Close()
-	client := abciclient.NewLocalClient(logger, kvstoreApp)
+	client := abciclient.NewLocalClient(logger, kvstore.NewApplication())
 
 	proxyApp := proxy.New(client, logger, proxy.NopMetrics())
 	require.NoError(t, proxyApp.Start(ctx))

--- a/internal/consensus/wal_generator.go
+++ b/internal/consensus/wal_generator.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	mrand "math/rand"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -26,18 +25,17 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-// WALGenerateNBlocks generates a consensus WAL. It does this by spinning up a
-// stripped down version of node (proxy app, event bus, consensus state) with a
-// persistent kvstore application and special consensus wal instance
-// (byteBufferWAL) and waits until numBlocks are created.
+// WALGenerateNBlocks generates a consensus WAL. It does this by
+// spinning up a stripped down version of node (proxy app, event bus,
+// consensus state) with a kvstore application and special consensus
+// wal instance (byteBufferWAL) and waits until numBlocks are created.
 // If the node fails to produce given numBlocks, it fails the test.
 func WALGenerateNBlocks(ctx context.Context, t *testing.T, logger log.Logger, wr io.Writer, numBlocks int) {
 	t.Helper()
 
 	cfg := getConfig(t)
 
-	app := kvstore.NewPersistentKVStoreApplication(logger, filepath.Join(cfg.DBDir(), "wal_generator"))
-	t.Cleanup(func() { require.NoError(t, app.Close()) })
+	app := kvstore.NewApplication()
 
 	logger.Info("generating WAL (last height msg excluded)", "numBlocks", numBlocks)
 


### PR DESCRIPTION
While I've made moves to reduce the use of the persistent KV store app
in the past, I had left it here before because I imagined that the
replay and WAL tests used the persistent kv store in tests that
started and stopped nodes and then let them handle the replay. 

This does not seem to be the case. 

In all of these tests WAL entries are generated and applied out of
band (which is probably good,) and the applications in question are
never stopped during the test and a new application object never
restarts with access to the files of a previously existing application. 

If this is the case, then the applications can just use ephemeral
storage, which makes for a much more reliable test execution plan.