### PR TITLE
p2p: return from conn send on stopped mconn

### DIFF
--- a/internal/p2p/conn/connection.go
+++ b/internal/p2p/conn/connection.go
@@ -807,6 +807,8 @@ func (ch *Channel) sendBytes(bytes []byte) bool {
 		return true
 	case <-time.After(defaultSendTimeout):
 		return false
+	case <-ch.conn.Quit():
+		return false
 	}
 }
 


### PR DESCRIPTION
This change aims to avoid waiting the enture `defaultSendTimeout` when the underlying conn is already stopped. There is no `Quit` in v0.36.x so I'm not sure what to do in that version. If anyone has a suggestion please let me know.

Related to: https://github.com/tendermint/tendermint/issues/8903