### PR TITLE
Only run the markdown link checker if markdown was touched.

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -12,7 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: technote-space/get-diff-action@v6.0.1
+        with:
+          PATTERNS: |
+            **/**.md
       - uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
         with:
           check-modified-files-only: 'yes'
           config-file: '.md-link-check.json'
+        if: env.GIT_DIFF


### PR DESCRIPTION
This averts a harmless but confusing actions plumbing issue.

A better fix would be on the link-checker side, but development there is not active.