### PR TITLE
abci++: Disable VerifyVoteExtension call on nil precommits

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2331,8 +2331,9 @@ func (cs *State) addVote(
 		return
 	}
 
-	// Verify VoteExtension if precommit
-	if vote.Type == tmproto.PrecommitType {
+	// Verify VoteExtension if precommit and not nil
+	// https://github.com/tendermint/tendermint/issues/8487
+	if vote.Type == tmproto.PrecommitType && !vote.BlockID.IsNil() {
 		if err = cs.blockExec.VerifyVoteExtension(ctx, vote); err != nil {
 			return false, err
 		}

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -1950,7 +1950,7 @@ func TestFinalizeBlockCalled(t *testing.T) {
 		expectCalled bool
 	}{
 		{
-			name:         "finalze block called when block committed",
+			name:         "finalize block called when block committed",
 			voteNil:      false,
 			expectCalled: true,
 		},
@@ -1970,9 +1970,13 @@ func TestFinalizeBlockCalled(t *testing.T) {
 				Status: abci.ResponseProcessProposal_ACCEPT,
 			}, nil)
 			m.On("PrepareProposal", mock.Anything, mock.Anything).Return(&abci.ResponsePrepareProposal{}, nil)
-			m.On("VerifyVoteExtension", mock.Anything, mock.Anything).Return(&abci.ResponseVerifyVoteExtension{
-				Status: abci.ResponseVerifyVoteExtension_ACCEPT,
-			}, nil)
+			// We only expect VerifyVoteExtension to be called on non-nil votes.
+			// https://github.com/tendermint/tendermint/issues/8487
+			if !testCase.voteNil {
+				m.On("VerifyVoteExtension", mock.Anything, mock.Anything).Return(&abci.ResponseVerifyVoteExtension{
+					Status: abci.ResponseVerifyVoteExtension_ACCEPT,
+				}, nil)
+			}
 			m.On("FinalizeBlock", mock.Anything, mock.Anything).Return(&abci.ResponseFinalizeBlock{}, nil).Maybe()
 			m.On("ExtendVote", mock.Anything, mock.Anything).Return(&abci.ResponseExtendVote{}, nil)
 			m.On("Commit", mock.Anything).Return(&abci.ResponseCommit{}, nil).Maybe()


### PR DESCRIPTION
Closes #8487 

Based on #8433 
