### PR TITLE
consensus: skip channel close during shutdown

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -511,8 +511,6 @@ func (cs *State) OnStop() {
 		}
 	}
 
-	close(cs.onStopCh)
-
 	if cs.timeoutTicker.IsRunning() {
 		cs.timeoutTicker.Stop()
 	}


### PR DESCRIPTION
I see this panic in tests occasionally, and I don't think there's any
need to close this channel:

- it's only sent to in one place which has a select case with a
  default clause, so there's no chance of deadlocks.

- the only place we recieve from it thas a timeout.