### PR TITLE
p2p: set empty timeouts to small values.

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -748,6 +748,8 @@ func getRouterConfig(conf *config.Config, appClient abciclient.Client) p2p.Route
 		}
 
 	}
+	opts.HandshakeTimeout = 15 * time.Second
+	opts.DialTimeout = 5 * time.Second
 
 	return opts
 }


### PR DESCRIPTION
These timeouts default to 'do not time out' if they are not set. This times up resources, potentially indefinitely. If node on the other side of the the handshake is up but unresponsive, the[ handshake call](https://github.com/tendermint/tendermint/blob/edec79448aa1d62b84683b1b22e12e145dbdda7c/internal/p2p/router.go#L720) will _never_ return.

These are proposed values that have not been validated. I intend to validate them in a production setting.