### PR TITLE
build: add CI check that generated files are up-to-date

### DIFF
--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -1,0 +1,76 @@
+# Verify that generated code is up-to-date.
+#
+# Note that we run these checks regardless whether the input files have
+# changed, because generated code can change in response to toolchain updates
+# even if no files in the repository are modified.
+name: Check generated code
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  check-mocks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.17'
+
+      - uses: actions/checkout@v3
+
+      - name: "Check generated mocks"
+        run: |
+          set -euo pipefail
+          make mockery 2>/dev/null
+
+          if ! git diff --stat --exit-code ; then
+            echo ">> ERROR:"
+            echo ">>"
+            echo ">> Generated mocks require update (either Mockery or source files may have changed)."
+            echo ">> Ensure your tools are up-to-date, re-run 'make mockery' and update this PR."
+            echo ">>"
+            exit 1
+          fi
+
+  check-proto:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.17'
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1  # we need a .git directory to run git diff
+
+      - name: "Check protobuf generated code"
+        run: |
+          set -euo pipefail
+
+          # Install buf and gogo tools, so that differences that arise from
+          # toolchain differences are also caught.
+          readonly tools="$(mktemp -d)"
+          export PATH="${PATH}:${tools}/bin"
+          export GOBIN="${tools}/bin"
+
+          readonly base='https://github.com/bufbuild/buf/releases/latest/download'
+          readonly OS="$(uname -s)" ARCH="$(uname -m)"
+          curl -sSL "${base}/buf-${OS}-${ARCH}.tar.gz" \
+          | tar -xzf -  -C "$tools" --strip-components=1
+
+          go install github.com/gogo/protobuf/protoc-gen-gogofaster@latest
+
+          make proto-gen
+
+          if ! git diff --stat --exit-code ; then
+            echo ">> ERROR:"
+            echo ">>"
+            echo ">> Protobuf generated code requires update (either tools or .proto files may have changed)."
+            echo ">> Ensure your tools are up-to-date, re-run 'make proto-gen' and update this PR."
+            echo ">>"
+            exit 1
+          fi


### PR DESCRIPTION
Add an actions workflow that verifies that generated files are up-to-date during a pull request. If not, give the reader instructions about what to do to update the PR.

Checks are included for protobuf and mockery.

We might also want to add a check for the generated metrics.
