### PR TITLE
consensus: avoid race in accessing channel

### DIFF
--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -348,6 +348,7 @@ func (r *Reactor) broadcastHasVoteMessage(ctx context.Context, vote *types.Vote)
 // internal pubsub defined in the consensus state to broadcast them to peers
 // upon receiving.
 func (r *Reactor) subscribeToBroadcastEvents() {
+	onStopCh := r.state.getOnStopCh()
 	err := r.state.evsw.AddListenerForEvent(
 		listenerIDConsensus,
 		types.EventNewRoundStepValue,
@@ -356,7 +357,7 @@ func (r *Reactor) subscribeToBroadcastEvents() {
 				return err
 			}
 			select {
-			case r.state.onStopCh <- data.(*cstypes.RoundState):
+			case onStopCh <- data.(*cstypes.RoundState):
 				return nil
 			case <-ctx.Done():
 				return ctx.Err()


### PR DESCRIPTION
The race detector occassionally raises an alarm during test cleanup
for accessing the field of the state object. It's minor, and I'm not
entirely convinced of the "wait to finish the current round" logic,
but this is a simple enough fix.

Basically this channel allows the state machinery to delay shutdown of
the consensus reactor if we're *about* to commit a block. This is sort
of an optional function (e.g. the consensus system recovers well if
you abort at arbitrary points in the process of creating a block), and
is meant (I think) to save doing redundant work. The problem is that
there are a lot of shutdown situations where this doesn't happen, and
if it takes a long time to get to the commit, orchestration/management
code is likely to terminate the process anyway beyond a certian
timeout. I don't feel confident in deleting it yet, but I could be
convinced.