### PR TITLE
Fix #8322

### DIFF
--- a/internal/eventbus/event_bus.go
+++ b/internal/eventbus/event_bus.go
@@ -51,7 +51,16 @@ func (b *EventBus) NumClientSubscriptions(clientID string) int {
 }
 
 func (b *EventBus) SubscribeWithArgs(ctx context.Context, args tmpubsub.SubscribeArgs) (Subscription, error) {
-	return b.pubsub.SubscribeWithArgs(ctx, args)
+	sub, err := b.pubsub.SubscribeWithArgs(ctx, args)
+	if sub != nil {
+		return sub, err
+	}
+
+	// A nil-valued *tmpubsub.Subscription is still a valid implementation of
+	// Subscription. Internally, interface values are `(concrete-type, value)`.
+	// In this case, it would be `(*tmpubsub.Subscription, nil)`. That will
+	// cause panics, so instead we need to explicitly return nil.
+	return nil, err
 }
 
 func (b *EventBus) Unsubscribe(ctx context.Context, args tmpubsub.UnsubscribeArgs) error {

--- a/internal/eventbus/event_bus_wb_test.go
+++ b/internal/eventbus/event_bus_wb_test.go
@@ -1,0 +1,24 @@
+package eventbus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/internal/pubsub"
+)
+
+func TestEventBusNilSubscription(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	eventBus := new(EventBus)
+	eventBus.pubsub = new(pubsub.Server)
+
+	txsSub, err := eventBus.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{})
+	assert.Error(t, err)
+	assert.True(t, txsSub == nil)
+
+	// This will panic
+	txsSub.ID()
+}

--- a/internal/eventbus/event_bus_wb_test.go
+++ b/internal/eventbus/event_bus_wb_test.go
@@ -20,5 +20,7 @@ func TestEventBusNilSubscription(t *testing.T) {
 	assert.True(t, txsSub == nil)
 
 	// This will panic
-	txsSub.ID()
+	if txsSub != nil {
+		txsSub.ID()
+	}
 }


### PR DESCRIPTION
Closes #8322. `internal/eventbus.EventBus.SubscribeWithArgs` has a bug: it can return a non-nil interface value with a nil underlying value, leading to panics. See [this article](https://go.dev/tour/methods/12), the issue, and the comment in the code for more details.