### PR TITLE
p2p: configure max accepted for non-legacy as well

### DIFF
--- a/node/setup.go
+++ b/node/setup.go
@@ -441,12 +441,23 @@ func createConsensusReactor(
 }
 
 func createTransport(logger log.Logger, cfg *config.Config) *p2p.MConnTransport {
+	var maxAccepted uint32
+	switch {
+	case cfg.P2P.MaxConnections > 0 && !cfg.P2P.UseLegacy:
+		maxAccepted = uint32(cfg.P2P.MaxConnections) +
+			uint32(len(tmstrings.SplitAndTrimEmpty(cfg.P2P.UnconditionalPeerIDs, ",", " ")))
+
+	case cfg.P2P.MaxNumInboundPeers > 0:
+		maxAccepted = uint32(cfg.P2P.MaxNumInboundPeers) +
+			uint32(len(tmstrings.SplitAndTrimEmpty(cfg.P2P.UnconditionalPeerIDs, ",", " ")))
+	default:
+		maxAccepted = 0
+	}
+
 	return p2p.NewMConnTransport(
 		logger, p2p.MConnConfig(cfg.P2P), []*p2p.ChannelDescriptor{},
 		p2p.MConnTransportOptions{
-			MaxAcceptedConnections: uint32(cfg.P2P.MaxNumInboundPeers +
-				len(tmstrings.SplitAndTrimEmpty(cfg.P2P.UnconditionalPeerIDs, ",", " ")),
-			),
+			MaxAcceptedConnections: maxAccepted,
 		},
 	)
 }


### PR DESCRIPTION
When using non-legacy p2p, this value still relied on the legacy p2p configuration value. This meant that the max accepted connections and the configured max connections could be out of sync, resulting in a failure of the router to actually process all of its pending connections.