### PR TITLE
mempool: ensure async requests are flushed to the server

### DIFF
--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -340,7 +340,9 @@ func (cli *grpcClient) finishSyncCall(reqres *ReqRes) *types.Response {
 //----------------------------------------
 
 func (cli *grpcClient) FlushSync() error {
-	return nil
+	reqres := cli.FlushAsync()
+	cli.finishSyncCall(reqres).GetFlush()
+	return cli.Error()
 }
 
 func (cli *grpcClient) EchoSync(msg string) (*types.ResponseEcho, error) {


### PR DESCRIPTION
In the v0.34 line, the socket and gRPC clients require explicit flushes to
ensure that the client and server have received an async request.  Add these
calls explicitly where required in the backport of the priority mempool.

In addition, the gRPC client's flush plumbing was not fully hooked up in the
v0.34 line, so this change includes that update as well.
