### PR TITLE
fix: fix reset commands

### DIFF
--- a/privval/file.go
+++ b/privval/file.go
@@ -63,11 +63,10 @@ func (pvKey FilePVKey) Save() {
 	if err != nil {
 		panic(err)
 	}
-	err = tempfile.WriteFileAtomic(outFile, jsonBytes, 0600)
-	if err != nil {
+
+	if err := tempfile.WriteFileAtomic(outFile, jsonBytes, 0600); err != nil {
 		panic(err)
 	}
-
 }
 
 //-------------------------------------------------------------------------------


### PR DESCRIPTION
Upstream consumers of Tendermint's commands that use them directly as opposed to using the `root` command will fail because `config` is a **private global**. This forces the upstream user to manually parse the config or having each command do it. This PR takes the latter approach.