### PR TITLE
config: fix the comments on p2p.queue-type

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -298,11 +298,12 @@ pprof-laddr = "{{ .RPC.PprofListenAddress }}"
 #######################################################
 [p2p]
 
+# Enable the legacy p2p layer.
+use-legacy = {{ .P2P.UseLegacy }}
+
 # Select the p2p internal queue.
 # Options are: "fifo", "simple-priority", "priority", and "wdrr"
 # with the default being "priority".
-use-legacy = {{ .P2P.UseLegacy }}
-
 queue-type = "{{ .P2P.QueueType }}"
 
 # Address to listen for incoming connections


### PR DESCRIPTION
These got disarranged during a previous cleanup.
