### PR TITLE
config: default indexer configuration to null

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,7 @@ Special thanks to external contributors on this release:
   - [config] \#7930 Add new event subscription options and defaults. (@creachadair)
   - [rpc] \#7982 Add new Events interface and deprecate Subscribe. (@creachadair)
   - [cli] \#8081 make the reset command safe to use. (@marbar3778)
+  - [config] \#xxxx default indexer configuration to null. (@creachadair)
 
 - Apps
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,7 +20,7 @@ Special thanks to external contributors on this release:
   - [config] \#7930 Add new event subscription options and defaults. (@creachadair)
   - [rpc] \#7982 Add new Events interface and deprecate Subscribe. (@creachadair)
   - [cli] \#8081 make the reset command safe to use. (@marbar3778)
-  - [config] \#xxxx default indexer configuration to null. (@creachadair)
+  - [config] \#8222 default indexer configuration to null. (@creachadair)
 
 - Apps
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,6 +26,13 @@ application concern so be very sure to test the application thoroughly
 using realistic workloads and the race detector to ensure your
 applications remains correct.
 
+### Config Changes
+
+The default configuration for a newly-created node now disables indexing for
+ABCI event metadata. Existing node configurations that already have indexing
+turned on are not affected. Operators who wish to enable indexing for a new
+node, however, must now edit the `config.toml` explicitly.
+
 ### RPC Changes
 
 Tendermint v0.36 adds a new RPC event subscription API. The existing event

--- a/config/config.go
+++ b/config/config.go
@@ -1088,9 +1088,8 @@ type TxIndexConfig struct {
 	// If list contains `null`, meaning no indexer service will be used.
 	//
 	// Options:
-	//   1) "null" - no indexer services.
-	//   2) "kv" (default) - the simplest possible indexer,
-	//      backed by key-value storage (defaults to levelDB; see DBBackend).
+	//   1) "null" (default) - no indexer services.
+	//   2) "kv" - a simple indexer backed by key-value storage (see DBBackend)
 	//   3) "psql" - the indexer services backed by PostgreSQL.
 	Indexer []string `mapstructure:"indexer"`
 
@@ -1101,14 +1100,12 @@ type TxIndexConfig struct {
 
 // DefaultTxIndexConfig returns a default configuration for the transaction indexer.
 func DefaultTxIndexConfig() *TxIndexConfig {
-	return &TxIndexConfig{
-		Indexer: []string{"kv"},
-	}
+	return &TxIndexConfig{Indexer: []string{"null"}}
 }
 
 // TestTxIndexConfig returns a default configuration for the transaction indexer.
 func TestTxIndexConfig() *TxIndexConfig {
-	return DefaultTxIndexConfig()
+	return &TxIndexConfig{Indexer: []string{"kv"}}
 }
 
 //-----------------------------------------------------------------------------

--- a/config/toml.go
+++ b/config/toml.go
@@ -520,8 +520,8 @@ peer-query-maj23-sleep-duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
 # to decide which txs to index based on configuration set in the application.
 #
 # Options:
-#   1) "null"
-#   2) "kv" (default) - the simplest possible indexer, backed by key-value storage (defaults to levelDB; see DBBackend).
+#   1) "null" (default) - no indexer services.
+#   2) "kv" - a simple indexer backed by key-value storage (see DBBackend)
 #   3) "psql" - the indexer services backed by PostgreSQL.
 # When "kv" or "psql" is chosen "tx.height" and "tx.hash" will always be indexed.
 indexer = [{{ range $i, $e := .TxIndex.Indexer }}{{if $i}}, {{end}}{{ printf "%q" $e}}{{end}}]

--- a/test/docker/config-template.toml
+++ b/test/docker/config-template.toml
@@ -1,2 +1,5 @@
 [rpc]
 laddr = "tcp://0.0.0.0:26657"
+
+[tx-index]
+indexer = ["kv"]

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -237,6 +237,7 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg := config.DefaultConfig()
 	cfg.Moniker = node.Name
 	cfg.ProxyApp = AppAddressTCP
+	cfg.TxIndex = config.TestTxIndexConfig()
 
 	if node.LogLevel != "" {
 		cfg.LogLevel = node.LogLevel


### PR DESCRIPTION
After this change, new nodes will not have indexing enabled by default.
Test configurations will still use "kv".

Update pending changelog.

Updates #8221.