### PR TITLE
p2p: shed peers from store from other networks

### DIFF
--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -720,6 +720,15 @@ func (r *Router) handshakePeer(
 	if err = peerInfo.Validate(); err != nil {
 		return peerInfo, fmt.Errorf("invalid handshake NodeInfo: %w", err)
 	}
+
+	if peerInfo.Network != nodeInfo.Network {
+		if err := r.peerManager.store.Delete(peerInfo.NodeID); err != nil {
+			return peerInfo, fmt.Errorf("problem removing peer from store from incorrect network [%s]: %w", peerInfo.Network, err)
+		}
+
+		return peerInfo, fmt.Errorf("connected to peer from wrong network, %q, removed from peer store", peerInfo.Network)
+	}
+
 	if types.NodeIDFromPubKey(peerKey) != peerInfo.NodeID {
 		return peerInfo, fmt.Errorf("peer's public key did not match its node ID %q (expected %q)",
 			peerInfo.NodeID, types.NodeIDFromPubKey(peerKey))
@@ -728,6 +737,7 @@ func (r *Router) handshakePeer(
 		return peerInfo, fmt.Errorf("expected to connect with peer %q, got %q",
 			expectID, peerInfo.NodeID)
 	}
+
 	if err := nodeInfo.CompatibleWith(peerInfo); err != nil {
 		return peerInfo, ErrRejected{
 			err:            err,


### PR DESCRIPTION
This should remedy a situation observbed by penumbra where stale peers
from old networks clog up the peer store and make it take longer for
peers/networks to become connected. This doesn't affect correctness
(e.g. we would never establish connections to these peers but we waste time
trying,) and the router/peermanager are very conservative about
removing peers from the database, which I think exacerbates this
issue.

The risk of this PR is that a peer will eventually recover and we will
have removed it from the network, and it will have a hard time
rejoining, but in these situations it will have to be correct, and
should have the same path through rentering the peer databases of
nodes on the network as a new node, which it is for all intents.