### PR TITLE
p2p: pass maxConns for MaxPeers during node setup

### DIFF
--- a/node/setup.go
+++ b/node/setup.go
@@ -227,7 +227,7 @@ func createPeerManager(
 		SelfAddress:            selfAddr,
 		MaxConnected:           maxConns,
 		MaxConnectedUpgrade:    4,
-		MaxPeers:               1000,
+		MaxPeers:               maxConns,
 		MinRetryTime:           250 * time.Millisecond,
 		MaxRetryTime:           30 * time.Minute,
 		MaxRetryTimePersistent: 5 * time.Minute,

--- a/node/setup.go
+++ b/node/setup.go
@@ -229,7 +229,7 @@ func createPeerManager(
 		SelfAddress:            selfAddr,
 		MaxConnected:           maxConns,
 		MaxConnectedUpgrade:    maxUpgradeConns,
-		MaxPeers:               maxConns + maxUpgradeConns,
+		MaxPeers:               maxUpgradeConns + 2*maxConns,
 		MinRetryTime:           250 * time.Millisecond,
 		MaxRetryTime:           30 * time.Minute,
 		MaxRetryTimePersistent: 5 * time.Minute,

--- a/node/setup.go
+++ b/node/setup.go
@@ -223,11 +223,13 @@ func createPeerManager(
 		maxConns = 64
 	}
 
+	maxUpgradeConns := uint16(4)
+
 	options := p2p.PeerManagerOptions{
 		SelfAddress:            selfAddr,
 		MaxConnected:           maxConns,
-		MaxConnectedUpgrade:    4,
-		MaxPeers:               maxConns,
+		MaxConnectedUpgrade:    maxUpgradeConns,
+		MaxPeers:               maxConns + maxUpgradeConns,
 		MinRetryTime:           250 * time.Millisecond,
 		MaxRetryTime:           30 * time.Minute,
 		MaxRetryTimePersistent: 5 * time.Minute,


### PR DESCRIPTION
This PR changes the node setup so that it passes the configured max connections instead of what I assume is accidental constant of 1000. As discussed in #8683, ~~we might want to instead take this opportunity to remove `MaxPeers` or `MaxConnected` from the peer manager options and only use one of those values.~~

Closes #8683 


