### PR TITLE
Improve handling of -short flag in tests

### DIFF
--- a/cmd/tendermint/commands/rollback_test.go
+++ b/cmd/tendermint/commands/rollback_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestRollbackIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	var height int64
 	dir := t.TempDir()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -33,6 +33,10 @@ import (
 // Byzantine node sends two different prevotes (nil and blockID) to the same
 // validator.
 func TestByzantinePrevoteEquivocation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	// empirically, this test either passes in <1s or hits some
 	// kind of deadlock and hit the larger timeout. This timeout
 	// can be extended a bunch if needed, but it's good to avoid

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -779,6 +779,10 @@ func TestReactorRecordsVotesAndBlockParts(t *testing.T) {
 }
 
 func TestReactorVotingPowerChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -885,6 +889,10 @@ func TestReactorVotingPowerChange(t *testing.T) {
 }
 
 func TestReactorValidatorSetChanges(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -118,6 +118,10 @@ func sendTxs(ctx context.Context, t *testing.T, cs *State) {
 
 // TestWALCrash uses crashing WAL to test we can recover from any WAL failure.
 func TestWALCrash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	testCases := []struct {
 		name         string
 		initFn       func(dbm.DB, *State, context.Context)

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -132,6 +132,10 @@ func convertTex(in []testTx) types.Txs {
 }
 
 func TestTxMempool_TxsAvailable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -540,6 +544,10 @@ func TestTxMempool_CheckTxSameSender(t *testing.T) {
 }
 
 func TestTxMempool_ConcurrentTxs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/p2p/conn/connection_test.go
+++ b/internal/p2p/conn/connection_test.go
@@ -315,6 +315,10 @@ func TestMConnectionMultiplePings(t *testing.T) {
 }
 
 func TestMConnectionPingPongs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	// check that we are not leaking any go-routines
 	t.Cleanup(leaktest.CheckTimeout(t, 10*time.Second))
 
@@ -558,6 +562,10 @@ func TestMConnectionReadErrorUnknownMsgType(t *testing.T) {
 }
 
 func TestMConnectionTrySend(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	server, client := net.Pipe()
 	t.Cleanup(closeAll(t, client, server))
 	ctx, cancel := context.WithCancel(context.Background())
@@ -606,6 +614,10 @@ func TestConnVectors(t *testing.T) {
 }
 
 func TestMConnectionChannelOverflow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	chOnErr := make(chan struct{})
 	chOnRcv := make(chan struct{})
 

--- a/internal/p2p/peermanager_test.go
+++ b/internal/p2p/peermanager_test.go
@@ -296,6 +296,10 @@ func TestPeerManager_DialNext(t *testing.T) {
 }
 
 func TestPeerManager_DialNext_Retry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/p2p/router_test.go
+++ b/internal/p2p/router_test.go
@@ -41,6 +41,10 @@ func echoReactor(ctx context.Context, channel p2p.Channel) {
 }
 
 func TestRouter_Network(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -162,6 +166,10 @@ func TestRouter_Channel_Basic(t *testing.T) {
 
 // Channel tests are hairy to mock, so we use an in-memory network instead.
 func TestRouter_Channel_SendReceive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -224,6 +232,10 @@ func TestRouter_Channel_SendReceive(t *testing.T) {
 }
 
 func TestRouter_Channel_Broadcast(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	t.Cleanup(leaktest.Check(t))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -255,6 +267,10 @@ func TestRouter_Channel_Broadcast(t *testing.T) {
 }
 
 func TestRouter_Channel_Wrapper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	t.Cleanup(leaktest.Check(t))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -443,6 +459,11 @@ func TestRouter_AcceptPeers(t *testing.T) {
 }
 
 func TestRouter_AcceptPeers_Errors(t *testing.T) {
+	if testing.Short() {
+		// Each subtest takes more than one second due to the time.Sleep call,
+		// so just skip from the parent test in short mode.
+		t.Skip("skipping test in short mode")
+	}
 
 	for _, err := range []error{io.EOF, context.Canceled, context.DeadlineExceeded} {
 		t.Run(err.Error(), func(t *testing.T) {
@@ -480,9 +501,7 @@ func TestRouter_AcceptPeers_Errors(t *testing.T) {
 			router.Stop()
 
 			mockTransport.AssertExpectations(t)
-
 		})
-
 	}
 }
 
@@ -811,6 +830,10 @@ func TestRouter_EvictPeers(t *testing.T) {
 }
 
 func TestRouter_ChannelCompatability(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	t.Cleanup(leaktest.Check(t))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/p2p/transport_mconn_test.go
+++ b/internal/p2p/transport_mconn_test.go
@@ -59,6 +59,10 @@ func TestMConnTransport_AcceptBeforeListen(t *testing.T) {
 }
 
 func TestMConnTransport_AcceptMaxAcceptedConnections(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/statesync/block_queue_test.go
+++ b/internal/statesync/block_queue_test.go
@@ -126,6 +126,10 @@ func TestBlockQueueWithFailures(t *testing.T) {
 // Test that when all the blocks are retrieved that the queue still holds on to
 // it's workers and in the event of failure can still fetch the failed block
 func TestBlockQueueBlocks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	peerID, err := types.NewNodeID("0011223344556677889900112233445566778899")
 	require.NoError(t, err)
 	queue := newBlockQueue(startHeight, stopHeight, 1, stopTime, 2)
@@ -176,6 +180,10 @@ loop:
 }
 
 func TestBlockQueueAcceptsNoMoreBlocks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	peerID, err := types.NewNodeID("0011223344556677889900112233445566778899")
 	require.NoError(t, err)
 	queue := newBlockQueue(startHeight, stopHeight, 1, stopTime, 1)

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -197,6 +197,10 @@ func setup(
 }
 
 func TestReactor_Sync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
@@ -618,6 +622,10 @@ func TestReactor_StateProviderP2P(t *testing.T) {
 }
 
 func TestReactor_Backfill(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -626,6 +634,10 @@ func TestReactor_Backfill(t *testing.T) {
 	for _, failureRate := range failureRates {
 		failureRate := failureRate
 		t.Run(fmt.Sprintf("failure rate: %d", failureRate), func(t *testing.T) {
+			if testing.Short() && failureRate > 0 {
+				t.Skip("skipping test in short mode")
+			}
+
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 

--- a/internal/statesync/syncer_test.go
+++ b/internal/statesync/syncer_test.go
@@ -22,6 +22,10 @@ import (
 )
 
 func TestSyncer_SyncAny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -235,6 +235,10 @@ func TestLightClientAttackEvidence_Equivocation(t *testing.T) {
 }
 
 func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	// primary performs a lunatic attack but changes the time of the header to
 	// something in the future relative to the blockchain
 	var (

--- a/light/example_test.go
+++ b/light/example_test.go
@@ -17,6 +17,10 @@ import (
 
 // Manually getting light blocks and verifying them.
 func TestExampleClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	conf, err := rpctest.CreateConfig(t, "ExampleClient_VerifyLightBlockAtHeight")

--- a/light/light_test.go
+++ b/light/light_test.go
@@ -23,6 +23,10 @@ import (
 
 // Automatically getting new headers and verifying them.
 func TestClientIntegration_Update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -84,6 +88,10 @@ func TestClientIntegration_Update(t *testing.T) {
 
 // Manually getting light blocks and verifying them.
 func TestClientIntegration_VerifyLightBlockAtHeight(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -162,6 +170,10 @@ func waitForBlock(ctx context.Context, p provider.Provider, height int64) (*type
 }
 
 func TestClientStatusRPC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	conf, err := rpctest.CreateConfig(t, t.Name())

--- a/light/provider/http/http_test.go
+++ b/light/provider/http/http_test.go
@@ -33,6 +33,10 @@ func TestNewProvider(t *testing.T) {
 }
 
 func TestProvider(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg, err := rpctest.CreateConfig(t, t.Name())

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -106,6 +106,10 @@ func getTestNode(ctx context.Context, t *testing.T, conf *config.Config, logger 
 }
 
 func TestNodeDelayedStart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	cfg, err := config.ResetTestRoot(t.TempDir(), "node_delayed_start_test")
 	require.NoError(t, err)
 
@@ -195,6 +199,10 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 
 // address without a protocol must result in error
 func TestPrivValidatorListenAddrNoProtocol(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -441,6 +449,10 @@ func TestMaxTxsProposalBlockSize(t *testing.T) {
 }
 
 func TestMaxProposalBlockSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/rpc/client/examples_test.go
+++ b/rpc/client/examples_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func TestHTTPSimple(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -68,6 +72,10 @@ func TestHTTPSimple(t *testing.T) {
 }
 
 func TestHTTPBatching(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/rpc/client/helpers_test.go
+++ b/rpc/client/helpers_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestWaitForHeight(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -133,6 +133,10 @@ func TestClientOperations(t *testing.T) {
 	})
 	t.Run("Batching", func(t *testing.T) {
 		t.Run("JSONRPCCalls", func(t *testing.T) {
+			if testing.Short() {
+				t.Skip("skipping test in short mode")
+			}
+
 			logger := log.NewTestingLogger(t)
 			c := getHTTPClient(t, logger, conf)
 			testBatchedJSONRPCCalls(ctx, t, c)
@@ -171,6 +175,10 @@ func TestClientOperations(t *testing.T) {
 			require.Zero(t, batch.Clear(), "clearing an empty batch of JSON RPC requests should result in a 0 result")
 		})
 		t.Run("ConcurrentJSONRPC", func(t *testing.T) {
+			if testing.Short() {
+				t.Skip("skipping test in short mode")
+			}
+
 			logger := log.NewTestingLogger(t)
 
 			var wg sync.WaitGroup
@@ -291,6 +299,10 @@ func TestClientMethodCalls(t *testing.T) {
 					"first: %+v, doc: %s", first, string(doc))
 			})
 			t.Run("ABCIQuery", func(t *testing.T) {
+				if testing.Short() {
+					t.Skip("skipping test in short mode")
+				}
+
 				// write something
 				k, v, tx := MakeTxKV()
 				status, err := c.Status(ctx)
@@ -309,6 +321,10 @@ func TestClientMethodCalls(t *testing.T) {
 				}
 			})
 			t.Run("AppCalls", func(t *testing.T) {
+				if testing.Short() {
+					t.Skip("skipping test in short mode")
+				}
+
 				// get an offset of height to avoid racing and guessing
 				s, err := c.Status(ctx)
 				require.NoError(t, err)
@@ -409,6 +425,10 @@ func TestClientMethodCalls(t *testing.T) {
 				// XXX Test proof
 			})
 			t.Run("BlockchainInfo", func(t *testing.T) {
+				if testing.Short() {
+					t.Skip("skipping test in short mode")
+				}
+
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
@@ -439,6 +459,10 @@ func TestClientMethodCalls(t *testing.T) {
 				assert.Contains(t, err.Error(), "can't be greater than max")
 			})
 			t.Run("BroadcastTxCommit", func(t *testing.T) {
+				if testing.Short() {
+					t.Skip("skipping test in short mode")
+				}
+
 				_, _, tx := MakeTxKV()
 				bres, err := c.BroadcastTxCommit(ctx, tx)
 				require.NoError(t, err, "%d: %+v", i, err)
@@ -481,6 +505,10 @@ func TestClientMethodCalls(t *testing.T) {
 					// TODO: more checks...
 				})
 				t.Run("Block", func(t *testing.T) {
+					if testing.Short() {
+						t.Skip("skipping test in short mode")
+					}
+
 					const subscriber = "TestBlockEvents"
 
 					eventCh, err := c.Subscribe(ctx, subscriber, types.QueryForEvent(types.EventNewBlockValue).String())
@@ -515,6 +543,10 @@ func TestClientMethodCalls(t *testing.T) {
 			})
 			t.Run("Evidence", func(t *testing.T) {
 				t.Run("BroadcastDuplicateVote", func(t *testing.T) {
+					if testing.Short() {
+						t.Skip("skipping test in short mode")
+					}
+
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
 
@@ -722,6 +754,10 @@ func TestClientMethodCallsAdvanced(t *testing.T) {
 		}
 	})
 	t.Run("TxSearchWithTimeout", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping test in short mode")
+		}
+
 		logger := log.NewTestingLogger(t)
 
 		timeoutClient := getHTTPClientWithTimeout(t, logger, conf, 10*time.Second)

--- a/rpc/jsonrpc/client/ws_client_test.go
+++ b/rpc/jsonrpc/client/ws_client_test.go
@@ -65,6 +65,10 @@ func (h *myTestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestWSClientReconnectsAfterReadFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	t.Cleanup(leaktest.Check(t))
 
 	// start server
@@ -97,6 +101,10 @@ func TestWSClientReconnectsAfterReadFailure(t *testing.T) {
 }
 
 func TestWSClientReconnectsAfterWriteFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	t.Cleanup(leaktest.Check(t))
 
 	// start server
@@ -127,6 +135,10 @@ func TestWSClientReconnectsAfterWriteFailure(t *testing.T) {
 }
 
 func TestWSClientReconnectFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	t.Cleanup(leaktest.Check(t))
 
 	// start server

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -340,6 +340,10 @@ func TestRPC(t *testing.T) {
 		}
 	})
 	t.Run("WSClientPingPong", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping test in short mode")
+		}
+
 		// TestWSClientPingPong checks that a client & server exchange pings
 		// & pongs so connection stays alive.
 		t.Cleanup(leaktest.CheckTimeout(t, 4*time.Second))

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -16,6 +16,10 @@ const (
 )
 
 func TestBasicPartSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	// Construct random data of size partSize * 100
 	nParts := 100
 	data := tmrand.Bytes(testPartSize * nParts)
@@ -64,6 +68,10 @@ func TestBasicPartSet(t *testing.T) {
 }
 
 func TestWrongProof(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	// Construct random data of size partSize * 100
 	data := tmrand.Bytes(testPartSize * 100)
 	partSet := NewPartSetFromData(data, testPartSize)
@@ -89,6 +97,10 @@ func TestWrongProof(t *testing.T) {
 }
 
 func TestPartSetHeaderValidateBasic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	testCases := []struct {
 		testName              string
 		malleatePartSetHeader func(*PartSetHeader)
@@ -110,6 +122,10 @@ func TestPartSetHeaderValidateBasic(t *testing.T) {
 }
 
 func TestPartValidateBasic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	testCases := []struct {
 		testName     string
 		malleatePart func(*Part)

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -1207,6 +1207,10 @@ func applyChangesToValSet(t *testing.T, expErr error, valSet *ValidatorSet, vals
 }
 
 func TestValSetUpdatePriorityOrderTests(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	const nMaxElections int32 = 5000
 
 	testCases := []testVSetCfg{


### PR DESCRIPTION
As a small developer quality of life improvement, I found many individual unit tests that take longer than around a second to complete, and set them to skip when run under `go test -short`.

On my machine, the wall timings for tests (with `go test -count=1 ./...` and optionally `-short` and `-race`) are roughly:

- Long tests, no race detector: about 1m42s
- Short tests, no race detector: about 17s
- Long tests, race detector enabled: about 2m1s
- Short tests, race detector enabled: about 28s

This PR is split into many commits each touching a single package, with commit messages detailing the approximate timing change per package.