### PR TITLE
Work around indexing problem for duplicate transactions (forward port: #8625)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -101,3 +101,4 @@ Special thanks to external contributors on this release:
 - [cli] \#8276 scmigrate: ensure target key is correctly renamed. (@creachadair)
 - [cli] \#8294 keymigrate: ensure block hash keys are correctly translated. (@creachadair)
 - [cli] \#8352 keymigrate: ensure transaction hash keys are correctly translated. (@creachadair)
+- (indexer) \#8625 Fix overriding tx index of duplicated txs.


### PR DESCRIPTION
Forward port: #8625

Port and refactored the bug fix terra-money#76 to upstream. This is critical for ethermint json-rpc to work.

- prevent duplicate tx index if it succeeded before
- handle duplicate txs within the same block

Co-authored-by: jess jesse@soob.co

ref: #5281

Please add a description of the changes that this PR introduces and the files that
are the most critical to review.

If this PR fixes an open Issue, please include "Closes #XXX" (where "XXX" is the Issue number) 
so that GitHub will automatically close the Issue when this PR is merged.


