### PR TITLE
ci: Update nightly E2E notifications

### DIFF
--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -71,3 +71,27 @@ jobs:
                 }
               ]
             }
+
+  e2e-nightly-success:  # may turn this off once they seem to pass consistently
+    needs: e2e-nightly-test
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on success
+        uses: slackapi/slack-github-action@v1.21.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":white_check_mark: Nightly E2E tests for `${{ github.ref_name }}` passed."
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -47,12 +47,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on failure
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7
+        uses: slackapi/slack-github-action@v1.21.0
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: tendermint-internal
-          SLACK_USERNAME: Nightly E2E Tests
-          SLACK_ICON_EMOJI: ':skull:'
-          SLACK_COLOR: danger
-          SLACK_MESSAGE: Nightly E2E tests failed on v0.34.x
-          SLACK_FOOTER: ''
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":skull: Nightly E2E tests for `${{ github.ref_name }}` failed."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run details> and the <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|commit> that caused the failure."
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/e2e-nightly-main.yml
+++ b/.github/workflows/e2e-nightly-main.yml
@@ -58,14 +58,14 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":skull: Nightly E2E tests for `${{ github.ref_name }}` failed.",
+                    "text": ":skull: Nightly E2E tests for `${{ github.ref_name }}` failed."
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run details> and the <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|commit> that caused the failure.",
+                    "text": "See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run details> and the <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|commit> that caused the failure."
                   }
                 }
               ]
@@ -76,7 +76,7 @@ jobs:
     if: ${{ success() }}
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Slack on failure
+      - name: Notify Slack on success
         uses: slackapi/slack-github-action@v1.21.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-nightly-main.yml
+++ b/.github/workflows/e2e-nightly-main.yml
@@ -46,28 +46,51 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on failure
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7
+        uses: slackapi/slack-github-action@v1.21.0
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: tendermint-internal
-          SLACK_USERNAME: Nightly E2E Tests
-          SLACK_ICON_EMOJI: ':skull:'
-          SLACK_COLOR: danger
-          SLACK_MESSAGE: Nightly E2E tests failed on main
-          SLACK_FOOTER: ''
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":skull: Nightly E2E tests for `${{ github.ref_name }}` failed.",
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run details> and the <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|commit> that caused the failure.",
+                  }
+                }
+              ]
+            }
 
   e2e-nightly-success:  # may turn this off once they seem to pass consistently
     needs: e2e-nightly-test
     if: ${{ success() }}
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Slack on success
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.21.0
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: tendermint-internal
-          SLACK_USERNAME: Nightly E2E Tests
-          SLACK_ICON_EMOJI: ':white_check_mark:'
-          SLACK_COLOR: good
-          SLACK_MESSAGE: Nightly E2E tests passed on main
-          SLACK_FOOTER: ''
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":white_check_mark: Nightly E2E tests for `${{ github.ref_name }}` passed."
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -75,13 +75,28 @@ jobs:
     if: ${{ needs.fuzz-nightly-test.outputs.crashers-count != 0 }}
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Slack if any crashers
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.21.0
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: tendermint-internal
-          SLACK_USERNAME: Nightly Fuzz Tests
-          SLACK_ICON_EMOJI: ':firecracker:'
-          SLACK_COLOR: danger
-          SLACK_MESSAGE: Crashers found in Nightly Fuzz tests
-          SLACK_FOOTER: ''
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":skull: Nightly fuzz tests for `${{ github.ref_name }}` failed.",
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run details> and the <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|commit> that caused the failure.",
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
Updates our nightly E2E notifications to use the [incoming webhook approach](https://github.com/slackapi/slack-github-action#technique-3-slack-incoming-webhook), targeting our engineering team channel.