### PR TITLE
Prepare changelog for v0.34.18 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Friendly reminder, we have a [bug bounty program](https://hackerone.com/cosmos).
 
+## v0.34.18
+
+### BREAKING CHANGES
+
+- CLI/RPC/Config
+    - [cli] [\#8258](https://github.com/tendermint/tendermint/pull/8258) Fix a bug in the cli that caused `unsafe-reset-all` to panic
+
 ## v0.34.17
 
 ### BREAKING CHANGES

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,6 @@
 # Unreleased Changes
 
-## v0.34.18
+## v0.34.19
 
 Special thanks to external contributors on this release:
 
@@ -9,7 +9,6 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 ### BREAKING CHANGES
 
 - CLI/RPC/Config
-    - [cli] [\#8258](https://github.com/tendermint/tendermint/pull/8258) Fix a bug in the cli that caused `unsafe-reset-all` to panic
 
 - Apps
 


### PR DESCRIPTION
A nightly test run is in-progress.
This release is to make #8258 available to the SDK et seq.