### PR TITLE
cli: fix reset command

### DIFF
--- a/cmd/tendermint/commands/reset.go
+++ b/cmd/tendermint/commands/reset.go
@@ -72,6 +72,11 @@ func resetAll(dbDir, addrBookFile, privValKeyFile, privValStateFile string, logg
 		logger.Error("Error removing all blockchain history", "dir", dbDir, "err", err)
 	}
 
+	if err := tmos.EnsureDir(dbDir, 0700); err != nil {
+		logger.Error("unable to recreate dbDir", "err", err)
+	}
+
+	// recreate the dbDir since the privVal state needs to live there
 	resetFilePV(privValKeyFile, privValStateFile, logger)
 	return nil
 }
@@ -83,7 +88,6 @@ func resetState(dbDir string, logger log.Logger) error {
 	wal := filepath.Join(dbDir, "cs.wal")
 	evidence := filepath.Join(dbDir, "evidence.db")
 	txIndex := filepath.Join(dbDir, "tx_index.db")
-	peerstore := filepath.Join(dbDir, "peerstore.db")
 
 	if tmos.FileExists(blockdb) {
 		if err := os.RemoveAll(blockdb); err == nil {
@@ -125,13 +129,6 @@ func resetState(dbDir string, logger log.Logger) error {
 		}
 	}
 
-	if tmos.FileExists(peerstore) {
-		if err := os.RemoveAll(peerstore); err == nil {
-			logger.Info("Removed peerstore.db", "dir", peerstore)
-		} else {
-			logger.Error("error removing peerstore.db", "dir", peerstore, "err", err)
-		}
-	}
 	if err := tmos.EnsureDir(dbDir, 0700); err != nil {
 		logger.Error("unable to recreate dbDir", "err", err)
 	}

--- a/cmd/tendermint/commands/reset_test.go
+++ b/cmd/tendermint/commands/reset_test.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/privval"
+)
+
+func Test_ResetAll(t *testing.T) {
+	config := cfg.TestConfig()
+	dir := t.TempDir()
+	config.SetRoot(dir)
+	cfg.EnsureRoot(dir)
+	require.NoError(t, initFilesWithConfig(config))
+	pv := privval.LoadFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile())
+	pv.LastSignState.Height = 10
+	pv.Save()
+	require.NoError(t, resetAll(config.DBDir(), config.P2P.AddrBookFile(), config.PrivValidatorKeyFile(),
+		config.PrivValidatorStateFile(), logger))
+	require.DirExists(t, config.DBDir())
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "block.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "state.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "evidence.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "tx_index.db"))
+	require.FileExists(t, config.PrivValidatorStateFile())
+	pv = privval.LoadFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile())
+	require.Equal(t, int64(0), pv.LastSignState.Height)
+}
+
+func Test_ResetState(t *testing.T) {
+	config := cfg.TestConfig()
+	dir := t.TempDir()
+	config.SetRoot(dir)
+	cfg.EnsureRoot(dir)
+	require.NoError(t, initFilesWithConfig(config))
+	pv := privval.LoadFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile())
+	pv.LastSignState.Height = 10
+	pv.Save()
+	require.NoError(t, resetState(config.DBDir(), logger))
+	require.DirExists(t, config.DBDir())
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "block.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "state.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "evidence.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "tx_index.db"))
+	require.FileExists(t, config.PrivValidatorStateFile())
+	pv = privval.LoadFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile())
+	// private validator state should still be in tact. 
+	require.Equal(t, int64(10), pv.LastSignState.Height)
+}
+


### PR DESCRIPTION
https://github.com/tendermint/tendermint/pull/8081 added a new command to remove all data whilst keeping the priv validator state in tact. `unsafe-reset-all` however now would panic because the data directory wasn't recreated for the priv validator state to be stored in. This remedies that and adds a few tests to asset correct behaviour.  


