### PR TITLE
Update config migration test data for v0.36.x

### DIFF
--- a/scripts/confix/testdata/diff-35-36.txt
+++ b/scripts/confix/testdata/diff-35-36.txt
@@ -16,6 +16,7 @@
 -M p2p.max-num-inbound-peers
 -M p2p.max-num-outbound-peers
 -M p2p.persistent-peers-max-dial-period
+-M p2p.seeds
 -M p2p.unconditional-peer-ids
 -M p2p.use-legacy
 +M rpc.event-log-max-items

--- a/scripts/confix/testdata/v36-config.toml
+++ b/scripts/confix/testdata/v36-config.toml
@@ -157,7 +157,7 @@ experimental-disable-websocket = false
 # the latest (up to EventLogMaxItems) will be available for subscribers to
 # fetch via the /events method.  If 0 (the default) the event log and the
 # /events RPC method are disabled.
-event-log-window-size = "0s"
+event-log-window-size = "30s"
 
 # The maxiumum number of events that may be retained by the event log.  If
 # this value is 0, no upper limit is set. Otherwise, items in excess of
@@ -220,13 +220,6 @@ laddr = "tcp://0.0.0.0:26656"
 # to figure out the address. ip and port are required
 # example: 159.89.10.97:26656
 external-address = ""
-
-# Comma separated list of seed nodes to connect to
-# We only use these if we can’t connect to peers in the addrbook
-# NOTE: not used by the new PEX reactor. Please use BootstrapPeers instead.
-# TODO: Remove once p2p refactor is complete
-# ref: https:#github.com/tendermint/tendermint/issues/5670
-seeds = ""
 
 # Comma separated list of peers to be added to the peer store
 # on startup. Either BootstrapPeers or PersistentPeers are


### PR DESCRIPTION
This is a trivial update, but also a convenient way to make sure the mergify settings are working.