### PR TITLE
rpc: fix byte string decoding for URL parameters

### DIFF
--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -118,17 +118,15 @@ func writeListOfEndpoints(w http.ResponseWriter, r *http.Request, funcMap map[st
 	noArgs := make(map[string]string)
 	for name, rf := range funcMap {
 		base := fmt.Sprintf("//%s/%s", r.Host, name)
-		// N.B. Check argNames, not args, since the type list includes the type
-		// of the leading context argument.
-		if len(rf.argNames) == 0 {
+		if len(rf.args) == 0 {
 			noArgs[name] = base
-		} else {
-			query := append([]string(nil), rf.argNames...)
-			for i, arg := range query {
-				query[i] = arg + "=_"
-			}
-			hasArgs[name] = base + "?" + strings.Join(query, "&")
+			continue
 		}
+		var query []string
+		for _, arg := range rf.args {
+			query = append(query, arg.name+"=_")
+		}
+		hasArgs[name] = base + "?" + strings.Join(query, "&")
 	}
 	w.Header().Set("Content-Type", "text/html")
 	_ = listOfEndpoints.Execute(w, map[string]map[string]string{

--- a/rpc/jsonrpc/server/rpc_func.go
+++ b/rpc/jsonrpc/server/rpc_func.go
@@ -39,6 +39,10 @@ type RPCFunc struct {
 	ws     bool          // websocket only
 }
 
+// argInfo records the name of a field, along with a bit to tell whether the
+// value of the field requires binary data, having underlying type []byte.  The
+// flag is needed when decoding URL parameters, where we permit quoted strings
+// to be passed for either argument type.
 type argInfo struct {
 	name     string
 	isBinary bool // value wants binary data

--- a/rpc/jsonrpc/server/rpc_func.go
+++ b/rpc/jsonrpc/server/rpc_func.go
@@ -32,11 +32,16 @@ func RegisterRPCFuncs(mux *http.ServeMux, funcMap map[string]*RPCFunc, logger lo
 
 // RPCFunc contains the introspected type information for a function.
 type RPCFunc struct {
-	f        reflect.Value // underlying rpc function
-	param    reflect.Type  // the parameter struct, or nil
-	result   reflect.Type  // the non-error result type, or nil
-	argNames []string      // name of each argument (for display)
-	ws       bool          // websocket only
+	f      reflect.Value // underlying rpc function
+	param  reflect.Type  // the parameter struct, or nil
+	result reflect.Type  // the non-error result type, or nil
+	args   []argInfo     // names and type information (for URL decoding)
+	ws     bool          // websocket only
+}
+
+type argInfo struct {
+	name     string
+	isBinary bool // value wants binary data
 }
 
 // Call parses the given JSON parameters and calls the function wrapped by rf
@@ -96,12 +101,12 @@ func (rf *RPCFunc) adjustParams(data []byte) (json.RawMessage, error) {
 		var args []json.RawMessage
 		if err := json.Unmarshal(base, &args); err != nil {
 			return nil, err
-		} else if len(args) != len(rf.argNames) {
-			return nil, fmt.Errorf("got %d arguments, want %d", len(args), len(rf.argNames))
+		} else if len(args) != len(rf.args) {
+			return nil, fmt.Errorf("got %d arguments, want %d", len(args), len(rf.args))
 		}
 		m := make(map[string]json.RawMessage)
 		for i, arg := range args {
-			m[rf.argNames[i]] = arg
+			m[rf.args[i].name] = arg
 		}
 		return json.Marshal(m)
 	} else if bytes.HasPrefix(base, []byte("{")) || bytes.Equal(base, []byte("null")) {
@@ -180,12 +185,15 @@ func newRPCFunc(f interface{}) (*RPCFunc, error) {
 		rtype = ft.Out(0)
 	}
 
-	var argNames []string
+	var args []argInfo
 	if ptype != nil {
 		for i := 0; i < ptype.NumField(); i++ {
 			field := ptype.Field(i)
 			if tag := strings.SplitN(field.Tag.Get("json"), ",", 2)[0]; tag != "" && tag != "-" {
-				argNames = append(argNames, tag)
+				args = append(args, argInfo{
+					name:     tag,
+					isBinary: isByteArray(field.Type),
+				})
 			} else if tag == "-" {
 				// If the tag is "-" the field should explicitly be ignored, even
 				// if it is otherwise eligible.
@@ -194,16 +202,19 @@ func newRPCFunc(f interface{}) (*RPCFunc, error) {
 				// Note that this is an aesthetic choice; the standard decoder will
 				// match without regard to case anyway.
 				name := strings.ToLower(field.Name[:1]) + field.Name[1:]
-				argNames = append(argNames, name)
+				args = append(args, argInfo{
+					name:     name,
+					isBinary: isByteArray(field.Type),
+				})
 			}
 		}
 	}
 
 	return &RPCFunc{
-		f:        fv,
-		param:    ptype,
-		result:   rtype,
-		argNames: argNames,
+		f:      fv,
+		param:  ptype,
+		result: rtype,
+		args:   args,
 	}, nil
 }
 
@@ -224,4 +235,9 @@ func isNullOrEmpty(params json.RawMessage) bool {
 		bytes.Equal(params, []byte("null")) ||
 		bytes.Equal(params, []byte("{}")) ||
 		bytes.Equal(params, []byte("[]"))
+}
+
+// isByteArray reports whether t is (equivalent to) []byte.
+func isByteArray(t reflect.Type) bool {
+	return t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8
 }


### PR DESCRIPTION
In #8397 I tried to remove all the cases where we needed to keep track of the
target type of parameters for JSON encoding, but there is one case still left:
When decoding parameters from URL query terms, there is no way to tell whether
or not we need base64 encoding without knowing whether the underlying type of
the target is string or []byte.

To fix this, keep track of parameters that are []byte valued when RPCFunc is
compiling its argument map, and use that when parsing URL query terms.  Update
the tests accordingly.
