### PR TITLE
p2p: only call dial waker on errors that should cause new dial

### DIFF
--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -649,9 +649,11 @@ func (m *PeerManager) Dialed(address NodeAddress) error {
 		}
 	}
 	if address.NodeID == m.selfID {
+		m.dialWaker.Wake()
 		return fmt.Errorf("rejecting connection to self (%v)", address.NodeID)
 	}
 	if m.isConnected(address.NodeID) {
+		m.dialWaker.Wake()
 		return fmt.Errorf("peer %v is already connected", address.NodeID)
 	}
 	if m.options.MaxConnected > 0 && len(m.connected) >= int(m.options.MaxConnected) {
@@ -662,6 +664,7 @@ func (m *PeerManager) Dialed(address NodeAddress) error {
 
 	peer, ok := m.store.Get(address.NodeID)
 	if !ok {
+		m.dialWaker.Wake()
 		return fmt.Errorf("peer %q was removed while dialing", address.NodeID)
 	}
 	now := time.Now().UTC()

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -634,7 +634,6 @@ func (r *Router) connectPeer(ctx context.Context, address NodeAddress) {
 
 	if err := r.runWithPeerMutex(func() error { return r.peerManager.Dialed(address) }); err != nil {
 		r.logger.Error("failed to dial peer", "op", "outgoing/dialing", "peer", address.NodeID, "err", err)
-		r.peerManager.dialWaker.Wake()
 		conn.Close()
 		return
 	}


### PR DESCRIPTION
Fixes the issue described here:
https://github.com/tendermint/tendermint/pull/8819/files#r903049564