### PR TITLE
p2p: base implementation of libp2p channel

### DIFF
--- a/internal/p2p/channel.go
+++ b/internal/p2p/channel.go
@@ -326,6 +326,10 @@ func (ch *libp2pChannelImpl) Send(ctx context.Context, e Envelope) error {
 		return ch.topic.Publish(ctx, bz)
 	}
 
+	// TODO: remove this, likely. Checking to see if a topic has a
+	// peer is *probably* right, but maybe it's better to just try
+	// and connect to a peer directly (using whatever method) and
+	// go from there.
 	if !ch.topicHasPeer(peer.ID(e.To)) {
 		return fmt.Errorf("peer %q does not exist", e.To)
 	}
@@ -333,7 +337,6 @@ func (ch *libp2pChannelImpl) Send(ctx context.Context, e Envelope) error {
 	// TODO: there's likely some tooling that exists for doing
 	// point-to-point messaging that we can leverage here, rather
 	// than implementing directly on-top of libp2p streams.
-
 	return errors.New("direct messages between peers not supported, yet")
 }
 
@@ -352,5 +355,6 @@ func (ch *libp2pChannelImpl) SendError(ctx context.Context, pe PeerError) error 
 	// rather as part of some peer-info/network-management
 	// interface, but we can do it here for now, to ensure compatibility.
 	ch.pubsub.BlacklistPeer(peer.ID(pe.NodeID))
+
 	return nil
 }

--- a/internal/p2p/channel.go
+++ b/internal/p2p/channel.go
@@ -273,6 +273,9 @@ func (ch *libp2pChannelImpl) Receive(ctx context.Context) *ChannelIterator {
 		for {
 			msg, err := sub.Next(ctx)
 			if err != nil {
+				// TODO: maybe signal to users that it
+				// was canceled, when we begin
+				// propagating errors out.
 				return
 			}
 
@@ -297,7 +300,6 @@ func (ch *libp2pChannelImpl) Receive(ctx context.Context) *ChannelIterator {
 				ChannelID: ch.chDesc.ID,
 			}:
 			}
-
 		}
 	}()
 

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -307,7 +307,8 @@ type ChannelCreator func(context.Context, *ChannelDescriptor) (Channel, error)
 // wrapper message. The caller may provide a size to make the channel buffered,
 // which internally makes the inbound, outbound, and error channel buffered.
 func (r *Router) OpenChannel(ctx context.Context, chDesc *ChannelDescriptor) (Channel, error) {
-	if r.options.UseLibP2P {
+	switch {
+	case r.options.UseLibP2P:
 		info := r.nodeInfoProducer()
 		ch, err := NewLibP2PChannel(info.Network, chDesc, r.options.NetworkPubSub, r.options.NetworkHost)
 		if err != nil {
@@ -330,7 +331,7 @@ func (r *Router) OpenChannel(ctx context.Context, chDesc *ChannelDescriptor) (Ch
 		r.network.channels[name] = ch
 
 		return ch, nil
-	} else {
+	default:
 		r.legacy.channelMtx.Lock()
 		defer r.legacy.channelMtx.Unlock()
 


### PR DESCRIPTION
This is some initial scafolding that I've been working on, and think
would be good to land so other people can help out or just as a basis
of doing more work (and letting me defer thinking about the p2p
branch) on the point to point protocol.

This model minimizes the entire action between the p2p later and the
reactor into the channel interface, and makes it much more synchronous
than it currently is. I think this is mostly ok, but I think it's
reasonable to have marshaling messages slightly less synchronous. In
any case, that's a thing we can polish off later.