### PR TITLE
p2p: set default outgoing connections to about 20% of total connections

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -671,7 +671,7 @@ func DefaultP2PConfig() *P2PConfig {
 		ExternalAddress:               "",
 		UPNP:                          false,
 		MaxConnections:                64,
-		MaxOutgoingConnections:        32,
+		MaxOutgoingConnections:        12,
 		MaxIncomingConnectionAttempts: 100,
 		FlushThrottleTimeout:          100 * time.Millisecond,
 		// The MTU (Maximum Transmission Unit) for Ethernet is 1500 bytes.


### PR DESCRIPTION
This sets the default closer to its value in the legacy stack.