### PR TITLE
test/fuzz: update oss-fuzz build script to match reality

### DIFF
--- a/test/fuzz/oss-fuzz-build.sh
+++ b/test/fuzz/oss-fuzz-build.sh
@@ -2,12 +2,8 @@
 
 export FUZZ_ROOT="github.com/tendermint/tendermint"
 
-(cd test/fuzz/p2p/addrbook; go run ./init-corpus/main.go)
-compile_go_fuzzer "$FUZZ_ROOT"/test/fuzz/p2p/addrbook Fuzz fuzz_p2p_addrbook fuzz
-(cd test/fuzz/p2p/pex; go run ./init-corpus/main.go)
-compile_go_fuzzer "$FUZZ_ROOT"/test/fuzz/p2p/pex Fuzz fuzz_p2p_pex fuzz
-(cd test/fuzz/p2p/secret_connection; go run ./init-corpus/main.go)
-compile_go_fuzzer "$FUZZ_ROOT"/test/fuzz/p2p/secret_connection Fuzz fuzz_p2p_secret_connection fuzz
+(cd test/fuzz/p2p/secretconnection; go run ./init-corpus/main.go)
+compile_go_fuzzer "$FUZZ_ROOT"/test/fuzz/p2p/secretconnection Fuzz fuzz_p2p_secretconnection fuzz
 
 compile_go_fuzzer "$FUZZ_ROOT"/test/fuzz/mempool Fuzz fuzz_mempool fuzz
 


### PR DESCRIPTION
p2p/pex and p2p/addrbook were deleted in 03ad7d6f20d9fd8fe83d31db168f433480552e94,
secret_connection was renamed to secretconnection in dd97ac6e1c8810a115e53a61c9a91dd40275b3fe.


