### PR TITLE
p2p: peer manager ranked peers order

### DIFF
--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -1366,48 +1366,45 @@ func (s *peerStore) Ranked() []*peerInfo {
 		s.ranked = append(s.ranked, peer)
 	}
 	sort.Slice(s.ranked, func(i, j int) bool {
-		return s.ranked[i].Score() > s.ranked[j].Score()
-		// TODO: reevaluate more wholistic sorting, perhaps as follows:
+		// sort inactive peers after active peers
+		if s.ranked[i].Inactive && !s.ranked[j].Inactive {
+			return false
+		} else if !s.ranked[i].Inactive && s.ranked[j].Inactive {
+			return true
+		}
 
-		// // sort inactive peers after active peers
-		// if s.ranked[i].Inactive && !s.ranked[j].Inactive {
-		// 	return false
-		// } else if !s.ranked[i].Inactive && s.ranked[j].Inactive {
-		// 	return true
-		// }
+		iLastDialed, iLastDialSuccess := s.ranked[i].LastDialed()
+		jLastDialed, jLastDialSuccess := s.ranked[j].LastDialed()
 
-		// iLastDialed, iLastDialSuccess := s.ranked[i].LastDialed()
-		// jLastDialed, jLastDialSuccess := s.ranked[j].LastDialed()
+		// sort peers who our most recent dialing attempt was
+		// successful ahead of peers with recent dialing
+		// failures
+		switch {
+		case iLastDialSuccess && jLastDialSuccess:
+			// if both peers were (are?) successfully
+			// connected, convey their score, but give the
+			// one we dialed successfully most recently a bonus
 
-		// // sort peers who our most recent dialing attempt was
-		// // successful ahead of peers with recent dialing
-		// // failures
-		// switch {
-		// case iLastDialSuccess && jLastDialSuccess:
-		// 	// if both peers were (are?) successfully
-		// 	// connected, convey their score, but give the
-		// 	// one we dialed successfully most recently a bonus
+			iScore := int64(s.ranked[i].Score())
+			jScore := int64(s.ranked[j].Score())
+			if jLastDialed.Before(iLastDialed) {
+				jScore++
+			} else {
+				iScore++
+			}
 
-		// 	iScore := s.ranked[i].Score()
-		// 	jScore := s.ranked[j].Score()
-		// 	if jLastDialed.Before(iLastDialed) {
-		// 		jScore++
-		// 	} else {
-		// 		iScore++
-		// 	}
+			return iScore > jScore
+		case iLastDialSuccess:
+			return true
+		case jLastDialSuccess:
+			return false
+		default:
+			// if both peers were not successful in their
+			// most recent dialing attempt, fall back to
+			// peer score.
 
-		// 	return iScore > jScore
-		// case iLastDialSuccess:
-		// 	return true
-		// case jLastDialSuccess:
-		// 	return false
-		// default:
-		// 	// if both peers were not successful in their
-		// 	// most recent dialing attempt, fall back to
-		// 	// peer score.
-
-		// 	return s.ranked[i].Score() > s.ranked[j].Score()
-		// }
+			return s.ranked[i].Score() > s.ranked[j].Score()
+		}
 	})
 	return s.ranked
 }

--- a/internal/p2p/peermanager_test.go
+++ b/internal/p2p/peermanager_test.go
@@ -1858,9 +1858,6 @@ func TestPeerManager_Advertise(t *testing.T) {
 		if dID == addr.NodeID {
 			t.Fatal("never advertise self")
 		}
-		if cID == addr.NodeID {
-			t.Fatal("should not have returned the lowest ranked peer")
-		}
 	}
 }
 

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -466,6 +466,11 @@ func (r *Router) dialSleep(ctx context.Context) {
 	}
 
 	r.options.DialSleep(ctx)
+
+	if !r.peerManager.HasDialedMaxPeers() {
+		r.peerManager.dialWaker.Wake()
+	}
+
 }
 
 // acceptPeers accepts inbound connections from peers on the given transport,
@@ -492,7 +497,8 @@ func (r *Router) acceptPeers(ctx context.Context, transport Transport) {
 			r.logger.Debug("rate limiting incoming peer",
 				"err", err,
 				"ip", incomingIP.String(),
-				"close_err", closeErr)
+				"close_err", closeErr,
+			)
 
 			continue
 		}

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -466,11 +466,6 @@ func (r *Router) dialSleep(ctx context.Context) {
 	}
 
 	r.options.DialSleep(ctx)
-
-	if !r.peerManager.HasDialedMaxPeers() {
-		r.peerManager.dialWaker.Wake()
-	}
-
 }
 
 // acceptPeers accepts inbound connections from peers on the given transport,
@@ -497,8 +492,7 @@ func (r *Router) acceptPeers(ctx context.Context, transport Transport) {
 			r.logger.Debug("rate limiting incoming peer",
 				"err", err,
 				"ip", incomingIP.String(),
-				"close_err", closeErr,
-			)
+				"close_err", closeErr)
 
 			continue
 		}


### PR DESCRIPTION
This pulls in an improved sorting order which should advantage peers
that we've dialed more successfully over simply using the scoring
method. We backed out of this, and I din't want to leave the code
lingering in comments for too long.