### PR TITLE
consensus: remove string indented function

### DIFF
--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -299,22 +299,6 @@ func (r *Reactor) String() string {
 	return "ConsensusReactor"
 }
 
-// StringIndented returns an indented string representation of the Reactor.
-func (r *Reactor) StringIndented(indent string) string {
-	r.mtx.RLock()
-	defer r.mtx.RUnlock()
-
-	s := "ConsensusReactor{\n"
-	s += indent + "  " + r.state.StringIndented(indent+"  ") + "\n"
-
-	for _, ps := range r.peers {
-		s += indent + "  " + ps.StringIndented(indent+"  ") + "\n"
-	}
-
-	s += indent + "}"
-	return s
-}
-
 // GetPeerState returns PeerState for a given NodeID.
 func (r *Reactor) GetPeerState(peerID types.NodeID) (*PeerState, bool) {
 	r.mtx.RLock()


### PR DESCRIPTION
I stumbled upon this function and was gratified to find that it wasn't
used, but I wanted to remove it before that changed.