### PR TITLE
consensus: switch timeout message to be debug and clarify meaning

### DIFF
--- a/internal/consensus/ticker.go
+++ b/internal/consensus/ticker.go
@@ -115,9 +115,9 @@ func (t *timeoutTicker) timeoutRoutine(ctx context.Context) {
 			// NOTE time.Timer allows duration to be non-positive
 			ti = newti
 			t.timer.Reset(ti.Duration)
-			t.logger.Debug("Scheduled timeout", "dur", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
+			t.logger.Debug("Internal state machine timeout scheduled", "duration", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
 		case <-t.timer.C:
-			t.logger.Info("Timed out", "dur", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
+			t.logger.Debug("Internal state machine timeout elapsed ", "duration", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
 			// go routine here guarantees timeoutRoutine doesn't block.
 			// Determinism comes from playback in the receiveRoutine.
 			// We can eliminate it by merging the timeoutRoutine into receiveRoutine


### PR DESCRIPTION
This timeout message is unclear and as a result is confusing to operators. Operators have the reasonable expectation that timeouts mean a desired input is not received in time. The consensus timeouts do not mean this. Timeouts are one of the main mechanisms by which Tendermint moves between consensus steps. Logging them frequently produces log spam that is not clear or actionable to operators. This PR switches the timeouts to be Debug level and attempts to clarify their phrasing.

Closes: #8639 