### PR TITLE
Update CODEOWNERS to use teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,6 @@
 # global owners are only requested if there isn't a more specific
 # codeowner specified below. For this reason, the global codeowners
 # are often repeated in package-level definitions.
-*      @ebuchman @cmwaters @tychoish @williambanfield @creachadair @thanethomson @sergio-mena @jmalicevic
+*     @tendermint/tendermint-engineering
 
-/spec @cason @sergio-mena @jmalicevic @milosevic
+/spec @tendermint/tendermint-research @tendermint/tendermint-engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,6 @@
 # global owners are only requested if there isn't a more specific
 # codeowner specified below. For this reason, the global codeowners
 # are often repeated in package-level definitions.
-*     @tendermint/tendermint-engineering
+*     @ebuchman @tendermint/tendermint-engineering
 
-/spec @tendermint/tendermint-research @tendermint/tendermint-engineering
+/spec @ebuchman @tendermint/tendermint-research @tendermint/tendermint-engineering


### PR DESCRIPTION
Updates the `CODEOWNERS` file to use the @tendermint/tendermint-engineering and @tendermint/tendermint-research teams as opposed to adding people one by one. This makes repository administration somewhat easier to manage, especially when onboarding/offboarding people.