### PR TITLE
mempool: reduce size of test

### DIFF
--- a/internal/mempool/reactor_test.go
+++ b/internal/mempool/reactor_test.go
@@ -130,7 +130,6 @@ func (rts *reactorTestSuite) waitForTxns(t *testing.T, txs []types.Tx, ids ...ty
 	// ensure that the transactions get fully broadcast to the
 	// rest of the network
 	wg := &sync.WaitGroup{}
-	var count int
 	for name, pool := range rts.mempools {
 		if !p2ptest.NodeInSlice(name, ids) {
 			continue
@@ -148,7 +147,6 @@ func (rts *reactorTestSuite) waitForTxns(t *testing.T, txs []types.Tx, ids ...ty
 				"node=%q, ntx=%d, size=%d", name, len(txs), pool.Size(),
 			)
 		}(name, pool)
-		count++
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
This is failing intermittently, but it's a really simple test, and I
suspect that we're just running into thread scheduling issues on CI
nodes. I don't think making the test smaller reduces the utility of
this test.