### PR TITLE
mempool: don't log message type mismatch in the default callback

### DIFF
--- a/internal/mempool/v1/mempool.go
+++ b/internal/mempool/v1/mempool.go
@@ -462,6 +462,10 @@ func (txmp *TxMempool) Update(
 func (txmp *TxMempool) initialTxCallback(wtx *WrappedTx, res *abci.Response) {
 	checkTxRes, ok := res.Value.(*abci.Response_CheckTx)
 	if !ok {
+		txmp.logger.Error("mempool: received incorrect result type in CheckTx callback",
+			"expected", reflect.TypeOf(&abci.Response_CheckTx{}).Name(),
+			"got", reflect.TypeOf(res.Value).Name(),
+		)
 		return
 	}
 
@@ -630,10 +634,8 @@ func (txmp *TxMempool) insertTx(wtx *WrappedTx) {
 func (txmp *TxMempool) recheckTxCallback(req *abci.Request, res *abci.Response) {
 	checkTxRes, ok := res.Value.(*abci.Response_CheckTx)
 	if !ok {
-		txmp.logger.Error("mempool: received incorrect result type in CheckTx callback",
-			"expected", reflect.TypeOf(&abci.Response_CheckTx{}).Name(),
-			"got", reflect.TypeOf(res.Value).Name(),
-		)
+		// Don't log this; this is the default callback and other response types
+		// can safely be ignored.
 		return
 	}
 


### PR DESCRIPTION
We use the default callback for rechecks, but because it is the default it will
be called for other message types too. These can be safely ignored to reduce
log spam. We should, however, log in the explicit (initial) callback.
