### PR TITLE
move docs deployment back to this repo

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,33 @@
+name: Documentation
+# This workflow clones the tendermint/tendermint repository, builds its static
+# documentation, and publishes the results to GitHub Pages.
+# It runs on every push to the main branch, with changes in the docs and spec directories
+on:
+  workflow_dispatch:  # allow manual updates
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "spec/**"
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    container:
+      image: tendermintdev/docker-website-deployment
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Install and Build 🔧
+        run: |
+          apk add rsync
+          make build-docs
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: ~/output
+          single-commit: true


### PR DESCRIPTION
Move docs deployment from tendermint/docs back to here. 
