### PR TITLE
Fix more broken Markdown links.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2795,7 +2795,7 @@ are affected by a change.
 
 A few more breaking changes are in the works - each will come with a clear
 Architecture Decision Record (ADR) explaining the change. You can review ADRs
-[here](https://github.com/tendermint/tendermint/tree/develop/docs/architecture)
+[here](https://github.com/tendermint/tendermint/tree/master/docs/architecture)
 or in the [open Pull Requests](https://github.com/tendermint/tendermint/pulls).
 You can also check in on the [issues marked as
 breaking](https://github.com/tendermint/tendermint/issues?q=is%3Aopen+is%3Aissue+label%3Abreaking).
@@ -3074,7 +3074,7 @@ BREAKING CHANGES:
 FEATURES
 - [cmd] Added metrics (served under `/metrics` using a Prometheus client;
   disabled by default). See the new `instrumentation` section in the config and
-  [metrics](https://tendermint.readthedocs.io/projects/tools/en/develop/metrics.html)
+  [metrics](https://github.com/tendermint/tendermint/blob/master/docs/nodes/metrics.md)
   guide.
 - [p2p] Add IPv6 support to peering.
 - [p2p] Add `external_address` to config to allow specifying the address for
@@ -3188,7 +3188,7 @@ BREAKING:
 
 FEATURES
 
-- [rpc] the RPC documentation is now published to https://tendermint.github.io/slate
+- [rpc] the RPC documentation is now published to `https://tendermint.github.io/slate`
 - [p2p] AllowDuplicateIP config option to refuse connections from same IP.
     - true by default for now, false by default in next breaking release
 - [docs] Add docs for query, tx indexing, events, pubsub

--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -8,7 +8,7 @@ Official releases can be found [here](https://github.com/tendermint/tendermint/r
 
 The Dockerfile for tendermint is not expected to change in the near future. The master file used for all builds can be found [here](https://raw.githubusercontent.com/tendermint/tendermint/master/DOCKER/Dockerfile).
 
-Respective versioned files can be found <https://raw.githubusercontent.com/tendermint/tendermint/vX.XX.XX/DOCKER/Dockerfile> (replace the Xs with the version number).
+Respective versioned files can be found at `https://raw.githubusercontent.com/tendermint/tendermint/vX.XX.XX/DOCKER/Dockerfile` (replace the Xs with the version number).
 
 ## Quick reference
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -100,7 +100,7 @@ these parameters may do so by setting the `ConsensusParams.Timeout` field of the
 As a safety measure in case of unusual timing issues during the upgrade to
 v0.36, an operator may override the consensus timeout values for a single node.
 Note, however, that these overrides will be removed in Tendermint v0.37. See
-[configuration](https://github.com/tendermint/tendermint/blob/wb/issue-8182/docs/nodes/configuration.md)
+[configuration](https://github.com/tendermint/tendermint/blob/master/docs/nodes/configuration.md)
 for more information about these overrides.
 
 For more discussion of this, see [ADR 074](https://tinyurl.com/adr074), which

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -12,7 +12,7 @@ For any specific algorithm, use its specific module e.g.
 
 ## Binary encoding
 
-For Binary encoding, please refer to the [Tendermint encoding specification](https://docs.tendermint.com/master/spec/blockchain/encoding.html).
+For Binary encoding, please refer to the [Tendermint encoding specification](https://docs.tendermint.com/master/spec/core/encoding.html).
 
 ## JSON Encoding
 

--- a/internal/p2p/README.md
+++ b/internal/p2p/README.md
@@ -7,5 +7,5 @@ Docs:
 - [Connection](https://docs.tendermint.com/master/spec/p2p/connection.html) for details on how connections and multiplexing work
 - [Peer](https://docs.tendermint.com/master/spec/p2p/node.html) for details on peer ID, handshakes, and peer exchange
 - [Node](https://docs.tendermint.com/master/spec/p2p/node.html) for details about different types of nodes and how they should work
-- [Pex](https://docs.tendermint.com/master/spec/reactors/pex/pex.html) for details on peer discovery and exchange
+- [Pex](https://docs.tendermint.com/master/spec/p2p/messages/pex.html) for details on peer discovery and exchange
 - [Config](https://docs.tendermint.com/master/spec/p2p/config.html) for details on some config option

--- a/networks/local/README.md
+++ b/networks/local/README.md
@@ -1,3 +1,3 @@
 # Local Cluster with Docker Compose
 
-See the [docs](https://docs.tendermint.com/master/networks/docker-compose.html).
+See the [docs](https://docs.tendermint.com/master/tools/docker-compose.html).

--- a/spec/p2p/messages/pex.md
+++ b/spec/p2p/messages/pex.md
@@ -26,7 +26,7 @@ PexResponse is an list of net addresses provided to a peer to dial.
 
 | Name  | Type                               | Description                              | Field Number |
 |-------|------------------------------------|------------------------------------------|--------------|
-| addresses | repeated [PexAddress](#PexAddress) | List of peer addresses available to dial | 1            |
+| addresses | repeated [PexAddress](#pexaddress) | List of peer addresses available to dial | 1            |
 
 ### PexAddress
 
@@ -41,7 +41,7 @@ into a `NodeAddress`. See [ParseNodeAddress](https://github.com/tendermint/tende
 
 Message is a [`oneof` protobuf type](https://developers.google.com/protocol-buffers/docs/proto#oneof). The one of consists of two messages.
 
-| Name         | Type                      | Description                                          | Field Number |
-|--------------|---------------------------|------------------------------------------------------|--------------|
-| pex_request  | [PexRequest](#PexRequest) | Empty request asking for a list of addresses to dial | 3            |
-| pex_response | [PexResponse](#PexResponse)  | List of addresses to dial                            | 4            |
+| Name         | Type                        | Description                                          | Field Number |
+|--------------|-----------------------------|------------------------------------------------------|--------------|
+| pex_request  | [PexRequest](#pexrequest)   | Empty request asking for a list of addresses to dial | 3            |
+| pex_response | [PexResponse](#pexresponse) | List of addresses to dial                            | 4            |

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -11,7 +11,7 @@ This creates and runs a testnet named `ci` under `networks/ci/`.
 
 ## Conceptual Overview
 
-End-to-end testnets are used to test Tendermint functionality as a user would use it, by spinning up a set of nodes with various configurations and making sure the nodes and network behave correctly. The background for the E2E test suite is outlined in [RFC-001](https://github.com/tendermint/tendermint/blob/master/docs/rfc/rfc-001-end-to-end-testing.md).
+End-to-end testnets are used to test Tendermint functionality as a user would use it, by spinning up a set of nodes with various configurations and making sure the nodes and network behave correctly. The background for the E2E test suite is outlined in [RFC-001](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-066-e2e-testing.md).
 
 The end-to-end tests can be thought of in this manner:
 


### PR DESCRIPTION
Found during attempts to upgrade the link checker.

Note: In a couple cases the link no longer exists, even at a new location. In those cases I've "commented out" the link by marking it as plain text.