### PR TITLE
build: use `go install` instead of `go get`

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install go-fuzz
         working-directory: test/fuzz
-        run: go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+        run: go install github.com/dvyukov/go-fuzz/go-fuzz@latest github.com/dvyukov/go-fuzz/go-fuzz-build@latest
 
       - name: Fuzz mempool
         working-directory: test/fuzz

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ go.sum: go.mod
 
 draw_deps:
 	@# requires brew install graphviz or apt-get install graphviz
-	go get github.com/RobotsAndPencils/goviz
+	go install github.com/RobotsAndPencils/goviz@latest
 	@goviz -i github.com/tendermint/tendermint/cmd/tendermint -d 3 | dot -Tpng -o dependency-graph.png
 .PHONY: draw_deps
 

--- a/docs/nodes/remote-signer.md
+++ b/docs/nodes/remote-signer.md
@@ -37,7 +37,7 @@ There are two ways to generate certificates, [openssl](https://www.openssl.org/)
 - Install `Certstrap`:
 
 ```sh
-  go get github.com/square/certstrap@v1.2.0
+  go install github.com/square/certstrap@v1.2.0
 ```
 
 - Create certificate authority for self signing.

--- a/docs/tools/terraform-and-ansible.md
+++ b/docs/tools/terraform-and-ansible.md
@@ -164,7 +164,7 @@ page](https://app.logz.io/#/dashboard/data-sources/Filebeat), then:
 yum install systemd-devel || echo "This will only work on RHEL-based systems."
 apt-get install libsystemd-dev || echo "This will only work on Debian-based systems."
 
-go get github.com/mheese/journalbeat
+go install github.com/mheese/journalbeat@latest
 ansible-playbook -i inventory/digital_ocean.py -l sentrynet logzio.yml -e LOGZIO_TOKEN=ABCDEFGHIJKLMNOPQRSTUVWXYZ012345
 ```
 


### PR DESCRIPTION
`go get` for binaries was deprecated in 1.17 and removed in 1.18 in favor of `go install`. https://go.dev/doc/go-get-install-deprecation