### PR TITLE
mempool: do not continue checking transactions if context was canceled

### DIFF
--- a/internal/mempool/reactor.go
+++ b/internal/mempool/reactor.go
@@ -153,6 +153,15 @@ func (r *Reactor) handleMempoolMessage(ctx context.Context, envelope *p2p.Envelo
 					// problem.
 					continue
 				}
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					// Do not propagate context
+					// cancellation errors, but do
+					// not continue to check
+					// transactions from this
+					// message if we are shutting down.
+					return nil
+				}
+
 				logger.Error("checktx failed for tx",
 					"tx", fmt.Sprintf("%X", types.Tx(tx).Hash()),
 					"err", err)


### PR DESCRIPTION
Found this while working on p2p, and think it would be good to have in mainline.