### PR TITLE
Chore(mempool): refactor mempool into ABCI concerns and Storage concerns with clear dependencies

### DIFF
--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -22,9 +22,9 @@ import (
 )
 
 // for testing
-func assertMempool(t *testing.T, txn txNotifier) mempool.Mempool {
+func assertMempool(t *testing.T, txn txNotifier) mempool.MempoolABCI {
 	t.Helper()
-	mp, ok := txn.(mempool.Mempool)
+	mp, ok := txn.(mempool.MempoolABCI)
 	require.True(t, ok)
 	return mp
 }
@@ -218,7 +218,8 @@ func TestMempoolRmBadTx(t *testing.T) {
 
 		// check for the tx
 		for {
-			txs := assertMempool(t, cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1)
+			txs, err := assertMempool(t, cs.txNotifier).Reap(ctx, mempool.ReapBytes(int64(len(txBytes))))
+			require.NoError(t, err)
 			if len(txs) == 0 {
 				emptyMempoolCh <- struct{}{}
 				return

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -24,9 +24,7 @@ import (
 // for testing
 func assertMempool(t *testing.T, txn txNotifier) mempool.MempoolABCI {
 	t.Helper()
-	mp, ok := txn.(mempool.MempoolABCI)
-	require.True(t, ok)
-	return mp
+	return txn.(mempool.MempoolABCI)
 }
 
 func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {

--- a/internal/consensus/replay_stubs.go
+++ b/internal/consensus/replay_stubs.go
@@ -17,17 +17,25 @@ import (
 
 type emptyMempool struct{}
 
-var _ mempool.Mempool = emptyMempool{}
+var _ mempool.MempoolABCI = emptyMempool{}
 
 func (emptyMempool) Lock()     {}
 func (emptyMempool) Unlock()   {}
-func (emptyMempool) Size() int { return 0 }
+func (emptyMempool) size() int { return 0 }
 func (emptyMempool) CheckTx(context.Context, types.Tx, func(*abci.ResponseCheckTx), mempool.TxInfo) error {
 	return nil
 }
-func (emptyMempool) RemoveTxByKey(txKey types.TxKey) error   { return nil }
-func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64) types.Txs { return types.Txs{} }
-func (emptyMempool) ReapMaxTxs(n int) types.Txs              { return types.Txs{} }
+func (m emptyMempool) PoolMeta() mempool.PoolMeta { return mempool.PoolMeta{} }
+func (m emptyMempool) PrepBlockFinality(ctx context.Context) (finishFn func(), err error) {
+	return func() {}, nil
+}
+func (m emptyMempool) Reap(ctx context.Context, opts ...mempool.ReapOptFn) (types.Txs, error) {
+	return types.Txs{}, nil
+}
+func (m emptyMempool) Remove(ctx context.Context, opts ...mempool.RemOptFn) error { return nil }
+func (emptyMempool) RemoveTxByKey(txKey types.TxKey) error                        { return nil }
+func (emptyMempool) ReapMaxBytesMaxGas(_, _ int64) types.Txs                      { return types.Txs{} }
+func (emptyMempool) ReapMaxTxs(n int) types.Txs                                   { return types.Txs{} }
 func (emptyMempool) Update(
 	_ context.Context,
 	_ int64,
@@ -38,7 +46,7 @@ func (emptyMempool) Update(
 ) error {
 	return nil
 }
-func (emptyMempool) Flush()                                 {}
+func (emptyMempool) Flush(ctx context.Context) error        { return nil }
 func (emptyMempool) FlushAppConn(ctx context.Context) error { return nil }
 func (emptyMempool) TxsAvailable() <-chan struct{}          { return make(chan struct{}) }
 func (emptyMempool) EnableTxsAvailable()                    {}

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -300,7 +300,7 @@ type simulatorTestSuite struct {
 	Commits      []*types.Commit
 	CleanupFunc  cleanupFunc
 
-	Mempool mempool.Mempool
+	Mempool mempool.MempoolABCI
 	Evpool  sm.EvidencePool
 }
 
@@ -819,7 +819,7 @@ func applyBlock(
 	ctx context.Context,
 	t *testing.T,
 	stateStore sm.Store,
-	mempool mempool.Mempool,
+	mempool mempool.MempoolABCI,
 	evpool sm.EvidencePool,
 	st sm.State,
 	blk *types.Block,
@@ -843,7 +843,7 @@ func buildAppStateFromChain(
 	t *testing.T,
 	appClient abciclient.Client,
 	stateStore sm.Store,
-	mempool mempool.Mempool,
+	mempool mempool.MempoolABCI,
 	evpool sm.EvidencePool,
 	state sm.State,
 	chain []*types.Block,
@@ -893,7 +893,7 @@ func buildTMStateFromChain(
 	t *testing.T,
 	cfg *config.Config,
 	logger log.Logger,
-	mempool mempool.Mempool,
+	mempool mempool.MempoolABCI,
 	evpool sm.EvidencePool,
 	stateStore sm.Store,
 	state sm.State,

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	abciclient "github.com/tendermint/tendermint/abci/client"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/config"
@@ -18,7 +19,7 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-var _ Mempool = (*TxMempool)(nil)
+var _ Pool = (*TxMempool)(nil)
 
 // TxMempoolOption sets an optional parameter on the TxMempool.
 type TxMempoolOption func(*TxMempool)
@@ -33,19 +34,11 @@ type TxMempool struct {
 	config       *config.MempoolConfig
 	proxyAppConn abciclient.Client
 
-	// txsAvailable fires once for each height when the mempool is not empty
-	txsAvailable         chan struct{}
-	notifiedTxsAvailable bool
-
 	// height defines the last block height process during Update()
 	height int64
 
-	// sizeBytes defines the total size of the mempool (sum of all tx bytes)
-	sizeBytes int64
-
-	// cache defines a fixed-size cache of already seen transactions as this
-	// reduces pressure on the proxyApp.
-	cache TxCache
+	// szBytes defines the total size of the mempool (sum of all tx bytes)
+	szBytes int64
 
 	// txStore defines the main storage of valid transactions. Indexes are built
 	// on top of this store.
@@ -86,7 +79,6 @@ type TxMempool struct {
 	// however, a caller must explicitly grab a write-lock via Lock when updating
 	// the mempool via Update().
 	mtx       sync.RWMutex
-	preCheck  PreCheckFunc
 	postCheck PostCheckFunc
 }
 
@@ -102,7 +94,6 @@ func NewTxMempool(
 		config:        cfg,
 		proxyAppConn:  proxyAppConn,
 		height:        -1,
-		cache:         NopTxCache{},
 		metrics:       NopMetrics(),
 		txStore:       NewTxStore(),
 		gossipIndex:   clist.New(),
@@ -115,22 +106,11 @@ func NewTxMempool(
 		}),
 	}
 
-	if cfg.CacheSize > 0 {
-		txmp.cache = NewLRUTxCache(cfg.CacheSize)
-	}
-
 	for _, opt := range options {
 		opt(txmp)
 	}
 
 	return txmp
-}
-
-// WithPreCheck sets a filter for the mempool to reject a transaction if f(tx)
-// returns an error. This is executed before CheckTx. It only applies to the
-// first created block. After that, Update() overwrites the existing value.
-func WithPreCheck(f PreCheckFunc) TxMempoolOption {
-	return func(txmp *TxMempool) { txmp.preCheck = f }
 }
 
 // WithPostCheck sets a filter for the mempool to reject a transaction if
@@ -145,34 +125,25 @@ func WithMetrics(metrics *Metrics) TxMempoolOption {
 	return func(txmp *TxMempool) { txmp.metrics = metrics }
 }
 
-// Lock obtains a write-lock on the mempool. A caller must be sure to explicitly
-// release the lock when finished.
-func (txmp *TxMempool) Lock() {
-	txmp.mtx.Lock()
-}
-
-// Unlock releases a write-lock on the mempool.
-func (txmp *TxMempool) Unlock() {
-	txmp.mtx.Unlock()
+// Meta returns the tx mempool's metatdata.
+func (txmp *TxMempool) Meta() PoolMeta {
+	return PoolMeta{
+		Type:       "priority",
+		Size:       txmp.txStore.Size(),
+		TotalBytes: atomic.LoadInt64(&txmp.szBytes),
+	}
 }
 
 // Size returns the number of valid transactions in the mempool. It is
 // thread-safe.
-func (txmp *TxMempool) Size() int {
+func (txmp *TxMempool) size() int {
 	return txmp.txStore.Size()
 }
 
 // SizeBytes return the total sum in bytes of all the valid transactions in the
 // mempool. It is thread-safe.
-func (txmp *TxMempool) SizeBytes() int64 {
-	return atomic.LoadInt64(&txmp.sizeBytes)
-}
-
-// FlushAppConn executes FlushSync on the mempool's proxyAppConn.
-//
-// NOTE: The caller must obtain a write-lock prior to execution.
-func (txmp *TxMempool) FlushAppConn(ctx context.Context) error {
-	return txmp.proxyAppConn.Flush(ctx)
+func (txmp *TxMempool) sizeBytes() int64 {
+	return atomic.LoadInt64(&txmp.szBytes)
 }
 
 // WaitForNextTx returns a blocking channel that will be closed when the next
@@ -188,116 +159,72 @@ func (txmp *TxMempool) NextGossipTx() *clist.CElement {
 	return txmp.gossipIndex.Front()
 }
 
-// EnableTxsAvailable enables the mempool to trigger events when transactions
-// are available on a block by block basis.
-func (txmp *TxMempool) EnableTxsAvailable() {
-	txmp.mtx.Lock()
-	defer txmp.mtx.Unlock()
-
-	txmp.txsAvailable = make(chan struct{}, 1)
-}
-
-// TxsAvailable returns a channel which fires once for every height, and only
-// when transactions are available in the mempool. It is thread-safe.
-func (txmp *TxMempool) TxsAvailable() <-chan struct{} {
-	return txmp.txsAvailable
-}
-
-// CheckTx executes the ABCI CheckTx method for a given transaction.
-// It acquires a read-lock and attempts to execute the application's
-// CheckTx ABCI method synchronously. We return an error if any of
-// the following happen:
-//
-// - The CheckTx execution fails.
-// - The transaction already exists in the cache and we've already received the
-//   transaction from the peer. Otherwise, if it solely exists in the cache, we
-//   return nil.
-// - The transaction size exceeds the maximum transaction size as defined by the
-//   configuration provided to the mempool.
-// - The transaction fails Pre-Check (if it is defined).
-// - The proxyAppConn fails, e.g. the buffer is full.
-//
-// If the mempool is full, we still execute CheckTx and attempt to find a lower
-// priority transaction to evict. If such a transaction exists, we remove the
-// lower priority transaction and add the new one with higher priority.
-//
-// NOTE:
-// - The applications' CheckTx implementation may panic.
-// - The caller is not to explicitly require any locks for executing CheckTx.
-func (txmp *TxMempool) CheckTx(
-	ctx context.Context,
-	tx types.Tx,
-	cb func(*abci.ResponseCheckTx),
-	txInfo TxInfo,
-) error {
-	txmp.mtx.RLock()
-	defer txmp.mtx.RUnlock()
-
-	if txSize := len(tx); txSize > txmp.config.MaxTxBytes {
-		return types.ErrTxTooLarge{
-			Max:    txmp.config.MaxTxBytes,
-			Actual: txSize,
-		}
-	}
-
-	if txmp.preCheck != nil {
-		if err := txmp.preCheck(tx); err != nil {
-			return types.ErrPreCheck{Reason: err}
-		}
-	}
-
-	if err := txmp.proxyAppConn.Error(); err != nil {
-		return err
-	}
-
-	txHash := tx.Key()
-
-	// We add the transaction to the mempool's cache and if the
-	// transaction is already present in the cache, i.e. false is returned, then we
-	// check if we've seen this transaction and error if we have.
-	if !txmp.cache.Push(tx) {
-		txmp.txStore.GetOrSetPeerByTxHash(txHash, txInfo.SenderID)
-		return types.ErrTxInCache
-	}
-
-	res, err := txmp.proxyAppConn.CheckTx(ctx, abci.RequestCheckTx{Tx: tx})
-	if err != nil {
-		txmp.cache.Remove(tx)
-		return err
-	}
-
+// CheckTXCallback satisfies the behavior the MempoolABCI client depends on from the
+// Pool type. In this, our MempoolABCI client is managing the Locking and app conn.
+// The CheckTXCallback only happens after the necessary abci preparations have been
+// made. Removing those concerns from our store implementation.
+func (txmp *TxMempool) CheckTXCallback(ctx context.Context, tx types.Tx, res *abci.ResponseCheckTx, txInfo TxInfo) (OpResult, error) {
 	if txmp.recheckCursor != nil {
-		return errors.New("recheck cursor is non-nil")
+		return OpResult{}, errors.New("recheck cursor is non-nil")
 	}
 
 	wtx := &WrappedTx{
 		tx:        tx,
-		hash:      txHash,
+		hash:      tx.Key(),
 		timestamp: time.Now().UTC(),
 		height:    txmp.height,
 	}
 
-	txmp.defaultTxCallback(tx, res)
-	txmp.initTxCallback(wtx, res, txInfo)
-
-	if cb != nil {
-		cb(res)
+	var opRes OpResult
+	defCBOpRes := txmp.defaultTxCallback(tx, res)
+	if defCBOpRes.Status != "" {
+		opRes.Status = defCBOpRes.Status
 	}
 
-	return nil
+	initCBOpRes := txmp.initTxCallback(wtx, res, txInfo)
+	if opRes.Status == "" && initCBOpRes.Status != "" {
+		opRes.Status = initCBOpRes.Status
+	}
+	opRes.RemovedTXs = make(types.Txs, 0, len(defCBOpRes.RemovedTXs)+len(initCBOpRes.RemovedTXs))
+	opRes.RemovedTXs = append(opRes.RemovedTXs, defCBOpRes.RemovedTXs...)
+	opRes.RemovedTXs = append(opRes.RemovedTXs, initCBOpRes.RemovedTXs...)
+
+	return opRes, nil
 }
 
-func (txmp *TxMempool) RemoveTxByKey(txKey types.TxKey) error {
-	txmp.Lock()
-	defer txmp.Unlock()
+// Remove removes TXs from the underlying store.
+func (txmp *TxMempool) Remove(ctx context.Context, opts ...RemOptFn) (OpResult, error) {
+	opt := CoalesceRemOptFns(opts...)
 
-	// remove the committed transaction from the transaction store and indexes
-	if wtx := txmp.txStore.GetTxByHash(txKey); wtx != nil {
-		txmp.removeTx(wtx, false)
-		return nil
+	var (
+		err   *multierror.Error
+		opRes OpResult
+	)
+
+	for _, txKey := range opt.TXKeys {
+		tx, remErr := txmp.removeTxByKey(txKey)
+		if remErr != nil {
+			err = multierror.Append(err, remErr)
+			continue
+		}
+		opRes.RemovedTXs = append(opRes.RemovedTXs, tx)
 	}
 
-	return errors.New("transaction not found")
+	return opRes, err.ErrorOrNil()
+}
+
+func (txmp *TxMempool) removeTxByKey(txKey types.TxKey) (types.Tx, error) {
+	txmp.mtx.Lock()
+	defer txmp.mtx.Unlock()
+
+	// remove the committed transaction from the transaction store and indexes
+	wtx := txmp.txStore.GetTxByHash(txKey)
+	if wtx == nil {
+		return nil, errors.New("transaction not found")
+	}
+	txmp.removeTx(wtx)
+
+	return wtx.tx, nil
 }
 
 // Flush empties the mempool. It acquires a read-lock, fetches all the
@@ -306,7 +233,7 @@ func (txmp *TxMempool) RemoveTxByKey(txKey types.TxKey) error {
 //
 // NOTE:
 // - Flushing the mempool may leave the mempool in an inconsistent state.
-func (txmp *TxMempool) Flush() {
+func (txmp *TxMempool) Flush(ctx context.Context) error {
 	txmp.mtx.RLock()
 	defer txmp.mtx.RUnlock()
 
@@ -314,20 +241,42 @@ func (txmp *TxMempool) Flush() {
 	txmp.timestampIndex.Reset()
 
 	for _, wtx := range txmp.txStore.GetAllTxs() {
-		txmp.removeTx(wtx, false)
+		txmp.removeTx(wtx)
 	}
 
-	atomic.SwapInt64(&txmp.sizeBytes, 0)
-	txmp.cache.Reset()
+	atomic.SwapInt64(&txmp.szBytes, 0)
+
+	return nil
 }
 
-// ReapMaxBytesMaxGas returns a list of transactions within the provided size
+// Reap will return a list of TXs by the chose input. As of writing this, this implementation
+// only supports providing either NumTXs or one of GasLimit BlockSizeLimit. Providing non
+// default values for all values, will result in an error.
+func (txmp *TxMempool) Reap(ctx context.Context, opts ...ReapOptFn) (types.Txs, error) {
+	opt := CoalesceReapOpts(opts...)
+
+	if opt.NumTXs > -1 && (opt.GasLimit > -1 || opt.BlockSizeLimit > -1) {
+		return nil, errors.New("reaping by num txs and one of gas limit or block size limit is not supported")
+	}
+
+	if opt.NumTXs == -1 && opt.GasLimit == -1 && opt.BlockSizeLimit == -1 {
+		return txmp.reapMaxTxs(-1), nil
+	}
+
+	if opt.NumTXs > -1 {
+		return txmp.reapMaxTxs(opt.NumTXs), nil
+	}
+
+	return txmp.reapMaxBytesMaxGas(opt.BlockSizeLimit, opt.GasLimit), nil
+}
+
+// reapMaxBytesMaxGas returns a list of transactions within the provided size
 // and gas constraints. Transaction are retrieved in priority order.
 //
 // NOTE:
 // - Transactions returned are not removed from the mempool transaction
 //   store or indexes.
-func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
+func (txmp *TxMempool) reapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
 	txmp.mtx.RLock()
 	defer txmp.mtx.RUnlock()
 
@@ -372,13 +321,13 @@ func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
 	return txs
 }
 
-// ReapMaxTxs returns a list of transactions within the provided number of
+// reapMaxTxs returns a list of transactions within the provided number of
 // transactions bound. Transaction are retrieved in priority order.
 //
 // NOTE:
 // - Transactions returned are not removed from the mempool transaction
 //   store or indexes.
-func (txmp *TxMempool) ReapMaxTxs(max int) types.Txs {
+func (txmp *TxMempool) reapMaxTxs(max int) types.Txs {
 	txmp.mtx.RLock()
 	defer txmp.mtx.RUnlock()
 
@@ -387,12 +336,12 @@ func (txmp *TxMempool) ReapMaxTxs(max int) types.Txs {
 		max = numTxs
 	}
 
-	cap := tmmath.MinInt(numTxs, max)
+	capacity := tmmath.MinInt(numTxs, max)
 
 	// wTxs contains a list of *WrappedTx retrieved from the priority queue that
 	// need to be re-enqueued prior to returning.
-	wTxs := make([]*WrappedTx, 0, cap)
-	txs := make([]types.Tx, 0, cap)
+	wTxs := make([]*WrappedTx, 0, capacity)
+	txs := make([]types.Tx, 0, capacity)
 	for txmp.priorityIndex.NumTxs() > 0 && len(txs) < max {
 		wtx := txmp.priorityIndex.PopTx()
 		txs = append(txs, wtx.tx)
@@ -404,45 +353,28 @@ func (txmp *TxMempool) ReapMaxTxs(max int) types.Txs {
 	return txs
 }
 
-// Update iterates over all the transactions provided by the block producer,
-// removes them from the cache (if applicable), and removes
-// the transactions from the main transaction store and associated indexes.
-// If there are transactions remaining in the mempool, we initiate a
-// re-CheckTx for them (if applicable), otherwise, we notify the caller more
-// transactions are available.
-//
-// NOTE:
-// - The caller must explicitly acquire a write-lock.
-func (txmp *TxMempool) Update(
-	ctx context.Context,
-	blockHeight int64,
-	blockTxs types.Txs,
-	execTxResult []*abci.ExecTxResult,
-	newPreFn PreCheckFunc,
-	newPostFn PostCheckFunc,
-) error {
+// OnUpdate fulfills the behavior the MempoolABCI client needs. The contract with the MempoolABCI
+// client is that the MempoolABCI client manages locking/unlocking and all preparation for the
+// update. Additionally, caching to reduce app pressure happens there as well.
+func (txmp *TxMempool) OnUpdate(ctx context.Context, blockHeight int64, blockTxs types.Txs, txResults []*abci.ExecTxResult, newPostFn PostCheckFunc) (OpResult, error) {
 	txmp.height = blockHeight
-	txmp.notifiedTxsAvailable = false
-
-	if newPreFn != nil {
-		txmp.preCheck = newPreFn
-	}
 	if newPostFn != nil {
 		txmp.postCheck = newPostFn
 	}
 
+	var opRes OpResult
 	for i, tx := range blockTxs {
-		if execTxResult[i].Code == abci.CodeTypeOK {
+		if txResults[i].Code == abci.CodeTypeOK {
 			// add the valid committed transaction to the cache (if missing)
-			_ = txmp.cache.Push(tx)
+			opRes.AddedTXs = append(opRes.AddedTXs, tx)
 		} else if !txmp.config.KeepInvalidTxsInCache {
 			// allow invalid transactions to be re-submitted
-			txmp.cache.Remove(tx)
+			opRes.RemovedTXs = append(opRes.RemovedTXs, tx)
 		}
 
 		// remove the committed transaction from the transaction store and indexes
 		if wtx := txmp.txStore.GetTxByHash(tx.Key()); wtx != nil {
-			txmp.removeTx(wtx, false)
+			txmp.removeTx(wtx)
 		}
 	}
 
@@ -451,21 +383,25 @@ func (txmp *TxMempool) Update(
 	// If there any uncommitted transactions left in the mempool, we either
 	// initiate re-CheckTx per remaining transaction or notify that remaining
 	// transactions are left.
-	if txmp.Size() > 0 {
+	if txmp.size() > 0 {
 		if txmp.config.Recheck {
 			txmp.logger.Debug(
 				"executing re-CheckTx for all remaining transactions",
-				"num_txs", txmp.Size(),
+				"num_txs", txmp.size(),
 				"height", blockHeight,
 			)
-			txmp.updateReCheckTxs(ctx)
+			updateOpRes := txmp.updateReCheckTxs(ctx)
+			opRes.Status = updateOpRes.Status
+			opRes.AddedTXs = append(opRes.AddedTXs, updateOpRes.AddedTXs...)
+			opRes.RemovedTXs = append(opRes.RemovedTXs, updateOpRes.RemovedTXs...)
 		} else {
-			txmp.notifyTxsAvailable()
+			opRes.Status = StatusTXsAvailable
 		}
 	}
 
-	txmp.metrics.Size.Set(float64(txmp.Size()))
-	return nil
+	txmp.metrics.Size.Set(float64(txmp.size()))
+
+	return opRes, nil
 }
 
 // initTxCallback is the callback invoked for a new unique transaction after CheckTx
@@ -487,7 +423,9 @@ func (txmp *TxMempool) Update(
 //
 // NOTE:
 // - An explicit lock is NOT required.
-func (txmp *TxMempool) initTxCallback(wtx *WrappedTx, res *abci.ResponseCheckTx, txInfo TxInfo) {
+// TODO(berg): move this into ABCI, this is likely universal, also we get to consolidate the
+// 			   postCheckFn in ABCI as well as the cache
+func (txmp *TxMempool) initTxCallback(wtx *WrappedTx, res *abci.ResponseCheckTx, txInfo TxInfo) OpResult {
 	var err error
 	if txmp.postCheck != nil {
 		err = txmp.postCheck(wtx.tx, res)
@@ -506,13 +444,10 @@ func (txmp *TxMempool) initTxCallback(wtx *WrappedTx, res *abci.ResponseCheckTx,
 
 		txmp.metrics.FailedTxs.Add(1)
 
-		if !txmp.config.KeepInvalidTxsInCache {
-			txmp.cache.Remove(wtx.tx)
-		}
 		if err != nil {
 			res.MempoolError = err.Error()
 		}
-		return
+		return OpResult{RemovedTXs: types.Txs{wtx.tx}}
 	}
 
 	sender := res.Sender
@@ -526,37 +461,39 @@ func (txmp *TxMempool) initTxCallback(wtx *WrappedTx, res *abci.ResponseCheckTx,
 				"sender", sender,
 			)
 			txmp.metrics.RejectedTxs.Add(1)
-			return
+			return OpResult{}
 		}
 	}
 
+	var evictedTXs types.Txs
 	if err := txmp.canAddTx(wtx); err != nil {
 		evictTxs := txmp.priorityIndex.GetEvictableTxs(
 			priority,
 			int64(wtx.Size()),
-			txmp.SizeBytes(),
+			txmp.sizeBytes(),
 			txmp.config.MaxTxsBytes,
 		)
 		if len(evictTxs) == 0 {
 			// No room for the new incoming transaction so we just remove it from
 			// the cache.
-			txmp.cache.Remove(wtx.tx)
 			txmp.logger.Error(
 				"rejected incoming good transaction; mempool full",
 				"tx", fmt.Sprintf("%X", wtx.tx.Hash()),
 				"err", err.Error(),
 			)
 			txmp.metrics.RejectedTxs.Add(1)
-			return
+			return OpResult{RemovedTXs: types.Txs{wtx.tx}}
 		}
 
+		evictedTXs = make(types.Txs, 0, len(evictTxs))
 		// evict an existing transaction(s)
 		//
 		// NOTE:
 		// - The transaction, toEvict, can be removed while a concurrent
 		//   reCheckTx callback is being executed for the same transaction.
 		for _, toEvict := range evictTxs {
-			txmp.removeTx(toEvict, true)
+			evictedTXs = append(evictedTXs, toEvict.tx)
+			txmp.removeTx(toEvict)
 			txmp.logger.Debug(
 				"evicted existing good transaction; mempool full",
 				"old_tx", fmt.Sprintf("%X", toEvict.tx.Hash()),
@@ -576,7 +513,7 @@ func (txmp *TxMempool) initTxCallback(wtx *WrappedTx, res *abci.ResponseCheckTx,
 	}
 
 	txmp.metrics.TxSizeBytes.Observe(float64(wtx.Size()))
-	txmp.metrics.Size.Set(float64(txmp.Size()))
+	txmp.metrics.Size.Set(float64(txmp.size()))
 
 	txmp.insertTx(wtx)
 	txmp.logger.Debug(
@@ -584,9 +521,13 @@ func (txmp *TxMempool) initTxCallback(wtx *WrappedTx, res *abci.ResponseCheckTx,
 		"priority", wtx.priority,
 		"tx", fmt.Sprintf("%X", wtx.tx.Hash()),
 		"height", txmp.height,
-		"num_txs", txmp.Size(),
+		"num_txs", txmp.size(),
 	)
-	txmp.notifyTxsAvailable()
+
+	return OpResult{
+		RemovedTXs: evictedTXs,
+		Status:     StatusTXsAvailable,
+	}
 }
 
 // defaultTxCallback is the CheckTx application callback used when a
@@ -596,9 +537,9 @@ func (txmp *TxMempool) initTxCallback(wtx *WrappedTx, res *abci.ResponseCheckTx,
 // enabled, then all remaining transactions will be rechecked via
 // CheckTx. The order transactions are rechecked must be the same as
 // the order in which this callback is called.
-func (txmp *TxMempool) defaultTxCallback(tx types.Tx, res *abci.ResponseCheckTx) {
+func (txmp *TxMempool) defaultTxCallback(tx types.Tx, res *abci.ResponseCheckTx) OpResult {
 	if txmp.recheckCursor == nil {
-		return
+		return OpResult{}
 	}
 
 	txmp.metrics.RecheckTimes.Add(1)
@@ -626,13 +567,14 @@ func (txmp *TxMempool) defaultTxCallback(tx types.Tx, res *abci.ResponseCheckTx)
 			// matching the one we received from the ABCI application.
 			// Return without processing any tx.
 			txmp.recheckCursor = nil
-			return
+			return OpResult{}
 		}
 
 		txmp.recheckCursor = txmp.recheckCursor.Next()
 		wtx = txmp.recheckCursor.Value.(*WrappedTx)
 	}
 
+	var opRes OpResult
 	// Only evaluate transactions that have not been removed. This can happen
 	// if an existing transaction is evicted during CheckTx and while this
 	// callback is being executed for the same evicted transaction.
@@ -656,8 +598,8 @@ func (txmp *TxMempool) defaultTxCallback(tx types.Tx, res *abci.ResponseCheckTx)
 			if wtx.gossipEl != txmp.recheckCursor {
 				panic("corrupted reCheckTx cursor")
 			}
-
-			txmp.removeTx(wtx, !txmp.config.KeepInvalidTxsInCache)
+			opRes.RemovedTXs = append(opRes.RemovedTXs, wtx.tx)
+			txmp.removeTx(wtx)
 		}
 	}
 
@@ -671,12 +613,14 @@ func (txmp *TxMempool) defaultTxCallback(tx types.Tx, res *abci.ResponseCheckTx)
 	if txmp.recheckCursor == nil {
 		txmp.logger.Debug("finished rechecking transactions")
 
-		if txmp.Size() > 0 {
-			txmp.notifyTxsAvailable()
+		if txmp.size() > 0 {
+			opRes.Status = StatusTXsAvailable
 		}
 	}
 
-	txmp.metrics.Size.Set(float64(txmp.Size()))
+	txmp.metrics.Size.Set(float64(txmp.size()))
+
+	return opRes
 }
 
 // updateReCheckTxs updates the recheck cursors using the gossipIndex. For
@@ -686,14 +630,15 @@ func (txmp *TxMempool) defaultTxCallback(tx types.Tx, res *abci.ResponseCheckTx)
 //
 // NOTE:
 // - The caller must have a write-lock when executing updateReCheckTxs.
-func (txmp *TxMempool) updateReCheckTxs(ctx context.Context) {
-	if txmp.Size() == 0 {
+func (txmp *TxMempool) updateReCheckTxs(ctx context.Context) OpResult {
+	if txmp.size() == 0 {
 		panic("attempted to update re-CheckTx txs when mempool is empty")
 	}
 
 	txmp.recheckCursor = txmp.gossipIndex.Front()
 	txmp.recheckEnd = txmp.gossipIndex.Back()
 
+	var opRes OpResult
 	for e := txmp.gossipIndex.Front(); e != nil; e = e.Next() {
 		wtx := e.Value.(*WrappedTx)
 
@@ -709,13 +654,19 @@ func (txmp *TxMempool) updateReCheckTxs(ctx context.Context) {
 				txmp.logger.Error("failed to execute CheckTx during rechecking", "err", err)
 				continue
 			}
-			txmp.defaultTxCallback(wtx.tx, res)
+			defCBOpRes := txmp.defaultTxCallback(wtx.tx, res)
+			if opRes.Status == "" && defCBOpRes.Status != "" {
+				opRes.Status = defCBOpRes.Status
+			}
+			opRes.RemovedTXs = append(opRes.RemovedTXs, defCBOpRes.RemovedTXs...)
 		}
 	}
 
 	if err := txmp.proxyAppConn.Flush(ctx); err != nil {
 		txmp.logger.Error("failed to flush transactions during rechecking", "err", err)
 	}
+
+	return opRes
 }
 
 // canAddTx returns an error if we cannot insert the provided *WrappedTx into
@@ -723,8 +674,8 @@ func (txmp *TxMempool) updateReCheckTxs(ctx context.Context) {
 // the transaction can be inserted into the mempool.
 func (txmp *TxMempool) canAddTx(wtx *WrappedTx) error {
 	var (
-		numTxs    = txmp.Size()
-		sizeBytes = txmp.SizeBytes()
+		numTxs    = txmp.size()
+		sizeBytes = txmp.sizeBytes()
 	)
 
 	if numTxs >= txmp.config.Size || int64(wtx.Size())+sizeBytes > txmp.config.MaxTxsBytes {
@@ -751,10 +702,10 @@ func (txmp *TxMempool) insertTx(wtx *WrappedTx) {
 	gossipEl := txmp.gossipIndex.PushBack(wtx)
 	wtx.gossipEl = gossipEl
 
-	atomic.AddInt64(&txmp.sizeBytes, int64(wtx.Size()))
+	atomic.AddInt64(&txmp.szBytes, int64(wtx.Size()))
 }
 
-func (txmp *TxMempool) removeTx(wtx *WrappedTx, removeFromCache bool) {
+func (txmp *TxMempool) removeTx(wtx *WrappedTx, ) {
 	if txmp.txStore.IsTxRemoved(wtx.hash) {
 		return
 	}
@@ -769,11 +720,7 @@ func (txmp *TxMempool) removeTx(wtx *WrappedTx, removeFromCache bool) {
 	txmp.gossipIndex.Remove(wtx.gossipEl)
 	wtx.gossipEl.DetachPrev()
 
-	atomic.AddInt64(&txmp.sizeBytes, int64(-wtx.Size()))
-
-	if removeFromCache {
-		txmp.cache.Remove(wtx.tx)
-	}
+	atomic.AddInt64(&txmp.szBytes, int64(-wtx.Size()))
 }
 
 // purgeExpiredTxs removes all transactions that have exceeded their respective
@@ -822,22 +769,6 @@ func (txmp *TxMempool) purgeExpiredTxs(blockHeight int64) {
 	}
 
 	for _, wtx := range expiredTxs {
-		txmp.removeTx(wtx, false)
-	}
-}
-
-func (txmp *TxMempool) notifyTxsAvailable() {
-	if txmp.Size() == 0 {
-		panic("attempt to notify txs available but mempool is empty!")
-	}
-
-	if txmp.txsAvailable != nil && !txmp.notifiedTxsAvailable {
-		// channel cap is 1, so this will send once
-		txmp.notifiedTxsAvailable = true
-
-		select {
-		case txmp.txsAvailable <- struct{}{}:
-		default:
-		}
+		txmp.removeTx(wtx)
 	}
 }

--- a/internal/mempool/mempool_abci.go
+++ b/internal/mempool/mempool_abci.go
@@ -1,0 +1,260 @@
+package mempool
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	abciclient "github.com/tendermint/tendermint/abci/client"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/types"
+)
+
+// ABCI provides an ABCI integration with a mempool store. The ABCI
+// client enforces the tendermint guarantees.
+type ABCI struct {
+	cfg                  *config.MempoolConfig
+	txsAvailable         chan struct{}
+	notifiedTxsAvailable bool
+
+	// cache defines a fixed-size cache of already seen transactions as this
+	// reduces pressure on the proxyApp.
+	cache TxCache
+
+	mtx     sync.RWMutex
+	pool    Pool
+	appConn abciclient.Client
+
+	preCheck PreCheckFunc
+}
+
+var _ MempoolABCI = (*ABCI)(nil)
+
+// NewABCI constructs a new ABCI type.
+func NewABCI(cfg *config.MempoolConfig, appClient abciclient.Client, pool Pool, preCheck PreCheckFunc) *ABCI {
+	out := ABCI{
+		cfg:      cfg,
+		cache:    NopTxCache{},
+		pool:     pool,
+		appConn:  appClient,
+		preCheck: preCheck,
+	}
+
+	if size := cfg.CacheSize; size > 0 {
+		out.cache = NewLRUTxCache(size)
+	}
+
+	return &out
+}
+
+// CheckTx executes the ABCI CheckTx method for a given transaction.
+// It acquires a read-lock and attempts to execute the application's
+// CheckTx ABCI method synchronously. We return an error if any of
+// the following happen:
+//
+// - The CheckTx execution fails.
+// - The transaction already exists in the cache and we've already received the
+//   transaction from the peer. Otherwise, if it solely exists in the cache, we
+//   return nil.
+//   TODO(berg): the above is not accurate, we do not error on that case. It makes
+//				 makes sense to include the peer state here in ABCI type and not the
+//				 mempool store itself.
+// - The transaction size exceeds the maximum transaction size as defined by the
+//   configuration provided to the mempool.
+// - The transaction fails Pre-Check (if it is defined).
+// - The proxyAppConn fails, e.g. the buffer is full.
+// NOTE:
+// - The applications' CheckTx implementation may panic.
+func (a *ABCI) CheckTx(ctx context.Context, tx types.Tx, callback func(*abci.ResponseCheckTx), txInfo TxInfo) error {
+	a.mtx.RLock()
+	defer a.mtx.RUnlock()
+
+	if txSize, maxTXBytes := len(tx), a.cfg.MaxTxBytes; txSize > maxTXBytes {
+		return types.ErrTxTooLarge{
+			Max:    maxTXBytes,
+			Actual: txSize,
+		}
+	}
+
+	if err := a.runPrecheck(tx); err != nil {
+		return types.ErrPreCheck{Reason: err}
+	}
+
+	if err := a.appConn.Error(); err != nil {
+		return err
+	}
+
+	// We add the transaction to the mempool's cache and if the
+	// transaction is already present in the cache, i.e. false is returned, then we
+	// check if we've seen this transaction and error if we have.
+	if !a.cache.Push(tx) {
+		// TODO(berg): the below is pulled directly from TxMempool. I don't understand what
+		// 			   it is doing? None of the returned types are being used? The comment
+		//			   feels before the if block feels misleading. We don't check if we've
+		//			   seen the tx before and error, we just call it and if it gets added
+		//			   to the txstore, so be it :shruggo:
+		//txmp.txStore.GetOrSetPeerByTxHash(txHash, info.SenderID)
+		return types.ErrTxInCache
+	}
+
+	res, err := a.appConn.CheckTx(ctx, abci.RequestCheckTx{Tx: tx})
+	if err != nil {
+		// TODO(berg): need something here for failed on CheckTx
+		return err
+	}
+
+	opRes, err := a.pool.CheckTXCallback(ctx, tx, res, txInfo)
+	if err != nil {
+		return err
+	}
+	a.applyOpResult(opRes)
+
+	if callback != nil {
+		callback(res)
+	}
+
+	return nil
+}
+
+// EnableTxsAvailable enables the mempool to trigger events when transactions
+// are available on a block by block basis.
+func (a *ABCI) EnableTxsAvailable() {
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+
+	a.txsAvailable = make(chan struct{}, 1)
+}
+
+// Flush clears the tx cache and the calls Flush on the underlying pool type.
+func (a *ABCI) Flush(ctx context.Context) error {
+	a.cache.Reset()
+	return a.pool.Flush(ctx)
+}
+
+// PoolMeta returns the metadata for the underlying pool implementation.
+func (a *ABCI) PoolMeta() PoolMeta {
+	return a.pool.Meta()
+}
+
+// PrepBlockFinality prepares the mempool for an upcoming block to be finalized. During
+// the execution of the new block, we want to make sure we are not running any additional
+// CheckTX calls to the application as well as flush any active connections underway.
+func (a *ABCI) PrepBlockFinality(ctx context.Context) (func(), error) {
+	a.mtx.Lock()
+	finishFn := func() { a.mtx.Unlock() }
+
+	err := a.appConn.Flush(ctx)
+	if err != nil {
+		finishFn() // make sure we unlock before returning
+		return func() {}, err
+	}
+
+	return finishFn, nil
+}
+
+// Reap is the sole means to reap TXs atm. Options are provided and when none are provide
+// the mempool store will typically return all TXs. It is up to the store implementation
+// to limit or allow that usecase.
+func (a *ABCI) Reap(ctx context.Context, opts ...ReapOptFn) (types.Txs, error) {
+	return a.pool.Reap(ctx, opts...)
+}
+
+func (a *ABCI) Remove(ctx context.Context, opts ...RemOptFn) error {
+	opRes, err := a.pool.Remove(ctx, opts...)
+	if err != nil {
+		return err
+	}
+	a.applyOpResult(opRes)
+
+	return nil
+}
+
+// Update iterates over all the transactions provided by the block producer,
+// removes them from the cache (if applicable), and removes
+// the transactions from the main transaction store and associated indexes.
+// If there are transactions remaining in the mempool, we initiate a
+// re-CheckTx for them (if applicable), otherwise, we notify the caller more
+// transactions are available.
+//
+// NOTE:
+// - The caller must explicitly call PrepBlockFinality, which locks the client
+//	 and flushes the appconn to enforce we sync state correctly with the app
+//	 on Update. Failure to do so will result in an error.
+func (a *ABCI) Update(
+	ctx context.Context,
+	blockHeight int64,
+	blockTxs types.Txs,
+	txResults []*abci.ExecTxResult,
+	newPreFn PreCheckFunc,
+	newPostFn PostCheckFunc,
+) error {
+	if a.mtx.TryLock() {
+		a.mtx.Unlock()
+		// this TryLock call enforces the caller having to Lock the ABCI client
+		// before executing the Update
+		return fmt.Errorf("caller failed to secure write lock on update; aborting to avoid corrupting application state")
+	}
+
+	a.notifiedTxsAvailable = false
+	if newPreFn != nil {
+		a.preCheck = newPreFn
+	}
+
+	// TODO(berg): the use of newPostFn is very involved in the current
+	//			   design that couples abci and mempool concerns. Need to
+	//			   investigate possiblity of breaking that down so only
+	//			   ABCI is in charge of PostCheckFuncs. Feels like a concern
+	//			   that belongs to ABCI and not the individual mempool
+	//			   implementations. Then again... it may make sense in the
+	//			   Pool itself :thinking_face:...
+	opRes, err := a.pool.OnUpdate(ctx, blockHeight, blockTxs, txResults, newPostFn)
+	if err != nil {
+		return err
+	}
+	a.applyOpResult(opRes)
+
+	return nil
+}
+
+// TxsAvailable returns a channel which fires once for every height, and only
+// when transactions are available in the mempool. It is thread-safe.
+func (a *ABCI) TxsAvailable() <-chan struct{} {
+	return a.txsAvailable
+}
+
+func (a *ABCI) applyOpResult(o OpResult) {
+	for _, tx := range o.AddedTXs {
+		a.cache.Push(tx)
+	}
+
+	if !a.cfg.KeepInvalidTxsInCache {
+		for _, tx := range o.RemovedTXs {
+			a.cache.Remove(tx)
+		}
+	}
+
+	if o.Status == StatusTXsAvailable {
+		a.notifyTxsAvailable()
+	}
+}
+
+func (a *ABCI) notifyTxsAvailable() {
+	if a.txsAvailable == nil || a.notifiedTxsAvailable {
+		return
+	}
+
+	// channel cap is 1, so this will send once
+	a.notifiedTxsAvailable = true
+	select {
+	case a.txsAvailable <- struct{}{}:
+	default:
+	}
+}
+
+func (a *ABCI) runPrecheck(tx types.Tx) error {
+	if a.preCheck == nil {
+		return nil
+	}
+	return a.preCheck(tx)
+}

--- a/internal/mempool/mempool_bench_test.go
+++ b/internal/mempool/mempool_bench_test.go
@@ -16,7 +16,7 @@ func BenchmarkTxMempool_CheckTx(b *testing.B) {
 
 	// setup the cache and the mempool number for hitting GetEvictableTxs during the
 	// benchmark. 5000 is the current default mempool size in the TM config.
-	txmp := setup(ctx, b, 10000)
+	txmp, mpABCI := setup(ctx, b, 10000)
 	txmp.config.Size = 5000
 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -36,6 +36,6 @@ func BenchmarkTxMempool_CheckTx(b *testing.B) {
 
 		b.StartTimer()
 
-		require.NoError(b, txmp.CheckTx(ctx, tx, nil, txInfo))
+		require.NoError(b, mpABCI.CheckTx(ctx, tx, nil, txInfo))
 	}
 }

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -351,7 +351,7 @@ func TestTxMempool_ReapMaxTxs(t *testing.T) {
 	require.Len(t, reapedTxs, len(tTxs))
 
 	// reap a single transaction
-	reapedTxs, err = mpABCI.Reap(ctx, ReapTXs(1))
+	reapedTxs, err = mpABCI.Reap(ctx, ReapTxs(1))
 	require.NoError(t, err)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), mpABCI.PoolMeta().Size)
@@ -359,7 +359,7 @@ func TestTxMempool_ReapMaxTxs(t *testing.T) {
 	require.Len(t, reapedTxs, 1)
 
 	// reap half of the transactions
-	reapedTxs, err = mpABCI.Reap(ctx, ReapTXs(len(tTxs)/2))
+	reapedTxs, err = mpABCI.Reap(ctx, ReapTxs(len(tTxs)/2))
 	require.NoError(t, err)
 	ensurePrioritized(reapedTxs)
 	require.Equal(t, len(tTxs), mpABCI.PoolMeta().Size)
@@ -461,7 +461,7 @@ func TestTxMempool_ConcurrentTxs(t *testing.T) {
 		var height int64 = 1
 
 		for range ticker.C {
-			reapedTxs, err := mpABCI.Reap(ctx, ReapTXs(200))
+			reapedTxs, err := mpABCI.Reap(ctx, ReapTxs(200))
 			require.NoError(t, err)
 			if len(reapedTxs) > 0 {
 				responses := make([]*abci.ExecTxResult, len(reapedTxs))
@@ -512,7 +512,7 @@ func TestTxMempool_ExpiredTxs_NumBlocks(t *testing.T) {
 	require.Equal(t, 100, txmp.heightIndex.Size())
 
 	// reap 5 txs at the next height -- no txs should expire
-	reapedTxs, err := mpABCI.Reap(ctx, ReapTXs(5))
+	reapedTxs, err := mpABCI.Reap(ctx, ReapTxs(5))
 	require.NoError(t, err)
 	responses := make([]*abci.ExecTxResult, len(reapedTxs))
 	for i := 0; i < len(responses); i++ {
@@ -539,7 +539,7 @@ func TestTxMempool_ExpiredTxs_NumBlocks(t *testing.T) {
 	// initial CheckTx calls or from the second round of CheckTx calls. Thus, we
 	// cannot guarantee that all 95 txs are remaining that should be expired and
 	// removed. However, we do know that at most 95 txs can be expired and removed.
-	reapedTxs, err = mpABCI.Reap(ctx, ReapTXs(5))
+	reapedTxs, err = mpABCI.Reap(ctx, ReapTxs(5))
 	require.NoError(t, err)
 	responses = make([]*abci.ExecTxResult, len(reapedTxs))
 	for i := 0; i < len(responses); i++ {

--- a/internal/mempool/mock/mempool.go
+++ b/internal/mempool/mock/mempool.go
@@ -12,17 +12,21 @@ import (
 // Mempool is an empty implementation of a Mempool, useful for testing.
 type Mempool struct{}
 
-var _ Mempool = Mempool{}
+var _ mempool.MempoolABCI = Mempool{}
 
-func (Mempool) Lock()     {}
-func (Mempool) Unlock()   {}
 func (Mempool) Size() int { return 0 }
 func (Mempool) CheckTx(context.Context, types.Tx, func(*abci.ResponseCheckTx), mempool.TxInfo) error {
 	return nil
 }
-func (Mempool) RemoveTxByKey(txKey types.TxKey) error   { return nil }
-func (Mempool) ReapMaxBytesMaxGas(_, _ int64) types.Txs { return types.Txs{} }
-func (Mempool) ReapMaxTxs(n int) types.Txs              { return types.Txs{} }
+func (m Mempool) Remove(ctx context.Context, opts ...mempool.RemOptFn) error { return nil }
+func (Mempool) RemoveTxByKey(txKey types.TxKey) error                        { return nil }
+func (m Mempool) PoolMeta() mempool.PoolMeta                                 { return mempool.PoolMeta{} }
+func (Mempool) PrepBlockFinality(ctx context.Context) (finishFn func(), err error) {
+	return func() {}, nil
+}
+func (m Mempool) Reap(ctx context.Context, opts ...mempool.ReapOptFn) (types.Txs, error) {
+	return types.Txs{}, nil
+}
 func (Mempool) Update(
 	_ context.Context,
 	_ int64,
@@ -33,7 +37,7 @@ func (Mempool) Update(
 ) error {
 	return nil
 }
-func (Mempool) Flush()                                 {}
+func (Mempool) Flush(ctx context.Context) error        { return nil }
 func (Mempool) FlushAppConn(ctx context.Context) error { return nil }
 func (Mempool) TxsAvailable() <-chan struct{}          { return make(chan struct{}) }
 func (Mempool) EnableTxsAvailable()                    {}

--- a/internal/mempool/types.go
+++ b/internal/mempool/types.go
@@ -23,63 +23,41 @@ const (
 	MaxActiveIDs = math.MaxUint16
 )
 
-// Mempool defines the mempool interface.
-//
-// Updates to the mempool need to be synchronized with committing a block so
-// applications can reset their transient state on Commit.
-type Mempool interface {
+// Status is the status of the Pool.
+type Status string
+
+const (
+	// StatusTXsAvailable indicates the pool has txs available.
+	StatusTXsAvailable = "txs_available"
+)
+
+type MempoolABCI interface {
 	// CheckTx executes a new transaction against the application to determine
 	// its validity and whether it should be added to the mempool.
 	CheckTx(ctx context.Context, tx types.Tx, callback func(*abci.ResponseCheckTx), txInfo TxInfo) error
 
-	// RemoveTxByKey removes a transaction, identified by its key,
-	// from the mempool.
-	RemoveTxByKey(txKey types.TxKey) error
+	// EnableTxsAvailable initializes the TxsAvailable channel, ensuring it will
+	// trigger once every height when transactions are available.
+	EnableTxsAvailable()
 
-	// ReapMaxBytesMaxGas reaps transactions from the mempool up to maxBytes
-	// bytes total with the condition that the total gasWanted must be less than
-	// maxGas.
-	//
-	// If both maxes are negative, there is no cap on the size of all returned
-	// transactions (~ all available transactions).
-	ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs
+	// Flush will clear all caches in the MempoolABCI and clear any volatile
+	// memory within the pool.
+	Flush(ctx context.Context) error
 
-	// ReapMaxTxs reaps up to max transactions from the mempool. If max is
-	// negative, there is no cap on the size of all returned transactions
-	// (~ all available transactions).
-	ReapMaxTxs(max int) types.Txs
+	// PoolMeta returns the metadata for the underlying pool implementation.
+	PoolMeta() PoolMeta
 
-	// Lock locks the mempool. The consensus must be able to hold lock to safely
-	// update.
-	Lock()
+	// PrepBlockFinality prepares the mempool for finalizing a block. This may require
+	// locking or other concerns that must be handled before a block is safe to commit.
+	PrepBlockFinality(ctx context.Context) (finishFn func(), err error)
 
-	// Unlock unlocks the mempool.
-	Unlock()
+	// Reap returns Txs from the given pool. It is up to the pool implementation to define
+	// how they handle the possible predicates from option combinations.
+	Reap(ctx context.Context, opts ...ReapOptFn) (types.Txs, error)
 
-	// Update informs the mempool that the given txs were committed and can be
-	// discarded.
-	//
-	// NOTE:
-	// 1. This should be called *after* block is committed by consensus.
-	// 2. Lock/Unlock must be managed by the caller.
-	Update(
-		ctx context.Context,
-		blockHeight int64,
-		blockTxs types.Txs,
-		txResults []*abci.ExecTxResult,
-		newPreFn PreCheckFunc,
-		newPostFn PostCheckFunc,
-	) error
-
-	// FlushAppConn flushes the mempool connection to ensure async callback calls
-	// are done, e.g. from CheckTx.
-	//
-	// NOTE:
-	// 1. Lock/Unlock must be managed by caller.
-	FlushAppConn(context.Context) error
-
-	// Flush removes all transactions from the mempool and caches.
-	Flush()
+	// Remove removes Txs from the given pool. It is up to the pool implementation to
+	// define how they handle the possible predicates from option combinations.
+	Remove(ctx context.Context, opts ...RemOptFn) error
 
 	// TxsAvailable returns a channel which fires once for every height, and only
 	// when transactions are available in the mempool.
@@ -88,15 +66,161 @@ type Mempool interface {
 	// 1. The returned channel may be nil if EnableTxsAvailable was not called.
 	TxsAvailable() <-chan struct{}
 
-	// EnableTxsAvailable initializes the TxsAvailable channel, ensuring it will
-	// trigger once every height when transactions are available.
-	EnableTxsAvailable()
+	// Update informs the mempool that the given txs were committed and can be
+	// discarded.
+	//
+	// NOTE:
+	// 1. This should be called *after* block is committed by consensus.
+	// 2. PrepBlockFinality must be called before calling Update, effectively
+	//	  preparing the MempoolABCI -> App communication so that the application
+	//	  state is correct.
+	Update(
+		ctx context.Context,
+		blockHeight int64,
+		blockTxs types.Txs,
+		txResults []*abci.ExecTxResult,
+		newPreFn PreCheckFunc,
+		newPostFn PostCheckFunc,
+	) error
+}
 
-	// Size returns the number of transactions in the mempool.
-	Size() int
+// OpResult is the result of a pool operation. This result informs the ABCI type
+// what happened in the storage/pool layer so it can maintain cache coherence.
+type OpResult struct {
+	AddedTXs   types.Txs
+	RemovedTXs types.Txs
+	Status     Status
+}
 
-	// SizeBytes returns the total size of all txs in the mempool.
-	SizeBytes() int64
+// PoolMeta is the metadata for a given pool.
+type PoolMeta struct {
+	// Type describes the type of mempool store. Examples could be priority or narwhal.
+	Type string
+	// Size is the num of TXs or whatever the unit of measure for the store.
+	Size int
+	// TotalBytes is a measure of hte store's data size.
+	TotalBytes int64
+}
+
+// Pool defines the underlying pool storage engine behavior.
+type Pool interface {
+	// CheckTXCallback is called by the ABCI type during CheckTX. When called by ABCI,
+	// the CheckTXCallback can assume the ABCI type will hold the app write lock.
+	CheckTXCallback(ctx context.Context, tx types.Tx, res *abci.ResponseCheckTx, txInfo TxInfo) (OpResult, error)
+
+	// Flush removes all transactions from the mempool and caches.
+	Flush(ctx context.Context) error
+
+	// Meta returns metadata for the pool.
+	Meta() PoolMeta
+
+	// OnUpdate is called by the ABCI on an Update. The ABCI type requires the caller
+	// to have called PrepBlockFinality before issuing an Update, thus forcing the
+	// caller to acquire the lock before Update and subsequently, this OnUpdate call
+	// is made.
+	OnUpdate(
+		ctx context.Context,
+		blockHeight int64,
+		blockTxs types.Txs,
+		txResults []*abci.ExecTxResult,
+		newPostFn PostCheckFunc,
+	) (OpResult, error)
+
+	// Reap returns Txs from the given pool. It is up to the pool implementation to define
+	// how they handle the possible predicates from option combinations.
+	Reap(ctx context.Context, opts ...ReapOptFn) (types.Txs, error)
+
+	// Remove removes TXs by the provided RemOptFn. If an argument is provided to the
+	// options that don't make sense for the given pool, then it will be ignored.
+	Remove(ctx context.Context, opts ...RemOptFn) (OpResult, error)
+}
+
+// DisableReapOpt sets the reap opt to disabled. This is the default value for all
+// fields in the ReapOption type. If you call Reap(ctx), you will get all TXs within
+// the mempool (if allowed).
+const DisableReapOpt = -1
+
+// ReapOption is the options to reaping a collection useful to proposal from the mempool.
+// A collection for proposal in teh Clist or Priority mempools, would be a list of TXs.
+// For a DAG (narwhal) mempool, we'd want the DAGCerts for the proposal. However,
+// we use the same predicates to reap from all mempools. When a predicate has multiple opts
+// specified, will take the collections that satisfy all limits specified are adhered too.
+// When a field is set to DisablePredicate (-1), the field will not be enforced.
+//
+// Example predicate: BlockSizeLimit AND NumTXs are both set enforcing that BlockSizeLimit
+//					  and NumTXs limits are satisfied in the Reaping.
+type ReapOption struct {
+	BlockSizeLimit int64
+	GasLimit       int64
+	NumTXs         int
+}
+
+// CoalesceReapOpts provides a quick way to coalesce ReapOptFn's with default field
+// values set to DisableReapOpt.
+func CoalesceReapOpts(opts ...ReapOptFn) ReapOption {
+	opt := ReapOption{
+		BlockSizeLimit: DisableReapOpt,
+		GasLimit:       DisableReapOpt,
+		NumTXs:         DisableReapOpt,
+	}
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}
+
+// ReapOptFn is a functional option for setting the reap predicates.
+type ReapOptFn func(*ReapOption)
+
+// ReapBytes will limit the reap by a maximum number of bytes. Note, if
+// you provide a value less than 0, it will ignore the max bytes limit.
+// This is the same as if you did not provide the option to the Reap method.
+func ReapBytes(maxBytes int64) ReapOptFn {
+	return func(option *ReapOption) {
+		option.BlockSizeLimit = maxBytes
+	}
+}
+
+// ReapGas will limit the reap by the maxGas. Note, if you provide a
+// value less than 0, it will ignore the gas limit. This is the same as if
+// you did not provide the option to the Reap method.
+func ReapGas(maxGas int64) ReapOptFn {
+	return func(option *ReapOption) {
+		option.GasLimit = maxGas
+	}
+}
+
+// ReapTXs will limit the reap to a number of TXs. Note, if you provide
+// a value less than 0, it will ignore the TXs. This is the same as if
+// you did not provide the option to the Reap method.
+func ReapTXs(maxTXs int) ReapOptFn {
+	return func(option *ReapOption) {
+		option.NumTXs = maxTXs
+	}
+}
+
+// RemOption is an option for removing TXs from a pool.
+type RemOption struct {
+	TXKeys []types.TxKey
+}
+
+// RemOptFn is a functional option definition for setting fields on RemOption.
+type RemOptFn func(option *RemOption)
+
+// CoalesceRemOptFns returns a RemOption ready for processing.
+func CoalesceRemOptFns(opts ...RemOptFn) RemOption {
+	var opt RemOption
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}
+
+// RemByTXKeys removes a transaction(s), identified by its key, from the mempool.
+func RemByTXKeys(txs ...types.TxKey) RemOptFn {
+	return func(option *RemOption) {
+		option.TXKeys = append(option.TXKeys, txs...)
+	}
 }
 
 // PreCheckFunc is an optional filter executed before CheckTx and rejects

--- a/internal/rpc/core/dev.go
+++ b/internal/rpc/core/dev.go
@@ -8,6 +8,8 @@ import (
 
 // UnsafeFlushMempool removes all transactions from the mempool.
 func (env *Environment) UnsafeFlushMempool(ctx context.Context) (*coretypes.ResultUnsafeFlushMempool, error) {
-	env.Mempool.Flush()
+	if err := env.Mempool.Flush(ctx); err != nil {
+		return nil, err
+	}
 	return &coretypes.ResultUnsafeFlushMempool{}, nil
 }

--- a/internal/rpc/core/env.go
+++ b/internal/rpc/core/env.go
@@ -90,7 +90,7 @@ type Environment struct {
 	EventSinks        []indexer.EventSink
 	EventBus          *eventbus.EventBus // thread safe
 	EventLog          *eventlog.Log
-	Mempool           mempool.Mempool
+	Mempool           mempool.MempoolABCI
 	StateSyncMetricer statesync.Metricer
 
 	Logger log.Logger

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -135,7 +135,7 @@ func (env *Environment) UnconfirmedTxs(ctx context.Context, pagePtr, perPagePtr 
 
 	skipCount := validateSkipCount(page, perPage)
 
-	txs, err := env.Mempool.Reap(ctx, mempool.ReapTXs(skipCount+tmmath.MinInt(perPage, totalCount-skipCount)))
+	txs, err := env.Mempool.Reap(ctx, mempool.ReapTxs(skipCount+tmmath.MinInt(perPage, totalCount-skipCount)))
 	if err != nil {
 		return nil, err
 	}
@@ -171,5 +171,5 @@ func (env *Environment) CheckTx(ctx context.Context, tx types.Tx) (*coretypes.Re
 }
 
 func (env *Environment) RemoveTx(ctx context.Context, txkey types.TxKey) error {
-	return env.Mempool.Remove(ctx, mempool.RemByTXKeys(txkey))
+	return env.Mempool.Remove(ctx, mempool.RemByTxKeys(txkey))
 }

--- a/node/node.go
+++ b/node/node.go
@@ -267,7 +267,7 @@ func makeNode(
 			makeCloser(closers))
 	}
 
-	mpReactor, mp, err := createMempoolReactor(ctx,
+	mpReactor, mpABCI, err := createMempoolReactor(ctx,
 		cfg, proxyApp, stateStore, nodeMetrics.mempool, peerManager, router, logger,
 	)
 	if err != nil {
@@ -286,7 +286,7 @@ func makeNode(
 		stateStore,
 		logger.With("module", "state"),
 		proxyApp,
-		mp,
+		mpABCI,
 		evPool,
 		blockStore,
 		eventBus,
@@ -298,7 +298,7 @@ func makeNode(
 	blockSync := !onlyValidatorIsUs(state, pubKey)
 
 	csReactor, csState, err := createConsensusReactor(ctx,
-		cfg, stateStore, blockExec, blockStore, mp, evPool,
+		cfg, stateStore, blockExec, blockStore, mpABCI, evPool,
 		privValidator, nodeMetrics.consensus, stateSync || blockSync, eventBus,
 		peerManager, router, logger,
 	)
@@ -411,7 +411,7 @@ func makeNode(
 			EventSinks: eventSinks,
 			EventBus:   eventBus,
 			EventLog:   eventLog,
-			Mempool:    mp,
+			Mempool:    mpABCI,
 			Logger:     logger.With("module", "rpc"),
 			Config:     *cfg.RPC,
 		},

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -293,6 +293,7 @@ func TestCreateProposalBlock(t *testing.T) {
 		cfg.Mempool,
 		proxyApp,
 	)
+	mpABCI := mempool.NewABCI(cfg.Mempool, proxyApp, mp, nil)
 
 	// Make EvidencePool
 	evidenceDB := dbm.NewMemDB()
@@ -319,7 +320,7 @@ func TestCreateProposalBlock(t *testing.T) {
 	txLength := 100
 	for i := 0; i <= maxBytes/txLength; i++ {
 		tx := tmrand.Bytes(txLength)
-		err := mp.CheckTx(ctx, tx, nil, mempool.TxInfo{})
+		err := mpABCI.CheckTx(ctx, tx, nil, mempool.TxInfo{})
 		assert.NoError(t, err)
 	}
 
@@ -329,7 +330,7 @@ func TestCreateProposalBlock(t *testing.T) {
 		stateStore,
 		logger,
 		proxyApp,
-		mp,
+		mpABCI,
 		evidencePool,
 		blockStore,
 		eventBus,
@@ -394,11 +395,12 @@ func TestMaxTxsProposalBlockSize(t *testing.T) {
 		cfg.Mempool,
 		proxyApp,
 	)
+	mpABCI := mempool.NewABCI(cfg.Mempool, proxyApp, mp, nil)
 
 	// fill the mempool with one txs just below the maximum size
 	txLength := int(types.MaxDataBytesNoEvidence(maxBytes, 1))
 	tx := tmrand.Bytes(txLength - 4) // to account for the varint
-	err = mp.CheckTx(ctx, tx, nil, mempool.TxInfo{})
+	err = mpABCI.CheckTx(ctx, tx, nil, mempool.TxInfo{})
 	assert.NoError(t, err)
 
 	eventBus := eventbus.NewDefault(logger)
@@ -408,7 +410,7 @@ func TestMaxTxsProposalBlockSize(t *testing.T) {
 		stateStore,
 		logger,
 		proxyApp,
-		mp,
+		mpABCI,
 		sm.EmptyEvidencePool{},
 		blockStore,
 		eventBus,
@@ -462,17 +464,18 @@ func TestMaxProposalBlockSize(t *testing.T) {
 		cfg.Mempool,
 		proxyApp,
 	)
+	mpABCI := mempool.NewABCI(cfg.Mempool, proxyApp, mp, nil)
 
 	// fill the mempool with one txs just below the maximum size
 	txLength := int(types.MaxDataBytesNoEvidence(maxBytes, types.MaxVotesCount))
 	tx := tmrand.Bytes(txLength - 6) // to account for the varint
-	err = mp.CheckTx(ctx, tx, nil, mempool.TxInfo{})
+	err = mpABCI.CheckTx(ctx, tx, nil, mempool.TxInfo{})
 	assert.NoError(t, err)
 	// now produce more txs than what a normal block can hold with 10 smaller txs
 	// At the end of the test, only the single big tx should be added
 	for i := 0; i < 10; i++ {
 		tx := tmrand.Bytes(10)
-		err = mp.CheckTx(ctx, tx, nil, mempool.TxInfo{})
+		err = mpABCI.CheckTx(ctx, tx, nil, mempool.TxInfo{})
 		assert.NoError(t, err)
 	}
 
@@ -483,7 +486,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 		stateStore,
 		logger,
 		proxyApp,
-		mp,
+		mpABCI,
 		sm.EmptyEvidencePool{},
 		blockStore,
 		eventBus,

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -112,7 +112,7 @@ func (c *Local) CheckTx(ctx context.Context, tx types.Tx) (*coretypes.ResultChec
 }
 
 func (c *Local) RemoveTx(ctx context.Context, txKey types.TxKey) error {
-	return c.env.Mempool.Remove(ctx, mempool.RemByTXKeys(txKey))
+	return c.env.Mempool.Remove(ctx, mempool.RemByTxKeys(txKey))
 }
 
 func (c *Local) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, error) {

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tendermint/tendermint/internal/eventbus"
 	"github.com/tendermint/tendermint/internal/eventlog/cursor"
+	"github.com/tendermint/tendermint/internal/mempool"
 	"github.com/tendermint/tendermint/internal/pubsub"
 	"github.com/tendermint/tendermint/internal/pubsub/query"
 	rpccore "github.com/tendermint/tendermint/internal/rpc/core"
@@ -111,7 +112,7 @@ func (c *Local) CheckTx(ctx context.Context, tx types.Tx) (*coretypes.ResultChec
 }
 
 func (c *Local) RemoveTx(ctx context.Context, txKey types.TxKey) error {
-	return c.env.Mempool.RemoveTxByKey(txKey)
+	return c.env.Mempool.Remove(ctx, mempool.RemByTXKeys(txKey))
 }
 
 func (c *Local) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, error) {

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -456,7 +456,7 @@ func TestClientMethodCalls(t *testing.T) {
 
 				require.Equal(t, initMempoolSize+1, pool.PoolMeta().Size)
 
-				txs, err := pool.Reap(ctx, mempool.ReapTXs(len(tx)))
+				txs, err := pool.Reap(ctx, mempool.ReapTxs(len(tx)))
 				require.NoError(t, err)
 				require.EqualValues(t, tx, txs[0])
 				require.NoError(t, pool.Flush(ctx))


### PR DESCRIPTION
This PR is aimed at separating concerns within the mempool. As part of an effort to create a new mempool for narwhal, we have run into a large impedance mismatch. Instead of boiling the ocean, we decided it would benefit us to first break up the mixed bag of ABCI concerns and storage concerns within the Mempool interface itself.

This makes it simpler for us to create a new storage engine without having to risk that we got Locking/Unlocking correct
at the mempool->app interface, b/c that layer shouldn't change as the concerns there are not changing. With this we have the ability to do so. 

Looking for feedback on this, as its a steep ask to add additional mempools when the coupling is so fierce

closes #9050 

