### PR TITLE
scmigrate: ensure target key is correctly renamed

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -81,3 +81,4 @@ Special thanks to external contributors on this release:
 - [light] \#7640 Light Client: fix absence proof verification (@ashcherbakov)
 - [light] \#7641 Light Client: fix querying against the latest height (@ashcherbakov)
 - [cli] [#7837](https://github.com/tendermint/tendermint/pull/7837) fix app hash in state rollback. (@yihuang)
+- [cli] \#8276 scmigrate: ensure target key is correctly renamed. (@creachadair)

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/charithe/durationcheck v0.0.9 // indirect
 	github.com/chavacava/garif v0.0.0-20210405164556-e8a0a408d6af // indirect
 	github.com/containerd/continuity v0.2.1 // indirect
+	github.com/creachadair/taskgroup v0.3.2 // indirect
 	github.com/daixiang0/gci v0.3.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denis-tingaikin/go-header v0.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creachadair/atomicfile v0.2.4 h1:GRjpQLmz/78I4+nBQpGMFrRa9yrL157AUTrA6hnF0YU=
 github.com/creachadair/atomicfile v0.2.4/go.mod h1:BRq8Une6ckFneYXZQ+kO7p1ZZP3I2fzVzf28JxrIkBc=
+github.com/creachadair/taskgroup v0.3.2 h1:zlfutDS+5XG40AOxcHDSThxKzns8Tnr9jnr6VqkYlkM=
+github.com/creachadair/taskgroup v0.3.2/go.mod h1:wieWwecHVzsidg2CsUnFinW1faVN4+kq+TDlRJQ0Wbk=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=

--- a/scripts/keymigrate/migrate_test.go
+++ b/scripts/keymigrate/migrate_test.go
@@ -117,7 +117,7 @@ func TestMigration(t *testing.T) {
 		})
 		t.Run("Conversion", func(t *testing.T) {
 			for kind, le := range legacyPrefixes {
-				nk, err := migarateKey(le)
+				nk, err := migrateKey(le)
 				require.NoError(t, err, kind)
 				require.False(t, keyIsLegacy(nk), kind)
 			}
@@ -159,7 +159,7 @@ func TestMigration(t *testing.T) {
 				"UserKey3":        []byte("foo/bar/baz/1.2/4"),
 			}
 			for kind, key := range table {
-				out, err := migarateKey(key)
+				out, err := migrateKey(key)
 				require.Error(t, err, kind)
 				require.Nil(t, out, kind)
 			}
@@ -177,7 +177,7 @@ func TestMigration(t *testing.T) {
 					return nil, errors.New("hi")
 				}))
 			})
-			t.Run("KeyDisapears", func(t *testing.T) {
+			t.Run("KeyDisappears", func(t *testing.T) {
 				db := dbm.NewMemDB()
 				key := keyID("hi")
 				require.NoError(t, db.Set(key, []byte("world")))
@@ -214,17 +214,6 @@ func TestMigration(t *testing.T) {
 			for _, key := range getNewPrefixKeys(t, 84) {
 				require.False(t, keyIsLegacy(key))
 			}
-		})
-		t.Run("ChannelConversion", func(t *testing.T) {
-			ch := makeKeyChan([]keyID{
-				makeKey(t, "abc", int64(2), int64(42)),
-				makeKey(t, int64(42)),
-			})
-			count := 0
-			for range ch {
-				count++
-			}
-			require.Equal(t, 2, count)
 		})
 		t.Run("Migrate", func(t *testing.T) {
 			_, db := getLegacyDatabase(t)

--- a/scripts/scmigrate/migrate.go
+++ b/scripts/scmigrate/migrate.go
@@ -116,6 +116,11 @@ func getAllSeenCommits(ctx context.Context, db dbm.DB) ([]toMigrate, error) {
 }
 
 func renameRecord(ctx context.Context, db dbm.DB, keep toMigrate) error {
+	wantKey := makeKeyFromPrefix(prefixSeenCommit)
+	if bytes.Equal(keep.key, wantKey) {
+		return nil // we already did this conversion
+	}
+
 	// This record's key has already been converted to the "new" format, we just
 	// now need to trim off the tail.
 	val, err := db.Get(keep.key)
@@ -123,8 +128,6 @@ func renameRecord(ctx context.Context, db dbm.DB, keep toMigrate) error {
 		return err
 	}
 
-	// N.B. Delete before adding so that if we already did this conversion we
-	// wind up with the same results.
 	batch := db.NewBatch()
 	batch.Delete(keep.key)
 	batch.Set(makeKeyFromPrefix(prefixSeenCommit), val)

--- a/scripts/scmigrate/migrate.go
+++ b/scripts/scmigrate/migrate.go
@@ -129,8 +129,12 @@ func renameRecord(ctx context.Context, db dbm.DB, keep toMigrate) error {
 	}
 
 	batch := db.NewBatch()
-	batch.Delete(keep.key)
-	batch.Set(wantKey, val)
+	if err := batch.Delete(keep.key); err != nil {
+		return err
+	}
+	if err := batch.Set(wantKey, val); err != nil {
+		return err
+	}
 	werr := batch.Write()
 	cerr := batch.Close()
 	if werr != nil {

--- a/scripts/scmigrate/migrate.go
+++ b/scripts/scmigrate/migrate.go
@@ -130,7 +130,7 @@ func renameRecord(ctx context.Context, db dbm.DB, keep toMigrate) error {
 
 	batch := db.NewBatch()
 	batch.Delete(keep.key)
-	batch.Set(makeKeyFromPrefix(prefixSeenCommit), val)
+	batch.Set(wantKey, val)
 	werr := batch.Write()
 	cerr := batch.Close()
 	if werr != nil {


### PR DESCRIPTION
Prior to v0.35, the keys for seen-commit records included the applicable
height.  In v0.35 and beyond, we only keep the record for the latest height,
and its key does not include the height.

Update the seen-commit migration to ensure that the record we retain after
migration is correctly renamed to omit the height from its key.

- Update the test cases to check for this condition after migrating.
- Simplify concurrency in the baseline key migration script.