### PR TITLE
p2p: use correct context error

### DIFF
--- a/internal/p2p/transport_mconn.go
+++ b/internal/p2p/transport_mconn.go
@@ -315,7 +315,7 @@ func (c *mConnConnection) Handshake(
 	select {
 	case <-handshakeCtx.Done():
 		_ = c.Close()
-		return types.NodeInfo{}, nil, ctx.Err()
+		return types.NodeInfo{}, nil, handshakeCtx.Err()
 
 	case err := <-errCh:
 		if err != nil {


### PR DESCRIPTION
handshakeCtx is the internal context carrying the timeout. Its error should be used for the error return.
