### PR TITLE
keymigrate: fix decoding of block-hash row keys

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -83,3 +83,4 @@ Special thanks to external contributors on this release:
 - [light] \#7641 Light Client: fix querying against the latest height (@ashcherbakov)
 - [cli] [#7837](https://github.com/tendermint/tendermint/pull/7837) fix app hash in state rollback. (@yihuang)
 - [cli] \#8276 scmigrate: ensure target key is correctly renamed. (@creachadair)
+- [cli] \#xxxx keymigrate: ensure block hash keys are correctly translated. (@creachadair)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -83,4 +83,4 @@ Special thanks to external contributors on this release:
 - [light] \#7641 Light Client: fix querying against the latest height (@ashcherbakov)
 - [cli] [#7837](https://github.com/tendermint/tendermint/pull/7837) fix app hash in state rollback. (@yihuang)
 - [cli] \#8276 scmigrate: ensure target key is correctly renamed. (@creachadair)
-- [cli] \#xxxx keymigrate: ensure block hash keys are correctly translated. (@creachadair)
+- [cli] \#8294 keymigrate: ensure block hash keys are correctly translated. (@creachadair)

--- a/scripts/keymigrate/migrate.go
+++ b/scripts/keymigrate/migrate.go
@@ -138,12 +138,16 @@ func migrateKey(key keyID) (keyID, error) {
 
 		return orderedcode.Append(nil, int64(3), int64(val))
 	case bytes.HasPrefix(key, keyID("BH:")):
-		val, err := strconv.Atoi(string(key[3:]))
+		hash := string(key[3:])
+		if len(hash)%2 == 1 {
+			hash = "0" + hash
+		}
+		val, err := hex.DecodeString(hash)
 		if err != nil {
 			return nil, err
 		}
 
-		return orderedcode.Append(nil, int64(4), int64(val))
+		return orderedcode.Append(nil, int64(4), string(val))
 	case bytes.HasPrefix(key, keyID("validatorsKey:")):
 		val, err := strconv.Atoi(string(key[14:]))
 		if err != nil {

--- a/scripts/keymigrate/migrate_test.go
+++ b/scripts/keymigrate/migrate_test.go
@@ -27,7 +27,7 @@ func getLegacyPrefixKeys(val int) map[string][]byte {
 		"BlockPartTwo":      []byte(fmt.Sprintf("P:%d:%d", val+2, val+val)),
 		"BlockCommit":       []byte(fmt.Sprintf("C:%d", val)),
 		"SeenCommit":        []byte(fmt.Sprintf("SC:%d", val)),
-		"BlockHeight":       []byte(fmt.Sprintf("BH:%d", val)),
+		"BlockHeight":       []byte(fmt.Sprintf("BH:%x", val)),
 		"Validators":        []byte(fmt.Sprintf("validatorsKey:%d", val)),
 		"ConsensusParams":   []byte(fmt.Sprintf("consensusParamsKey:%d", val)),
 		"ABCIResponse":      []byte(fmt.Sprintf("abciResponsesKey:%d", val)),


### PR DESCRIPTION
The suffix of BH: (block hash) row keys in v0.34.x is hexadecimal, but we were
parsing it as a plain integer.
