### PR TITLE
p2p: cache libp2p streams

### DIFF
--- a/internal/p2p/channel.go
+++ b/internal/p2p/channel.go
@@ -448,7 +448,7 @@ func (ch *libp2pChannelImpl) getStream(ctx context.Context, peer peer.ID) (netwo
 
 	}
 
-	// TODO: these context should be a braoder context rather than
+	// TODO: these context should be a broader context rather than
 	// the one from send to avoid shutting down the stream when
 	// the context that's sending the message closes. Right now
 	// they're functionally synonymous so it's safe, but it'd be

--- a/internal/p2p/channel.go
+++ b/internal/p2p/channel.go
@@ -389,13 +389,13 @@ func (ch *libp2pChannelImpl) Send(ctx context.Context, e Envelope) error {
 		e.Message = msg
 	}
 
-	e.From = types.NodeID(ch.host.ID())
-	bz, err := proto.Marshal(e.Message)
-	if err != nil {
-		return err
-	}
-
 	if e.Broadcast {
+		e.From = types.NodeID(ch.host.ID())
+		bz, err := proto.Marshal(e.Message)
+		if err != nil {
+			return err
+		}
+
 		return ch.topic.Publish(ctx, bz)
 	}
 
@@ -404,17 +404,48 @@ func (ch *libp2pChannelImpl) Send(ctx context.Context, e Envelope) error {
 		return fmt.Errorf("cannot connect to %q", e.To)
 	default:
 		// TODO: should we should attempt to reuse between peers?
-		stream, err := ch.host.NewStream(ctx, peer.ID(e.To), protocol.ID(ch.canonicalizedTopicName()))
+		stream, err := ch.getStream(ctx, peer.ID(e.To))
 		if err != nil {
 			return err
 		}
 
-		_, err = stream.Write(bz)
+		writer := protoio.NewDelimitedWriter(bufio.NewWriter(stream))
+		_, err = writer.WriteMsg(e.Message)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (ch *libp2pChannelImpl) getStream(ctx context.Context, peer peer.ID) (network.Stream, error) {
+	conns := ch.host.Network().ConnsToPeer(peer)
+	pid := protocol.ID(ch.canonicalizedTopicName())
+	if len(conns) > 0 {
+		for cidx := range conns {
+			streams := conns[cidx].GetStreams()
+			for sidx := range streams {
+				stream := streams[sidx]
+				if stream.Protocol() == pid && stream.Stat().Direction == network.DirOutbound {
+					return stream, nil
+				}
+			}
+		}
+
+	}
+	conn, err := ch.host.Network().DialPeer(ctx, peer)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: this context should be a more global context rather
+	// than by the send op to avoid.
+	stream, err := ch.host.NewStream(ctx, conn.RemotePeer(), pid)
+	if err != nil {
+		return nil, err
+	}
+
+	return stream, nil
 }
 
 func (ch *libp2pChannelImpl) SendError(ctx context.Context, pe PeerError) error {

--- a/internal/p2p/channel.go
+++ b/internal/p2p/channel.go
@@ -447,15 +447,17 @@ func (ch *libp2pChannelImpl) getStream(ctx context.Context, peer peer.ID) (netwo
 		}
 
 	}
+
+	// TODO: these context should be a braoder context rather than
+	// the one from send to avoid shutting down the stream when
+	// the context that's sending the message closes. Right now
+	// they're functionally synonymous so it's safe, but it'd be
+	// possible to introduce an unintended bug here.
 	conn, err := ch.host.Network().DialPeer(ctx, peer)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: this context should be a more global context rather
-	// than by the send op to avoid shutting down the stream
-	// when the context that's sending the message closes and
-	// rather have it be tied to the process or router lifecycle.
 	stream, err := ch.host.NewStream(ctx, conn.RemotePeer(), pid)
 	if err != nil {
 		return nil, err

--- a/internal/p2p/channel.go
+++ b/internal/p2p/channel.go
@@ -453,7 +453,9 @@ func (ch *libp2pChannelImpl) getStream(ctx context.Context, peer peer.ID) (netwo
 	}
 
 	// TODO: this context should be a more global context rather
-	// than by the send op to avoid.
+	// than by the send op to avoid shutting down the stream
+	// when the context that's sending the message closes and
+	// rather have it be tied to the process or router lifecycle.
 	stream, err := ch.host.NewStream(ctx, conn.RemotePeer(), pid)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Mostly (entirely?) cribbed from
[this](https://github.com/ElrondNetwork/elrond-go/blob/2a92e671ad845a9773257fb80cd5a596e16201d6/p2p/libp2p/directSender.go#L154),
but should let us:

- reuse existing streams. 
- send messages delimited.