### PR TITLE
ci: Fix nightly E2E notifications and improve readability

### DIFF
--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -27,6 +27,12 @@ jobs:
         with:
           ref: 'v0.34.x'
 
+      - name: Capture git repo info
+        id: git-info
+        run: |
+          echo "::set-output name=branch::`git branch --show-current`"
+          echo "::set-output name=commit::`git rev-parse HEAD`"
+
       - name: Build
         working-directory: test/e2e
         # Run make jobs in parallel, since we can't run steps in parallel.
@@ -41,6 +47,10 @@ jobs:
         working-directory: test/e2e
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
 
+    outputs:
+      git-branch: ${{ steps.git-info.outputs.branch }}
+      git-commit: ${{ steps.git-info.outputs.commit }}
+
   e2e-nightly-fail:
     needs: e2e-nightly-test
     if: ${{ failure() }}
@@ -51,6 +61,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ needs.e2e-nightly-test.outputs.git-branch }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMIT_URL: "${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.e2e-nightly-test.outputs.git-commit }}"
         with:
           payload: |
             {
@@ -59,14 +72,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":skull: Nightly E2E tests for `${{ github.ref_name }}` failed."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run details> and the <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|commit> that caused the failure."
+                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMIT_URL }}|commit> that caused the failure."
                   }
                 }
               ]
@@ -82,6 +88,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ needs.e2e-nightly-test.outputs.git-branch }}
         with:
           payload: |
             {
@@ -90,7 +97,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":white_check_mark: Nightly E2E tests for `${{ github.ref_name }}` passed."
+                    "text": ":white_check_mark: Nightly E2E tests for `${{ env.BRANCH }}` passed."
                   }
                 }
               ]

--- a/.github/workflows/e2e-nightly-main.yml
+++ b/.github/workflows/e2e-nightly-main.yml
@@ -50,6 +50,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ github.ref_name }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMIT_URL: "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
         with:
           payload: |
             {
@@ -58,14 +61,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":skull: Nightly E2E tests for `${{ github.ref_name }}` failed."
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run details> and the <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|commit> that caused the failure."
+                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMIT_URL }}|commit> that caused the failure."
                   }
                 }
               ]
@@ -81,6 +77,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ github.ref_name }}
         with:
           payload: |
             {
@@ -89,7 +86,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":white_check_mark: Nightly E2E tests for `${{ github.ref_name }}` passed."
+                    "text": ":white_check_mark: Nightly E2E tests for `${{ env.BRANCH }}` passed."
                   }
                 }
               ]

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -80,6 +80,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ github.ref_name }}
+          CRASHERS: ${{ needs.fuzz-nightly-test.outputs.crashers-count }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         with:
           payload: |
             {
@@ -88,14 +91,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":skull: Nightly fuzz tests for `${{ github.ref_name }}` failed.",
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "See the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run details> and the <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|commit> that caused the failure.",
+                    "text": ":skull: Nightly fuzz tests for `${{ env.BRANCH }}` failed with ${{ env.CRASHERS }} crasher(s). See the <${{ env.RUN_URL }}|run details>."
                   }
                 }
               ]


### PR DESCRIPTION
A follow-up to #9177.

This updates the nightly E2E workflows to fix the notifications for the `v0.34.x` branch while also simplifying the messages and making them a little more readable.

I've tested these notifications out in a private repo, sending them directly to myself, and they appear to work now.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

