### PR TITLE
abci: serialize semantics of abci client

### DIFF
--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -17,12 +17,6 @@ import (
 	"github.com/tendermint/tendermint/libs/service"
 )
 
-const (
-	// reqQueueSize is the max number of queued async requests.
-	// (memory: 256MB max assuming 1MB transactions)
-	reqQueueSize = 256
-)
-
 // This is goroutine-safe, but users should beware that the application in
 // general is not meant to be interfaced with concurrent callers.
 type socketClient struct {
@@ -48,7 +42,7 @@ var _ Client = (*socketClient)(nil)
 func NewSocketClient(logger log.Logger, addr string, mustConnect bool) Client {
 	cli := &socketClient{
 		logger:      logger,
-		reqQueue:    make(chan *requestAndResponse, reqQueueSize),
+		reqQueue:    make(chan *requestAndResponse, 0),
 		mustConnect: mustConnect,
 		addr:        addr,
 		reqSent:     list.New(),
@@ -127,6 +121,7 @@ func (cli *socketClient) sendRequestsRoutine(ctx context.Context, conn io.Writer
 				cli.stopForError(fmt.Errorf("flush buffer: %w", err))
 				return
 			}
+			cli.trackRequest(reqres)
 		}
 	}
 }
@@ -158,7 +153,7 @@ func (cli *socketClient) recvResponseRoutine(ctx context.Context, conn io.Reader
 	}
 }
 
-func (cli *socketClient) willSendReq(reqres *requestAndResponse) {
+func (cli *socketClient) trackRequest(reqres *requestAndResponse) {
 	cli.mtx.Lock()
 	defer cli.mtx.Unlock()
 
@@ -199,7 +194,6 @@ func (cli *socketClient) doRequest(ctx context.Context, req *types.Request) (*ty
 	}
 
 	reqres := makeReqRes(req)
-	cli.willSendReq(reqres)
 
 	select {
 	case cli.reqQueue <- reqres:

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -42,7 +42,7 @@ var _ Client = (*socketClient)(nil)
 func NewSocketClient(logger log.Logger, addr string, mustConnect bool) Client {
 	cli := &socketClient{
 		logger:      logger,
-		reqQueue:    make(chan *requestAndResponse, 0),
+		reqQueue:    make(chan *requestAndResponse),
 		mustConnect: mustConnect,
 		addr:        addr,
 		reqSent:     list.New(),
@@ -121,6 +121,7 @@ func (cli *socketClient) sendRequestsRoutine(ctx context.Context, conn io.Writer
 				cli.stopForError(fmt.Errorf("flush buffer: %w", err))
 				return
 			}
+
 			cli.trackRequest(reqres)
 		}
 	}


### PR DESCRIPTION
I believe this will make the socket client (e.g. tendermint's access
to abci apps over the socket protocol.) more serial/sequential, and
get us out of the situation where requests are sent out of order
relative to how they're returned. Callers can still get asynchronicity
by wrapping synchronous calls in threads, so I think this ok.