### PR TITLE
use go 1.19 for ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: 1.19
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: 1.19
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: 1.19
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - uses: actions/checkout@v3
 
@@ -42,11 +42,11 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 1  # we need a .git directory to run git diff
+          fetch-depth: 1 # we need a .git directory to run git diff
 
       - name: "Check protobuf generated code"
         run: |

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ["00", "01", "02", "03"]
+        group: ['00', '01', '02', '03']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -11,13 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02', '03']
+        group: ["00", "01", "02", "03"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -6,7 +6,7 @@
 name: e2e-nightly-34x
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
 
 jobs:
   e2e-nightly-test:
@@ -21,11 +21,11 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - uses: actions/checkout@v3
         with:
-          ref: 'v0.34.x'
+          ref: "v0.34.x"
 
       - name: Capture git repo info
         id: git-info
@@ -78,7 +78,7 @@ jobs:
               ]
             }
 
-  e2e-nightly-success:  # may turn this off once they seem to pass consistently
+  e2e-nightly-success: # may turn this off once they seem to pass consistently
     needs: e2e-nightly-test
     if: ${{ success() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-nightly-main.yml
+++ b/.github/workflows/e2e-nightly-main.yml
@@ -7,7 +7,7 @@
 name: e2e-nightly-main
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
 
 jobs:
   e2e-nightly-test:
@@ -16,13 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02', '03', "04"]
+        group: ["00", "01", "02", "03", "04"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - uses: actions/checkout@v3
 
@@ -67,7 +67,7 @@ jobs:
               ]
             }
 
-  e2e-nightly-success:  # may turn this off once they seem to pass consistently
+  e2e-nightly-success: # may turn this off once they seem to pass consistently
     needs: e2e-nightly-test
     if: ${{ success() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: e2e
 # Runs the CI end-to-end test network on all pushes to main or release branches
 # and every pull request, but only if any Go files have been changed.
 on:
-  workflow_dispatch:  # allow running workflow manually
+  workflow_dispatch: # allow running workflow manually
   pull_request:
   push:
     branches:
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,9 +1,9 @@
 # Runs fuzzing nightly.
 name: Fuzz Tests
 on:
-  workflow_dispatch:  # allow running workflow manually
+  workflow_dispatch: # allow running workflow manually
   schedule:
-    - cron: '0 3 * * *'
+    - cron: "0 3 * * *"
   pull_request:
     branches: [main]
     paths:
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
       - uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |
@@ -34,7 +34,7 @@ jobs:
           # Required: the version of golangci-lint is required and
           # must be specified without patch version: we always use the
           # latest patch version.
-          version: v1.47.3
+          version: latest
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         if: env.GIT_DIFF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Release"
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"  # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   goreleaser:
@@ -16,14 +16,14 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         if: ${{ github.event_name == 'pull_request' }}
         with:
           version: latest
-          args: build --skip-validate   # skip validate skips initial sanity checks in order to be able to fully run
+          args: build --skip-validate # skip validate skips initial sanity checks in order to be able to fully run
 
       - run: echo https://github.com/tendermint/tendermint/blob/${GITHUB_REF#refs/tags/}/CHANGELOG.md#${GITHUB_REF#refs/tags/} > ../release_notes.md
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: 1.19
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:


### PR DESCRIPTION
This PR upgrades CI to go 1.19



---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

