### PR TITLE
confix: clean up and document transformations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,8 +73,7 @@ require (
 	github.com/charithe/durationcheck v0.0.9 // indirect
 	github.com/chavacava/garif v0.0.0-20210405164556-e8a0a408d6af // indirect
 	github.com/containerd/continuity v0.2.1 // indirect
-	github.com/creachadair/taskgroup v0.3.2
-	github.com/creachadair/tomledit v0.0.5
+	github.com/creachadair/tomledit v0.0.11
 	github.com/daixiang0/gci v0.3.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denis-tingaikin/go-header v0.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/creachadair/atomicfile v0.2.4 h1:GRjpQLmz/78I4+nBQpGMFrRa9yrL157AUTrA
 github.com/creachadair/atomicfile v0.2.4/go.mod h1:BRq8Une6ckFneYXZQ+kO7p1ZZP3I2fzVzf28JxrIkBc=
 github.com/creachadair/taskgroup v0.3.2 h1:zlfutDS+5XG40AOxcHDSThxKzns8Tnr9jnr6VqkYlkM=
 github.com/creachadair/taskgroup v0.3.2/go.mod h1:wieWwecHVzsidg2CsUnFinW1faVN4+kq+TDlRJQ0Wbk=
-github.com/creachadair/tomledit v0.0.5 h1:ILJt2EO93fr8w2UAUA5FPNThk1Pq5m4KX2qUZ1Xz4Xs=
-github.com/creachadair/tomledit v0.0.5/go.mod h1:gvtfnSZLa+YNQD28vaPq0Nk12bRxEhmUdBzAWn+EGF4=
+github.com/creachadair/tomledit v0.0.11 h1:6fHNLdCa5pNudF+5Sb+3M+hPHz/q1fMoAm+MI6TWIR4=
+github.com/creachadair/tomledit v0.0.11/go.mod h1:gvtfnSZLa+YNQD28vaPq0Nk12bRxEhmUdBzAWn+EGF4=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=


### PR DESCRIPTION
Right now the confix tool works up to v0.35. This change is preparation for
extending the tool to handle additional changes in v0.36.

Mostly this is adding documentation. The one functional change is to fix the
name of the moved "fast-sync" parameter, which was renamed "enable".

- Document the origin of each transformation step.
- Update fast-sync target name.
