### PR TITLE
Documentation Fix -> Intro -> Quickstart - > value is returned in `base64` format, not `hex`

### DIFF
--- a/docs/introduction/quick-start.md
+++ b/docs/introduction/quick-start.md
@@ -84,7 +84,7 @@ and query the key:
 curl -s 'localhost:26657/abci_query?data="name"'
 ```
 
-where the value is returned in hex.
+where the value is returned in base64.
 
 ## Cluster of Nodes
 


### PR DESCRIPTION
## This Pull Request fixes a documentation typo

When running the following quickstart command: 


```
curl -s 'localhost:26657/abci_query?data="name"'
```

The value returned was `base64`, not `hex`.

```
{
  "jsonrpc": "2.0",
  "id": -1,
  "result": {
    "response": {
      "code": 0,
      "log": "exists",
      "info": "",
      "index": "0",
      "key": "bmFtZQ==",
      "value": "c2F0b3NoaQ==",
      "proofOps": null,
      "height": "43",
      "codespace": ""
    }
  }
}
```

Please let us know if this is not correct. Thank you!