### PR TITLE
Fix typo in Using Tendermint section

### DIFF
--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -254,7 +254,7 @@ afford to lose all blockchain data!
 To reset a blockchain, stop the node and run:
 
 ```sh
-tendermint unsafe_reset_all
+tendermint unsafe-reset-all
 ```
 
 This command will remove the data directory and reset private validator and


### PR DESCRIPTION
Modify using-tendermint.md to replace unsafe_reset_all to unsafe-reset-all . Closes #8779 .

