### PR TITLE
Fix unsafe-reset-all for working with default home

### DIFF
--- a/cmd/tendermint/commands/reset.go
+++ b/cmd/tendermint/commands/reset.go
@@ -29,7 +29,7 @@ var ResetStateCmd = &cobra.Command{
 	Short:  "Remove all the data and WAL",
 	PreRun: deprecateSnakeCase,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		config, err = ParseConfig()
+		config, err = ParseConfig(cmd)
 		if err != nil {
 			return err
 		}
@@ -54,7 +54,7 @@ var ResetPrivValidatorCmd = &cobra.Command{
 // XXX: this is totally unsafe.
 // it's only suitable for testnets.
 func resetAllCmd(cmd *cobra.Command, args []string) (err error) {
-	config, err = ParseConfig()
+	config, err = ParseConfig(cmd)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func resetAllCmd(cmd *cobra.Command, args []string) (err error) {
 // XXX: this is totally unsafe.
 // it's only suitable for testnets.
 func resetPrivValidator(cmd *cobra.Command, args []string) (err error) {
-	config, err = ParseConfig()
+	config, err = ParseConfig(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/tendermint/commands/root.go
+++ b/cmd/tendermint/commands/root.go
@@ -29,12 +29,20 @@ func registerFlagsRootCmd(cmd *cobra.Command) {
 
 // ParseConfig retrieves the default environment configuration,
 // sets up the Tendermint root and ensures that the root exists
-func ParseConfig() (*cfg.Config, error) {
+func ParseConfig(cmd *cobra.Command) (*cfg.Config, error) {
 	conf := cfg.DefaultConfig()
 	err := viper.Unmarshal(conf)
 	if err != nil {
 		return nil, err
 	}
+
+	home, err := cmd.Flags().GetString(cli.HomeFlag)
+	if err != nil {
+		return nil, err
+	}
+
+	conf.RootDir = home
+
 	conf.SetRoot(conf.RootDir)
 	cfg.EnsureRoot(conf.RootDir)
 	if err := conf.ValidateBasic(); err != nil {
@@ -52,7 +60,7 @@ var RootCmd = &cobra.Command{
 			return nil
 		}
 
-		config, err = ParseConfig()
+		config, err = ParseConfig(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/tendermint/commands/root.go
+++ b/cmd/tendermint/commands/root.go
@@ -36,9 +36,14 @@ func ParseConfig(cmd *cobra.Command) (*cfg.Config, error) {
 		return nil, err
 	}
 
-	home, err := cmd.Flags().GetString(cli.HomeFlag)
-	if err != nil {
-		return nil, err
+	var home string
+	if os.Getenv("TMHOME") != "" {
+		home = os.Getenv("TMHOME")
+	} else {
+		home, err = cmd.Flags().GetString(cli.HomeFlag)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	conf.RootDir = home


### PR DESCRIPTION
Ref. #9102 
close #9102

`tendermint unsafe-reset-all` command should clear client's home directory
but this command is not working with default home flags.

Ad described #9102, `unsafe-reset-all` command try to clear `#HOME/data` directory by default
where is not client's home.

To resolve this issue, `ParseConfig` function explicitly get client's home
and set it into config.