### PR TITLE
pex: align max address thresholds

### DIFF
--- a/internal/p2p/pex/params.go
+++ b/internal/p2p/pex/params.go
@@ -51,5 +51,5 @@ const (
 
 	// max addresses returned by GetSelection
 	// NOTE: this must match "maxMsgSize"
-	maxGetSelection = 250
+	maxGetSelection = 100
 )

--- a/internal/p2p/pex/pex_reactor.go
+++ b/internal/p2p/pex/pex_reactor.go
@@ -102,12 +102,6 @@ type Reactor struct {
 	crawlPeerInfos map[types.NodeID]crawlPeerInfo
 }
 
-func (r *Reactor) minReceiveRequestInterval() time.Duration {
-	// NOTE: must be less than ensurePeersPeriod, otherwise we'll request
-	// peers too quickly from others and they'll think we're bad!
-	return minReceiveRequestInterval
-}
-
 // ReactorConfig holds reactor specific configuration data.
 type ReactorConfig struct {
 	// Seed/Crawler mode
@@ -331,7 +325,7 @@ func (r *Reactor) receiveRequest(src Peer) error {
 	}
 
 	now := time.Now()
-	minInterval := r.minReceiveRequestInterval()
+	minInterval := minReceiveRequestInterval
 	if now.Sub(lastReceived) < minInterval {
 		return fmt.Errorf(
 			"peer (%v) sent next PEX request too soon. lastReceived: %v, now: %v, minInterval: %v. Disconnecting",

--- a/internal/p2p/pex/pex_reactor.go
+++ b/internal/p2p/pex/pex_reactor.go
@@ -105,7 +105,7 @@ type Reactor struct {
 func (r *Reactor) minReceiveRequestInterval() time.Duration {
 	// NOTE: must be less than ensurePeersPeriod, otherwise we'll request
 	// peers too quickly from others and they'll think we're bad!
-	return r.ensurePeersPeriod / 3
+	return minReceiveRequestInterval
 }
 
 // ReactorConfig holds reactor specific configuration data.

--- a/internal/p2p/pex/reactor.go
+++ b/internal/p2p/pex/reactor.go
@@ -24,7 +24,7 @@ var (
 // See https://github.com/tendermint/tendermint/issues/6371
 const (
 	// the minimum time one peer can send another request to the same peer
-	minReceiveRequestInterval = 100 * time.Millisecond
+	minReceiveRequestInterval = 200 * time.Millisecond
 
 	// the maximum amount of addresses that can be included in a response
 	maxAddresses uint16 = 100


### PR DESCRIPTION
The two pex reactors use different values to define what the maximum amount of addresses it should send (and expect to receive). This can cause nodes to occasionally be unnecessary punished. This PR fixes this by setting everything to 100 addresses at a time


