### PR TITLE
p2p: ensure closed channels stop receiving service

### DIFF
--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -427,8 +427,10 @@ func (r *Router) routeChannel(
 ) {
 	for {
 		select {
-		case envelope := <-outCh:
-			if envelope.IsZero() {
+		case envelope, ok := <-outCh:
+			if !ok {
+				return
+			} else if envelope.IsZero() {
 				continue
 			}
 			// Mark the envelope with the channel ID to allow sendPeer() to pass
@@ -507,7 +509,10 @@ func (r *Router) routeChannel(
 				}
 			}
 
-		case peerError := <-errCh:
+		case peerError, ok := <-errCh:
+			if !ok {
+				return
+			}
 			maxPeerCapacity := r.peerManager.HasMaxPeerCapacity()
 			r.logger.Error("peer error",
 				"peer", peerError.NodeID,


### PR DESCRIPTION
Once these channels are closed, we should not continue to service them, as they
will never again deliver nonzero values.

Fixes #8978.