### PR TITLE
p2p: libp2p constructor scafolding

### DIFF
--- a/internal/p2p/host.go
+++ b/internal/p2p/host.go
@@ -1,10 +1,19 @@
 package p2p
 
 import (
+	"context"
+	"errors"
+
 	"github.com/libp2p/go-libp2p-core/host"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/tendermint/tendermint/config"
 )
 
-func NewHost(conf *config.P2PConfig) (host.Host, error)        { return nil, nil }
-func NewPubSub(conf *config.P2PConfig) (*pubsub.PubSub, error) { return nil, nil }
+// NewHost constructs a default networking connection for a libp2p
+// network and returns the top level host object.
+func NewHost(conf *config.P2PConfig) (host.Host, error) { return nil, errors.New("not implemented") }
+
+// NewPubSub constructs a pubsub protocol using a libp2p host object.
+func NewPubSub(ctx context.Context, conf *config.P2PConfig, host host.Host) (*pubsub.PubSub, error) {
+	return nil, errors.New("not implemented")
+}

--- a/internal/p2p/host.go
+++ b/internal/p2p/host.go
@@ -1,0 +1,10 @@
+package p2p
+
+import (
+	"github.com/libp2p/go-libp2p-core/host"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/tendermint/tendermint/config"
+)
+
+func NewHost(conf *config.P2PConfig) (host.Host, error)        { return nil, nil }
+func NewPubSub(conf *config.P2PConfig) (*pubsub.PubSub, error) { return nil, nil }

