### PR TITLE
abci: application type should take contexts

### DIFF
--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -44,71 +44,71 @@ func (app *localClient) Echo(_ context.Context, msg string) (*types.ResponseEcho
 }
 
 func (app *localClient) Info(ctx context.Context, req types.RequestInfo) (*types.ResponseInfo, error) {
-	res := app.Application.Info(req)
+	res := app.Application.Info(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) CheckTx(_ context.Context, req types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	res := app.Application.CheckTx(req)
+func (app *localClient) CheckTx(ctx context.Context, req types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+	res := app.Application.CheckTx(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) Query(_ context.Context, req types.RequestQuery) (*types.ResponseQuery, error) {
-	res := app.Application.Query(req)
+func (app *localClient) Query(ctx context.Context, req types.RequestQuery) (*types.ResponseQuery, error) {
+	res := app.Application.Query(ctx, req)
 	return &res, nil
 }
 
 func (app *localClient) Commit(ctx context.Context) (*types.ResponseCommit, error) {
-	res := app.Application.Commit()
+	res := app.Application.Commit(ctx)
 	return &res, nil
 }
 
-func (app *localClient) InitChain(_ context.Context, req types.RequestInitChain) (*types.ResponseInitChain, error) {
-	res := app.Application.InitChain(req)
+func (app *localClient) InitChain(ctx context.Context, req types.RequestInitChain) (*types.ResponseInitChain, error) {
+	res := app.Application.InitChain(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) ListSnapshots(_ context.Context, req types.RequestListSnapshots) (*types.ResponseListSnapshots, error) {
-	res := app.Application.ListSnapshots(req)
+func (app *localClient) ListSnapshots(ctx context.Context, req types.RequestListSnapshots) (*types.ResponseListSnapshots, error) {
+	res := app.Application.ListSnapshots(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) OfferSnapshot(_ context.Context, req types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error) {
-	res := app.Application.OfferSnapshot(req)
+func (app *localClient) OfferSnapshot(ctx context.Context, req types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error) {
+	res := app.Application.OfferSnapshot(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) LoadSnapshotChunk(_ context.Context, req types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
-	res := app.Application.LoadSnapshotChunk(req)
+func (app *localClient) LoadSnapshotChunk(ctx context.Context, req types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
+	res := app.Application.LoadSnapshotChunk(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) ApplySnapshotChunk(_ context.Context, req types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
-	res := app.Application.ApplySnapshotChunk(req)
+func (app *localClient) ApplySnapshotChunk(ctx context.Context, req types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
+	res := app.Application.ApplySnapshotChunk(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) PrepareProposal(_ context.Context, req types.RequestPrepareProposal) (*types.ResponsePrepareProposal, error) {
-	res := app.Application.PrepareProposal(req)
+func (app *localClient) PrepareProposal(ctx context.Context, req types.RequestPrepareProposal) (*types.ResponsePrepareProposal, error) {
+	res := app.Application.PrepareProposal(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) ProcessProposal(_ context.Context, req types.RequestProcessProposal) (*types.ResponseProcessProposal, error) {
-	res := app.Application.ProcessProposal(req)
+func (app *localClient) ProcessProposal(ctx context.Context, req types.RequestProcessProposal) (*types.ResponseProcessProposal, error) {
+	res := app.Application.ProcessProposal(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) ExtendVote(_ context.Context, req types.RequestExtendVote) (*types.ResponseExtendVote, error) {
-	res := app.Application.ExtendVote(req)
+func (app *localClient) ExtendVote(ctx context.Context, req types.RequestExtendVote) (*types.ResponseExtendVote, error) {
+	res := app.Application.ExtendVote(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) VerifyVoteExtension(_ context.Context, req types.RequestVerifyVoteExtension) (*types.ResponseVerifyVoteExtension, error) {
-	res := app.Application.VerifyVoteExtension(req)
+func (app *localClient) VerifyVoteExtension(ctx context.Context, req types.RequestVerifyVoteExtension) (*types.ResponseVerifyVoteExtension, error) {
+	res := app.Application.VerifyVoteExtension(ctx, req)
 	return &res, nil
 }
 
-func (app *localClient) FinalizeBlock(_ context.Context, req types.RequestFinalizeBlock) (*types.ResponseFinalizeBlock, error) {
-	res := app.Application.FinalizeBlock(req)
+func (app *localClient) FinalizeBlock(ctx context.Context, req types.RequestFinalizeBlock) (*types.ResponseFinalizeBlock, error) {
+	res := app.Application.FinalizeBlock(ctx, req)
 	return &res, nil
 }

--- a/abci/example/kvstore/helpers.go
+++ b/abci/example/kvstore/helpers.go
@@ -1,6 +1,7 @@
 package kvstore
 
 import (
+	"context"
 	mrand "math/rand"
 
 	"github.com/tendermint/tendermint/abci/types"
@@ -32,8 +33,8 @@ func RandVals(cnt int) []types.ValidatorUpdate {
 // InitKVStore initializes the kvstore app with some data,
 // which allows tests to pass and is fine as long as you
 // don't make any tx that modify the validator state
-func InitKVStore(app *PersistentKVStoreApplication) {
-	app.InitChain(types.RequestInitChain{
+func InitKVStore(ctx context.Context, app *PersistentKVStoreApplication) {
+	app.InitChain(ctx, types.RequestInitChain{
 		Validators: RandVals(1),
 	})
 }

--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -2,6 +2,7 @@ package kvstore
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -90,7 +91,7 @@ func NewApplication() *Application {
 	}
 }
 
-func (app *Application) InitChain(req types.RequestInitChain) types.ResponseInitChain {
+func (app *Application) InitChain(_ context.Context, req types.RequestInitChain) types.ResponseInitChain {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -104,7 +105,7 @@ func (app *Application) InitChain(req types.RequestInitChain) types.ResponseInit
 	return types.ResponseInitChain{}
 }
 
-func (app *Application) Info(req types.RequestInfo) types.ResponseInfo {
+func (app *Application) Info(_ context.Context, req types.RequestInfo) types.ResponseInfo {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 	return types.ResponseInfo{
@@ -166,7 +167,7 @@ func (app *Application) Close() error {
 	return app.state.db.Close()
 }
 
-func (app *Application) FinalizeBlock(req types.RequestFinalizeBlock) types.ResponseFinalizeBlock {
+func (app *Application) FinalizeBlock(_ context.Context, req types.RequestFinalizeBlock) types.ResponseFinalizeBlock {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -198,11 +199,11 @@ func (app *Application) FinalizeBlock(req types.RequestFinalizeBlock) types.Resp
 	return types.ResponseFinalizeBlock{TxResults: respTxs, ValidatorUpdates: app.ValUpdates}
 }
 
-func (*Application) CheckTx(req types.RequestCheckTx) types.ResponseCheckTx {
+func (*Application) CheckTx(_ context.Context, req types.RequestCheckTx) types.ResponseCheckTx {
 	return types.ResponseCheckTx{Code: code.CodeTypeOK, GasWanted: 1}
 }
 
-func (app *Application) Commit() types.ResponseCommit {
+func (app *Application) Commit(_ context.Context) types.ResponseCommit {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -221,7 +222,7 @@ func (app *Application) Commit() types.ResponseCommit {
 }
 
 // Returns an associated value or nil if missing.
-func (app *Application) Query(reqQuery types.RequestQuery) types.ResponseQuery {
+func (app *Application) Query(_ context.Context, reqQuery types.RequestQuery) types.ResponseQuery {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -280,7 +281,7 @@ func (app *Application) Query(reqQuery types.RequestQuery) types.ResponseQuery {
 	return resQuery
 }
 
-func (app *Application) PrepareProposal(req types.RequestPrepareProposal) types.ResponsePrepareProposal {
+func (app *Application) PrepareProposal(_ context.Context, req types.RequestPrepareProposal) types.ResponsePrepareProposal {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -289,7 +290,7 @@ func (app *Application) PrepareProposal(req types.RequestPrepareProposal) types.
 	}
 }
 
-func (*Application) ProcessProposal(req types.RequestProcessProposal) types.ResponseProcessProposal {
+func (*Application) ProcessProposal(_ context.Context, req types.RequestProcessProposal) types.ResponseProcessProposal {
 	for _, tx := range req.Txs {
 		if len(tx) == 0 {
 			return types.ResponseProcessProposal{Status: types.ResponseProcessProposal_REJECT}

--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -1,6 +1,8 @@
 package kvstore
 
 import (
+	"context"
+
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/tendermint/tendermint/abci/types"
@@ -35,10 +37,10 @@ func NewPersistentKVStoreApplication(logger log.Logger, dbDir string) *Persisten
 	}
 }
 
-func (app *PersistentKVStoreApplication) OfferSnapshot(req types.RequestOfferSnapshot) types.ResponseOfferSnapshot {
+func (app *PersistentKVStoreApplication) OfferSnapshot(_ context.Context, req types.RequestOfferSnapshot) types.ResponseOfferSnapshot {
 	return types.ResponseOfferSnapshot{Result: types.ResponseOfferSnapshot_ABORT}
 }
 
-func (app *PersistentKVStoreApplication) ApplySnapshotChunk(req types.RequestApplySnapshotChunk) types.ResponseApplySnapshotChunk {
+func (app *PersistentKVStoreApplication) ApplySnapshotChunk(_ context.Context, req types.RequestApplySnapshotChunk) types.ResponseApplySnapshotChunk {
 	return types.ResponseApplySnapshotChunk{Result: types.ResponseApplySnapshotChunk_ABORT}
 }

--- a/abci/server/grpc_server.go
+++ b/abci/server/grpc_server.go
@@ -78,72 +78,72 @@ func (app *gRPCApplication) Flush(_ context.Context, req *types.RequestFlush) (*
 	return &types.ResponseFlush{}, nil
 }
 
-func (app *gRPCApplication) Info(_ context.Context, req *types.RequestInfo) (*types.ResponseInfo, error) {
-	res := app.app.Info(*req)
+func (app *gRPCApplication) Info(ctx context.Context, req *types.RequestInfo) (*types.ResponseInfo, error) {
+	res := app.app.Info(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) CheckTx(_ context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	res := app.app.CheckTx(*req)
+func (app *gRPCApplication) CheckTx(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+	res := app.app.CheckTx(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) Query(_ context.Context, req *types.RequestQuery) (*types.ResponseQuery, error) {
-	res := app.app.Query(*req)
+func (app *gRPCApplication) Query(ctx context.Context, req *types.RequestQuery) (*types.ResponseQuery, error) {
+	res := app.app.Query(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) Commit(_ context.Context, req *types.RequestCommit) (*types.ResponseCommit, error) {
-	res := app.app.Commit()
+func (app *gRPCApplication) Commit(ctx context.Context, req *types.RequestCommit) (*types.ResponseCommit, error) {
+	res := app.app.Commit(ctx)
 	return &res, nil
 }
 
-func (app *gRPCApplication) InitChain(_ context.Context, req *types.RequestInitChain) (*types.ResponseInitChain, error) {
-	res := app.app.InitChain(*req)
+func (app *gRPCApplication) InitChain(ctx context.Context, req *types.RequestInitChain) (*types.ResponseInitChain, error) {
+	res := app.app.InitChain(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) ListSnapshots(_ context.Context, req *types.RequestListSnapshots) (*types.ResponseListSnapshots, error) {
-	res := app.app.ListSnapshots(*req)
+func (app *gRPCApplication) ListSnapshots(ctx context.Context, req *types.RequestListSnapshots) (*types.ResponseListSnapshots, error) {
+	res := app.app.ListSnapshots(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) OfferSnapshot(_ context.Context, req *types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error) {
-	res := app.app.OfferSnapshot(*req)
+func (app *gRPCApplication) OfferSnapshot(ctx context.Context, req *types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error) {
+	res := app.app.OfferSnapshot(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) LoadSnapshotChunk(_ context.Context, req *types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
-	res := app.app.LoadSnapshotChunk(*req)
+func (app *gRPCApplication) LoadSnapshotChunk(ctx context.Context, req *types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
+	res := app.app.LoadSnapshotChunk(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) ApplySnapshotChunk(_ context.Context, req *types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
-	res := app.app.ApplySnapshotChunk(*req)
+func (app *gRPCApplication) ApplySnapshotChunk(ctx context.Context, req *types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
+	res := app.app.ApplySnapshotChunk(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) ExtendVote(_ context.Context, req *types.RequestExtendVote) (*types.ResponseExtendVote, error) {
-	res := app.app.ExtendVote(*req)
+func (app *gRPCApplication) ExtendVote(ctx context.Context, req *types.RequestExtendVote) (*types.ResponseExtendVote, error) {
+	res := app.app.ExtendVote(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) VerifyVoteExtension(_ context.Context, req *types.RequestVerifyVoteExtension) (*types.ResponseVerifyVoteExtension, error) {
-	res := app.app.VerifyVoteExtension(*req)
+func (app *gRPCApplication) VerifyVoteExtension(ctx context.Context, req *types.RequestVerifyVoteExtension) (*types.ResponseVerifyVoteExtension, error) {
+	res := app.app.VerifyVoteExtension(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) PrepareProposal(_ context.Context, req *types.RequestPrepareProposal) (*types.ResponsePrepareProposal, error) {
-	res := app.app.PrepareProposal(*req)
+func (app *gRPCApplication) PrepareProposal(ctx context.Context, req *types.RequestPrepareProposal) (*types.ResponsePrepareProposal, error) {
+	res := app.app.PrepareProposal(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) ProcessProposal(_ context.Context, req *types.RequestProcessProposal) (*types.ResponseProcessProposal, error) {
-	res := app.app.ProcessProposal(*req)
+func (app *gRPCApplication) ProcessProposal(ctx context.Context, req *types.RequestProcessProposal) (*types.ResponseProcessProposal, error) {
+	res := app.app.ProcessProposal(ctx, *req)
 	return &res, nil
 }
 
-func (app *gRPCApplication) FinalizeBlock(_ context.Context, req *types.RequestFinalizeBlock) (*types.ResponseFinalizeBlock, error) {
-	res := app.app.FinalizeBlock(*req)
+func (app *gRPCApplication) FinalizeBlock(ctx context.Context, req *types.RequestFinalizeBlock) (*types.ResponseFinalizeBlock, error) {
+	res := app.app.FinalizeBlock(ctx, *req)
 	return &res, nil
 }

--- a/abci/server/socket_server.go
+++ b/abci/server/socket_server.go
@@ -159,11 +159,7 @@ func (s *SocketServer) acceptConnectionsRoutine(ctx context.Context) {
 }
 
 // Read requests from conn and deal with them
-func (s *SocketServer) handleRequests(
-	ctx context.Context,
-	closer func(error),
-	conn io.Reader,
-	responses chan<- *types.Response,
+func (s *SocketServer) handleRequests(ctx context.Context, closer func(error), conn io.Reader, responses chan<- *types.Response,
 ) {
 	var bufReader = bufio.NewReader(conn)
 
@@ -184,7 +180,7 @@ func (s *SocketServer) handleRequests(
 			return
 		}
 
-		resp := s.processRequest(req)
+		resp := s.processRequest(ctx, req)
 		select {
 		case <-ctx.Done():
 			closer(ctx.Err())
@@ -194,40 +190,40 @@ func (s *SocketServer) handleRequests(
 	}
 }
 
-func (s *SocketServer) processRequest(req *types.Request) *types.Response {
+func (s *SocketServer) processRequest(ctx context.Context, req *types.Request) *types.Response {
 	switch r := req.Value.(type) {
 	case *types.Request_Echo:
 		return types.ToResponseEcho(r.Echo.Message)
 	case *types.Request_Flush:
 		return types.ToResponseFlush()
 	case *types.Request_Info:
-		return types.ToResponseInfo(s.app.Info(*r.Info))
+		return types.ToResponseInfo(s.app.Info(ctx, *r.Info))
 	case *types.Request_CheckTx:
-		return types.ToResponseCheckTx(s.app.CheckTx(*r.CheckTx))
+		return types.ToResponseCheckTx(s.app.CheckTx(ctx, *r.CheckTx))
 	case *types.Request_Commit:
-		return types.ToResponseCommit(s.app.Commit())
+		return types.ToResponseCommit(s.app.Commit(ctx))
 	case *types.Request_Query:
-		return types.ToResponseQuery(s.app.Query(*r.Query))
+		return types.ToResponseQuery(s.app.Query(ctx, *r.Query))
 	case *types.Request_InitChain:
-		return types.ToResponseInitChain(s.app.InitChain(*r.InitChain))
+		return types.ToResponseInitChain(s.app.InitChain(ctx, *r.InitChain))
 	case *types.Request_ListSnapshots:
-		return types.ToResponseListSnapshots(s.app.ListSnapshots(*r.ListSnapshots))
+		return types.ToResponseListSnapshots(s.app.ListSnapshots(ctx, *r.ListSnapshots))
 	case *types.Request_OfferSnapshot:
-		return types.ToResponseOfferSnapshot(s.app.OfferSnapshot(*r.OfferSnapshot))
+		return types.ToResponseOfferSnapshot(s.app.OfferSnapshot(ctx, *r.OfferSnapshot))
 	case *types.Request_PrepareProposal:
-		return types.ToResponsePrepareProposal(s.app.PrepareProposal(*r.PrepareProposal))
+		return types.ToResponsePrepareProposal(s.app.PrepareProposal(ctx, *r.PrepareProposal))
 	case *types.Request_ProcessProposal:
-		return types.ToResponseProcessProposal(s.app.ProcessProposal(*r.ProcessProposal))
+		return types.ToResponseProcessProposal(s.app.ProcessProposal(ctx, *r.ProcessProposal))
 	case *types.Request_LoadSnapshotChunk:
-		return types.ToResponseLoadSnapshotChunk(s.app.LoadSnapshotChunk(*r.LoadSnapshotChunk))
+		return types.ToResponseLoadSnapshotChunk(s.app.LoadSnapshotChunk(ctx, *r.LoadSnapshotChunk))
 	case *types.Request_ApplySnapshotChunk:
-		return types.ToResponseApplySnapshotChunk(s.app.ApplySnapshotChunk(*r.ApplySnapshotChunk))
+		return types.ToResponseApplySnapshotChunk(s.app.ApplySnapshotChunk(ctx, *r.ApplySnapshotChunk))
 	case *types.Request_ExtendVote:
-		return types.ToResponseExtendVote(s.app.ExtendVote(*r.ExtendVote))
+		return types.ToResponseExtendVote(s.app.ExtendVote(ctx, *r.ExtendVote))
 	case *types.Request_VerifyVoteExtension:
-		return types.ToResponseVerifyVoteExtension(s.app.VerifyVoteExtension(*r.VerifyVoteExtension))
+		return types.ToResponseVerifyVoteExtension(s.app.VerifyVoteExtension(ctx, *r.VerifyVoteExtension))
 	case *types.Request_FinalizeBlock:
-		return types.ToResponseFinalizeBlock(s.app.FinalizeBlock(*r.FinalizeBlock))
+		return types.ToResponseFinalizeBlock(s.app.FinalizeBlock(ctx, *r.FinalizeBlock))
 	default:
 		return types.ToResponseException("Unknown request")
 	}

--- a/abci/types/application.go
+++ b/abci/types/application.go
@@ -1,5 +1,7 @@
 package types
 
+import "context"
+
 //go:generate ../../scripts/mockery_generate.sh Application
 // Application is an interface that enables any finite, deterministic state machine
 // to be driven by a blockchain-based replication engine via the ABCI.
@@ -7,30 +9,30 @@ package types
 // except CheckTx/DeliverTx, which take `tx []byte`, and `Commit`, which takes nothing.
 type Application interface {
 	// Info/Query Connection
-	Info(RequestInfo) ResponseInfo    // Return application info
-	Query(RequestQuery) ResponseQuery // Query for state
+	Info(context.Context, RequestInfo) ResponseInfo    // Return application info
+	Query(context.Context, RequestQuery) ResponseQuery // Query for state
 
 	// Mempool Connection
-	CheckTx(RequestCheckTx) ResponseCheckTx // Validate a tx for the mempool
+	CheckTx(context.Context, RequestCheckTx) ResponseCheckTx // Validate a tx for the mempool
 
 	// Consensus Connection
-	InitChain(RequestInitChain) ResponseInitChain // Initialize blockchain w validators/other info from TendermintCore
-	PrepareProposal(RequestPrepareProposal) ResponsePrepareProposal
-	ProcessProposal(RequestProcessProposal) ResponseProcessProposal
+	InitChain(context.Context, RequestInitChain) ResponseInitChain // Initialize blockchain w validators/other info from TendermintCore
+	PrepareProposal(context.Context, RequestPrepareProposal) ResponsePrepareProposal
+	ProcessProposal(context.Context, RequestProcessProposal) ResponseProcessProposal
 	// Commit the state and return the application Merkle root hash
-	Commit() ResponseCommit
+	Commit(context.Context) ResponseCommit
 	// Create application specific vote extension
-	ExtendVote(RequestExtendVote) ResponseExtendVote
+	ExtendVote(context.Context, RequestExtendVote) ResponseExtendVote
 	// Verify application's vote extension data
-	VerifyVoteExtension(RequestVerifyVoteExtension) ResponseVerifyVoteExtension
+	VerifyVoteExtension(context.Context, RequestVerifyVoteExtension) ResponseVerifyVoteExtension
 	// Deliver the decided block with its txs to the Application
-	FinalizeBlock(RequestFinalizeBlock) ResponseFinalizeBlock
+	FinalizeBlock(context.Context, RequestFinalizeBlock) ResponseFinalizeBlock
 
 	// State Sync Connection
-	ListSnapshots(RequestListSnapshots) ResponseListSnapshots                // List available snapshots
-	OfferSnapshot(RequestOfferSnapshot) ResponseOfferSnapshot                // Offer a snapshot to the application
-	LoadSnapshotChunk(RequestLoadSnapshotChunk) ResponseLoadSnapshotChunk    // Load a snapshot chunk
-	ApplySnapshotChunk(RequestApplySnapshotChunk) ResponseApplySnapshotChunk // Apply a shapshot chunk
+	ListSnapshots(context.Context, RequestListSnapshots) ResponseListSnapshots                // List available snapshots
+	OfferSnapshot(context.Context, RequestOfferSnapshot) ResponseOfferSnapshot                // Offer a snapshot to the application
+	LoadSnapshotChunk(context.Context, RequestLoadSnapshotChunk) ResponseLoadSnapshotChunk    // Load a snapshot chunk
+	ApplySnapshotChunk(context.Context, RequestApplySnapshotChunk) ResponseApplySnapshotChunk // Apply a shapshot chunk
 }
 
 //-------------------------------------------------------
@@ -44,53 +46,53 @@ func NewBaseApplication() *BaseApplication {
 	return &BaseApplication{}
 }
 
-func (BaseApplication) Info(req RequestInfo) ResponseInfo {
+func (BaseApplication) Info(_ context.Context, req RequestInfo) ResponseInfo {
 	return ResponseInfo{}
 }
 
-func (BaseApplication) CheckTx(req RequestCheckTx) ResponseCheckTx {
+func (BaseApplication) CheckTx(_ context.Context, req RequestCheckTx) ResponseCheckTx {
 	return ResponseCheckTx{Code: CodeTypeOK}
 }
 
-func (BaseApplication) Commit() ResponseCommit {
+func (BaseApplication) Commit(_ context.Context) ResponseCommit {
 	return ResponseCommit{}
 }
 
-func (BaseApplication) ExtendVote(req RequestExtendVote) ResponseExtendVote {
+func (BaseApplication) ExtendVote(_ context.Context, req RequestExtendVote) ResponseExtendVote {
 	return ResponseExtendVote{}
 }
 
-func (BaseApplication) VerifyVoteExtension(req RequestVerifyVoteExtension) ResponseVerifyVoteExtension {
+func (BaseApplication) VerifyVoteExtension(_ context.Context, req RequestVerifyVoteExtension) ResponseVerifyVoteExtension {
 	return ResponseVerifyVoteExtension{
 		Status: ResponseVerifyVoteExtension_ACCEPT,
 	}
 }
 
-func (BaseApplication) Query(req RequestQuery) ResponseQuery {
+func (BaseApplication) Query(_ context.Context, req RequestQuery) ResponseQuery {
 	return ResponseQuery{Code: CodeTypeOK}
 }
 
-func (BaseApplication) InitChain(req RequestInitChain) ResponseInitChain {
+func (BaseApplication) InitChain(_ context.Context, req RequestInitChain) ResponseInitChain {
 	return ResponseInitChain{}
 }
 
-func (BaseApplication) ListSnapshots(req RequestListSnapshots) ResponseListSnapshots {
+func (BaseApplication) ListSnapshots(_ context.Context, req RequestListSnapshots) ResponseListSnapshots {
 	return ResponseListSnapshots{}
 }
 
-func (BaseApplication) OfferSnapshot(req RequestOfferSnapshot) ResponseOfferSnapshot {
+func (BaseApplication) OfferSnapshot(_ context.Context, req RequestOfferSnapshot) ResponseOfferSnapshot {
 	return ResponseOfferSnapshot{}
 }
 
-func (BaseApplication) LoadSnapshotChunk(req RequestLoadSnapshotChunk) ResponseLoadSnapshotChunk {
+func (BaseApplication) LoadSnapshotChunk(_ context.Context, _ RequestLoadSnapshotChunk) ResponseLoadSnapshotChunk {
 	return ResponseLoadSnapshotChunk{}
 }
 
-func (BaseApplication) ApplySnapshotChunk(req RequestApplySnapshotChunk) ResponseApplySnapshotChunk {
+func (BaseApplication) ApplySnapshotChunk(_ context.Context, req RequestApplySnapshotChunk) ResponseApplySnapshotChunk {
 	return ResponseApplySnapshotChunk{}
 }
 
-func (BaseApplication) PrepareProposal(req RequestPrepareProposal) ResponsePrepareProposal {
+func (BaseApplication) PrepareProposal(_ context.Context, req RequestPrepareProposal) ResponsePrepareProposal {
 	trs := make([]*TxRecord, 0, len(req.Txs))
 	var totalBytes int64
 	for _, tx := range req.Txs {
@@ -106,11 +108,11 @@ func (BaseApplication) PrepareProposal(req RequestPrepareProposal) ResponsePrepa
 	return ResponsePrepareProposal{TxRecords: trs}
 }
 
-func (BaseApplication) ProcessProposal(req RequestProcessProposal) ResponseProcessProposal {
+func (BaseApplication) ProcessProposal(_ context.Context, req RequestProcessProposal) ResponseProcessProposal {
 	return ResponseProcessProposal{Status: ResponseProcessProposal_ACCEPT}
 }
 
-func (BaseApplication) FinalizeBlock(req RequestFinalizeBlock) ResponseFinalizeBlock {
+func (BaseApplication) FinalizeBlock(_ context.Context, req RequestFinalizeBlock) ResponseFinalizeBlock {
 	txs := make([]*ExecTxResult, len(req.Txs))
 	for i := range req.Txs {
 		txs[i] = &ExecTxResult{Code: CodeTypeOK}

--- a/abci/types/mocks/application.go
+++ b/abci/types/mocks/application.go
@@ -3,7 +3,11 @@
 package mocks
 
 import (
+	context "context"
+	testing "testing"
+
 	mock "github.com/stretchr/testify/mock"
+
 	types "github.com/tendermint/tendermint/abci/types"
 )
 
@@ -12,13 +16,13 @@ type Application struct {
 	mock.Mock
 }
 
-// ApplySnapshotChunk provides a mock function with given fields: _a0
-func (_m *Application) ApplySnapshotChunk(_a0 types.RequestApplySnapshotChunk) types.ResponseApplySnapshotChunk {
-	ret := _m.Called(_a0)
+// ApplySnapshotChunk provides a mock function with given fields: _a0, _a1
+func (_m *Application) ApplySnapshotChunk(_a0 context.Context, _a1 types.RequestApplySnapshotChunk) types.ResponseApplySnapshotChunk {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseApplySnapshotChunk
-	if rf, ok := ret.Get(0).(func(types.RequestApplySnapshotChunk) types.ResponseApplySnapshotChunk); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestApplySnapshotChunk) types.ResponseApplySnapshotChunk); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseApplySnapshotChunk)
 	}
@@ -26,13 +30,13 @@ func (_m *Application) ApplySnapshotChunk(_a0 types.RequestApplySnapshotChunk) t
 	return r0
 }
 
-// CheckTx provides a mock function with given fields: _a0
-func (_m *Application) CheckTx(_a0 types.RequestCheckTx) types.ResponseCheckTx {
-	ret := _m.Called(_a0)
+// CheckTx provides a mock function with given fields: _a0, _a1
+func (_m *Application) CheckTx(_a0 context.Context, _a1 types.RequestCheckTx) types.ResponseCheckTx {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseCheckTx
-	if rf, ok := ret.Get(0).(func(types.RequestCheckTx) types.ResponseCheckTx); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestCheckTx) types.ResponseCheckTx); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseCheckTx)
 	}
@@ -40,13 +44,13 @@ func (_m *Application) CheckTx(_a0 types.RequestCheckTx) types.ResponseCheckTx {
 	return r0
 }
 
-// Commit provides a mock function with given fields:
-func (_m *Application) Commit() types.ResponseCommit {
-	ret := _m.Called()
+// Commit provides a mock function with given fields: _a0
+func (_m *Application) Commit(_a0 context.Context) types.ResponseCommit {
+	ret := _m.Called(_a0)
 
 	var r0 types.ResponseCommit
-	if rf, ok := ret.Get(0).(func() types.ResponseCommit); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) types.ResponseCommit); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Get(0).(types.ResponseCommit)
 	}
@@ -54,13 +58,13 @@ func (_m *Application) Commit() types.ResponseCommit {
 	return r0
 }
 
-// ExtendVote provides a mock function with given fields: _a0
-func (_m *Application) ExtendVote(_a0 types.RequestExtendVote) types.ResponseExtendVote {
-	ret := _m.Called(_a0)
+// ExtendVote provides a mock function with given fields: _a0, _a1
+func (_m *Application) ExtendVote(_a0 context.Context, _a1 types.RequestExtendVote) types.ResponseExtendVote {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseExtendVote
-	if rf, ok := ret.Get(0).(func(types.RequestExtendVote) types.ResponseExtendVote); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestExtendVote) types.ResponseExtendVote); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseExtendVote)
 	}
@@ -68,13 +72,13 @@ func (_m *Application) ExtendVote(_a0 types.RequestExtendVote) types.ResponseExt
 	return r0
 }
 
-// FinalizeBlock provides a mock function with given fields: _a0
-func (_m *Application) FinalizeBlock(_a0 types.RequestFinalizeBlock) types.ResponseFinalizeBlock {
-	ret := _m.Called(_a0)
+// FinalizeBlock provides a mock function with given fields: _a0, _a1
+func (_m *Application) FinalizeBlock(_a0 context.Context, _a1 types.RequestFinalizeBlock) types.ResponseFinalizeBlock {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseFinalizeBlock
-	if rf, ok := ret.Get(0).(func(types.RequestFinalizeBlock) types.ResponseFinalizeBlock); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestFinalizeBlock) types.ResponseFinalizeBlock); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseFinalizeBlock)
 	}
@@ -82,13 +86,13 @@ func (_m *Application) FinalizeBlock(_a0 types.RequestFinalizeBlock) types.Respo
 	return r0
 }
 
-// Info provides a mock function with given fields: _a0
-func (_m *Application) Info(_a0 types.RequestInfo) types.ResponseInfo {
-	ret := _m.Called(_a0)
+// Info provides a mock function with given fields: _a0, _a1
+func (_m *Application) Info(_a0 context.Context, _a1 types.RequestInfo) types.ResponseInfo {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseInfo
-	if rf, ok := ret.Get(0).(func(types.RequestInfo) types.ResponseInfo); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestInfo) types.ResponseInfo); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseInfo)
 	}
@@ -96,13 +100,13 @@ func (_m *Application) Info(_a0 types.RequestInfo) types.ResponseInfo {
 	return r0
 }
 
-// InitChain provides a mock function with given fields: _a0
-func (_m *Application) InitChain(_a0 types.RequestInitChain) types.ResponseInitChain {
-	ret := _m.Called(_a0)
+// InitChain provides a mock function with given fields: _a0, _a1
+func (_m *Application) InitChain(_a0 context.Context, _a1 types.RequestInitChain) types.ResponseInitChain {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseInitChain
-	if rf, ok := ret.Get(0).(func(types.RequestInitChain) types.ResponseInitChain); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestInitChain) types.ResponseInitChain); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseInitChain)
 	}
@@ -110,13 +114,13 @@ func (_m *Application) InitChain(_a0 types.RequestInitChain) types.ResponseInitC
 	return r0
 }
 
-// ListSnapshots provides a mock function with given fields: _a0
-func (_m *Application) ListSnapshots(_a0 types.RequestListSnapshots) types.ResponseListSnapshots {
-	ret := _m.Called(_a0)
+// ListSnapshots provides a mock function with given fields: _a0, _a1
+func (_m *Application) ListSnapshots(_a0 context.Context, _a1 types.RequestListSnapshots) types.ResponseListSnapshots {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseListSnapshots
-	if rf, ok := ret.Get(0).(func(types.RequestListSnapshots) types.ResponseListSnapshots); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestListSnapshots) types.ResponseListSnapshots); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseListSnapshots)
 	}
@@ -124,13 +128,13 @@ func (_m *Application) ListSnapshots(_a0 types.RequestListSnapshots) types.Respo
 	return r0
 }
 
-// LoadSnapshotChunk provides a mock function with given fields: _a0
-func (_m *Application) LoadSnapshotChunk(_a0 types.RequestLoadSnapshotChunk) types.ResponseLoadSnapshotChunk {
-	ret := _m.Called(_a0)
+// LoadSnapshotChunk provides a mock function with given fields: _a0, _a1
+func (_m *Application) LoadSnapshotChunk(_a0 context.Context, _a1 types.RequestLoadSnapshotChunk) types.ResponseLoadSnapshotChunk {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseLoadSnapshotChunk
-	if rf, ok := ret.Get(0).(func(types.RequestLoadSnapshotChunk) types.ResponseLoadSnapshotChunk); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestLoadSnapshotChunk) types.ResponseLoadSnapshotChunk); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseLoadSnapshotChunk)
 	}
@@ -138,13 +142,13 @@ func (_m *Application) LoadSnapshotChunk(_a0 types.RequestLoadSnapshotChunk) typ
 	return r0
 }
 
-// OfferSnapshot provides a mock function with given fields: _a0
-func (_m *Application) OfferSnapshot(_a0 types.RequestOfferSnapshot) types.ResponseOfferSnapshot {
-	ret := _m.Called(_a0)
+// OfferSnapshot provides a mock function with given fields: _a0, _a1
+func (_m *Application) OfferSnapshot(_a0 context.Context, _a1 types.RequestOfferSnapshot) types.ResponseOfferSnapshot {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseOfferSnapshot
-	if rf, ok := ret.Get(0).(func(types.RequestOfferSnapshot) types.ResponseOfferSnapshot); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestOfferSnapshot) types.ResponseOfferSnapshot); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseOfferSnapshot)
 	}
@@ -152,13 +156,13 @@ func (_m *Application) OfferSnapshot(_a0 types.RequestOfferSnapshot) types.Respo
 	return r0
 }
 
-// PrepareProposal provides a mock function with given fields: _a0
-func (_m *Application) PrepareProposal(_a0 types.RequestPrepareProposal) types.ResponsePrepareProposal {
-	ret := _m.Called(_a0)
+// PrepareProposal provides a mock function with given fields: _a0, _a1
+func (_m *Application) PrepareProposal(_a0 context.Context, _a1 types.RequestPrepareProposal) types.ResponsePrepareProposal {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponsePrepareProposal
-	if rf, ok := ret.Get(0).(func(types.RequestPrepareProposal) types.ResponsePrepareProposal); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestPrepareProposal) types.ResponsePrepareProposal); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponsePrepareProposal)
 	}
@@ -166,13 +170,13 @@ func (_m *Application) PrepareProposal(_a0 types.RequestPrepareProposal) types.R
 	return r0
 }
 
-// ProcessProposal provides a mock function with given fields: _a0
-func (_m *Application) ProcessProposal(_a0 types.RequestProcessProposal) types.ResponseProcessProposal {
-	ret := _m.Called(_a0)
+// ProcessProposal provides a mock function with given fields: _a0, _a1
+func (_m *Application) ProcessProposal(_a0 context.Context, _a1 types.RequestProcessProposal) types.ResponseProcessProposal {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseProcessProposal
-	if rf, ok := ret.Get(0).(func(types.RequestProcessProposal) types.ResponseProcessProposal); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestProcessProposal) types.ResponseProcessProposal); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseProcessProposal)
 	}
@@ -180,13 +184,13 @@ func (_m *Application) ProcessProposal(_a0 types.RequestProcessProposal) types.R
 	return r0
 }
 
-// Query provides a mock function with given fields: _a0
-func (_m *Application) Query(_a0 types.RequestQuery) types.ResponseQuery {
-	ret := _m.Called(_a0)
+// Query provides a mock function with given fields: _a0, _a1
+func (_m *Application) Query(_a0 context.Context, _a1 types.RequestQuery) types.ResponseQuery {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseQuery
-	if rf, ok := ret.Get(0).(func(types.RequestQuery) types.ResponseQuery); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestQuery) types.ResponseQuery); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseQuery)
 	}
@@ -194,16 +198,25 @@ func (_m *Application) Query(_a0 types.RequestQuery) types.ResponseQuery {
 	return r0
 }
 
-// VerifyVoteExtension provides a mock function with given fields: _a0
-func (_m *Application) VerifyVoteExtension(_a0 types.RequestVerifyVoteExtension) types.ResponseVerifyVoteExtension {
-	ret := _m.Called(_a0)
+// VerifyVoteExtension provides a mock function with given fields: _a0, _a1
+func (_m *Application) VerifyVoteExtension(_a0 context.Context, _a1 types.RequestVerifyVoteExtension) types.ResponseVerifyVoteExtension {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.ResponseVerifyVoteExtension
-	if rf, ok := ret.Get(0).(func(types.RequestVerifyVoteExtension) types.ResponseVerifyVoteExtension); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RequestVerifyVoteExtension) types.ResponseVerifyVoteExtension); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(types.ResponseVerifyVoteExtension)
 	}
 
 	return r0
+}
+
+// NewApplication creates a new instance of Application. It also registers a cleanup function to assert the mocks expectations.
+func NewApplication(t testing.TB) *Application {
+	mock := &Application{}
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
 }

--- a/abci/types/mocks/base.go
+++ b/abci/types/mocks/base.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	context "context"
+
 	types "github.com/tendermint/tendermint/abci/types"
 )
 
@@ -25,151 +27,151 @@ func NewBaseMock() BaseMock {
 
 // Info/Query Connection
 // Return application info
-func (m BaseMock) Info(input types.RequestInfo) (ret types.ResponseInfo) {
+func (m BaseMock) Info(ctx context.Context, input types.RequestInfo) (ret types.ResponseInfo) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.Info(input)
+			ret = m.base.Info(ctx, input)
 		}
 	}()
-	ret = m.Application.Info(input)
+	ret = m.Application.Info(ctx, input)
 	return ret
 }
 
-func (m BaseMock) Query(input types.RequestQuery) (ret types.ResponseQuery) {
+func (m BaseMock) Query(ctx context.Context, input types.RequestQuery) (ret types.ResponseQuery) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.Query(input)
+			ret = m.base.Query(ctx, input)
 		}
 	}()
-	ret = m.Application.Query(input)
+	ret = m.Application.Query(ctx, input)
 	return ret
 }
 
 // Mempool Connection
 // Validate a tx for the mempool
-func (m BaseMock) CheckTx(input types.RequestCheckTx) (ret types.ResponseCheckTx) {
+func (m BaseMock) CheckTx(ctx context.Context, input types.RequestCheckTx) (ret types.ResponseCheckTx) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.CheckTx(input)
+			ret = m.base.CheckTx(ctx, input)
 		}
 	}()
-	ret = m.Application.CheckTx(input)
+	ret = m.Application.CheckTx(ctx, input)
 	return ret
 }
 
 // Consensus Connection
 // Initialize blockchain w validators/other info from TendermintCore
-func (m BaseMock) InitChain(input types.RequestInitChain) (ret types.ResponseInitChain) {
+func (m BaseMock) InitChain(ctx context.Context, input types.RequestInitChain) (ret types.ResponseInitChain) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.InitChain(input)
+			ret = m.base.InitChain(ctx, input)
 		}
 	}()
-	ret = m.Application.InitChain(input)
+	ret = m.Application.InitChain(ctx, input)
 	return ret
 }
 
-func (m BaseMock) PrepareProposal(input types.RequestPrepareProposal) (ret types.ResponsePrepareProposal) {
+func (m BaseMock) PrepareProposal(ctx context.Context, input types.RequestPrepareProposal) (ret types.ResponsePrepareProposal) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.PrepareProposal(input)
+			ret = m.base.PrepareProposal(ctx, input)
 		}
 	}()
-	ret = m.Application.PrepareProposal(input)
+	ret = m.Application.PrepareProposal(ctx, input)
 	return ret
 }
 
-func (m BaseMock) ProcessProposal(input types.RequestProcessProposal) (ret types.ResponseProcessProposal) {
+func (m BaseMock) ProcessProposal(ctx context.Context, input types.RequestProcessProposal) (ret types.ResponseProcessProposal) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.ProcessProposal(input)
+			ret = m.base.ProcessProposal(ctx, input)
 		}
 	}()
-	ret = m.Application.ProcessProposal(input)
+	ret = m.Application.ProcessProposal(ctx, input)
 	return ret
 }
 
 // Commit the state and return the application Merkle root hash
-func (m BaseMock) Commit() (ret types.ResponseCommit) {
+func (m BaseMock) Commit(ctx context.Context) (ret types.ResponseCommit) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.Commit()
+			ret = m.base.Commit(ctx)
 		}
 	}()
-	ret = m.Application.Commit()
+	ret = m.Application.Commit(ctx)
 	return ret
 }
 
 // Create application specific vote extension
-func (m BaseMock) ExtendVote(input types.RequestExtendVote) (ret types.ResponseExtendVote) {
+func (m BaseMock) ExtendVote(ctx context.Context, input types.RequestExtendVote) (ret types.ResponseExtendVote) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.ExtendVote(input)
+			ret = m.base.ExtendVote(ctx, input)
 		}
 	}()
-	ret = m.Application.ExtendVote(input)
+	ret = m.Application.ExtendVote(ctx, input)
 	return ret
 }
 
 // Verify application's vote extension data
-func (m BaseMock) VerifyVoteExtension(input types.RequestVerifyVoteExtension) (ret types.ResponseVerifyVoteExtension) {
+func (m BaseMock) VerifyVoteExtension(ctx context.Context, input types.RequestVerifyVoteExtension) (ret types.ResponseVerifyVoteExtension) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.VerifyVoteExtension(input)
+			ret = m.base.VerifyVoteExtension(ctx, input)
 		}
 	}()
-	ret = m.Application.VerifyVoteExtension(input)
+	ret = m.Application.VerifyVoteExtension(ctx, input)
 	return ret
 }
 
 // State Sync Connection
 // List available snapshots
-func (m BaseMock) ListSnapshots(input types.RequestListSnapshots) (ret types.ResponseListSnapshots) {
+func (m BaseMock) ListSnapshots(ctx context.Context, input types.RequestListSnapshots) (ret types.ResponseListSnapshots) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.ListSnapshots(input)
+			ret = m.base.ListSnapshots(ctx, input)
 		}
 	}()
-	ret = m.Application.ListSnapshots(input)
+	ret = m.Application.ListSnapshots(ctx, input)
 	return ret
 }
 
-func (m BaseMock) OfferSnapshot(input types.RequestOfferSnapshot) (ret types.ResponseOfferSnapshot) {
+func (m BaseMock) OfferSnapshot(ctx context.Context, input types.RequestOfferSnapshot) (ret types.ResponseOfferSnapshot) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.OfferSnapshot(input)
+			ret = m.base.OfferSnapshot(ctx, input)
 		}
 	}()
-	ret = m.Application.OfferSnapshot(input)
+	ret = m.Application.OfferSnapshot(ctx, input)
 	return ret
 }
 
-func (m BaseMock) LoadSnapshotChunk(input types.RequestLoadSnapshotChunk) (ret types.ResponseLoadSnapshotChunk) {
+func (m BaseMock) LoadSnapshotChunk(ctx context.Context, input types.RequestLoadSnapshotChunk) (ret types.ResponseLoadSnapshotChunk) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.LoadSnapshotChunk(input)
+			ret = m.base.LoadSnapshotChunk(ctx, input)
 		}
 	}()
-	ret = m.Application.LoadSnapshotChunk(input)
+	ret = m.Application.LoadSnapshotChunk(ctx, input)
 	return ret
 }
 
-func (m BaseMock) ApplySnapshotChunk(input types.RequestApplySnapshotChunk) (ret types.ResponseApplySnapshotChunk) {
+func (m BaseMock) ApplySnapshotChunk(ctx context.Context, input types.RequestApplySnapshotChunk) (ret types.ResponseApplySnapshotChunk) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.ApplySnapshotChunk(input)
+			ret = m.base.ApplySnapshotChunk(ctx, input)
 		}
 	}()
-	ret = m.Application.ApplySnapshotChunk(input)
+	ret = m.Application.ApplySnapshotChunk(ctx, input)
 	return ret
 }
 
-func (m BaseMock) FinalizeBlock(input types.RequestFinalizeBlock) (ret types.ResponseFinalizeBlock) {
+func (m BaseMock) FinalizeBlock(ctx context.Context, input types.RequestFinalizeBlock) (ret types.ResponseFinalizeBlock) {
 	defer func() {
 		if r := recover(); r != nil {
-			ret = m.base.FinalizeBlock(input)
+			ret = m.base.FinalizeBlock(ctx, input)
 		}
 	}()
-	ret = m.Application.FinalizeBlock(input)
+	ret = m.Application.FinalizeBlock(ctx, input)
 	return ret
 }

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -68,7 +68,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			ensureDir(t, path.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
 			app := kvstore.NewApplication()
 			vals := types.TM2PB.ValidatorUpdates(state.Validators)
-			app.InitChain(abci.RequestInitChain{Validators: vals})
+			app.InitChain(ctx, abci.RequestInitChain{Validators: vals})
 
 			blockDB := dbm.NewMemDB()
 			blockStore := store.NewBlockStore(blockDB)

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -820,7 +820,7 @@ func makeConsensusState(
 		closeFuncs = append(closeFuncs, app.Close)
 
 		vals := types.TM2PB.ValidatorUpdates(state.Validators)
-		app.InitChain(abci.RequestInitChain{Validators: vals})
+		app.InitChain(ctx, abci.RequestInitChain{Validators: vals})
 
 		l := logger.With("validator", i, "module", "consensus")
 		css[i] = newStateWithConfigAndBlockStore(ctx, t, l, thisConfig, state, privVals[i], app, blockStore)
@@ -891,7 +891,7 @@ func randConsensusNetWithPeers(
 		case *kvstore.Application:
 			state.Version.Consensus.App = kvstore.ProtocolVersion
 		}
-		app.InitChain(abci.RequestInitChain{Validators: vals})
+		app.InitChain(ctx, abci.RequestInitChain{Validators: vals})
 		// sm.SaveState(stateDB,state)	//height 1's validatorsInfo already saved in LoadStateFromDBOrGenesisDoc above
 
 		css[i] = newStateWithConfig(ctx, t, logger.With("validator", i, "module", "consensus"), thisConfig, state, privVal, app)

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -466,7 +466,7 @@ func TestReactorWithEvidence(t *testing.T) {
 
 		app := kvstore.NewApplication()
 		vals := types.TM2PB.ValidatorUpdates(state.Validators)
-		app.InitChain(abci.RequestInitChain{Validators: vals})
+		app.InitChain(ctx, abci.RequestInitChain{Validators: vals})
 
 		pv := privVals[i]
 		blockDB := dbm.NewMemDB()

--- a/internal/consensus/replay_stubs.go
+++ b/internal/consensus/replay_stubs.go
@@ -75,7 +75,7 @@ type mockProxyApp struct {
 	abciResponses *tmstate.ABCIResponses
 }
 
-func (mock *mockProxyApp) FinalizeBlock(req abci.RequestFinalizeBlock) abci.ResponseFinalizeBlock {
+func (mock *mockProxyApp) FinalizeBlock(_ context.Context, req abci.RequestFinalizeBlock) abci.ResponseFinalizeBlock {
 	r := mock.abciResponses.FinalizeBlock
 	mock.txCount++
 	if r == nil {
@@ -84,6 +84,6 @@ func (mock *mockProxyApp) FinalizeBlock(req abci.RequestFinalizeBlock) abci.Resp
 	return *r
 }
 
-func (mock *mockProxyApp) Commit() abci.ResponseCommit {
+func (mock *mockProxyApp) Commit(context.Context) abci.ResponseCommit {
 	return abci.ResponseCommit{Data: mock.appHash}
 }

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -1017,7 +1017,7 @@ type badApp struct {
 	onlyLastHashIsWrong bool
 }
 
-func (app *badApp) Commit() abci.ResponseCommit {
+func (app *badApp) Commit(context.Context) abci.ResponseCommit {
 	app.height++
 	if app.onlyLastHashIsWrong {
 		if app.height == app.numBlocks {
@@ -1275,7 +1275,7 @@ type initChainApp struct {
 	vals []abci.ValidatorUpdate
 }
 
-func (ica *initChainApp) InitChain(req abci.RequestInitChain) abci.ResponseInitChain {
+func (ica *initChainApp) InitChain(_ context.Context, req abci.RequestInitChain) abci.ResponseInitChain {
 	return abci.ResponseInitChain{
 		Validators: ica.vals,
 	}

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -36,7 +36,7 @@ type testTx struct {
 	priority int64
 }
 
-func (app *application) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
+func (app *application) CheckTx(_ context.Context, req abci.RequestCheckTx) abci.ResponseCheckTx {
 	var (
 		priority int64
 		sender   string

--- a/internal/state/helpers_test.go
+++ b/internal/state/helpers_test.go
@@ -278,11 +278,11 @@ type testApp struct {
 
 var _ abci.Application = (*testApp)(nil)
 
-func (app *testApp) Info(req abci.RequestInfo) (resInfo abci.ResponseInfo) {
+func (app *testApp) Info(_ context.Context, req abci.RequestInfo) (resInfo abci.ResponseInfo) {
 	return abci.ResponseInfo{}
 }
 
-func (app *testApp) FinalizeBlock(req abci.RequestFinalizeBlock) abci.ResponseFinalizeBlock {
+func (app *testApp) FinalizeBlock(_ context.Context, req abci.RequestFinalizeBlock) abci.ResponseFinalizeBlock {
 	app.CommitVotes = req.DecidedLastCommit.Votes
 	app.ByzantineValidators = req.ByzantineValidators
 
@@ -307,19 +307,19 @@ func (app *testApp) FinalizeBlock(req abci.RequestFinalizeBlock) abci.ResponseFi
 	}
 }
 
-func (app *testApp) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
+func (app *testApp) CheckTx(_ context.Context, req abci.RequestCheckTx) abci.ResponseCheckTx {
 	return abci.ResponseCheckTx{}
 }
 
-func (app *testApp) Commit() abci.ResponseCommit {
+func (app *testApp) Commit(context.Context) abci.ResponseCommit {
 	return abci.ResponseCommit{RetainHeight: 1}
 }
 
-func (app *testApp) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQuery) {
+func (app *testApp) Query(_ context.Context, req abci.RequestQuery) (resQuery abci.ResponseQuery) {
 	return
 }
 
-func (app *testApp) ProcessProposal(req abci.RequestProcessProposal) abci.ResponseProcessProposal {
+func (app *testApp) ProcessProposal(_ context.Context, req abci.RequestProcessProposal) abci.ResponseProcessProposal {
 	for _, tx := range req.Txs {
 		if len(tx) == 0 {
 			return abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_REJECT}

--- a/rpc/client/mock/abci_test.go
+++ b/rpc/client/mock/abci_test.go
@@ -185,7 +185,7 @@ func TestABCIApp(t *testing.T) {
 	// commit
 	// TODO: This may not be necessary in the future
 	if res.Height == -1 {
-		m.App.Commit()
+		m.App.Commit(ctx)
 	}
 
 	// check the key

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
@@ -113,7 +114,7 @@ func NewApplication(cfg *Config) (*Application, error) {
 }
 
 // Info implements ABCI.
-func (app *Application) Info(req abci.RequestInfo) abci.ResponseInfo {
+func (app *Application) Info(_ context.Context, req abci.RequestInfo) abci.ResponseInfo {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -126,7 +127,7 @@ func (app *Application) Info(req abci.RequestInfo) abci.ResponseInfo {
 }
 
 // Info implements ABCI.
-func (app *Application) InitChain(req abci.RequestInitChain) abci.ResponseInitChain {
+func (app *Application) InitChain(_ context.Context, req abci.RequestInitChain) abci.ResponseInitChain {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -153,7 +154,7 @@ func (app *Application) InitChain(req abci.RequestInitChain) abci.ResponseInitCh
 }
 
 // CheckTx implements ABCI.
-func (app *Application) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
+func (app *Application) CheckTx(_ context.Context, req abci.RequestCheckTx) abci.ResponseCheckTx {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -168,7 +169,7 @@ func (app *Application) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
 }
 
 // FinalizeBlock implements ABCI.
-func (app *Application) FinalizeBlock(req abci.RequestFinalizeBlock) abci.ResponseFinalizeBlock {
+func (app *Application) FinalizeBlock(_ context.Context, req abci.RequestFinalizeBlock) abci.ResponseFinalizeBlock {
 	var txs = make([]*abci.ExecTxResult, len(req.Txs))
 
 	app.mu.Lock()
@@ -211,7 +212,7 @@ func (app *Application) FinalizeBlock(req abci.RequestFinalizeBlock) abci.Respon
 }
 
 // Commit implements ABCI.
-func (app *Application) Commit() abci.ResponseCommit {
+func (app *Application) Commit(_ context.Context) abci.ResponseCommit {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -241,7 +242,7 @@ func (app *Application) Commit() abci.ResponseCommit {
 }
 
 // Query implements ABCI.
-func (app *Application) Query(req abci.RequestQuery) abci.ResponseQuery {
+func (app *Application) Query(_ context.Context, req abci.RequestQuery) abci.ResponseQuery {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -253,7 +254,7 @@ func (app *Application) Query(req abci.RequestQuery) abci.ResponseQuery {
 }
 
 // ListSnapshots implements ABCI.
-func (app *Application) ListSnapshots(req abci.RequestListSnapshots) abci.ResponseListSnapshots {
+func (app *Application) ListSnapshots(_ context.Context, req abci.RequestListSnapshots) abci.ResponseListSnapshots {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -265,7 +266,7 @@ func (app *Application) ListSnapshots(req abci.RequestListSnapshots) abci.Respon
 }
 
 // LoadSnapshotChunk implements ABCI.
-func (app *Application) LoadSnapshotChunk(req abci.RequestLoadSnapshotChunk) abci.ResponseLoadSnapshotChunk {
+func (app *Application) LoadSnapshotChunk(_ context.Context, req abci.RequestLoadSnapshotChunk) abci.ResponseLoadSnapshotChunk {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -277,7 +278,7 @@ func (app *Application) LoadSnapshotChunk(req abci.RequestLoadSnapshotChunk) abc
 }
 
 // OfferSnapshot implements ABCI.
-func (app *Application) OfferSnapshot(req abci.RequestOfferSnapshot) abci.ResponseOfferSnapshot {
+func (app *Application) OfferSnapshot(_ context.Context, req abci.RequestOfferSnapshot) abci.ResponseOfferSnapshot {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -290,7 +291,7 @@ func (app *Application) OfferSnapshot(req abci.RequestOfferSnapshot) abci.Respon
 }
 
 // ApplySnapshotChunk implements ABCI.
-func (app *Application) ApplySnapshotChunk(req abci.RequestApplySnapshotChunk) abci.ResponseApplySnapshotChunk {
+func (app *Application) ApplySnapshotChunk(_ context.Context, req abci.RequestApplySnapshotChunk) abci.ResponseApplySnapshotChunk {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
@@ -323,7 +324,7 @@ func (app *Application) ApplySnapshotChunk(req abci.RequestApplySnapshotChunk) a
 // If adding a special vote extension-generated transaction would cause the
 // total number of transaction bytes to exceed `req.MaxTxBytes`, we will not
 // append our special vote extension transaction.
-func (app *Application) PrepareProposal(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+func (app *Application) PrepareProposal(_ context.Context, req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
 	var sum int64
 	var extCount int
 	for _, vote := range req.LocalLastCommit.Votes {
@@ -399,7 +400,7 @@ func (app *Application) PrepareProposal(req abci.RequestPrepareProposal) abci.Re
 
 // ProcessProposal implements part of the Application interface.
 // It accepts any proposal that does not contain a malformed transaction.
-func (app *Application) ProcessProposal(req abci.RequestProcessProposal) abci.ResponseProcessProposal {
+func (app *Application) ProcessProposal(_ context.Context, req abci.RequestProcessProposal) abci.ResponseProcessProposal {
 	for _, tx := range req.Txs {
 		k, v, err := parseTx(tx)
 		if err != nil {
@@ -425,7 +426,7 @@ func (app *Application) ProcessProposal(req abci.RequestProcessProposal) abci.Re
 // a new transaction will be proposed that updates a special value in the
 // key/value store ("extensionSum") with the sum of all of the numbers collected
 // from the vote extensions.
-func (app *Application) ExtendVote(req abci.RequestExtendVote) abci.ResponseExtendVote {
+func (app *Application) ExtendVote(_ context.Context, req abci.RequestExtendVote) abci.ResponseExtendVote {
 	// We ignore any requests for vote extensions that don't match our expected
 	// next height.
 	if req.Height != int64(app.state.Height)+1 {
@@ -451,7 +452,7 @@ func (app *Application) ExtendVote(req abci.RequestExtendVote) abci.ResponseExte
 // VerifyVoteExtension simply validates vote extensions from other validators
 // without doing anything about them. In this case, it just makes sure that the
 // vote extension is a well-formed integer value.
-func (app *Application) VerifyVoteExtension(req abci.RequestVerifyVoteExtension) abci.ResponseVerifyVoteExtension {
+func (app *Application) VerifyVoteExtension(_ context.Context, req abci.RequestVerifyVoteExtension) abci.ResponseVerifyVoteExtension {
 	// We allow vote extensions to be optional
 	if len(req.VoteExtension) == 0 {
 		return abci.ResponseVerifyVoteExtension{


### PR DESCRIPTION
I think it makes sense to land this before the release, because we're
already changing this interface a bunch so the additionl churn is
minor. 

I'll do some follow up PRs to turn things into errors, and maybe make
the return types pointers to simplify error return cases.