### PR TITLE
mempool: fix error message check in test

### DIFF
--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -631,7 +631,7 @@ func TestTxMempool_CheckTxPostCheckError(t *testing.T) {
 				require.NoError(t, txmp.CheckTx(ctx, tx, callback, TxInfo{SenderID: 0}))
 			} else {
 				err = txmp.CheckTx(ctx, tx, callback, TxInfo{SenderID: 0})
-				fmt.Print(err.Error())
+				require.EqualError(t, err, "test error")
 			}
 		})
 	}


### PR DESCRIPTION
Current test case prints out "test error" to console even when it succeeds, and it can mislead.