### PR TITLE
config: complete removal of seed addresses in config

### DIFF
--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -63,7 +63,6 @@ func AddNodeFlags(cmd *cobra.Command, conf *cfg.Config) {
 		"p2p.laddr",
 		conf.P2P.ListenAddress,
 		"node listen address. (0.0.0.0:0 means any interface, any port)")
-	cmd.Flags().String("p2p.seeds", conf.P2P.Seeds, "comma-delimited ID@host:port seed nodes") //nolint: staticcheck
 	cmd.Flags().String("p2p.persistent-peers", conf.P2P.PersistentPeers, "comma-delimited ID@host:port persistent peers")
 	cmd.Flags().Bool("p2p.upnp", conf.P2P.UPNP, "enable/disable UPNP port forwarding")
 	cmd.Flags().Bool("p2p.pex", conf.P2P.PexReactor, "enable/disable Peer-Exchange")

--- a/config/config.go
+++ b/config/config.go
@@ -612,15 +612,6 @@ type P2PConfig struct { //nolint: maligned
 	// Address to advertise to peers for them to dial
 	ExternalAddress string `mapstructure:"external-address"`
 
-	// Comma separated list of seed nodes to connect to
-	// We only use these if we can’t connect to peers in the addrbook
-	//
-	// Deprecated: This value is not used by the new PEX reactor. Use
-	// BootstrapPeers instead.
-	//
-	// TODO(#5670): Remove once the p2p refactor is complete.
-	Seeds string `mapstructure:"seeds"`
-
 	// Comma separated list of peers to be added to the peer store
 	// on startup. Either BootstrapPeers or PersistentPeers are
 	// needed for peer discovery

--- a/config/toml.go
+++ b/config/toml.go
@@ -295,13 +295,6 @@ laddr = "{{ .P2P.ListenAddress }}"
 # example: 159.89.10.97:26656
 external-address = "{{ .P2P.ExternalAddress }}"
 
-# Comma separated list of seed nodes to connect to
-# We only use these if we can’t connect to peers in the addrbook
-# NOTE: not used by the new PEX reactor. Please use BootstrapPeers instead.
-# TODO: Remove once p2p refactor is complete
-# ref: https:#github.com/tendermint/tendermint/issues/5670
-seeds = "{{ .P2P.Seeds }}"
-
 # Comma separated list of peers to be added to the peer store
 # on startup. Either BootstrapPeers or PersistentPeers are
 # needed for peer discovery

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -322,14 +322,6 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 		}
 	}
 
-	cfg.P2P.Seeds = "" //nolint: staticcheck
-	for _, seed := range node.Seeds {
-		if len(cfg.P2P.Seeds) > 0 { //nolint: staticcheck
-			cfg.P2P.Seeds += "," //nolint: staticcheck
-		}
-		cfg.P2P.Seeds += seed.AddressP2P(true) //nolint: staticcheck
-	}
-
 	cfg.P2P.PersistentPeers = ""
 	for _, peer := range node.PersistentPeers {
 		if len(cfg.P2P.PersistentPeers) > 0 {


### PR DESCRIPTION
As part of moving away from the legacy p2p stack. Seed addresses don't need to be specified - they are treated like normal addresses and users can use either `BootstrapPeers` or `PersistentPeers`.

