### PR TITLE
privval/grpc: normalize function signature

### DIFF
--- a/cmd/priv_val_server/main.go
+++ b/cmd/priv_val_server/main.go
@@ -113,7 +113,7 @@ func main() {
 	// add prometheus metrics for unary RPC calls
 	opts = append(opts, grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor))
 
-	ss := grpcprivval.NewSignerServer(*chainID, pv, logger)
+	ss := grpcprivval.NewSignerServer(logger, *chainID, pv)
 
 	protocol, address := tmnet.ProtocolAndAddress(*addr)
 

--- a/privval/grpc/client_test.go
+++ b/privval/grpc/client_test.go
@@ -29,7 +29,7 @@ func dialer(t *testing.T, pv types.PrivValidator, logger log.Logger) (*grpc.Serv
 
 	server := grpc.NewServer()
 
-	s := tmgrpc.NewSignerServer(chainID, pv, logger)
+	s := tmgrpc.NewSignerServer(logger, chainID, pv)
 
 	privvalproto.RegisterPrivValidatorAPIServer(server, s)
 

--- a/privval/grpc/server.go
+++ b/privval/grpc/server.go
@@ -21,11 +21,9 @@ type SignerServer struct {
 	privVal types.PrivValidator
 }
 
-func NewSignerServer(chainID string,
-	privVal types.PrivValidator, log log.Logger) *SignerServer {
-
+func NewSignerServer(logger log.Logger, chainID string, privVal types.PrivValidator) *SignerServer {
 	return &SignerServer{
-		logger:  log,
+		logger:  logger,
 		chainID: chainID,
 		privVal: privVal,
 	}
@@ -56,8 +54,7 @@ func (ss *SignerServer) GetPubKey(ctx context.Context, req *privvalproto.PubKeyR
 
 // SignVote receives a vote sign requests, attempts to sign it
 // returns SignedVoteResponse on success and error on failure
-func (ss *SignerServer) SignVote(ctx context.Context, req *privvalproto.SignVoteRequest) (
-	*privvalproto.SignedVoteResponse, error) {
+func (ss *SignerServer) SignVote(ctx context.Context, req *privvalproto.SignVoteRequest) (*privvalproto.SignedVoteResponse, error) {
 	vote := req.Vote
 
 	err := ss.privVal.SignVote(ctx, req.ChainId, vote)
@@ -72,8 +69,7 @@ func (ss *SignerServer) SignVote(ctx context.Context, req *privvalproto.SignVote
 
 // SignProposal receives a proposal sign requests, attempts to sign it
 // returns SignedProposalResponse on success and error on failure
-func (ss *SignerServer) SignProposal(ctx context.Context, req *privvalproto.SignProposalRequest) (
-	*privvalproto.SignedProposalResponse, error) {
+func (ss *SignerServer) SignProposal(ctx context.Context, req *privvalproto.SignProposalRequest) (*privvalproto.SignedProposalResponse, error) {
 	proposal := req.Proposal
 
 	err := ss.privVal.SignProposal(ctx, req.ChainId, proposal)

--- a/privval/grpc/server_test.go
+++ b/privval/grpc/server_test.go
@@ -37,7 +37,7 @@ func TestGetPubKey(t *testing.T) {
 			defer cancel()
 			logger := log.NewTestingLogger(t)
 
-			s := tmgrpc.NewSignerServer(ChainID, tc.pv, logger)
+			s := tmgrpc.NewSignerServer(logger, ChainID, tc.pv)
 
 			req := &privvalproto.PubKeyRequest{ChainId: ChainID}
 			resp, err := s.GetPubKey(ctx, req)
@@ -112,7 +112,7 @@ func TestSignVote(t *testing.T) {
 			defer cancel()
 			logger := log.NewTestingLogger(t)
 
-			s := tmgrpc.NewSignerServer(ChainID, tc.pv, logger)
+			s := tmgrpc.NewSignerServer(logger, ChainID, tc.pv)
 
 			req := &privvalproto.SignVoteRequest{ChainId: ChainID, Vote: tc.have.ToProto()}
 			resp, err := s.SignVote(ctx, req)
@@ -183,7 +183,7 @@ func TestSignProposal(t *testing.T) {
 			defer cancel()
 			logger := log.NewTestingLogger(t)
 
-			s := tmgrpc.NewSignerServer(ChainID, tc.pv, logger)
+			s := tmgrpc.NewSignerServer(logger, ChainID, tc.pv)
 
 			req := &privvalproto.SignProposalRequest{ChainId: ChainID, Proposal: tc.have.ToProto()}
 			resp, err := s.SignProposal(ctx, req)

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -248,7 +248,7 @@ func startSigner(ctx context.Context, logger log.Logger, cfg *Config) error {
 		if err != nil {
 			return err
 		}
-		ss := grpcprivval.NewSignerServer(cfg.ChainID, filePV, logger)
+		ss := grpcprivval.NewSignerServer(logger, cfg.ChainID, filePV)
 
 		s := grpc.NewServer()
 


### PR DESCRIPTION
Minor irksome tweaks: some awkwardly wrapped function signatures and
putting the logger argument in last rather than first (which has
become our convention in other parts.)