### PR TITLE
Revert CI cache override.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,5 +35,4 @@ jobs:
           version: v1.45
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
-          skip-cache: true
         if: env.GIT_DIFF


### PR DESCRIPTION
The caches for golangci-lint failed to update correctly causing spurious
failures on #8300. To work around this, I disabled caching temporarily.
This change removes that override, restoring the default.
