### PR TITLE
e2e: fix out of sync configuration

### DIFF
--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02', '03']
+        group: ['00', '01', '02']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -41,7 +41,7 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 4 -d networks/nightly
+        run: ./build/generator -g 3 -d networks/nightly
 
       - name: Run testnets in group ${{ matrix.group }}
         working-directory: test/e2e

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02', '03', "04"]
+        group: ['00', '01', '02', '03']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -41,7 +41,7 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 2 -d networks/nightly
+        run: ./build/generator -g 4 -d networks/nightly
 
       - name: Run testnets in group ${{ matrix.group }}
         working-directory: test/e2e

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02']
+        group: ['00', '01']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -41,7 +41,7 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 3 -d networks/nightly
+        run: ./build/generator -g 2 -d networks/nightly
 
       - name: Run testnets in group ${{ matrix.group }}
         working-directory: test/e2e


### PR DESCRIPTION
The v0.34.x tests have been failing (or reporting failures, I don't
believe that this is a real failure,) because the CI configuration has
been out of sync with itself, likely due to a mistake during
backporting configs from the `master` branch.

The entire 0.34.x e2e test suite takes 26 minutes to run, plus about 7
minutes to build the docker image. Each split has to build the same
docker image, (and is therefore a cap on the amount of parallelism we
can get at the moment.) Having more groups, just seems like we'll be
burning money building the docker image with no really meaningful
difference in throughput. For a nightly test that people don't really
wait on, the current latency (time-to-completion) of roughly 19
minutes, isn't causing in friction.