### PR TITLE
e2e: fix client accessor

### DIFF
--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -459,9 +459,9 @@ func (n Node) AddressRPC() string {
 	ip := n.IP.String()
 	if n.IP.To4() == nil {
 		// IPv6 addresses must be wrapped in [] to avoid conflict with : port separator
-		ip = fmt.Sprintf("[%v]", ip)
+		ip = fmt.Sprintf("[%s]:%d", ip, n.ProxyPort)
 	}
-	return fmt.Sprintf("%v:26657", ip)
+	return fmt.Sprintf("%s:%d", ip, n.ProxyPort)
 }
 
 // Client returns an RPC client for a node.

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -466,7 +466,7 @@ func (n Node) AddressRPC() string {
 
 // Client returns an RPC client for a node.
 func (n Node) Client() (*rpchttp.HTTP, error) {
-	return rpchttp.New(fmt.Sprintf("http://%s", n.AddressRPC()))
+	return rpchttp.New(fmt.Sprintf("http://127.0.0.1:%d", n.ProxyPort))
 }
 
 // Stateless returns true if the node is either a seed node or a light node


### PR DESCRIPTION
Following up on: #9097 and  #8754, it seems like tweaking the way we access clients may help address. 

I'm open to more clearly reverting #8754 here and putting in `127.0.0.1` but this seems like a good compromise.