### PR TITLE
Update golangci-lint-action and golang-ci versions.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,10 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: golangci/golangci-lint-action@v2.5.2
+      - uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.42.1
+          version: v1.45
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         if: env.GIT_DIFF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,9 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
       - uses: technote-space/get-diff-action@v5
         with:
           PATTERNS: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tendermint/tendermint
 
-go 1.15
+go 1.16
 
 require (
 	github.com/BurntSushi/toml v1.0.0


### PR DESCRIPTION
I'm not sure why this wasn't updated automatically, but it appears to be causing heartache in Dependabot PRs.