### PR TITLE
e2e/ci: add extra split to 0.36

### DIFF
--- a/.github/workflows/e2e-nightly-36x.yml
+++ b/.github/workflows/e2e-nightly-36x.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02', '03']
+        group: ['00', '01', '02', '03', '04']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -35,7 +35,7 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 4 -d networks/nightly
+        run: ./build/generator -g 5 -d networks/nightly
 
       - name: Run testnets in group ${{ matrix.group }}
         working-directory: test/e2e


### PR DESCRIPTION
I accidentially backported #8731 rather than edit this file, which
will split up the now-much-longer e2e tests.