### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,14 @@ on:
       - master
       - release/**
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     name: Build
     runs-on: ubuntu-latest
     strategy:
@@ -37,6 +43,9 @@ jobs:
         if: "env.GIT_DIFF != ''"
 
   test_abci_cli:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 5
@@ -59,6 +68,9 @@ jobs:
         if: "env.GIT_DIFF != ''"
 
   test_apps:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,9 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"  # Push events to matching v*, i.e. v1.0, v20.15.10
       - "v[0-9]+.[0-9]+.[0-9]+-rc*"  # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-toc.yml
+++ b/.github/workflows/docs-toc.yml
@@ -6,8 +6,14 @@ on:
       branches:
         - master
 
+permissions:
+  contents: read
+
 jobs:
   check:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -4,6 +4,9 @@ name: e2e-manual
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-nightly-test:
     # Run parallel jobs for the listed testnet groups (must match the

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-nightly-test:
     # Run parallel jobs for the listed testnet groups (must match the
@@ -43,6 +46,8 @@ jobs:
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
 
   e2e-nightly-fail:
+    permissions:
+      contents: none
     needs: e2e-nightly-test
     if: ${{ failure() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-nightly-35x.yml
+++ b/.github/workflows/e2e-nightly-35x.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-nightly-test:
     # Run parallel jobs for the listed testnet groups (must match the
@@ -43,6 +46,8 @@ jobs:
         run: ./run-multiple.sh networks/nightly/${{ matrix.p2p }}/*-group${{ matrix.group }}-*.toml
 
   e2e-nightly-fail-2:
+    permissions:
+      contents: none
     needs: e2e-nightly-test
     if: ${{ failure() }}
     runs-on: ubuntu-latest
@@ -59,6 +64,8 @@ jobs:
           SLACK_FOOTER: ''
 
   e2e-nightly-success:  # may turn this off once they seem to pass consistently
+    permissions:
+      contents: none
     needs: e2e-nightly-test
     if: ${{ success() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-nightly-test:
     # Run parallel jobs for the listed testnet groups (must match the
@@ -40,6 +43,8 @@ jobs:
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
 
   e2e-nightly-fail-2:
+    permissions:
+      contents: none
     needs: e2e-nightly-test
     if: ${{ failure() }}
     runs-on: ubuntu-latest
@@ -56,6 +61,8 @@ jobs:
           SLACK_FOOTER: ''
 
   e2e-nightly-success:  # may turn this off once they seem to pass consistently
+    permissions:
+      contents: none
     needs: e2e-nightly-test
     if: ${{ success() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,8 +9,14 @@ on:
       - master
       - release/**
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - "test/fuzz/**/*.go"
 
+permissions:
+  contents: read
+
 jobs:
   fuzz-nightly-test:
     runs-on: ubuntu-latest
@@ -61,6 +64,8 @@ jobs:
       crashers-count: ${{ steps.set-crashers-count.outputs.count }}
 
   fuzz-nightly-fail:
+    permissions:
+      contents: none
     needs: fuzz-nightly-test
     if: ${{ needs.fuzz-nightly-test.outputs.crashers-count != 0 }}
     runs-on: ubuntu-latest

--- a/.github/workflows/janitor.yml
+++ b/.github/workflows/janitor.yml
@@ -4,8 +4,13 @@ name: Janitor
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   cancel:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     name: "Cancel Previous Runs"
     runs-on: ubuntu-latest
     timeout-minutes: 3

--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -41,6 +41,9 @@ on:
         required: true
         default: 'https://github.com/tendermint/jepsen/releases/download/0.2.1/merkleeyes_0.1.7.tar.gz'
 
+permissions:
+  contents: read
+
 jobs:
   jepsen-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,14 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
+
 jobs:
   golangci:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: golangci-lint
     runs-on: ubuntu-latest
     timeout-minutes: 8

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - 'proto/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,13 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"  # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
+    permissions:
+      contents: write  # for goreleaser/goreleaser-action to create a GitHub release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,14 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,14 @@ on:
       - master
       - release/**
 
+permissions:
+  contents: read
+
 jobs:
   tests:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -38,6 +44,9 @@ jobs:
           path: ./build/${{ matrix.part }}.profile.out
 
   upload-coverage-report:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: ubuntu-latest
     needs: tests
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
