### PR TITLE
p2p: accept should not abort on first error

### DIFF
--- a/internal/p2p/router_test.go
+++ b/internal/p2p/router_test.go
@@ -452,7 +452,7 @@ func TestRouter_AcceptPeers_Error(t *testing.T) {
 	// the router from calling Accept again.
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("String").Maybe().Return("mock")
-	mockTransport.On("Accept", mock.Anything).Once().Return(nil, errors.New("boom"))
+	mockTransport.On("Accept", mock.Anything).Return(nil, io.EOF)
 	mockTransport.On("Close").Return(nil)
 	mockTransport.On("Listen", mock.Anything).Return(nil)
 

--- a/internal/p2p/router_test.go
+++ b/internal/p2p/router_test.go
@@ -478,6 +478,7 @@ func TestRouter_AcceptPeers_ErrorEOF(t *testing.T) {
 
 	mockTransport.AssertExpectations(t)
 }
+
 func TestRouter_AcceptPeers_ErrorCanceled(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
 

--- a/internal/p2p/router_test.go
+++ b/internal/p2p/router_test.go
@@ -442,17 +442,17 @@ func TestRouter_AcceptPeers(t *testing.T) {
 	}
 }
 
-func TestRouter_AcceptPeers_Error(t *testing.T) {
+func TestRouter_AcceptPeers_ErrorEOF(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Set up a mock transport that returns an error, which should prevent
+	// Set up a mock transport that returns io.EOF once, which should prevent
 	// the router from calling Accept again.
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("String").Maybe().Return("mock")
-	mockTransport.On("Accept", mock.Anything).Return(nil, io.EOF)
+	mockTransport.On("Accept", mock.Anything).Once().Return(nil, io.EOF)
 	mockTransport.On("Close").Return(nil)
 	mockTransport.On("Listen", mock.Anything).Return(nil)
 
@@ -478,8 +478,7 @@ func TestRouter_AcceptPeers_Error(t *testing.T) {
 
 	mockTransport.AssertExpectations(t)
 }
-
-func TestRouter_AcceptPeers_ErrorEOF(t *testing.T) {
+func TestRouter_AcceptPeers_ErrorCanceled(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -489,7 +488,7 @@ func TestRouter_AcceptPeers_ErrorEOF(t *testing.T) {
 	// the router from calling Accept again.
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("String").Maybe().Return("mock")
-	mockTransport.On("Accept", mock.Anything).Once().Return(nil, io.EOF)
+	mockTransport.On("Accept", mock.Anything).Once().Return(nil, context.Canceled)
 	mockTransport.On("Close").Return(nil)
 	mockTransport.On("Listen", mock.Anything).Return(nil)
 


### PR DESCRIPTION
Previously, the "accept connections" routine would return (and stop doing work) as soon as it encountered an error, even if the error was potentially transient. As a result, a node could easily stop accepting new connections fairly early on in its lifecycle. Because the lifecylce of this routine isn't tracked, the node would continue doing work (and dialing peers) but just not accepting new peers. This is likely an oversight, and this change should make it more likely that a node will acquire peers in a more expected way. 

Peers attempting to connect to the node experiencing this issue would not be able to complete the dial and may not see any error in their logs. The issue would present as the node not being able to complete an initial sync and not ever being able to join the network. The following snippet of logs demonstrates such a case:

```
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=multiAppConn module=proxy service=multiAppConn
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service connection=query impl=localClient module=abci-client service=localClient
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service connection=snapshot impl=localClient module=abci-client service=localClient
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service connection=mempool impl=localClient module=abci-client service=localClient
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service connection=consensus impl=localClient module=abci-client service=localClient
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=EventBus module=events service=EventBus
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=PubSub module=pubsub service=PubSub
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=IndexerService module=txindex service=IndexerService
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO ABCI Handshake App Info hash="�Up���\vz���K�\nf\x0f\r�\x1eB��\x1dM��2���=�" height=0 module=consensus protocol-version=1 software-version=0.17.0
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO ABCI Replay Blocks appHeight=0 module=consensus stateHeight=0 storeHeight=0
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO Completed ABCI Handshake - Tendermint and App are synced appHash="�Up���\vz���K�\nf\x0f\r�\x1eB��\x1dM��2���=�" appHeight=0 module=consensus
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO Version info block=11 mode=validator module=main p2p=8 tmVersion=0.35.6
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO This node is a validator (NOT in the active validator set) addr=AB89F26F1F1DF494FB1B111B5AB51FBC0BD5565E module=consensus pubKey="m�\x06D�2\x168���K�4����}\x02:�f\a�Ml�����"
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=Node module=main service=Node
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO Starting pprof server laddr=:6060 module=main
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO Starting RPC HTTP server on [::]:26657 module=rpc-server
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO p2p service legacy_enabled=false module=main
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=router module=p2p service=router
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting router channels=402021222330386061626300 listen_addr=tcp://167.71.32.151:26656 module=p2p net_addr={"id":"74b286b93c68878a15a6dcf3ac489cb4b42bc027","ip":"167.71.32.151","port":26656} node_id=74b286b93c68878a15a6dcf3ac489cb4b42bc027
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=BlockSync module=blockchain service=BlockSync
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=ConsensusReactor module=consensus service=Consensus
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=StateSync module=statesync service=StateSync
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=Mempool module=mempool service=Mempool version=v1
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=Evidence module=evidence service=Evidence
Jun 14 18:23:58 ephemeral00 node[46269]: 2022-06-14T18:23:58Z INFO starting service impl=PEX module=main service=PEX
Jun 14 18:23:59 ephemeral00 node[46269]: 2022-06-14T18:23:59Z INFO not caught up yet height=1 max_peer_height=0 module=blockchain timeout_in=58998.907029
Jun 14 18:24:00 ephemeral00 node[46269]: 2022-06-14T18:24:00Z INFO not caught up yet height=1 max_peer_height=0 module=blockchain timeout_in=57998.596222
Jun 14 18:24:01 ephemeral00 node[46269]: 2022-06-14T18:24:01Z INFO not caught up yet height=1 max_peer_height=0 module=blockchain timeout_in=56998.129085
...
Jun 14 18:24:57 ephemeral00 node[46269]: 2022-06-14T18:24:57Z INFO not caught up yet height=1 max_peer_height=0 module=blockchain timeout_in=998.540946
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z ERROR no progress since last advance last_advance=2022-06-14T18:23:58Z module=blockchain
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z INFO switching to consensus module=consensus
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z INFO starting service impl=ConsensusState module=consensus service=State
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z INFO starting service impl=baseWAL module=consensus service=baseWAL wal=/root/.testapp/data/cs.wal/wal
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z INFO starting service impl=Group module=consensus service=Group wal=/root/.testapp/data/cs.wal/wal
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z INFO starting service impl=TimeoutTicker module=consensus service=TimeoutTicker
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z INFO Searching for height height=1 max=0 min=0 module=consensus wal=/root/.testapp/data/cs.wal/wal
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z INFO Searching for height height=0 max=0 min=0 module=consensus wal=/root/.testapp/data/cs.wal/wal
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z INFO Found height=0 index=0 module=consensus wal=/root/.testapp/data/cs.wal/wal
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z INFO Catchup by replaying consensus messages height=1 module=consensus
Jun 14 18:24:58 ephemeral00 node[46269]: 2022-06-14T18:24:58Z INFO Replay: Done module=consensus
```