### PR TITLE
p2p: peermanager try dial next

### DIFF
--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -517,6 +517,15 @@ func (m *PeerManager) DialNext(ctx context.Context) (NodeAddress, error) {
 		if err != nil || (address != NodeAddress{}) {
 			return address, err
 		}
+
+		if ctx.Err() != nil {
+			return NodeAddress{}, ctx.Err()
+		}
+
+		if !m.HasDialedMaxPeers() {
+			continue
+		}
+
 		select {
 		case <-m.dialWaker.Sleep():
 		case <-ctx.Done():

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -466,11 +466,6 @@ func (r *Router) dialSleep(ctx context.Context) {
 	}
 
 	r.options.DialSleep(ctx)
-
-	if !r.peerManager.HasDialedMaxPeers() {
-		r.peerManager.dialWaker.Wake()
-	}
-
 }
 
 // acceptPeers accepts inbound connections from peers on the given transport,


### PR DESCRIPTION
This is an improvement on #8803 with the operative code more well
placed and with beter shutdown compatibility.

The core idea is: if we haven't dialed the maximum number of peers, avoid sleeping as much when we're trying to get an address. 