### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,14 @@ on:
       - master
       - release/**
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     name: Build
     runs-on: ubuntu-latest
     strategy:
@@ -20,11 +26,11 @@ jobs:
         goos: ["linux"]
     timeout-minutes: 5
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: "1.17"
-      - uses: actions/checkout@v3
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      - uses: technote-space/get-diff-action@832a70d288f9623f9af054e9f5d8f52df7492c0a # v6.0.1
         with:
           PATTERNS: |
             **/**.go
@@ -37,15 +43,18 @@ jobs:
         if: "env.GIT_DIFF != ''"
 
   test_abci_cli:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 5
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: "1.17"
-      - uses: actions/checkout@v3
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      - uses: technote-space/get-diff-action@832a70d288f9623f9af054e9f5d8f52df7492c0a # v6.0.1
         with:
           PATTERNS: |
             **/**.go
@@ -59,15 +68,18 @@ jobs:
         if: "env.GIT_DIFF != ''"
 
   test_apps:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 5
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: "1.17"
-      - uses: actions/checkout@v3
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      - uses: technote-space/get-diff-action@832a70d288f9623f9af054e9f5d8f52df7492c0a # v6.0.1
         with:
           PATTERNS: |
             **/**.go

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,11 +9,14 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"  # Push events to matching v*, i.e. v1.0, v20.15.10
       - "v[0-9]+.[0-9]+.[0-9]+-rc*"  # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
       - name: Prepare
         id: prep
         run: |
@@ -34,22 +37,22 @@ jobs:
           echo ::set-output name=tags::${TAGS}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@95bd86577812b34f1db6d5e57b728cb63b9aa388 # master
         with:
           platforms: all
 
       - name: Set up Docker Build
-        uses: docker/setup-buildx-action@v1.6.0
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0
 
       - name: Login to DockerHub
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Publish to Docker Hub
-        uses: docker/build-push-action@v2.9.0
+        uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b # v2.9.0
         with:
           context: .
           file: ./DOCKER/Dockerfile

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -4,6 +4,9 @@ name: e2e-manual
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-nightly-test:
     # Run parallel jobs for the listed testnet groups (must match the
@@ -15,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: '1.17'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
 
       - name: Build
         working-directory: test/e2e

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-nightly-test:
     # Run parallel jobs for the listed testnet groups (must match the
@@ -20,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: '1.17'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
         with:
           ref: 'v0.34.x'
 
@@ -43,6 +46,8 @@ jobs:
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
 
   e2e-nightly-fail:
