### PR TITLE
fix rollback app version mismatch

### DIFF
--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/libs/log"
 	cryptoproto "github.com/tendermint/tendermint/proto/tendermint/crypto"
+	protoTypes "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/version"
 )
 
@@ -101,7 +102,13 @@ func (app *Application) InitChain(req types.RequestInitChain) types.ResponseInit
 			panic("problem updating validators")
 		}
 	}
-	return types.ResponseInitChain{}
+	return types.ResponseInitChain{
+		ConsensusParams: &protoTypes.ConsensusParams{
+			Version: &protoTypes.VersionParams{
+				AppVersion: ProtocolVersion,
+			},
+		},
+	}
 }
 
 func (app *Application) Info(req types.RequestInfo) types.ResponseInfo {

--- a/internal/consensus/replay.go
+++ b/internal/consensus/replay.go
@@ -260,6 +260,7 @@ func (h *Handshaker) Handshake(ctx context.Context, appClient abciclient.Client)
 	// Only set the version if there is no existing state.
 	if h.initialState.LastBlockHeight == 0 {
 		h.initialState.Version.Consensus.App = res.AppVersion
+		h.initialState.ConsensusParams.Version.AppVersion = res.AppVersion
 	}
 
 	// Replay blocks up to the latest in the blockstore.

--- a/internal/consensus/replay.go
+++ b/internal/consensus/replay.go
@@ -244,14 +244,14 @@ func (h *Handshaker) Handshake(ctx context.Context, appClient abciclient.Client)
 		return fmt.Errorf("error calling Info: %w", err)
 	}
 
-	blockHeight := res.LastBlockHeight
-	if blockHeight < 0 {
-		return fmt.Errorf("got a negative last block height (%d) from the app", blockHeight)
+	appBlockHeight := res.LastBlockHeight
+	if appBlockHeight < 0 {
+		return fmt.Errorf("got a negative last block height (%d) from the app", appBlockHeight)
 	}
 	appHash := res.LastBlockAppHash
 
 	h.logger.Info("ABCI Handshake App Info",
-		"height", blockHeight,
+		"height", appBlockHeight,
 		"hash", appHash,
 		"software-version", res.Version,
 		"protocol-version", res.AppVersion,
@@ -263,13 +263,13 @@ func (h *Handshaker) Handshake(ctx context.Context, appClient abciclient.Client)
 	}
 
 	// Replay blocks up to the latest in the blockstore.
-	_, err = h.ReplayBlocks(ctx, h.initialState, appHash, blockHeight, appClient)
+	_, err = h.ReplayBlocks(ctx, h.initialState, appHash, appBlockHeight, appClient)
 	if err != nil {
 		return fmt.Errorf("error on replay: %w", err)
 	}
 
 	h.logger.Info("Completed ABCI Handshake - Tendermint and App are synced",
-		"appHeight", blockHeight, "appHash", appHash)
+		"appHeight", appBlockHeight, "appHash", appHash)
 
 	// TODO: (on restart) replay mempool
 

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -1306,7 +1306,7 @@ func TestReplayUpdateAppVerion(t *testing.T) {
 	testGenesusAppVer := kvstore.ProtocolVersion + 1
 	state.Version.Consensus.App = testGenesusAppVer
 	state.ConsensusParams.Version.AppVersion = testGenesusAppVer
-	stateStore.Save(state)
+	require.NoError(t, stateStore.Save(state))
 
 	// the genDoc has the default genesis app version which it's fine because it's be used in the app InitChain request.
 	genDoc, err := sm.MakeGenesisDocFromFile(cfg.GenesisFile())


### PR DESCRIPTION
This PR is trying to fix the #8095, the root cause is the state stores the app version info in two different places, [Version](https://github.com/tendermint/tendermint/blob/1db41663c7025a6c87b698108239c9ceb081a15c/internal/state/state.go#L71), and [ConsensusParams](https://github.com/tendermint/tendermint/blob/1db41663c7025a6c87b698108239c9ceb081a15c/internal/state/state.go#L95). The value will be different if the genesis file uses the different App Version. And the rollback process can only see the ConsensusParams of the previous state if the app doesn't respond to the ConsensusParam in the app.InitChain call.

Note:
- This fix won't work with the rollback node that already has the state using the TM core built with the prior commit version when the app.InitChain doesn't set the ConsensusParam properly.

- By the [spec](https://github.com/tendermint/tendermint/blob/94b409e407e60719795b42ae7d33cfd011204117/spec/core/genesis.md#L27), the `app_version` is set by the application, it brings another issue. If it can be determined at the initial state. Why are we using app_version in the genesis file? 

- The complete fix should remove [Version](https://github.com/tendermint/tendermint/blob/1db41663c7025a6c87b698108239c9ceb081a15c/internal/state/state.go#L71) and just using ConsensusParams, but it will bring a new issue - the state will need migration (a consensus break). 

Update:

The build-in kvstore is a special case because it doesn't return the ConsensusParams when calling InitChain. Therefore, the init state will use the genesis which unmatch the app version of the kvstore. Otherwise, the ConsensusParams of the init state will be updated in [ReplayBlocks](https://github.com/tendermint/tendermint/blob/0bded371c59162b3f555767376a32e199c51b9d5/internal/consensus/replay.go#L348). The `TestRollbackIntegration` explains why it always works.