### PR TITLE
Set a cap on the length of subscription queries.

### DIFF
--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -12,6 +12,12 @@ import (
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
+const (
+	// maxQueryLength is the maximum length of a query string that will be
+	// accepted. This is just a safety check to avoid outlandish queries.
+	maxQueryLength = 512
+)
+
 // Subscribe for events via WebSocket.
 // More: https://docs.tendermint.com/master/rpc/#/Websocket/subscribe
 func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, error) {
@@ -21,6 +27,8 @@ func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, er
 		return nil, fmt.Errorf("max_subscription_clients %d reached", env.Config.MaxSubscriptionClients)
 	} else if env.EventBus.NumClientSubscriptions(addr) >= env.Config.MaxSubscriptionsPerClient {
 		return nil, fmt.Errorf("max_subscriptions_per_client %d reached", env.Config.MaxSubscriptionsPerClient)
+	} else if len(query) > maxQueryLength {
+		return nil, errors.New("maximum query length exceeded")
 	}
 
 	env.Logger.Info("Subscribe to query", "remote", addr, "query", query)

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -65,6 +65,8 @@ func TxSearch(
 	// if index is disabled, return error
 	if _, ok := env.TxIndexer.(*null.TxIndex); ok {
 		return nil, errors.New("transaction indexing is disabled")
+	} else if len(query) > maxQueryLength {
+		return nil, errors.New("maximum query length exceeded")
 	}
 
 	q, err := tmquery.New(query)


### PR DESCRIPTION
A manual backport of #7263.

As a safety measure, don't allow a query string to be unreasonably long. The
query filter is not especially efficient, so a query that needs more than basic
detail should filter coarsely in the subscriber and refine on the client side.

This affects Subscribe and TxSearch queries.
