### PR TITLE
Make encoding of HexBytes values more robust.

### DIFF
--- a/libs/bytes/bytes_test.go
+++ b/libs/bytes/bytes_test.go
@@ -61,7 +61,7 @@ func TestJSONMarshal(t *testing.T) {
 				t.Fatal(err)
 			}
 			assert.Equal(t, ts2.B1, tc.input)
-			assert.Equal(t, ts2.B2, HexBytes(tc.input))
+			assert.Equal(t, string(ts2.B2), string(tc.input))
 		})
 	}
 }


### PR DESCRIPTION
The HexBytes wrapper type handles decoding byte strings from JSON.  In the RPC
API, hashes are encoded as hex digits rather than the standard base64.

Simplify the implementation of this wrapper using the TextMarshaler interface,
which the encoding/json package uses for values (like these) that are meant to
be wrapped in JSON strings.

In addition, allow HexBytes values to be decoded from either hex OR base64
input. This preserves all existing use, but will allow us to remove some
reflection special cases in the RPC decoder plumbing.