### PR TITLE
Reintegrate docs deployment into the main TM repo

### DIFF
--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -1,0 +1,59 @@
+# Build and deploy the docs.tendermint.com website content.
+# The static content is published to GitHub Pages.
+#
+# For documentation build info, see docs/DOCS_README.md.
+name: Build static documentation site
+on:
+  workflow_dispatch:  # allow manual updates
+  push:
+    branches:
+      - master
+
+jobs:
+  # This is split into two jobs so that the build, which runs npm, does not
+  # have write access to anything. The deploy requires write access to publish
+  # to the branch used by GitHub Pages, however, so we can't just make the
+  # whole workflow read-only.
+  build:
+    name: VuePress build
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    permissions:
+      contents: read
+    steps:
+      - name: Install generator dependencies
+        run: |
+          apk add --no-cache make bash curl git npm rsync unzip
+      - uses: actions/checkout@v3
+        with:
+          # We need to fetch full history so the backport branches for previous
+          # versions will be available for the build.
+          fetch-depth: 0
+      - name: Build documentation
+        run: |
+          git config --global --add safe.directory "$PWD"
+          make build-docs
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build-output
+          path: ~/output/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-output
+          path: ~/output
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: 'docs-tendermint-com'
+          folder: ~/output
+          single-commit: true

--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Install generator dependencies
         run: |
-          apk add --no-cache make bash curl git npm rsync unzip
+          apk add --no-cache make bash git npm
       - uses: actions/checkout@v3
         with:
           # We need to fetch full history so the backport branches for previous

--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - docs/**
+      - spec/**
 
 jobs:
   # This is split into two jobs so that the build, which runs npm, does not

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,8 @@ DESTINATION = ./index.html.md
 build-docs:
 	@cd docs && \
 	while read -r branch path_prefix; do \
-		(git checkout $${branch} && npm ci && VUEPRESS_BASE="/$${path_prefix}/" npm run build) ; \
+		( git checkout $${branch} && npm ci --quiet && \
+			VUEPRESS_BASE="/$${path_prefix}/" npm run build --quiet ) ; \
 		mkdir -p ~/output/$${path_prefix} ; \
 		cp -r .vuepress/dist/* ~/output/$${path_prefix}/ ; \
 		cp ~/output/$${path_prefix}/index.html ~/output ; \

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "serve": "trap 'exit 0' SIGINT; vuepress dev --no-cache",
     "postserve": "./post.sh",
     "prebuild": "./pre.sh",
-    "build": "trap 'exit 0' SIGINT; vuepress build --no-cache",
+    "build": "trap 'exit 0' SIGINT; vuepress build --no-cache --silent",
     "postbuild": "./post.sh"
   },
   "author": "",


### PR DESCRIPTION
**Note to reviewers:** It is safe to merge this PR as-is. It will trigger on the main repo, but it is publishing to a Pages branch that does not yet connect to docs.tendermint.com. The latter we must do as a follow-up to update the domain pointer.

## Description

Updates #7297. Fixes https://github.com/tendermint/docs/issues/20.

Per https://github.com/tendermint/docs/issues/20, it is no longer necessary to build the static documentation out of a separate repository.

This change:

- Adds an actions workflow to build and deploy the docs to GitHub Pages.
- Updates some build settings in a compatible manner.

This change does not affect the existing site deployment. To complete this change, we will need to update the custom domain pointer and disable the corresponding workflow in the tendermint/docs repository. Those changes can and must be done after this is merged.

In the future should probably also move the build rule out of the Makefile and into the workflow directly. That will also make it easier to manage caching of build artifacts. For now, however, I've left it as-is, so that we do not break the active workflow on tendermint/docs, which depends on it.

### Future work (follow-up after this change)

- [ ] Update custom domain.
- [ ] Remove workflow from docs repo.
- [ ] Move build instructions from Makefile into workflow maybe.