+    permissions:
+      contents: none
     needs: e2e-nightly-test
     if: ${{ failure() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-nightly-35x.yml
+++ b/.github/workflows/e2e-nightly-35x.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-nightly-test:
     # Run parallel jobs for the listed testnet groups (must match the
@@ -20,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: '1.17'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
         with:
           ref: 'v0.35.x'
 
@@ -43,6 +46,8 @@ jobs:
         run: ./run-multiple.sh networks/nightly/${{ matrix.p2p }}/*-group${{ matrix.group }}-*.toml
 
   e2e-nightly-fail-2:
+    permissions:
+      contents: none
     needs: e2e-nightly-test
     if: ${{ failure() }}
     runs-on: ubuntu-latest
@@ -59,6 +64,8 @@ jobs:
           SLACK_FOOTER: ''
 
   e2e-nightly-success:  # may turn this off once they seem to pass consistently
+    permissions:
+      contents: none
     needs: e2e-nightly-test
     if: ${{ success() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-nightly-test:
     # Run parallel jobs for the listed testnet groups (must match the
@@ -19,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: '1.17'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
 
       - name: Build
         working-directory: test/e2e
@@ -40,6 +43,8 @@ jobs:
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
 
   e2e-nightly-fail-2:
+    permissions:
+      contents: none
     needs: e2e-nightly-test
     if: ${{ failure() }}
     runs-on: ubuntu-latest
@@ -56,6 +61,8 @@ jobs:
           SLACK_FOOTER: ''
 
   e2e-nightly-success:  # may turn this off once they seem to pass consistently
+    permissions:
+      contents: none
     needs: e2e-nightly-test
     if: ${{ success() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,16 +9,22 @@ on:
       - master
       - release/**
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: '1.17'
-      - uses: actions/checkout@v3
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      - uses: technote-space/get-diff-action@832a70d288f9623f9af054e9f5d8f52df7492c0a # v6.0.1
         with:
           PATTERNS: |
             **/**.go

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -9,15 +9,18 @@ on:
     paths:
       - "test/fuzz/**/*.go"
 
+permissions:
+  contents: read
+
 jobs:
   fuzz-nightly-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: '1.17'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
 
       - name: Install go-fuzz
         working-directory: test/fuzz
@@ -39,14 +42,14 @@ jobs:
         continue-on-error: true
 
       - name: Archive crashers
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: crashers
           path: test/fuzz/**/crashers
           retention-days: 3
 
       - name: Archive suppressions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: suppressions
           path: test/fuzz/**/suppressions
@@ -61,6 +64,8 @@ jobs:
       crashers-count: ${{ steps.set-crashers-count.outputs.count }}
 
   fuzz-nightly-fail:
+    permissions:
+      contents: none
     needs: fuzz-nightly-test
     if: ${{ needs.fuzz-nightly-test.outputs.crashers-count != 0 }}
     runs-on: ubuntu-latest

--- a/.github/workflows/janitor.yml
+++ b/.github/workflows/janitor.yml
@@ -4,13 +4,18 @@ name: Janitor
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   cancel:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     name: "Cancel Previous Runs"
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
+      - uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
         with:
           workflow_id: 1041851,1401230,2837803
           access_token: ${{ github.token }}

--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -41,12 +41,15 @@ on:
         required: true
         default: 'https://github.com/tendermint/jepsen/releases/download/0.2.1/merkleeyes_0.1.7.tar.gz'
 
+permissions:
+  contents: read
+
 jobs:
   jepsen-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the Jepsen repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
         with:
           repository: 'tendermint/jepsen'
 
@@ -58,7 +61,7 @@ jobs:
         run: docker exec -i jepsen-control bash -c 'source /root/.bashrc; cd /jepsen/tendermint; lein run test --nemesis ${{ github.event.inputs.nemesis }} --workload ${{ github.event.inputs.workload }} --concurrency ${{ github.event.inputs.concurrency }} --tendermint-url ${{ github.event.inputs.tendermintUrl }} --merkleeyes-url ${{ github.event.inputs.merkleeyesUrl }} --time-limit ${{ github.event.inputs.timeLimit }} ${{ github.event.inputs.dupOrSuperByzValidators }}'
 
       - name: Archive results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: results
           path: tendermint/store/latest

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -6,7 +6,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      - uses: gaurav-nelson/github-action-markdown-link-check@58f84fd654812d0d8da4e4d4a559eda087daf8ce # 1.0.14
         with:
           folder-path: "docs"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,23 +7,29 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
+
 jobs:
   golangci:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: golangci-lint
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: '^1.17'
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: technote-space/get-diff-action@832a70d288f9623f9af054e9f5d8f52df7492c0a # v6.0.1
         with:
           PATTERNS: |
             **/**.go
             go.mod
             go.sum
-      - uses: golangci/golangci-lint-action@v3.1.0
+      - uses: golangci/golangci-lint-action@b517f99ae23d86ecc4c0dec08dcf48d2336abc29 # v3.1.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.44

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
       - name: Lint Code Base
-        uses: docker://github/super-linter:v4
+        uses: docker://github/super-linter@sha256:a39073f3991044b0f0280e2eab2ff489ee62005c06d2ccc3c33d05a6b0cf1680 # v4
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: master

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -9,13 +9,16 @@ on:
     paths:
       - 'proto/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1.1.0
-      - uses: bufbuild/buf-lint-action@v1
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      - uses: bufbuild/buf-setup-action@f739118bb90b0752c8e1b620e193b9625d6c094b # v1.1.0
+      - uses: bufbuild/buf-lint-action@f5029cc05a2a5d95c2edc7d203e4efce0a3b65ed # v1
         with:
           input: 'proto'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,28 +7,33 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"  # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
+    permissions:
+      contents: write  # for goreleaser/goreleaser-action to create a GitHub release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: '1.17'
 
       - name: Build
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@b9169ea22c1ccccedd39ec5d5898be710305f8eb # v2
         if: ${{ github.event_name == 'pull_request' }}
         with:
           version: latest
           args: build --skip-validate   # skip validate skips initial sanity checks in order to be able to fully run
 
       - name: Release
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@b9169ea22c1ccccedd39ec5d5898be710305f8eb # v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           version: latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,11 +3,17 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@7fb802b3079a276cf3c7e6ba9aa003c665b3f838 # v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: "This pull request has been automatically marked as stale because it has not had

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,19 +8,25 @@ on:
       - master
       - release/**
 
+permissions:
+  contents: read
+
 jobs:
   tests:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         part: ["00", "01", "02", "03", "04", "05"]
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: "1.17"
-      - uses: actions/checkout@v3
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      - uses: technote-space/get-diff-action@832a70d288f9623f9af054e9f5d8f52df7492c0a # v6.0.1
         with:
           PATTERNS: |
             **/**.go
@@ -32,17 +38,20 @@ jobs:
         run: |
           make test-group-${{ matrix.part }} NUM_SPLIT=6
         if: env.GIT_DIFF
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: "${{ github.sha }}-${{ matrix.part }}-coverage"
           path: ./build/${{ matrix.part }}.profile.out
 
   upload-coverage-report:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     needs: tests
     steps:
-      - uses: actions/checkout@v3
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      - uses: technote-space/get-diff-action@832a70d288f9623f9af054e9f5d8f52df7492c0a # v6.0.1
         with:
           PATTERNS: |
             **/**.go
@@ -50,26 +59,26 @@ jobs:
             go.mod
             go.sum
             Makefile
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # v2
         with:
           name: "${{ github.sha }}-00-coverage"
         if: env.GIT_DIFF
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # v2
         with:
           name: "${{ github.sha }}-01-coverage"
         if: env.GIT_DIFF
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # v2
         with:
           name: "${{ github.sha }}-02-coverage"
         if: env.GIT_DIFF
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # v2
         with:
           name: "${{ github.sha }}-03-coverage"
         if: env.GIT_DIFF
       - run: |
           cat ./*profile.out | grep -v "mode: set" >> coverage.txt
         if: env.GIT_DIFF
-      - uses: codecov/codecov-action@v2.1.0
+      - uses: codecov/codecov-action@50ffd5fc58ed613b7848c7604df3a1effc13d659 # v2.1.0
         with:
           file: ./coverage.txt
         if: env.GIT_DIFF


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

