### PR TITLE
Add public API `BlockStore.Rollback`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,4 +22,6 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### IMPROVEMENTS
 
+- []() Add public API `BlockStore.Rollback`.
+
 ### BUG FIXES

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,6 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 
 ### IMPROVEMENTS
 
-- []() Add public API `BlockStore.Rollback`.
+- [#8574](https://github.com/tendermint/tendermint/pull/8574) Add public API `BlockStore.Rollback`.
 
 ### BUG FIXES


### PR DESCRIPTION
The context: https://github.com/tendermint/tendermint/pull/8223#issuecomment-1123800668, https://github.com/tendermint/tendermint/pull/8493

So although the newest tendermint has implemented the "validate block before persist", but since the production node could be still using the old version, and when app hash mismatch happens, the pending block is already persisted, so we still want to be able to delete that pending block manually.
By exposing this public API, we can do the block store rollback in the application side.