### PR TITLE
timeout parameters take the default if not set

### DIFF
--- a/internal/rpc/core/consensus.go
+++ b/internal/rpc/core/consensus.go
@@ -113,6 +113,9 @@ func (env *Environment) ConsensusParams(ctx context.Context, heightPtr *int64) (
 		return nil, err
 	}
 
+	consensusParams.Synchrony = consensusParams.Synchrony.SynchronyParamsOrDefaults()
+	consensusParams.Timeout = consensusParams.Timeout.TimeoutParamsOrDefaults()
+
 	return &coretypes.ResultConsensusParams{
 		BlockHeight:     height,
 		ConsensusParams: consensusParams}, nil

--- a/types/params.go
+++ b/types/params.go
@@ -147,7 +147,22 @@ func DefaultSynchronyParams() SynchronyParams {
 		Precision:    505 * time.Millisecond,
 		MessageDelay: 12 * time.Second,
 	}
+}
 
+// SynchronyParamsOrDefaults returns the SynchronyParams, filling in any zero values
+// with the Tendermint defined default values.
+func (s SynchronyParams) SynchronyParamsOrDefaults() SynchronyParams {
+	// TODO: Remove this method and all uses once development on v0.37 begins.
+	// See: https://github.com/tendermint/tendermint/issues/8187
+
+	defaults := DefaultSynchronyParams()
+	if s.Precision == 0 {
+		s.Precision = defaults.Precision
+	}
+	if s.MessageDelay == 0 {
+		s.MessageDelay = defaults.MessageDelay
+	}
+	return s
 }
 
 func DefaultTimeoutParams() TimeoutParams {
@@ -159,6 +174,31 @@ func DefaultTimeoutParams() TimeoutParams {
 		Commit:              1000 * time.Millisecond,
 		BypassCommitTimeout: false,
 	}
+}
+
+// TimeoutParamsOrDefaults returns the SynchronyParams, filling in any zero values
+// with the Tendermint defined default values.
+func (t TimeoutParams) TimeoutParamsOrDefaults() TimeoutParams {
+	// TODO: Remove this method and all uses once development on v0.37 begins.
+	// See: https://github.com/tendermint/tendermint/issues/8187
+
+	defaults := DefaultTimeoutParams()
+	if t.Propose == 0 {
+		t.Propose = defaults.Propose
+	}
+	if t.ProposeDelta == 0 {
+		t.ProposeDelta = defaults.ProposeDelta
+	}
+	if t.Vote == 0 {
+		t.Vote = defaults.Vote
+	}
+	if t.VoteDelta == 0 {
+		t.VoteDelta = defaults.VoteDelta
+	}
+	if t.Commit == 0 {
+		t.Commit = defaults.Commit
+	}
+	return t
 }
 
 // ProposeTimeout returns the amount of time to wait for a proposal.


### PR DESCRIPTION
closes: #8156 
# What does this change do? 
* Continues the work of [ADR-74](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-074-timeout-params.md)
* Adds a set of `*OrDefault()` methods to the new `Timeout` and `Synchrony` `ConsensusParams`. These types return the consensus parameters with any 0 values filled in with the default value for the field.
* Uses these new methods in both the `consensus` and `rpc` code.
# Notes to reviewers
This change does not write the new parameters into the database. The new values will not written into the data base until the application issues a change to the consensus parameters. There is no issue with using these default values for historical blocks that were created before these parameters existed because these are timing parameters.