### PR TITLE
build: clean up an unnecessary dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,10 +228,8 @@ build-docs:
 ###                            Docker image                                 ###
 ###############################################################################
 
-build-docker: build-linux
-	cp $(BUILDDIR)/tendermint DOCKER/tendermint
+build-docker:
 	docker build --label=tendermint --tag="tendermint/tendermint" -f DOCKER/Dockerfile .
-	rm -rf DOCKER/tendermint
 .PHONY: build-docker
 
 


### PR DESCRIPTION
Fixes #8362. We already made this fix on master so this is notionally a backport, but only for part of the much larger changes at tip.