### PR TITLE
log: do not pre-process log results

### DIFF
--- a/libs/log/default.go
+++ b/libs/log/default.go
@@ -61,20 +61,20 @@ func NewDefaultLogger(format, level string) (Logger, error) {
 }
 
 func (l defaultLogger) Info(msg string, keyVals ...interface{}) {
-	l.Logger.Info().Fields(getLogFields(keyVals...)).Msg(msg)
+	l.Logger.Info().Fields(keyVals).Msg(msg)
 }
 
 func (l defaultLogger) Error(msg string, keyVals ...interface{}) {
-	l.Logger.Error().Fields(getLogFields(keyVals...)).Msg(msg)
+	l.Logger.Error().Fields(keyVals).Msg(msg)
 }
 
 func (l defaultLogger) Debug(msg string, keyVals ...interface{}) {
-	l.Logger.Debug().Fields(getLogFields(keyVals...)).Msg(msg)
+	l.Logger.Debug().Fields(keyVals).Msg(msg)
 }
 
 func (l defaultLogger) With(keyVals ...interface{}) Logger {
 	return &defaultLogger{
-		Logger: l.Logger.With().Fields(getLogFields(keyVals...)).Logger(),
+		Logger: l.Logger.With().Fields(keyVals).Logger(),
 	}
 }
 
@@ -98,17 +98,4 @@ func OverrideWithNewLogger(logger Logger, format, level string) error {
 
 	ol.Logger = nl.Logger
 	return nil
-}
-
-func getLogFields(keyVals ...interface{}) map[string]interface{} {
-	if len(keyVals)%2 != 0 {
-		return nil
-	}
-
-	fields := make(map[string]interface{}, len(keyVals))
-	for i := 0; i < len(keyVals); i += 2 {
-		fields[fmt.Sprint(keyVals[i])] = keyVals[i+1]
-	}
-
-	return fields
 }


### PR DESCRIPTION
I was digging around in the zero log functions, and the following
functions using the `Fields()` method directly in zerolog, 

- https://github.com/rs/zerolog/blob/v1.27.0/event.go#L161
- https://github.com/rs/zerolog/blob/e9344a8c507b5f25a4962ff022526be0ddab8e72/fields.go#L15

Have meaningfully equivalent semantics and our pre-processing of
values is getting us much (except forcing zerolog to always sort our
keys, and nooping in the case when you miss the last field.)

With this change also, we can pass maps (or, pratically a single map)
to the logger, which might be a less wacky seeming interface.