### PR TITLE
cli: set node p2p external address with cmd flag

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,6 +24,7 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 ### FEATURES
 
 - [#9083] backport cli command to reindex missed events (@cmwaters)
+- [cli] \#9107 Add the `p2p.external-address` argument to set the node P2P external address (@amimart)
 
 ### IMPROVEMENTS
 

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -63,6 +63,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 		"p2p.laddr",
 		config.P2P.ListenAddress,
 		"node listen address. (0.0.0.0:0 means any interface, any port)")
+	cmd.Flags().String("p2p.external-address", config.P2P.ExternalAddress, "ip:port address to advertise to peers for them to dial")
 	cmd.Flags().String("p2p.seeds", config.P2P.Seeds, "comma-delimited ID@host:port seed nodes")
 	cmd.Flags().String("p2p.persistent_peers", config.P2P.PersistentPeers, "comma-delimited ID@host:port persistent peers")
 	cmd.Flags().String("p2p.unconditional_peer_ids",


### PR DESCRIPTION
Closes #9035

Add the `p2p.external-address` command line argument to configure the node external address.


