### PR TITLE
e2e: Fix hashing for app + Fix logic of TestApp_Hash

### DIFF
--- a/test/e2e/app/snapshots.go
+++ b/test/e2e/app/snapshots.go
@@ -92,7 +92,7 @@ func (s *SnapshotStore) Create(state *State) (abci.Snapshot, error) {
 	snapshot := abci.Snapshot{
 		Height: state.Height,
 		Format: 1,
-		Hash:   hashItems(state.Values),
+		Hash:   hashItems(state.Values, state.Height),
 		Chunks: byteChunks(bz),
 	}
 	err = os.WriteFile(filepath.Join(s.dir, fmt.Sprintf("%v.json", state.Height)), bz, 0644)

--- a/test/e2e/app/state.go
+++ b/test/e2e/app/state.go
@@ -180,10 +180,9 @@ func hashItems(items map[string]string, height uint64) []byte {
 	sort.Strings(keys)
 
 	hasher := sha256.New()
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, height)
-	_, _ = hasher.Write(b)
-	_, _ = hasher.Write([]byte{0})
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], height)
+	_, _ = hasher.Write(b[:])
 	for _, key := range keys {
 		_, _ = hasher.Write([]byte(key))
 		_, _ = hasher.Write([]byte{0})

--- a/test/e2e/app/state.go
+++ b/test/e2e/app/state.go
@@ -3,6 +3,7 @@ package app
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -38,7 +39,7 @@ func NewState(dir string, persistInterval uint64) (*State, error) {
 		previousFile:    filepath.Join(dir, prevStateFileName),
 		persistInterval: persistInterval,
 	}
-	state.Hash = hashItems(state.Values)
+	state.Hash = hashItems(state.Values, state.Height)
 	err := state.load()
 	switch {
 	case errors.Is(err, os.ErrNotExist):
@@ -114,7 +115,7 @@ func (s *State) Import(height uint64, jsonBytes []byte) error {
 	}
 	s.Height = height
 	s.Values = values
-	s.Hash = hashItems(values)
+	s.Hash = hashItems(values, height)
 	return s.save()
 }
 
@@ -140,7 +141,6 @@ func (s *State) Set(key, value string) {
 func (s *State) Commit() (uint64, []byte, error) {
 	s.Lock()
 	defer s.Unlock()
-	s.Hash = hashItems(s.Values)
 	switch {
 	case s.Height > 0:
 		s.Height++
@@ -149,6 +149,7 @@ func (s *State) Commit() (uint64, []byte, error) {
 	default:
 		s.Height = 1
 	}
+	s.Hash = hashItems(s.Values, s.Height)
 	if s.persistInterval > 0 && s.Height%s.persistInterval == 0 {
 		err := s.save()
 		if err != nil {
@@ -171,7 +172,7 @@ func (s *State) Rollback() error {
 }
 
 // hashItems hashes a set of key/value items.
-func hashItems(items map[string]string) []byte {
+func hashItems(items map[string]string, height uint64) []byte {
 	keys := make([]string, 0, len(items))
 	for key := range items {
 		keys = append(keys, key)
@@ -179,6 +180,10 @@ func hashItems(items map[string]string) []byte {
 	sort.Strings(keys)
 
 	hasher := sha256.New()
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, height)
+	_, _ = hasher.Write(b)
+	_, _ = hasher.Write([]byte{0})
 	for _, key := range keys {
 		_, _ = hasher.Write([]byte(key))
 		_, _ = hasher.Write([]byte{0})

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -51,25 +51,21 @@ func TestApp_Hash(t *testing.T) {
 		// In next-block execution, the app hash is stored in the next block
 		blockHeight := info.Response.LastBlockHeight + 1
 
-		for {
+		require.Eventually(t, func () bool {
 			status, err := client.Status(ctx)
 			require.NoError(t, err)
 			require.NotZero(t, status.SyncInfo.LatestBlockHeight)
-			if status.SyncInfo.LatestBlockHeight >= blockHeight {
-				break
-			}
-		}
+			return status.SyncInfo.LatestBlockHeight >= blockHeight
+		}, 60*time.Second, 3*time.Second)
 
 		block, err := client.Block(ctx, &blockHeight)
 		require.NoError(t, err)
 
-		if info.Response.LastBlockHeight == block.Block.Height {
-			require.Equal(t,
-				fmt.Sprintf("%x", info.Response.LastBlockAppHash),
-				fmt.Sprintf("%x", block.Block.AppHash.Bytes()),
-				"app hash does not match last block's app hash")
-		}
-
+		require.Equal(t, blockHeight, block.Block.Height)
+		require.Equal(t,
+			fmt.Sprintf("%x", info.Response.LastBlockAppHash),
+			fmt.Sprintf("%x", block.Block.AppHash.Bytes()),
+			"app hash does not match last block's app hash")
 	})
 }
 

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -56,7 +56,7 @@ func TestApp_Hash(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, status.SyncInfo.LatestBlockHeight)
 			return status.SyncInfo.LatestBlockHeight >= blockHeight
-		}, 60*time.Second, 3*time.Second)
+		}, 60*time.Second, 500*time.Millisecond)
 
 		block, err := client.Block(ctx, &blockHeight)
 		require.NoError(t, err)

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -49,18 +49,18 @@ func TestApp_Hash(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, info.Response.LastBlockAppHash, "expected app to return app hash")
 		// In next-block execution, the app hash is stored in the next block
-		block_height := info.Response.LastBlockHeight + 1
+		blockHeight := info.Response.LastBlockHeight + 1
 
 		for {
 			status, err := client.Status(ctx)
 			require.NoError(t, err)
 			require.NotZero(t, status.SyncInfo.LatestBlockHeight)
-			if status.SyncInfo.LatestBlockHeight >= block_height {
+			if status.SyncInfo.LatestBlockHeight >= blockHeight {
 				break
 			}
 		}
 
-		block, err := client.Block(ctx, &block_height)
+		block, err := client.Block(ctx, &blockHeight)
 		require.NoError(t, err)
 
 		if info.Response.LastBlockHeight == block.Block.Height {

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -51,7 +51,7 @@ func TestApp_Hash(t *testing.T) {
 		// In next-block execution, the app hash is stored in the next block
 		blockHeight := info.Response.LastBlockHeight + 1
 
-		require.Eventually(t, func () bool {
+		require.Eventually(t, func() bool {
 			status, err := client.Status(ctx)
 			require.NoError(t, err)
 			require.NotZero(t, status.SyncInfo.LatestBlockHeight)


### PR DESCRIPTION
This PR addressed two issues:
1. the hashing algorithm for the application used in e2e test only takes into account the keys and values. Therefore, if a block has no txs, the app hash doesn't change. This is problematic in an App used for testing, since it might hide off-by-1 problems
2. TestApp_Hash is comparing the (height, app hash) pair obtained via `Info` ABCI call, with the contents of the block corresponding to that height. This is incorrect in _next-block_ exection mode (the only one currently supported)

To show that this addresses the problem seen in #8141, I did the following tests:
* e2e tests with only the first commit of this PR applied --> e2e tests fail on TestApp_Hash
* e2e tests (several times) with both commits in this PR applied --> all e2e tests pass