### PR TITLE
Make rollback command usable to fix missed hard upgrades

### DIFF
--- a/state/services.go
+++ b/state/services.go
@@ -33,6 +33,8 @@ type BlockStore interface {
 
 	LoadBlockCommit(height int64) *types.Commit
 	LoadSeenCommit(height int64) *types.Commit
+
+	DeleteLatestBlock() error
 }
 
 //-----------------------------------------------------------------------------

--- a/store/store.go
+++ b/store/store.go
@@ -500,3 +500,50 @@ func mustEncode(pb proto.Message) []byte {
 	}
 	return bz
 }
+
+//-----------------------------------------------------------------------------
+
+// DeleteLatestBlock removes the block pointed to by height,
+// lowering height by one.
+func (bs *BlockStore) DeleteLatestBlock() error {
+	bs.mtx.RLock()
+	targetHeight := bs.height
+	bs.mtx.RUnlock()
+
+	batch := bs.db.NewBatch()
+	defer batch.Close()
+
+  // delete what we can, skipping what's already missing, to ensure partial
+  // blocks get deleted fully.
+	if meta := bs.LoadBlockMeta(targetHeight); meta != nil {
+		if err := batch.Delete(calcBlockHashKey(meta.BlockID.Hash)); err != nil {
+			return err
+		}
+		for p := 0; p < int(meta.BlockID.PartSetHeader.Total); p++ {
+			if err := batch.Delete(calcBlockPartKey(targetHeight, p)); err != nil {
+				return err
+			}
+		}
+	}
+	if err := batch.Delete(calcBlockCommitKey(targetHeight)); err != nil {
+		return err
+	}
+	if err := batch.Delete(calcSeenCommitKey(targetHeight)); err != nil {
+		return err
+	}
+	// delete last, so as to not leave keys built on meta.BlockID dangling
+	if err := batch.Delete(calcBlockMetaKey(targetHeight)); err != nil {
+		return err
+	}
+
+	bs.mtx.Lock()
+	bs.height = targetHeight - 1
+	bs.mtx.Unlock()
+	bs.saveState()
+
+	err := batch.WriteSync()
+	if err != nil {
+		return fmt.Errorf("failed to delete height %v: %w", targetHeight, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #9174.

This PR addresses this edge case, by making the `tendermint rollback` command also remove the `blockstore` data for the block from which the invalid app-state was derived. This fixes cases where it's not the application's execution of the block that's incorrect, but the block itself that's invalid. (Presumably this condition only ever pertains in a hard-fork scenario — i.e. when a block that would be valid under node-software version N, becomes invalid under node-software version N+1; and such a block is produced by a validator who hasn't upgraded to version N+1.)

This code has been smoke-tested in a real-world use-case: I wrote this code "in anger", as a hotpatch to fix an evmos node that was experiencing exactly the problem described in #9174, so that the node could resume sync rather than needing to re-start sync from genesis. It worked!

Coincidentally, adding this logic also enables `tendermint rollback` to be used repeatedly, to walk the state back by more than one block. Previously, once `tendermint rollback` had been used once, the "state height + 1 == blockstore height" branch of `state.Rollback` would always be followed, early-returning success without doing anything. This code-path now just removes the blockstore data for the "pending" block before proceeding to purge the state + blockstore of the "latest" block.

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

