### PR TITLE
p2p: add libp2p feature flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -678,7 +678,7 @@ type P2PConfig struct { //nolint: maligned
 	// UseLibP2P switches to using the new networking layer based
 	// on libp2p. This option is unlikely to persist into a
 	// release of tendermint, but will ease the transition.
-	UseLibP2P bool `mapstructure:"use-lib-p2p"`
+	UseLibP2P bool `mapstructure:"experimental-use-lib-p2p"`
 }
 
 // DefaultP2PConfig returns a default configuration for the peer-to-peer layer

--- a/config/config.go
+++ b/config/config.go
@@ -674,6 +674,11 @@ type P2PConfig struct { //nolint: maligned
 	// layer uses. Options are: "fifo" and "priority",
 	// with the default being "priority".
 	QueueType string `mapstructure:"queue-type"`
+
+	// UseLibP2P switches to using the new networking layer based
+	// on libp2p. This option is unlikely to persist into a
+	// release of tendermint, but will ease the transition.
+	UseLibP2P bool `mapstructure:"use-lib-p2p"`
 }
 
 // DefaultP2PConfig returns a default configuration for the peer-to-peer layer

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -72,6 +72,10 @@ type RouterOptions struct {
 	// are used to dial peers. This defaults to the value of
 	// runtime.NumCPU.
 	NumConcurrentDials func() int
+
+	// UseLibP2P toggles the use of the new networking layer
+	// within the router.
+	UseLibP2P bool
 }
 
 const (
@@ -189,6 +193,10 @@ func NewRouter(
 
 	if err := options.Validate(); err != nil {
 		return nil, err
+	}
+
+	if options.UseLibP2P {
+		return nil, errors.New("libp2p is not supported")
 	}
 
 	router := &Router{

--- a/internal/p2p/router_test.go
+++ b/internal/p2p/router_test.go
@@ -26,6 +26,34 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
+func TestRouterConstruction(t *testing.T) {
+	opts := p2p.RouterOptions{UseLibP2P: true}
+	if err := opts.Validate(); err != nil {
+		t.Fatalf("options should validate: %v", err)
+	}
+	logger := log.NewNopLogger()
+	metrics := p2p.NopMetrics()
+
+	router, err := p2p.NewRouter(
+		logger,
+		metrics,
+		nil, // privkey
+		nil, // peermanager
+		func() *types.NodeInfo { return &types.NodeInfo{} },
+		[]p2p.Transport{},
+		[]p2p.Endpoint{},
+		opts,
+	)
+	if err == nil {
+		t.Error("support for libp2p does not exist, and should prevent the router from being constructed")
+	} else if err.Error() != "libp2p is not supported" {
+		t.Errorf("incorrect error: %q", err.Error())
+	}
+	if router != nil {
+		t.Error("router was constructed when it should not have been")
+	}
+}
+
 func echoReactor(ctx context.Context, channel *p2p.Channel) {
 	iter := channel.Receive(ctx)
 	for iter.Next(ctx) {

--- a/node/node.go
+++ b/node/node.go
@@ -716,6 +716,7 @@ func loadStateFromDBOrGenesisDocProvider(stateStore sm.Store, genDoc *types.Gene
 func getRouterConfig(conf *config.Config, appClient abciclient.Client) p2p.RouterOptions {
 	opts := p2p.RouterOptions{
 		QueueType: conf.P2P.QueueType,
+		UseLibP2P: conf.P2P.UseLibP2P,
 	}
 
 	if conf.FilterPeers && appClient != nil {


### PR DESCRIPTION
This is a really simple/small PR mostly to mark the initial work on
the libp2p project. I thought adding a feature flag would be a good
place to start. 

While I do **not** intend to ship a version of tendermint with this as
a feature flag that users can take, I think doing *development* with
the flag will let us continue to leverage the existing test
infrastructure until we can migrate those tests over. 

This also marks the creation of the `main/libp2p` topic branch, which
I would like to inaugurate with the following rules of engagement:

- I will merge `master` into this branch regularly and without
  review. 
  
- We will never rebase this branch. (In situations that might warrant
  a rebase, we will create a new branch (e.g. `main/libp2p/0`,
  `main/libp2p/1` etc.))
  
- All merges into the topic branch will be code reviewed as if they're
  going in to `master`, and merged accordingly (e.g. every PR should
  be squashed and pass tests.)

- All PRs related to this work and branch should get the `B:libp2p` tag.

The following open questions, for decision at a later date:

- At some point we should turn on nightly e2e testing for the branch,
  when there's something reasonable to test. 
  
- We should decide how the final merge is going to go. I think there
  are three options:
  
  - squash the branch entirely into one commit. This will make a lot
    of the archaeology difficult, particularly for such a big project. 
  
  - merge everything in without squashing or rebasing. This seems like
    it would be messy, but might be fine. 
  
  - rebase once at the end (or periodically), preserving the
    individual commits but not the merge commits.