### PR TITLE
Set up automation settings for the v0.36.x backport branch.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    target-branch: "v0.34.x"
+    target-branch: "v0.36.x"
     open-pull-requests-limit: 10
     labels:
       - T:dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,17 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    target-branch: "v0.34.x"
+    open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+      - S:automerge
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
     target-branch: "v0.35.x"
     open-pull-requests-limit: 10
     labels:
@@ -69,6 +80,16 @@ updates:
     schedule:
       interval: daily
     target-branch: "v0.35.x"
+    open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+      - S:automerge
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    target-branch: "v0.36.x"
     open-pull-requests-limit: 10
     labels:
       - T:dependencies

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -33,3 +33,11 @@ pull_request_rules:
       backport:
         branches:
           - v0.35.x
+  - name: backport patches to v0.36.x branch
+    conditions:
+      - base=master
+      - label=S:backport-to-v0.36.x
+    actions:
+      backport:
+        branches:
+          - v0.36.x

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -1,8 +1,7 @@
-# Runs randomly generated E2E testnets nightly
-# on the 0.34.x release branch
+# Runs randomly generated E2E testnets nightly on the 0.34.x branch.
 
-# !! If you change something in this file, you probably want
-# to update the e2e-nightly-master workflow as well!
+# !! This file should be kept in sync with the e2e-nightly-master.yml file,
+# modulo changes to the version labels.
 
 name: e2e-nightly-34x
 on:

--- a/.github/workflows/e2e-nightly-36x.yml
+++ b/.github/workflows/e2e-nightly-36x.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        p2p: ['legacy', 'new', 'hybrid']
         group: ['00', '01', '02', '03']
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -36,11 +35,11 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 4 -d networks/nightly/${{ matrix.p2p }} -p ${{ matrix.p2p }}
+        run: ./build/generator -g 4 -d networks/nightly
 
-      - name: Run ${{ matrix.p2p }} p2p testnets in group ${{ matrix.group }}
+      - name: Run testnets in group ${{ matrix.group }}
         working-directory: test/e2e
-        run: ./run-multiple.sh networks/nightly/${{ matrix.p2p }}/*-group${{ matrix.group }}-*.toml
+        run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
 
   e2e-nightly-fail-2:
     needs: e2e-nightly-test

--- a/.github/workflows/e2e-nightly-36x.yml
+++ b/.github/workflows/e2e-nightly-36x.yml
@@ -1,9 +1,9 @@
-# Runs randomly generated E2E testnets nightly on the v0.35.x branch.
+# Runs randomly generated E2E testnets nightly on the v0.36.x branch.
 
 # !! This file should be kept in sync with the e2e-nightly-master.yml file,
 # modulo changes to the version labels.
 
-name: e2e-nightly-35x
+name: e2e-nightly-36x
 on:
   schedule:
     - cron: '0 2 * * *'
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: 'v0.35.x'
+          ref: 'v0.36.x'
 
       - name: Build
         working-directory: test/e2e
@@ -55,7 +55,7 @@ jobs:
           SLACK_USERNAME: Nightly E2E Tests
           SLACK_ICON_EMOJI: ':skull:'
           SLACK_COLOR: danger
-          SLACK_MESSAGE: Nightly E2E tests failed on v0.35.x
+          SLACK_MESSAGE: Nightly E2E tests failed on v0.36.x
           SLACK_FOOTER: ''
 
   e2e-nightly-success:  # may turn this off once they seem to pass consistently
@@ -71,5 +71,5 @@ jobs:
           SLACK_USERNAME: Nightly E2E Tests
           SLACK_ICON_EMOJI: ':white_check_mark:'
           SLACK_COLOR: good
-          SLACK_MESSAGE: Nightly E2E tests passed on v0.35.x
+          SLACK_MESSAGE: Nightly E2E tests passed on v0.36.x
           SLACK_FOOTER: ''

--- a/.github/workflows/e2e-nightly-master.yml
+++ b/.github/workflows/e2e-nightly-master.yml
@@ -1,7 +1,8 @@
 # Runs randomly generated E2E testnets nightly on master
 
-# !! If you change something in this file, you probably want
-# to update the e2e-nightly-34x workflow as well!
+# !! Relevant changes to this file should be propagated to the e2e-nightly-<V>x
+# files for the supported backport branches, when appropriate, modulo version
+# markers.
 
 name: e2e-nightly-master
 on:


### PR DESCRIPTION
- Add Mergify settings for backport labels.
- Add e2e nightly workflow for v0.36.x.
- Update documentation on e2e workflows.
- Add v0.36.x to the Dependabot configs.

N.B.: This change targets `master` since that is where we keep workflow settings.