### PR TITLE
abci++: Vote extension cleanup

### DIFF
--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -159,7 +159,11 @@ func signVote(
 	chainID string,
 	blockID types.BlockID) *types.Vote {
 
-	v, err := vs.signVote(ctx, voteType, chainID, blockID, []byte("extension"))
+	var ext []byte
+	if voteType == tmproto.PrecommitType {
+		ext = []byte("extension")
+	}
+	v, err := vs.signVote(ctx, voteType, chainID, blockID, ext)
 	require.NoError(t, err, "failed to sign vote")
 
 	vs.lastVote = v

--- a/internal/consensus/msgs.go
+++ b/internal/consensus/msgs.go
@@ -536,6 +536,8 @@ func MsgFromProto(msg *tmcons.Message) (Message, error) {
 			Part:   parts,
 		}
 	case *tmcons.Message_Vote:
+		// Vote validation will be handled in the vote message ValidateBasic
+		// call below.
 		vote, err := types.VoteFromProto(msg.Vote.Vote)
 		if err != nil {
 			return nil, fmt.Errorf("vote msg to proto error: %w", err)

--- a/internal/consensus/msgs.go
+++ b/internal/consensus/msgs.go
@@ -220,9 +220,11 @@ type VoteMessage struct {
 
 func (*VoteMessage) TypeTag() string { return "tendermint/Vote" }
 
-// ValidateBasic performs basic validation.
+// ValidateBasic checks whether the vote within the message is well-formed.
 func (m *VoteMessage) ValidateBasic() error {
-	return m.Vote.ValidateBasic()
+	// Here we validate votes with vote extensions, since we require vote
+	// extensions to be sent in vote messages during consensus.
+	return m.Vote.ValidateWithExtension()
 }
 
 // String returns a string representation.

--- a/internal/consensus/msgs.go
+++ b/internal/consensus/msgs.go
@@ -223,7 +223,9 @@ func (*VoteMessage) TypeTag() string { return "tendermint/Vote" }
 // ValidateBasic checks whether the vote within the message is well-formed.
 func (m *VoteMessage) ValidateBasic() error {
 	// Here we validate votes with vote extensions, since we require vote
-	// extensions to be sent in vote messages during consensus.
+	// extensions to be sent in precommit messages during consensus. Prevote
+	// messages should never have vote extensions, and this is also validated
+	// here.
 	return m.Vote.ValidateWithExtension()
 }
 

--- a/internal/test/factory/vote.go
+++ b/internal/test/factory/vote.go
@@ -40,5 +40,6 @@ func MakeVote(
 	}
 
 	v.Signature = vpb.Signature
+	v.ExtensionSignature = vpb.ExtensionSignature
 	return v, nil
 }

--- a/privval/file.go
+++ b/privval/file.go
@@ -373,9 +373,12 @@ func (pv *FilePV) signVote(chainID string, vote *tmproto.Vote) error {
 
 	signBytes := types.VoteSignBytes(chainID, vote)
 
+	// Vote extensions are non-deterministic, so it is possible that an
+	// application may have created a different extension. We therefore always
+	// re-sign the vote extensions of precommits. For prevotes, the extension
+	// signature will always be empty.
 	var extSig []byte
 	if vote.Type == tmproto.PrecommitType {
-		// We always sign the vote extension for precommits. See below for details.
 		extSignBytes := types.VoteExtensionSignBytes(chainID, vote)
 		extSig, err = pv.Key.PrivKey.Sign(extSignBytes)
 		if err != nil {
@@ -406,9 +409,6 @@ func (pv *FilePV) signVote(chainID string, vote *tmproto.Vote) error {
 			vote.Signature = lss.Signature
 		}
 
-		// Vote extensions are non-deterministic, so it's possible that an
-		// application may have created a different extension. We therefore
-		// always re-sign the vote extensions of precommits.
 		vote.ExtensionSignature = extSig
 
 		return nil

--- a/privval/file.go
+++ b/privval/file.go
@@ -408,7 +408,7 @@ func (pv *FilePV) signVote(chainID string, vote *tmproto.Vote) error {
 
 		// Vote extensions are non-deterministic, so it's possible that an
 		// application may have created a different extension. We therefore
-		// always re-sign the vote extension (if it's a precommit).
+		// always re-sign the vote extensions of precommits.
 		vote.ExtensionSignature = extSig
 
 		return nil

--- a/privval/file.go
+++ b/privval/file.go
@@ -384,6 +384,8 @@ func (pv *FilePV) signVote(chainID string, vote *tmproto.Vote) error {
 		if err != nil {
 			return err
 		}
+	} else if len(vote.Extension) > 0 {
+		return errors.New("unexpected vote extension - extensions are only allowed in precommits")
 	}
 
 	// We might crash before writing to the wal,

--- a/types/block.go
+++ b/types/block.go
@@ -780,7 +780,11 @@ func CommitToVoteSet(chainID string, commit *Commit, vals *ValidatorSet) *VoteSe
 		if commitSig.Absent() {
 			continue // OK, some precommits can be missing.
 		}
-		added, err := voteSet.AddVote(commit.GetVote(int32(idx)))
+		vote := commit.GetVote(int32(idx))
+		if err := vote.ValidateBasic(); err != nil {
+			panic(fmt.Errorf("failed to validate vote reconstructed from LastCommit: %w", err))
+		}
+		added, err := voteSet.AddVote(vote)
 		if !added || err != nil {
 			panic(fmt.Errorf("failed to reconstruct LastCommit: %w", err))
 		}

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -211,14 +211,28 @@ func DuplicateVoteEvidenceFromProto(pb *tmproto.DuplicateVoteEvidence) (*Duplica
 		return nil, errors.New("nil duplicate vote evidence")
 	}
 
-	vA, err := VoteFromProto(pb.VoteA)
-	if err != nil {
-		return nil, err
+	var vA *Vote
+	if pb.VoteA != nil {
+		var err error
+		vA, err = VoteFromProto(pb.VoteA)
+		if err != nil {
+			return nil, err
+		}
+		if err = vA.ValidateBasic(); err != nil {
+			return nil, err
+		}
 	}
 
-	vB, err := VoteFromProto(pb.VoteB)
-	if err != nil {
-		return nil, err
+	var vB *Vote
+	if pb.VoteB != nil {
+		var err error
+		vB, err = VoteFromProto(pb.VoteB)
+		if err != nil {
+			return nil, err
+		}
+		if err = vB.ValidateBasic(); err != nil {
+			return nil, err
+		}
 	}
 
 	dve := &DuplicateVoteEvidence{

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -96,9 +96,14 @@ func (pv MockPV) SignVote(ctx context.Context, chainID string, vote *tmproto.Vot
 		return err
 	}
 	vote.Signature = sig
-	extSig, err := pv.PrivKey.Sign(extSignBytes)
-	if err != nil {
-		return err
+
+	var extSig []byte
+	// We only sign vote extensions for precommits
+	if vote.Type == tmproto.PrecommitType {
+		extSig, err = pv.PrivKey.Sign(extSignBytes)
+		if err != nil {
+			return err
+		}
 	}
 	vote.ExtensionSignature = extSig
 	return nil

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -104,6 +104,8 @@ func (pv MockPV) SignVote(ctx context.Context, chainID string, vote *tmproto.Vot
 		if err != nil {
 			return err
 		}
+	} else if len(vote.Extension) > 0 {
+		return errors.New("unexpected vote extension - vote extensions are only allowed in precommits")
 	}
 	vote.ExtensionSignature = extSig
 	return nil

--- a/types/vote.go
+++ b/types/vote.go
@@ -61,11 +61,11 @@ type Vote struct {
 	ExtensionSignature []byte                `json:"extension_signature"`
 }
 
-func voteFromProto(pv *tmproto.Vote) (*Vote, error) {
-	if pv == nil {
-		return nil, errors.New("nil vote")
-	}
-
+// VoteFromProto attempts to convert the given serialization (Protobuf) type to
+// our Vote domain type. No validation is performed on the resulting vote -
+// this is left up to the caller to decide whether to call ValidateBasic or
+// ValidateWithExtension.
+func VoteFromProto(pv *tmproto.Vote) (*Vote, error) {
 	blockID, err := BlockIDFromProto(&pv.BlockID)
 	if err != nil {
 		return nil, err
@@ -83,29 +83,6 @@ func voteFromProto(pv *tmproto.Vote) (*Vote, error) {
 		Extension:          pv.Extension,
 		ExtensionSignature: pv.ExtensionSignature,
 	}, nil
-}
-
-// VoteFromProto attempts to convert the given serialization (Protobuf) type to
-// our Vote domain type, performing basic validation with ValidateBasic. Note
-// that this performs no vote extension validation - to additionally validate
-// vote extensions, use VoteWithExtensionFromProto instead.
-func VoteFromProto(pv *tmproto.Vote) (*Vote, error) {
-	vote, err := voteFromProto(pv)
-	if err != nil {
-		return nil, err
-	}
-	return vote, vote.ValidateBasic()
-}
-
-// VoteWithExtensionFromProto attempts to convert the given serialization
-// (Protobuf) type to our Vote domain type, performing validation with
-// ValidateWithExtension.
-func VoteWithExtensionFromProto(pv *tmproto.Vote) (*Vote, error) {
-	vote, err := voteFromProto(pv)
-	if err != nil {
-		return nil, err
-	}
-	return vote, vote.ValidateWithExtension()
 }
 
 // CommitSig converts the Vote to a CommitSig.

--- a/types/vote.go
+++ b/types/vote.go
@@ -295,12 +295,15 @@ func (vote *Vote) ValidateWithExtension() error {
 	}
 
 	// We should always see vote extension signatures in precommits
-	if vote.Type == tmproto.PrecommitType && len(vote.ExtensionSignature) == 0 {
+	if vote.Type == tmproto.PrecommitType {
 		// TODO(thane): Remove extension length check once
 		//              https://github.com/tendermint/tendermint/issues/8272 is
 		//              resolved.
-		if len(vote.Extension) > 0 {
+		if len(vote.Extension) > 0 && len(vote.ExtensionSignature) == 0 {
 			return errors.New("vote extension signature is missing")
+		}
+		if len(vote.ExtensionSignature) > MaxSignatureSize {
+			return fmt.Errorf("vote extension signature is too big (max: %d)", MaxSignatureSize)
 		}
 	}
 

--- a/types/vote.go
+++ b/types/vote.go
@@ -276,10 +276,10 @@ func (vote *Vote) ValidateBasic() error {
 	// We should only ever see vote extensions in precommits.
 	if vote.Type != tmproto.PrecommitType {
 		if len(vote.Extension) > 0 {
-			return errors.New("unexpected vote extension in prevote")
+			return errors.New("unexpected vote extension")
 		}
 		if len(vote.ExtensionSignature) > 0 {
-			return errors.New("unexpected vote extension signature in prevote")
+			return errors.New("unexpected vote extension signature")
 		}
 	}
 

--- a/types/vote.go
+++ b/types/vote.go
@@ -273,6 +273,16 @@ func (vote *Vote) ValidateBasic() error {
 		return fmt.Errorf("signature is too big (max: %d)", MaxSignatureSize)
 	}
 
+	// We should only ever see vote extensions in precommits.
+	if vote.Type != tmproto.PrecommitType {
+		if len(vote.Extension) > 0 {
+			return errors.New("unexpected vote extension in prevote")
+		}
+		if len(vote.ExtensionSignature) > 0 {
+			return errors.New("unexpected vote extension signature in prevote")
+		}
+	}
+
 	return nil
 }
 
@@ -282,17 +292,6 @@ func (vote *Vote) ValidateBasic() error {
 func (vote *Vote) ValidateWithExtension() error {
 	if err := vote.ValidateBasic(); err != nil {
 		return err
-	}
-
-	// We should never see a vote extension or vote extension signature in a
-	// prevote
-	if vote.Type == tmproto.PrevoteType {
-		if len(vote.Extension) > 0 {
-			return errors.New("unexpected vote extension in prevote")
-		}
-		if len(vote.ExtensionSignature) > 0 {
-			return errors.New("unexpected vote extension signature in prevote")
-		}
 	}
 
 	// We should always see vote extension signatures in precommits

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -194,6 +194,7 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 	}
 
 	// Check signature.
+	// TODO(thane): Should we always require vote extensions in vote sets?
 	if err := vote.Verify(voteSet.chainID, val.PubKey); err != nil {
 		return false, fmt.Errorf("failed to verify vote with ChainID %s and PubKey %s: %w", voteSet.chainID, val.PubKey, err)
 	}

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -194,8 +194,7 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 	}
 
 	// Check signature.
-	// TODO(thane): Should we always require vote extensions in vote sets?
-	if err := vote.Verify(voteSet.chainID, val.PubKey); err != nil {
+	if err := vote.VerifyWithExtension(voteSet.chainID, val.PubKey); err != nil {
 		return false, fmt.Errorf("failed to verify vote with ChainID %s and PubKey %s: %w", voteSet.chainID, val.PubKey, err)
 	}
 

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -224,22 +224,26 @@ func TestVoteExtension(t *testing.T) {
 			includeSignature: true,
 			expectError:      false,
 		},
-		{
-			name:             "no extension signature",
-			extension:        []byte("extension"),
-			includeSignature: false,
-			expectError:      true,
-		},
+		// TODO(thane): Re-enable once
+		// https://github.com/tendermint/tendermint/issues/8272 is resolved
+		//{
+		//	name:             "no extension signature",
+		//	extension:        []byte("extension"),
+		//	includeSignature: false,
+		//	expectError:      true,
+		//},
 		{
 			name:             "empty extension",
 			includeSignature: true,
 			expectError:      false,
 		},
-		{
-			name:             "no extension and no signature",
-			includeSignature: false,
-			expectError:      true,
-		},
+		// TODO: Re-enable once
+		// https://github.com/tendermint/tendermint/issues/8272 is resolved.
+		//{
+		//	name:             "no extension and no signature",
+		//	includeSignature: false,
+		//	expectError:      true,
+		//},
 	}
 
 	for _, tc := range testCases {
@@ -356,7 +360,8 @@ func TestVoteValidation(t *testing.T) {
 		{"Invalid Signature", func(v *Vote) { v.Signature = nil }, true, true, true},
 		{"Too big Signature", func(v *Vote) { v.Signature = make([]byte, MaxSignatureSize+1) }, true, true, true},
 		{"Vote extension present", func(v *Vote) { v.Extension = []byte("extension") }, false, true, false},
-		{"Missing vote extension signature", func(v *Vote) { v.ExtensionSignature = nil }, false, false, true},
+		// TODO(thane): Re-enable once https://github.com/tendermint/tendermint/issues/8272 is resolved
+		//{"Missing vote extension signature", func(v *Vote) { v.ExtensionSignature = nil }, false, false, true},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -367,9 +367,8 @@ func TestVoteValidation(t *testing.T) {
 			votes := []*Vote{examplePrevote(t), examplePrecommit(t)}
 			for i, vote := range votes {
 				v := vote.ToProto()
-				err := privVal.SignVote(ctx, "test_chain_id", v)
+				require.NoError(t, privVal.SignVote(ctx, "test_chain_id", v))
 				vote.Signature = v.Signature
-				require.NoError(t, err)
 				tc.malleateVote(vote)
 				// ValidateBasic errors should be consistent across prevotes and precommits
 				assert.Equal(t, tc.expectBasicErr, vote.ValidateBasic() != nil, "ValidateBasic had an unexpected result")

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -24,7 +24,9 @@ func examplePrevote(t *testing.T) *Vote {
 
 func examplePrecommit(t testing.TB) *Vote {
 	t.Helper()
-	return exampleVote(t, byte(tmproto.PrecommitType))
+	vote := exampleVote(t, byte(tmproto.PrecommitType))
+	vote.ExtensionSignature = []byte("signature")
+	return vote
 }
 
 func exampleVote(tb testing.TB, t byte) *Vote {
@@ -48,6 +50,7 @@ func exampleVote(tb testing.TB, t byte) *Vote {
 		ValidatorIndex:   56789,
 	}
 }
+
 func TestVoteSignable(t *testing.T) {
 	vote := examplePrecommit(t)
 	v := vote.ToProto()
@@ -221,26 +224,22 @@ func TestVoteExtension(t *testing.T) {
 			includeSignature: true,
 			expectError:      false,
 		},
-		// TODO: Re-enable once
-		// https://github.com/tendermint/tendermint/issues/8272 is resolved.
-		//{
-		//	name:             "no extension signature",
-		//	extension:        []byte("extension"),
-		//	includeSignature: false,
-		//	expectError:      true,
-		//},
+		{
+			name:             "no extension signature",
+			extension:        []byte("extension"),
+			includeSignature: false,
+			expectError:      true,
+		},
 		{
 			name:             "empty extension",
 			includeSignature: true,
 			expectError:      false,
 		},
-		// TODO: Re-enable once
-		// https://github.com/tendermint/tendermint/issues/8272 is resolved.
-		//{
-		//	name:             "no extension and no signature",
-		//	includeSignature: false,
-		//	expectError:      true,
-		//},
+		{
+			name:             "no extension and no signature",
+			includeSignature: false,
+			expectError:      true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -269,7 +268,7 @@ func TestVoteExtension(t *testing.T) {
 			if tc.includeSignature {
 				vote.ExtensionSignature = v.ExtensionSignature
 			}
-			err = vote.Verify("test_chain_id", pk)
+			err = vote.VerifyWithExtension("test_chain_id", pk)
 			if tc.expectError {
 				require.Error(t, err)
 			} else {
@@ -336,24 +335,28 @@ func TestVoteString(t *testing.T) {
 	}
 }
 
-func TestVoteValidateBasic(t *testing.T) {
+func TestVoteValidation(t *testing.T) {
 	privVal := NewMockPV()
 
 	testCases := []struct {
-		testName     string
-		malleateVote func(*Vote)
-		expectErr    bool
+		testName                 string
+		malleateVote             func(*Vote)
+		expectBasicErr           bool
+		expectExtErrForPrevote   bool
+		expectExtErrForPrecommit bool
 	}{
-		{"Good Vote", func(v *Vote) {}, false},
-		{"Negative Height", func(v *Vote) { v.Height = -1 }, true},
-		{"Negative Round", func(v *Vote) { v.Round = -1 }, true},
+		{"Good Vote", func(v *Vote) {}, false, false, false},
+		{"Negative Height", func(v *Vote) { v.Height = -1 }, true, true, true},
+		{"Negative Round", func(v *Vote) { v.Round = -1 }, true, true, true},
 		{"Invalid BlockID", func(v *Vote) {
 			v.BlockID = BlockID{[]byte{1, 2, 3}, PartSetHeader{111, []byte("blockparts")}}
-		}, true},
-		{"Invalid Address", func(v *Vote) { v.ValidatorAddress = make([]byte, 1) }, true},
-		{"Invalid ValidatorIndex", func(v *Vote) { v.ValidatorIndex = -1 }, true},
-		{"Invalid Signature", func(v *Vote) { v.Signature = nil }, true},
-		{"Too big Signature", func(v *Vote) { v.Signature = make([]byte, MaxSignatureSize+1) }, true},
+		}, true, true, true},
+		{"Invalid Address", func(v *Vote) { v.ValidatorAddress = make([]byte, 1) }, true, true, true},
+		{"Invalid ValidatorIndex", func(v *Vote) { v.ValidatorIndex = -1 }, true, true, true},
+		{"Invalid Signature", func(v *Vote) { v.Signature = nil }, true, true, true},
+		{"Too big Signature", func(v *Vote) { v.Signature = make([]byte, MaxSignatureSize+1) }, true, true, true},
+		{"Vote extension present", func(v *Vote) { v.Extension = []byte("extension") }, false, true, false},
+		{"Missing vote extension signature", func(v *Vote) { v.ExtensionSignature = nil }, false, false, true},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -361,13 +364,22 @@ func TestVoteValidateBasic(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			vote := examplePrecommit(t)
-			v := vote.ToProto()
-			err := privVal.SignVote(ctx, "test_chain_id", v)
-			vote.Signature = v.Signature
-			require.NoError(t, err)
-			tc.malleateVote(vote)
-			assert.Equal(t, tc.expectErr, vote.ValidateBasic() != nil, "Validate Basic had an unexpected result")
+			votes := []*Vote{examplePrevote(t), examplePrecommit(t)}
+			for i, vote := range votes {
+				v := vote.ToProto()
+				err := privVal.SignVote(ctx, "test_chain_id", v)
+				vote.Signature = v.Signature
+				require.NoError(t, err)
+				tc.malleateVote(vote)
+				// ValidateBasic errors should be consistent across prevotes and precommits
+				assert.Equal(t, tc.expectBasicErr, vote.ValidateBasic() != nil, "ValidateBasic had an unexpected result")
+				// ValidateWithExtension errors can vary depending on vote type
+				if i == 0 {
+					assert.Equal(t, tc.expectExtErrForPrevote, vote.ValidateWithExtension() != nil, "ValidateWithExtension had an unexpected result for prevote")
+				} else {
+					assert.Equal(t, tc.expectExtErrForPrecommit, vote.ValidateWithExtension() != nil, "ValidateWithExtension had an unexpected result for precommit")
+				}
+			}
 		})
 	}
 }

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -400,21 +400,28 @@ func TestVoteProtobuf(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		msg     string
-		v1      *Vote
-		expPass bool
+		msg                 string
+		vote                *Vote
+		convertsOk          bool
+		passesValidateBasic bool
 	}{
-		{"success", vote, true},
-		{"fail vote validate basic", &Vote{}, false},
-		{"failure nil", nil, false},
+		{"success", vote, true, true},
+		{"fail vote validate basic", &Vote{}, true, false},
 	}
 	for _, tc := range testCases {
-		protoProposal := tc.v1.ToProto()
+		protoProposal := tc.vote.ToProto()
 
 		v, err := VoteFromProto(protoProposal)
-		if tc.expPass {
+		if tc.convertsOk {
 			require.NoError(t, err)
-			require.Equal(t, tc.v1, v, tc.msg)
+		} else {
+			require.Error(t, err)
+		}
+
+		err = v.ValidateBasic()
+		if tc.passesValidateBasic {
+			require.NoError(t, err)
+			require.Equal(t, tc.vote, v, tc.msg)
 		} else {
 			require.Error(t, err)
 		}

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -438,6 +438,7 @@ func TestInvalidPrecommitExtensions(t *testing.T) {
 		}},
 		// TODO(thane): Re-enable once https://github.com/tendermint/tendermint/issues/8272 is resolved
 		//{"missing vote extension signature", func(v *Vote) { v.ExtensionSignature = nil }},
+		{"oversized vote extension signature", func(v *Vote) { v.ExtensionSignature = make([]byte, MaxSignatureSize+1) }},
 	}
 	for _, tc := range testCases {
 		precommit := examplePrecommit(t)

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -400,7 +400,7 @@ func TestInvalidVotes(t *testing.T) {
 	}
 }
 
-func TestInvalidPrevoteExtensions(t *testing.T) {
+func TestInvalidPrevotes(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	privVal := NewMockPV()
@@ -415,9 +415,7 @@ func TestInvalidPrevoteExtensions(t *testing.T) {
 	for _, tc := range testCases {
 		prevote := examplePrevote(t)
 		signAndMalleateVote(ctx, t, privVal, "test_chain_id", tc.malleateVote, prevote)
-		// We don't expect an error from ValidateBasic, because it doesn't
-		// handle vote extensions.
-		require.NoError(t, prevote.ValidateBasic(), "ValidateBasic for %s", tc.name)
+		require.Error(t, prevote.ValidateBasic(), "ValidateBasic for %s", tc.name)
 		require.Error(t, prevote.ValidateWithExtension(), "ValidateWithExtension for %s", tc.name)
 	}
 }


### PR DESCRIPTION
Follows from #8141. Relates to #8272, but does not close it.

I realized that we're signing prevotes' vote extensions too, which is incorrect (we should only be signing and verifying/validating precommits' vote extensions).

After trying to work with #8375 and discussion with @tychoish, we realized that we should rather expose different validation methods than introduce a boolean flag into the `ValidateBasic` method for `Vote`.

I'll be submitting several separate PRs that build on this one and each other (eventually including some commits from #8375) in order to implement RFC 017 (#8317).