### PR TITLE
Fix release notes to match the prevailing style.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,13 @@ jobs:
           version: latest
           args: build --skip-validate   # skip validate skips initial sanity checks in order to be able to fully run
 
+      - run: echo https://github.com/tendermint/tendermint/blob/${GITHUB_REF#refs/tags/}/CHANGELOG.md#${GITHUB_REF#refs/tags/} > ../release_notes.md
+
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --release-notes=../release_notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Our release notes are intended to point to the CHANGELOG section for that
release, rather than the default commit log summary.

This still works correctly in v0.34, but v0.35 et seq. dropped that.  Restore
that change, while preserving other improvements to the config.

This averts the need to manually edit the release notes after goreleaser is finished running.
I will backport this into v0.35 too.