--- a/node/node.go
+++ b/node/node.go
@@ -88,6 +88,7 @@ func newDefaultNode(
 	}
 	if cfg.Mode == config.ModeSeed {
 		return makeSeedNode(
+			ctx,
 			logger,
 			cfg,
 			config.DefaultDBProvider,
@@ -248,7 +249,7 @@ func makeNode(
 		},
 	}
 
-	node.router, err = createRouter(logger, nodeMetrics.p2p, node.NodeInfo, nodeKey, peerManager, cfg, proxyApp)
+	node.router, err = createRouter(ctx, logger, nodeMetrics.p2p, node.NodeInfo, nodeKey, peerManager, cfg, proxyApp)
 	if err != nil {
 		return nil, combineCloseError(
 			fmt.Errorf("failed to create router: %w", err),

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -598,6 +598,7 @@ func TestNodeNewSeedNode(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	ns, err := makeSeedNode(
+		ctx,
 		logger,
 		cfg,
 		config.DefaultDBProvider,

--- a/node/public.go
+++ b/node/public.go
@@ -31,8 +31,7 @@ func NewDefault(
 // Genesis document: if the value is nil, the genesis document is read
 // from the file specified in the config, and otherwise the node uses
 // value of the final argument.
-func New(
-	ctx context.Context,
+func New(ctx context.Context,
 	conf *config.Config,
 	logger log.Logger,
 	cf abciclient.Client,
@@ -68,7 +67,7 @@ func New(
 			config.DefaultDBProvider,
 			logger)
 	case config.ModeSeed:
-		return makeSeedNode(logger, conf, config.DefaultDBProvider, nodeKey, genProvider)
+		return makeSeedNode(ctx, logger, conf, config.DefaultDBProvider, nodeKey, genProvider)
 	default:
 		return nil, fmt.Errorf("%q is not a valid mode", conf.Mode)
 	}

--- a/node/seed.go
+++ b/node/seed.go
@@ -39,6 +39,7 @@ type seedNodeImpl struct {
 
 // makeSeedNode returns a new seed node, containing only p2p, pex reactor
 func makeSeedNode(
+	ctx context.Context,
 	logger log.Logger,
 	cfg *config.Config,
 	dbProvider config.DBProvider,
@@ -74,7 +75,7 @@ func makeSeedNode(
 			closer)
 	}
 
-	router, err := createRouter(logger, p2pMetrics, func() *types.NodeInfo { return &nodeInfo }, nodeKey, peerManager, cfg, nil)
+	router, err := createRouter(ctx, logger, p2pMetrics, func() *types.NodeInfo { return &nodeInfo }, nodeKey, peerManager, cfg, nil)
 	if err != nil {
 		return nil, combineCloseError(
 			fmt.Errorf("failed to create router: %w", err),

--- a/node/setup.go
+++ b/node/setup.go
@@ -284,28 +284,42 @@ func createRouter(
 ) (*p2p.Router, error) {
 
 	p2pLogger := logger.With("module", "p2p")
+	opts := getRouterConfig(cfg, appClient)
+	opts.NodeInfoProducer = nodeInfoProducer
 
-	transportConf := conn.DefaultMConnConfig()
-	transportConf.FlushThrottle = cfg.P2P.FlushThrottleTimeout
-	transportConf.SendRate = cfg.P2P.SendRate
-	transportConf.RecvRate = cfg.P2P.RecvRate
-	transportConf.MaxPacketMsgPayloadSize = cfg.P2P.MaxPacketMsgPayloadSize
-	transport := p2p.NewMConnTransport(
-		p2pLogger, transportConf, []*p2p.ChannelDescriptor{},
-		p2p.MConnTransportOptions{
-			MaxAcceptedConnections: uint32(cfg.P2P.MaxConnections),
-		},
-	)
+	if cfg.P2P.UseLibP2P {
+		host, err := p2p.NewHost(cfg.P2P)
+		if err != nil {
+			return nil, err
+		}
+		opts.NetworkHost = host
 
-	ep, err := p2p.NewEndpoint(nodeKey.ID.AddressString(cfg.P2P.ListenAddress))
-	if err != nil {
-		return nil, err
+		ps, err := p2p.NewPubSub(cfg.P2P)
+		if err != nil {
+			return nil, err
+		}
+		opts.NetworkPubSub = ps
+	} else {
+		transportConf := conn.DefaultMConnConfig()
+		transportConf.FlushThrottle = cfg.P2P.FlushThrottleTimeout
+		transportConf.SendRate = cfg.P2P.SendRate
+		transportConf.RecvRate = cfg.P2P.RecvRate
+		transportConf.MaxPacketMsgPayloadSize = cfg.P2P.MaxPacketMsgPayloadSize
+		transport := p2p.NewMConnTransport(
+			p2pLogger, transportConf, []*p2p.ChannelDescriptor{},
+			p2p.MConnTransportOptions{
+				MaxAcceptedConnections: uint32(cfg.P2P.MaxConnections),
+			},
+		)
+
+		ep, err := p2p.NewEndpoint(nodeKey.ID.AddressString(cfg.P2P.ListenAddress))
+		if err != nil {
+			return nil, err
+		}
+		opts.LegacyEndpoint = ep
+		opts.LegacyTransport = transport
 	}
 
-	opts := getRouterConfig(cfg, appClient)
-	opts.LegacyEndpoint = ep
-	opts.LegacyTransport = transport
-	opts.NodeInfoProducer = nodeInfoProducer
 	return p2p.NewRouter(
 		p2pLogger,
 		p2pMetrics,

--- a/node/setup.go
+++ b/node/setup.go
@@ -274,6 +274,7 @@ func createPeerManager(
 }
 
 func createRouter(
+	ctx context.Context,
 	logger log.Logger,
 	p2pMetrics *p2p.Metrics,
 	nodeInfoProducer func() *types.NodeInfo,
@@ -294,7 +295,7 @@ func createRouter(
 		}
 		opts.NetworkHost = host
 
-		ps, err := p2p.NewPubSub(cfg.P2P)
+		ps, err := p2p.NewPubSub(ctx, cfg.P2P, host)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is an initial bit of scafodling to outline structure of the
design, but there's more work, noticably:

- using some kind of default constructor, as for the database, to make
  it possible for users to hand us pre-made libp2p components, and
  changing the public interface of the node constructors accordingly. 
  
- implementing the host and pubsub constructors in the p2p package. I
  think that the pubsub constructor might need access to the host
  object, so the current interface might need to change a bit