### PR TITLE
cmd, internal/*, node: fix resource leaks

### DIFF
--- a/internal/consensus/replay_file.go
+++ b/internal/consensus/replay_file.go
@@ -299,7 +299,7 @@ func newConsensusStateForReplay(
 	cfg config.BaseConfig,
 	logger log.Logger,
 	csConfig *config.ConsensusConfig,
-) (*State, error) {
+) (_ *State, rerr error) {
 	dbType := dbm.BackendType(cfg.DBBackend)
 	// Get BlockStore
 	blockStoreDB, err := dbm.NewDB("blockstore", dbType, cfg.DBDir())
@@ -307,6 +307,11 @@ func newConsensusStateForReplay(
 		return nil, err
 	}
 	blockStore := store.NewBlockStore(blockStoreDB)
+	defer func() {
+		if rerr != nil {
+			blockStore.Close()
+		}
+	}()
 
 	// Get State
 	stateDB, err := dbm.NewDB("state", dbType, cfg.DBDir())

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -59,12 +59,18 @@ func New(cfg *config.RPCConfig, bs state.BlockStore, ss state.Store, es []indexe
 }
 
 // NewFromConfig constructs an Inspector using the values defined in the passed in config.
-func NewFromConfig(logger log.Logger, cfg *config.Config) (*Inspector, error) {
+func NewFromConfig(logger log.Logger, cfg *config.Config) (_ *Inspector, rerr error) {
 	bsDB, err := config.DefaultDBProvider(&config.DBContext{ID: "blockstore", Config: cfg})
 	if err != nil {
 		return nil, err
 	}
 	bs := store.NewBlockStore(bsDB)
+	defer func() {
+		if rerr != nil {
+			bs.Close()
+		}
+	}()
+
 	sDB, err := config.DefaultDBProvider(&config.DBContext{ID: "state", Config: cfg})
 	if err != nil {
 		return nil, err

--- a/internal/libs/autofile/group.go
+++ b/internal/libs/autofile/group.go
@@ -349,6 +349,7 @@ func (g *Group) NewReader(index int) (*GroupReader, error) {
 	r := newGroupReader(g)
 	err := r.SetIndex(index)
 	if err != nil {
+		r.Close()
 		return nil, err
 	}
 	return r, nil

--- a/internal/p2p/transport_memory.go
+++ b/internal/p2p/transport_memory.go
@@ -49,6 +49,7 @@ func (n *MemoryNetwork) CreateTransport(nodeID types.NodeID) *MemoryTransport {
 	n.mtx.Lock()
 	defer n.mtx.Unlock()
 	if _, ok := n.transports[nodeID]; ok {
+		t.Close()
 		panic(fmt.Sprintf("memory transport with node ID %q already exists", nodeID))
 	}
 	n.transports[nodeID] = t


### PR DESCRIPTION
Fixes resources leaks found internally at Orijtech Inc during
security audits by our cyber team.
Fixing these used the technique of named error return values
that check if the return value was an non-nil error and if so
close the target resource.

Fixes #8892
Fixes #8893