### PR TITLE
Update how Mockery mocks are checked for currency.

### DIFF
--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -25,6 +25,9 @@ jobs:
       - name: "Check generated mocks"
         run: |
           set -euo pipefail
+
+          readonly MOCKERY=2.12.3  # N.B. no leading "v"
+          curl -L "https://github.com/vektra/mockery/releases/download/v${MOCKERY}/mockery_${MOCKERY}_Linux_x86_64.tar.gz" | tar -C /usr/local/bin -xzvf -
           make mockery 2>/dev/null
 
           if ! git diff --stat --exit-code ; then

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -27,7 +27,7 @@ jobs:
           set -euo pipefail
 
           readonly MOCKERY=2.12.3  # N.B. no leading "v"
-          curl -L "https://github.com/vektra/mockery/releases/download/v${MOCKERY}/mockery_${MOCKERY}_Linux_x86_64.tar.gz" | tar -C /usr/local/bin -xzvf -
+          curl -sL "https://github.com/vektra/mockery/releases/download/v${MOCKERY}/mockery_${MOCKERY}_Linux_x86_64.tar.gz" | tar -C /usr/local/bin -xzf -
           make mockery 2>/dev/null
 
           if ! git diff --stat --exit-code ; then

--- a/scripts/mockery_generate.sh
+++ b/scripts/mockery_generate.sh
@@ -2,9 +2,9 @@
 #
 # Invoke Mockery v2 to update generated mocks for the given type.
 #
-# This script runs a locall-installed "mockery" if available, otherwise it runs
-# the published Docker container. This legerdemain is so that the CI build and
-# a local build can work off the same script.
+# This script runs a locally-installed "mockery" if available, otherwise it
+# runs the published Docker container. This legerdemain is so that the CI build
+# and a local build can work off the same script.
 #
 if ! which mockery ; then
   mockery() {

--- a/scripts/mockery_generate.sh
+++ b/scripts/mockery_generate.sh
@@ -1,3 +1,15 @@
 #!/bin/sh
+#
+# Invoke Mockery v2 to update generated mocks for the given type.
+#
+# This script runs a locall-installed "mockery" if available, otherwise it runs
+# the published Docker container. This legerdemain is so that the CI build and
+# a local build can work off the same script.
+#
+if ! which mockery ; then
+  mockery() {
+    docker run --rm -v "$PWD":/w --workdir=/w vektra/mockery:v2.12.3
+  }
+fi
 
-go run github.com/vektra/mockery/v2 --disable-version-string --case underscore --name $*
+mockery --disable-version-string --case underscore --name "$@"


### PR DESCRIPTION
The use of "go install" is deprecated as a way of installing and running the
Mockery binary. Update the runner script to depend on an ambient version of the
tool and ensure that in CI it's installed.

Fixes #8693.