### PR TITLE
p2p: dial even faster

### DIFF
--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -445,8 +445,8 @@ func (r *Router) dialSleep(ctx context.Context) {
 		// limits peers for dialing more than once every 10ms,
 		// so these numbers are safe.
 		const (
-			maxDialerInterval = 500 // ms
-			minDialerInterval = 100 // ms
+			maxDialerInterval = 30 // ms
+			minDialerInterval = 10 // ms
 		)
 
 		// nolint:gosec // G404: Use of weak random number generator


### PR DESCRIPTION
A key differentiator between the new and old p2p stack is how fast we dial peers. This brings the dial times even low, although, we may even want to go lower than this.