### PR TITLE
rpc: make block.height visible to event subscription

### DIFF
--- a/internal/state/indexer/block/kv/kv.go
+++ b/internal/state/indexer/block/kv/kv.go
@@ -65,7 +65,7 @@ func (idx *BlockerIndexer) Index(bh types.EventDataNewBlockHeader) error {
 	}
 
 	// 2. index FinalizeBlock events
-	if err := idx.indexEvents(batch, bh.ResultFinalizeBlock.Events, types.EventTypeFinalizeBlock, height); err != nil {
+	if err := idx.indexEvents(batch, bh.ResultFinalizeBlock.Events, "finalize_block", height); err != nil {
 		return fmt.Errorf("failed to index FinalizeBlock events: %w", err)
 	}
 

--- a/types/events.go
+++ b/types/events.go
@@ -131,7 +131,10 @@ type EventDataNewBlock struct {
 func (EventDataNewBlock) TypeTag() string { return "tendermint/event/NewBlock" }
 
 // ABCIEvents implements the eventlog.ABCIEventer interface.
-func (e EventDataNewBlock) ABCIEvents() []abci.Event { return e.ResultFinalizeBlock.Events }
+func (e EventDataNewBlock) ABCIEvents() []abci.Event {
+	base := []abci.Event{eventWithAttr(BlockHeightKey, fmt.Sprint(e.Block.Header.Height))}
+	return append(base, e.ResultFinalizeBlock.Events...)
+}
 
 type EventDataNewBlockHeader struct {
 	Header Header `json:"header"`
@@ -144,7 +147,10 @@ type EventDataNewBlockHeader struct {
 func (EventDataNewBlockHeader) TypeTag() string { return "tendermint/event/NewBlockHeader" }
 
 // ABCIEvents implements the eventlog.ABCIEventer interface.
-func (e EventDataNewBlockHeader) ABCIEvents() []abci.Event { return e.ResultFinalizeBlock.Events }
+func (e EventDataNewBlockHeader) ABCIEvents() []abci.Event {
+	base := []abci.Event{eventWithAttr(BlockHeightKey, fmt.Sprint(e.Header.Height))}
+	return append(base, e.ResultFinalizeBlock.Events...)
+}
 
 type EventDataNewEvidence struct {
 	Evidence Evidence `json:"evidence"`
@@ -262,18 +268,17 @@ func (EventDataEvidenceValidated) TypeTag() string { return "tendermint/event/Ev
 const (
 	// EventTypeKey is a reserved composite key for event name.
 	EventTypeKey = "tm.event"
+
 	// TxHashKey is a reserved key, used to specify transaction's hash.
 	// see EventBus#PublishEventTx
 	TxHashKey = "tx.hash"
+
 	// TxHeightKey is a reserved key, used to specify transaction block's height.
 	// see EventBus#PublishEventTx
 	TxHeightKey = "tx.height"
 
 	// BlockHeightKey is a reserved key used for indexing FinalizeBlock events.
 	BlockHeightKey = "block.height"
-
-	// EventTypeFinalizeBlock is a reserved key used for indexing FinalizeBlock events.
-	EventTypeFinalizeBlock = "finalize_block"
 )
 
 var (


### PR DESCRIPTION
Although we index block.height for blocks in the KV indexer, this reserved
attribute was not previously exposed to the event subscription API. Despite
being advertised in the OpenAPI spec, neither the old (websocket) nor new
(events) query interface could see it.  This change exposes block.height to the
/events API.

In addition: Remove a non-public constant from types (finalize_block). This
value is used only as an internal tag by the indexer, and should not be exposed
to users of the public interface. (We could probably drop it entirely, as it
was previously a disambiguator for BeginBlock vs. EndBlock events, but keeping
a tag here simplifies the cleanup).
