### PR TITLE
Convert explicit zero comparison to a method.

### DIFF
--- a/light/verifier.go
+++ b/light/verifier.go
@@ -279,8 +279,7 @@ func checkRequiredHeaderFields(h *types.SignedHeader) error {
 		return errors.New("height in trusted header must be set (non zero")
 	}
 
-	zeroTime := time.Time{}
-	if h.Time == zeroTime {
+	if h.Time.IsZero() {
 		return errors.New("time in trusted header must be set")
 	}
 


### PR DESCRIPTION
Fixes #8472.

I didn't see any other obvious cases of us doing this (although we do return zeroes in other places alongside errors, which is fine).
