### PR TITLE
consensus: update state from store before use in reactor

### DIFF
--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -216,6 +216,10 @@ func (r *Reactor) OnStart(ctx context.Context) error {
 		if err := r.state.Start(ctx); err != nil {
 			return err
 		}
+	} else {
+		if err := r.state.updateStateFromStore(); err != nil {
+			return err
+		}
 	}
 
 	go r.updateRoundStateRoutine(ctx)

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -216,10 +216,8 @@ func (r *Reactor) OnStart(ctx context.Context) error {
 		if err := r.state.Start(ctx); err != nil {
 			return err
 		}
-	} else {
-		if err := r.state.updateStateFromStore(); err != nil {
-			return err
-		}
+	} else if err := r.state.updateStateFromStore(); err != nil {
+		return err
 	}
 
 	go r.updateRoundStateRoutine(ctx)

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -122,9 +122,8 @@ type State struct {
 	// store blocks and commits
 	blockStore sm.BlockStore
 
-	stateStore            sm.Store
-	initialStatePopulated bool
-	skipBootstrapping     bool
+	stateStore        sm.Store
+	skipBootstrapping bool
 
 	// create and execute blocks
 	blockExec *sm.BlockExecutor

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -255,6 +255,15 @@ func (cs *State) updateStateFromStore() error {
 		return nil
 	}
 
+	eq, err := state.Equals(cs.state)
+	if err != nil {
+		return fmt.Errorf("comparing state: %w", err)
+	}
+	// if the new state is equivalent to the old state, we should not trigger a state update.
+	if eq {
+		return nil
+	}
+
 	// We have no votes, so reconstruct LastCommit from SeenCommit.
 	if state.LastBlockHeight > 0 {
 		cs.reconstructLastCommit(state)

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -248,9 +248,6 @@ func NewState(
 }
 
 func (cs *State) updateStateFromStore() error {
-	if cs.initialStatePopulated {
-		return nil
-	}
 	state, err := cs.stateStore.Load()
 	if err != nil {
 		return fmt.Errorf("loading state: %w", err)
@@ -266,7 +263,6 @@ func (cs *State) updateStateFromStore() error {
 
 	cs.updateToState(state)
 
-	cs.initialStatePopulated = true
 	return nil
 }
 


### PR DESCRIPTION
Closes: #8575

This PR aims to fix the `LastCommitRound can only be negative for initial height 0` issue we see in the e2e tests by initializing the `state` object before starting the receive routines in the consensus reactor. This is somewhat inelegant, but it should fix the issue.