### PR TITLE
mempool: minor cleanup after backport from v0.35

### DIFF
--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -450,6 +450,10 @@ func (txmp *TxMempool) Update(
 func (txmp *TxMempool) initialTxCallback(wtx *WrappedTx, res *abci.Response) {
 	checkTxRes, ok := res.Value.(*abci.Response_CheckTx)
 	if !ok {
+		txmp.logger.Error("mempool: received incorrect result type in CheckTx callback",
+			"expected", reflect.TypeOf(&abci.Response_CheckTx{}).Name(),
+			"got", reflect.TypeOf(res.Value).Name(),
+		)
 		return
 	}
 
@@ -618,10 +622,8 @@ func (txmp *TxMempool) insertTx(wtx *WrappedTx) {
 func (txmp *TxMempool) recheckTxCallback(req *abci.Request, res *abci.Response) {
 	checkTxRes, ok := res.Value.(*abci.Response_CheckTx)
 	if !ok {
-		txmp.logger.Error("mempool: received incorrect result type in CheckTx callback",
-			"expected", reflect.TypeOf(&abci.Response_CheckTx{}).Name(),
-			"got", reflect.TypeOf(res.Value).Name(),
-		)
+		// Don't log this; this is the default callback and other response types
+		// can safely be ignored.
 		return
 	}
 
@@ -709,9 +711,7 @@ func (txmp *TxMempool) recheckTransactions() {
 		})
 	}
 
-	if err := txmp.proxyAppConn.FlushAsync(); err != nil {
-		txmp.logger.Error("failed to flush transactions during recheck", "err", err)
-	}
+	txmp.proxyAppConn.FlushAsync()
 }
 
 // canAddTx returns an error if we cannot insert the provided *WrappedTx into

--- a/node/node.go
+++ b/node/node.go
@@ -374,8 +374,6 @@ func createMempoolAndMempoolReactor(
 
 	switch config.Mempool.Version {
 	case cfg.MempoolV1:
-		// TODO(thane): Remove log once https://github.com/tendermint/tendermint/issues/8775 is resolved.
-		logger.Error("While the prioritized mempool API is stable, there is a critical bug in it that is currently under investigation. See https://github.com/tendermint/tendermint/issues/8775 for details")
 		mp := mempoolv1.NewTxMempool(
 			logger,
 			config.Mempool,
@@ -406,7 +404,6 @@ func createMempoolAndMempoolReactor(
 			mempoolv0.WithPostCheck(sm.TxPostCheck(state)),
 		)
 
-		mp.SetLogger(logger)
 		mp.SetLogger(logger)
 
 		reactor := mempoolv0.NewReactor(


### PR DESCRIPTION
- Remove warning log for issue #8775.
- Fix call to FlushAsync (no error is reported).
- Don't log on rechecks, it's the default (manual backport of #8969).
