### PR TITLE
rpc: fix encoding of block_results responses (backport #8593)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,8 @@ Special thanks to external contributors on this release:
 
 - CLI/RPC/Config
 
+   - [rpc] \#8594 fix encoding of block_results responses (@creachadair)
+
 - Apps
 
 - P2P Protocol

--- a/rpc/coretypes/responses_test.go
+++ b/rpc/coretypes/responses_test.go
@@ -1,9 +1,18 @@
 package coretypes
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	pbcrypto "github.com/tendermint/tendermint/proto/tendermint/crypto"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -30,5 +39,56 @@ func TestStatusIndexer(t *testing.T) {
 	for _, tc := range cases {
 		status.NodeInfo.Other = tc.other
 		assert.Equal(t, tc.expected, status.TxIndexEnabled())
+	}
+}
+
+// A regression test for https://github.com/tendermint/tendermint/issues/8583.
+func TestResultBlockResults_regression8583(t *testing.T) {
+	const keyData = "0123456789abcdef0123456789abcdef" // 32 bytes
+	wantKey := base64.StdEncoding.EncodeToString([]byte(keyData))
+
+	rsp := &ResultBlockResults{
+		ValidatorUpdates: []abci.ValidatorUpdate{{
+			PubKey: pbcrypto.PublicKey{
+				Sum: &pbcrypto.PublicKey_Ed25519{Ed25519: []byte(keyData)},
+			},
+			Power: 400,
+		}},
+	}
+
+	// Use compact here so the test data remain legible. The output from the
+	// marshaler will have whitespace folded out so we need to do that too for
+	// the comparison to be valid.
+	var buf bytes.Buffer
+	require.NoError(t, json.Compact(&buf, []byte(fmt.Sprintf(`
+{
+  "height": 0,
+  "txs_results": null,
+  "total_gas_used": 0,
+  "begin_block_events": null,
+  "end_block_events": null,
+  "validator_updates": [
+    {
+      "pub_key":{"type": "tendermint/PubKeyEd25519", "value": "%s"},
+      "power": "400"
+    }
+  ],
+  "consensus_param_updates": null
+}`, wantKey))))
+
+	bits, err := json.Marshal(rsp)
+	if err != nil {
+		t.Fatalf("Encoding block result: %v", err)
+	}
+	if diff := cmp.Diff(buf.String(), string(bits)); diff != "" {
+		t.Errorf("Marshaled result (-want, +got):\n%s", diff)
+	}
+
+	back := new(ResultBlockResults)
+	if err := json.Unmarshal(bits, back); err != nil {
+		t.Fatalf("Unmarshaling: %v", err)
+	}
+	if diff := cmp.Diff(rsp, back); diff != "" {
+		t.Errorf("Unmarshaled result (-want, +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Updates #8583.

The block results include validator updates in ABCI protobuf format, which does not encode "correctly" according to the expected Amino style RPC clients use.

- Write a regression test for this issue.
- Add JSON marshaling overrides for ABCI ValidatorUpdate messages.

Patches for v0.35.x:

- Replace jsontypes with tmjson (removed in v0.36)
- Regress test data for BeginBlock / EndBlock
