### PR TITLE
Use patched link-checker for periodic checks.

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
+      - uses: creachadair/github-action-markdown-link-check@master
         with:
           folder-path: "docs"


### PR DESCRIPTION
In #8339 we pointed the markdown link checker action to a patched version that
has the up-to-date version of the underlying check tool. In doing so, I missed
the periodic cron job that runs the same workflow. Update it to use the patched
version also.

**Alternatively:** We could probably just delete this cron workflow. I'm not sure it's really buying us much over running the check during PRs, which we now do.
