### PR TITLE
Work around a permissions bug in actions/checkout.

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           PATTERNS: |
             **/**.md
-      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
+      - uses: creachadair/github-action-markdown-link-check@master
         with:
           check-modified-files-only: 'yes'
           config-file: '.md-link-check.json'


### PR DESCRIPTION
Work around markdown-link-check issues.

This PR works around two issues causing the markdown link check to fail in CI.

1. https://github.com/actions/checkout/pull/760. A git permissions issue,
   apparently triggered by a combination of a git change and the behaviour of
   actions/checkout.

2. https://github.com/gaurav-nelson/github-action-markdown-link-check/pull/129.
   Merging an updated version of the underlying package that fixes a bug in the
   handling of local #anchors.

The workaround is a temporary patched fork of the link-checker action.  This
should be removed once the upstream issues are addressed.
