### PR TITLE
rpc: enable the ADR 075 event log by default in new configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -523,7 +523,7 @@ func DefaultRPCConfig() *RPCConfig {
 		MaxSubscriptionClients:       100,
 		MaxSubscriptionsPerClient:    5,
 		ExperimentalDisableWebsocket: false, // compatible with TM v0.35 and earlier
-		EventLogWindowSize:           0,     // disables /events RPC by default
+		EventLogWindowSize:           30 * time.Second,
 		EventLogMaxItems:             0,
 
 		TimeoutBroadcastTxCommit: 10 * time.Second,


### PR DESCRIPTION
Since we are deprecating the stream-based event subscription in v0.36, we should ensure that new nodes enable the replacement by default.  For now, just set a baseline 30-second window.

We already have a changelog entry for the ADR 075 interface, that should be sufficient to cover this as well.