### PR TITLE
stop using %w in testing errors

### DIFF
--- a/crypto/xchacha20poly1305/xchachapoly_test.go
+++ b/crypto/xchacha20poly1305/xchachapoly_test.go
@@ -25,19 +25,19 @@ func TestRandom(t *testing.T) {
 		plaintext := make([]byte, pl)
 		_, err := cr.Read(key[:])
 		if err != nil {
-			t.Errorf("error on read: %w", err)
+			t.Errorf("error on read: %v", err)
 		}
 		_, err = cr.Read(nonce[:])
 		if err != nil {
-			t.Errorf("error on read: %w", err)
+			t.Errorf("error on read: %v", err)
 		}
 		_, err = cr.Read(ad)
 		if err != nil {
-			t.Errorf("error on read: %w", err)
+			t.Errorf("error on read: %v", err)
 		}
 		_, err = cr.Read(plaintext)
 		if err != nil {
-			t.Errorf("error on read: %w", err)
+			t.Errorf("error on read: %v", err)
 		}
 
 		aead, err := New(key[:])


### PR DESCRIPTION
govet complains about using the "%w" format in `t.Errorf` statements. This updates invocations of `t.Errorf` using the `%w` directive to use `%v` instead to fix the govet error.