### PR TITLE
Consolidate Dependabot checks for GitHub Actions deps.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,30 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+      day: monday
+    target-branch: "master"
+    open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+      - S:automerge
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    target-branch: "v0.35.x"
+    open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+      - S:automerge
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    target-branch: "v0.34.x"
     open-pull-requests-limit: 10
     labels:
       - T:dependencies
@@ -13,6 +37,7 @@ updates:
     directory: "/docs"
     schedule:
       interval: weekly
+      day: monday
     open-pull-requests-limit: 10
 
   ###################################


### PR DESCRIPTION
We currently have Dependabot check for updates to GitHub actions once a week on
master, but daily on the backport branches. This is unnecessarily noisy.

As a first step to reducing this noise, consolidate all the settings onto the
default branch (master).
