### PR TITLE
fuzz: don't panic on expected errors

### DIFF
--- a/test/fuzz/tests/mempool_test.go
+++ b/test/fuzz/tests/mempool_test.go
@@ -13,10 +13,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 )
 
-var mp *mempool.TxMempool
-var getMp func() mempool.Mempool
-
-func init() {
+func FuzzMempool(f *testing.F) {
 	app := kvstore.NewApplication()
 	logger := log.NewNopLogger()
 	conn := abciclient.NewLocalClient(logger, app)
@@ -28,19 +25,9 @@ func init() {
 	cfg := config.DefaultMempoolConfig()
 	cfg.Broadcast = false
 
-	getMp = func() mempool.Mempool {
-		if mp == nil {
-			mp = mempool.NewTxMempool(logger, cfg, conn)
-		}
-		return mp
-	}
-}
+	mp := mempool.NewTxMempool(logger, cfg, conn)
 
-func FuzzMempool(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		err := getMp().CheckTx(context.Background(), data, nil, mempool.TxInfo{})
-		if err != nil {
-			panic(err)
-		}
+		_ = mp.CheckTx(context.Background(), data, nil, mempool.TxInfo{})
 	})
 }


### PR DESCRIPTION
In the conversion to Go 1.18 fuzzing in e4991fd862c8300254417360feb2d66c5861aa54,
a `return 0` was converted to a panic. A `return 0` is a hint to the fuzzer, not
a failing testcase.

While here, clean up the test by folding setup code into it.

CC @odeke-em 

