### PR TITLE
docs: Update v0.34.x to prepare for v0.37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ docs/.vuepress/dist
 *.log
 abci-cli
 docs/node_modules/
+docs/.vuepress/public/rpc
 index.html.md
 
 scripts/wal2json/wal2json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -564,7 +564,7 @@ This security release fixes:
 Tendermint 0.33.0 and above allow block proposers to include signatures for the
 wrong block. This may happen naturally if you start a network, have it run for
 some time and restart it **without changing the chainID**. (It is a
-[misconfiguration](https://docs.tendermint.com/main/tendermint-core/using-tendermint.html)
+[misconfiguration](https://docs.tendermint.com/v0.34/tendermint-core/using-tendermint.html)
 to reuse chainIDs.) Correct block proposers will accidentally include signatures
 for the wrong block if they see these signatures, and then commits won't validate,
 making all proposed blocks invalid. A malicious validator (even with a minimal
@@ -1574,7 +1574,7 @@ Special thanks to external contributors on this release:
 - [libs/db] [\#3611](https://github.com/tendermint/tendermint/issues/3611) Conditional compilation
   * Use `cleveldb` tag instead of `gcc` to compile Tendermint with CLevelDB or
     use `make build_c` / `make install_c` (full instructions can be found at
-    https://docs.tendermint.com/main/introduction/install.html#compile-with-cleveldb-support)
+    https://docs.tendermint.com/v0.34/introduction/install.html#compile-with-cleveldb-support)
   * Use `boltdb` tag to compile Tendermint with bolt db
 - [node] [\#3362](https://github.com/tendermint/tendermint/issues/3362) Return an error if `persistent_peers` list is invalid (except
   when IP lookup fails)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -564,7 +564,7 @@ This security release fixes:
 Tendermint 0.33.0 and above allow block proposers to include signatures for the
 wrong block. This may happen naturally if you start a network, have it run for
 some time and restart it **without changing the chainID**. (It is a
-[misconfiguration](https://docs.tendermint.com/master/tendermint-core/using-tendermint.html)
+[misconfiguration](https://docs.tendermint.com/main/tendermint-core/using-tendermint.html)
 to reuse chainIDs.) Correct block proposers will accidentally include signatures
 for the wrong block if they see these signatures, and then commits won't validate,
 making all proposed blocks invalid. A malicious validator (even with a minimal
@@ -1574,7 +1574,7 @@ Special thanks to external contributors on this release:
 - [libs/db] [\#3611](https://github.com/tendermint/tendermint/issues/3611) Conditional compilation
   * Use `cleveldb` tag instead of `gcc` to compile Tendermint with CLevelDB or
     use `make build_c` / `make install_c` (full instructions can be found at
-    https://docs.tendermint.com/master/introduction/install.html#compile-with-cleveldb-support)
+    https://docs.tendermint.com/main/introduction/install.html#compile-with-cleveldb-support)
   * Use `boltdb` tag to compile Tendermint with bolt db
 - [node] [\#3362](https://github.com/tendermint/tendermint/issues/3362) Return an error if `persistent_peers` list is invalid (except
   when IP lookup fails)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,7 +470,7 @@ Special thanks to external contributors on this release: @james-ray, @fedekunze,
 - [abci] [\#5174](https://github.com/tendermint/tendermint/pull/5174) Remove `MockEvidence` in favor of testing with actual evidence types (`DuplicateVoteEvidence` & `LightClientAttackEvidence`) (@cmwaters)
 - [abci] [\#5191](https://github.com/tendermint/tendermint/pull/5191) Add `InitChain.InitialHeight` field giving the initial block height (@erikgrinaker)
 - [abci] [\#5227](https://github.com/tendermint/tendermint/pull/5227) Add `ResponseInitChain.app_hash` which is recorded in genesis block (@erikgrinaker)
-- [config] [\#5147](https://github.com/tendermint/tendermint/pull/5147) Add `--consensus.double_sign_check_height` flag and `DoubleSignCheckHeight` config variable. See [ADR-51](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-051-double-signing-risk-reduction.md) (@dongsam)
+- [config] [\#5147](https://github.com/tendermint/tendermint/pull/5147) Add `--consensus.double_sign_check_height` flag and `DoubleSignCheckHeight` config variable. See [ADR-51](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-051-double-signing-risk-reduction.md) (@dongsam)
 - [db] [\#5233](https://github.com/tendermint/tendermint/pull/5233) Add support for `badgerdb` database backend (@erikgrinaker)
 - [evidence] [\#4532](https://github.com/tendermint/tendermint/pull/4532) Handle evidence from light clients (@melekes)
 - [evidence] [#4821](https://github.com/tendermint/tendermint/pull/4821) Amnesia (light client attack) evidence can be detected, verified and committed (@cmwaters)
@@ -484,7 +484,7 @@ Special thanks to external contributors on this release: @james-ray, @fedekunze,
 - [rpc] [\#5017](https://github.com/tendermint/tendermint/pull/5017) Add `/check_tx` endpoint to check transactions without executing them or adding them to the mempool (@melekes)
 - [rpc] [\#5108](https://github.com/tendermint/tendermint/pull/5108) Subscribe using the websocket for new evidence events (@cmwaters)
 - [statesync] Add state sync support, where a new node can be rapidly bootstrapped by fetching state snapshots from peers instead of replaying blocks. See the `[statesync]` config section.
-- [evidence] [\#5361](https://github.com/tendermint/tendermint/pull/5361) Add LightClientAttackEvidence and refactor evidence lifecycle - for more information see [ADR-059](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-059-evidence-composition-and-lifecycle.md) (@cmwaters)
+- [evidence] [\#5361](https://github.com/tendermint/tendermint/pull/5361) Add LightClientAttackEvidence and refactor evidence lifecycle - for more information see [ADR-059](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-059-evidence-composition-and-lifecycle.md) (@cmwaters)
 
 ### IMPROVEMENTS
 
@@ -1224,7 +1224,7 @@ Special thanks to external contributors on this release: @jon-certik, @gracenoah
 *August 28, 2019*
 
 @climber73 wrote the [Writing a Tendermint Core application in Java
-(gRPC)](https://github.com/tendermint/tendermint/blob/master/docs/guides/java.md)
+(gRPC)](https://github.com/tendermint/tendermint/blob/main/docs/guides/java.md)
 guide.
 
 Special thanks to external contributors on this release:
@@ -1257,7 +1257,7 @@ Special thanks to external contributors on this release:
 
 ### FEATURES:
 
-- [blockchain] [\#3561](https://github.com/tendermint/tendermint/issues/3561) Add early version of the new blockchain reactor, which is supposed to be more modular and testable compared to the old version. To try it, you'll have to change `version` in the config file, [here](https://github.com/tendermint/tendermint/blob/master/config/toml.go#L303) NOTE: It's not ready for a production yet. For further information, see [ADR-40](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-040-blockchain-reactor-refactor.md) & [ADR-43](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-043-blockchain-riri-org.md)
+- [blockchain] [\#3561](https://github.com/tendermint/tendermint/issues/3561) Add early version of the new blockchain reactor, which is supposed to be more modular and testable compared to the old version. To try it, you'll have to change `version` in the config file, [here](https://github.com/tendermint/tendermint/blob/main/config/toml.go#L303) NOTE: It's not ready for a production yet. For further information, see [ADR-40](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-040-blockchain-reactor-refactor.md) & [ADR-43](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-043-blockchain-riri-org.md)
 - [mempool] [\#3826](https://github.com/tendermint/tendermint/issues/3826) Make `max_msg_bytes` configurable(@bluele)
 - [node] [\#3846](https://github.com/tendermint/tendermint/pull/3846) Allow replacing existing p2p.Reactor(s) using [`CustomReactors`
   option](https://godoc.org/github.com/tendermint/tendermint/node#CustomReactors).
@@ -1798,7 +1798,7 @@ more details.
   - [rpc] [\#3269](https://github.com/tendermint/tendermint/issues/2826) Limit number of unique clientIDs with open subscriptions. Configurable via `rpc.max_subscription_clients`
   - [rpc] [\#3269](https://github.com/tendermint/tendermint/issues/2826) Limit number of unique queries a given client can subscribe to at once. Configurable via `rpc.max_subscriptions_per_client`.
   - [rpc] [\#3435](https://github.com/tendermint/tendermint/issues/3435) Default ReadTimeout and WriteTimeout changed to 10s. WriteTimeout can increased by setting `rpc.timeout_broadcast_tx_commit` in the config.
-  - [rpc/client] [\#3269](https://github.com/tendermint/tendermint/issues/3269) Update `EventsClient` interface to reflect new pubsub/eventBus API [ADR-33](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-033-pubsub.md). This includes `Subscribe`, `Unsubscribe`, and `UnsubscribeAll` methods.
+  - [rpc/client] [\#3269](https://github.com/tendermint/tendermint/issues/3269) Update `EventsClient` interface to reflect new pubsub/eventBus API [ADR-33](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-033-pubsub.md). This includes `Subscribe`, `Unsubscribe`, and `UnsubscribeAll` methods.
 
 * Apps
   - [abci] [\#3403](https://github.com/tendermint/tendermint/issues/3403) Remove `time_iota_ms` from BlockParams. This is a
@@ -1851,7 +1851,7 @@ more details.
 - [blockchain] [\#3358](https://github.com/tendermint/tendermint/pull/3358) Fix timer leak in `BlockPool` (@guagualvcha)
 - [cmd] [\#3408](https://github.com/tendermint/tendermint/issues/3408) Fix `testnet` command's panic when creating non-validator configs (using `--n` flag) (@srmo)
 - [libs/db/remotedb/grpcdb] [\#3402](https://github.com/tendermint/tendermint/issues/3402) Close Iterator/ReverseIterator after use
-- [libs/pubsub] [\#951](https://github.com/tendermint/tendermint/issues/951), [\#1880](https://github.com/tendermint/tendermint/issues/1880) Use non-blocking send when dispatching messages [ADR-33](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-033-pubsub.md)
+- [libs/pubsub] [\#951](https://github.com/tendermint/tendermint/issues/951), [\#1880](https://github.com/tendermint/tendermint/issues/1880) Use non-blocking send when dispatching messages [ADR-33](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-033-pubsub.md)
 - [lite] [\#3364](https://github.com/tendermint/tendermint/issues/3364) Fix `/validators` and `/abci_query` proxy endpoints
   (@guagualvcha)
 - [p2p/conn] [\#3347](https://github.com/tendermint/tendermint/issues/3347) Reject all-zero shared secrets in the Diffie-Hellman step of secret-connection
@@ -2549,7 +2549,7 @@ Special thanks to external contributors on this release:
 This release is mostly about the ConsensusParams - removing fields and enforcing MaxGas.
 It also addresses some issues found via security audit, removes various unused
 functions from `libs/common`, and implements
-[ADR-012](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-012-peer-transport.md).
+[ADR-012](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-012-peer-transport.md).
 
 BREAKING CHANGES:
 
@@ -2630,7 +2630,7 @@ BREAKING CHANGES:
   - [abci] Added address of the original proposer of the block to Header
   - [abci] Change ABCI Header to match Tendermint exactly
   - [abci] [\#2159](https://github.com/tendermint/tendermint/issues/2159) Update use of `Validator` (see
-    [ADR-018](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-018-ABCI-Validators.md)):
+    [ADR-018](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-018-ABCI-Validators.md)):
     - Remove PubKey from `Validator` (so it's just Address and Power)
     - Introduce `ValidatorUpdate` (with just PubKey and Power)
     - InitChain and EndBlock use ValidatorUpdate
@@ -2652,7 +2652,7 @@ BREAKING CHANGES:
   - [state] [\#1815](https://github.com/tendermint/tendermint/issues/1815) Validator set changes are now delayed by one block (!)
     - Add NextValidatorSet to State, changes on-disk representation of state
   - [state] [\#2184](https://github.com/tendermint/tendermint/issues/2184) Enforce ConsensusParams.BlockSize.MaxBytes (See
-    [ADR-020](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-020-block-size.md)).
+    [ADR-020](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-020-block-size.md)).
     - Remove ConsensusParams.BlockSize.MaxTxs
     - Introduce maximum sizes for all components of a block, including ChainID
   - [types] Updates to the block Header:
@@ -2663,7 +2663,7 @@ BREAKING CHANGES:
   - [consensus] [\#2203](https://github.com/tendermint/tendermint/issues/2203) Implement BFT time
     - Timestamp in block must be monotonic and equal the median of timestamps in block's LastCommit
   - [crypto] [\#2239](https://github.com/tendermint/tendermint/issues/2239) Secp256k1 signature changes (See
-    [ADR-014](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-014-secp-malleability.md)):
+    [ADR-014](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-014-secp-malleability.md)):
     - format changed from DER to `r || s`, both little endian encoded as 32 bytes.
     - malleability removed by requiring `s` to be in canonical form.
 
@@ -3463,7 +3463,7 @@ Also includes the Grand Repo-Merge of 2017.
 BREAKING CHANGES:
 
 - Config and Flags:
-  - The `config` map is replaced with a [`Config` struct](https://github.com/tendermint/tendermint/blob/master/config/config.go#L11),
+  - The `config` map is replaced with a [`Config` struct](https://github.com/tendermint/tendermint/blob/main/config/config.go#L11),
 containing substructs: `BaseConfig`, `P2PConfig`, `MempoolConfig`, `ConsensusConfig`, `RPCConfig`
   - This affects the following flags:
     - `--seeds` is now `--p2p.seeds`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -863,7 +863,7 @@ and a validator address plus a timestamp. Note we may remove the validator
 address & timestamp fields in the future (see ADR-25).
 
 `lite2` package has been added to solve `lite` issues and introduce weak
-subjectivity interface. Refer to the [spec](https://github.com/tendermint/spec/blob/master/spec/consensus/light-client.md) for complete details.
+subjectivity interface. Refer to the [spec](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/consensus/light-client.md) for complete details.
 `lite` package is now deprecated and will be removed in v0.34 release.
 
 ### BREAKING CHANGES:
@@ -1224,7 +1224,7 @@ Special thanks to external contributors on this release: @jon-certik, @gracenoah
 *August 28, 2019*
 
 @climber73 wrote the [Writing a Tendermint Core application in Java
-(gRPC)](https://github.com/tendermint/tendermint/blob/main/docs/guides/java.md)
+(gRPC)](https://github.com/tendermint/tendermint/blob/v0.32.x/docs/guides/java.md)
 guide.
 
 Special thanks to external contributors on this release:
@@ -1257,7 +1257,7 @@ Special thanks to external contributors on this release:
 
 ### FEATURES:
 
-- [blockchain] [\#3561](https://github.com/tendermint/tendermint/issues/3561) Add early version of the new blockchain reactor, which is supposed to be more modular and testable compared to the old version. To try it, you'll have to change `version` in the config file, [here](https://github.com/tendermint/tendermint/blob/main/config/toml.go#L303) NOTE: It's not ready for a production yet. For further information, see [ADR-40](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-040-blockchain-reactor-refactor.md) & [ADR-43](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-043-blockchain-riri-org.md)
+- [blockchain] [\#3561](https://github.com/tendermint/tendermint/issues/3561) Add early version of the new blockchain reactor, which is supposed to be more modular and testable compared to the old version. To try it, you'll have to change `version` in the config file, [here](https://github.com/tendermint/tendermint/blob/v0.34.x/config/toml.go#L303) NOTE: It's not ready for a production yet. For further information, see [ADR-40](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-040-blockchain-reactor-refactor.md) & [ADR-43](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-043-blockchain-riri-org.md)
 - [mempool] [\#3826](https://github.com/tendermint/tendermint/issues/3826) Make `max_msg_bytes` configurable(@bluele)
 - [node] [\#3846](https://github.com/tendermint/tendermint/pull/3846) Allow replacing existing p2p.Reactor(s) using [`CustomReactors`
   option](https://godoc.org/github.com/tendermint/tendermint/node#CustomReactors).
@@ -3463,7 +3463,7 @@ Also includes the Grand Repo-Merge of 2017.
 BREAKING CHANGES:
 
 - Config and Flags:
-  - The `config` map is replaced with a [`Config` struct](https://github.com/tendermint/tendermint/blob/main/config/config.go#L11),
+  - The `config` map is replaced with a [`Config` struct](https://github.com/tendermint/tendermint/blob/v0.10.0/config/config.go#L11),
 containing substructs: `BaseConfig`, `P2PConfig`, `MempoolConfig`, `ConsensusConfig`, `RPCConfig`
   - This affects the following flags:
     - `--seeds` is now `--p2p.seeds`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -564,7 +564,7 @@ This security release fixes:
 Tendermint 0.33.0 and above allow block proposers to include signatures for the
 wrong block. This may happen naturally if you start a network, have it run for
 some time and restart it **without changing the chainID**. (It is a
-[misconfiguration](https://docs.tendermint.com/v0.34/tendermint-core/using-tendermint.html)
+[misconfiguration](https://docs.tendermint.com/v0.33/tendermint-core/using-tendermint.html)
 to reuse chainIDs.) Correct block proposers will accidentally include signatures
 for the wrong block if they see these signatures, and then commits won't validate,
 making all proposed blocks invalid. A malicious validator (even with a minimal
@@ -1574,7 +1574,7 @@ Special thanks to external contributors on this release:
 - [libs/db] [\#3611](https://github.com/tendermint/tendermint/issues/3611) Conditional compilation
   * Use `cleveldb` tag instead of `gcc` to compile Tendermint with CLevelDB or
     use `make build_c` / `make install_c` (full instructions can be found at
-    https://docs.tendermint.com/v0.34/introduction/install.html#compile-with-cleveldb-support)
+    <https://docs.tendermint.com/>)
   * Use `boltdb` tag to compile Tendermint with bolt db
 - [node] [\#3362](https://github.com/tendermint/tendermint/issues/3362) Return an error if `persistent_peers` list is invalid (except
   when IP lookup fails)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ will indicate their support with a heartfelt emoji.
 
 If the issue would benefit from thorough discussion, maintainers may
 request that you create a [Request For
-Comment](https://github.com/tendermint/spec/tree/master/rfc). Discussion
+Comment](https://github.com/tendermint/tendermint/tree/main/rfc). Discussion
 at the RFC stage will build collective understanding of the dimensions
 of the problems and help structure conversations around trade-offs.
 

--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -20,9 +20,9 @@ Respective versioned files can be found <https://raw.githubusercontent.com/tende
 
 Tendermint Core is Byzantine Fault Tolerant (BFT) middleware that takes a state transition machine, written in any programming language, and securely replicates it on many machines.
 
-For more background, see the [the docs](https://docs.tendermint.com/main/introduction/#quick-start).
+For more background, see the [the docs](https://docs.tendermint.com/v0.34/introduction/#quick-start).
 
-To get started developing applications, see the [application developers guide](https://docs.tendermint.com/main/introduction/quick-start.html).
+To get started developing applications, see the [application developers guide](https://docs.tendermint.com/v0.34/introduction/quick-start.html).
 
 ## How to use this image
 

--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -6,7 +6,7 @@ DockerHub tags for official releases are [here](https://hub.docker.com/r/tenderm
 
 Official releases can be found [here](https://github.com/tendermint/tendermint/releases).
 
-The Dockerfile for tendermint is not expected to change in the near future. The master file used for all builds can be found [here](https://raw.githubusercontent.com/tendermint/tendermint/master/DOCKER/Dockerfile).
+The Dockerfile for tendermint is not expected to change in the near future. The master file used for all builds can be found [here](https://raw.githubusercontent.com/tendermint/tendermint/main/DOCKER/Dockerfile).
 
 Respective versioned files can be found <https://raw.githubusercontent.com/tendermint/tendermint/vX.XX.XX/DOCKER/Dockerfile> (replace the Xs with the version number).
 
@@ -20,9 +20,9 @@ Respective versioned files can be found <https://raw.githubusercontent.com/tende
 
 Tendermint Core is Byzantine Fault Tolerant (BFT) middleware that takes a state transition machine, written in any programming language, and securely replicates it on many machines.
 
-For more background, see the [the docs](https://docs.tendermint.com/master/introduction/#quick-start).
+For more background, see the [the docs](https://docs.tendermint.com/main/introduction/#quick-start).
 
-To get started developing applications, see the [application developers guide](https://docs.tendermint.com/master/introduction/quick-start.html).
+To get started developing applications, see the [application developers guide](https://docs.tendermint.com/main/introduction/quick-start.html).
 
 ## How to use this image
 
@@ -37,7 +37,7 @@ docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint node --proxy_app
 
 ## Local cluster
 
-To run a 4-node network, see the `Makefile` in the root of [the repo](https://github.com/tendermint/tendermint/blob/master/Makefile) and run:
+To run a 4-node network, see the `Makefile` in the root of [the repo](https://github.com/tendermint/tendermint/blob/main/Makefile) and run:
 
 ```sh
 make build-linux
@@ -49,8 +49,8 @@ Note that this will build and use a different image than the ones provided here.
 
 ## License
 
-- Tendermint's license is [Apache 2.0](https://github.com/tendermint/tendermint/blob/master/LICENSE).
+- Tendermint's license is [Apache 2.0](https://github.com/tendermint/tendermint/blob/main/LICENSE).
 
 ## Contributing
 
-Contributions are most welcome! See the [contributing file](https://github.com/tendermint/tendermint/blob/master/CONTRIBUTING.md) for more information.
+Contributions are most welcome! See the [contributing file](https://github.com/tendermint/tendermint/blob/main/CONTRIBUTING.md) for more information.

--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -37,7 +37,7 @@ docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint node --proxy_app
 
 ## Local cluster
 
-To run a 4-node network, see the `Makefile` in the root of [the repo](https://github.com/tendermint/tendermint/blob/main/Makefile) and run:
+To run a 4-node network, see the `Makefile` in the root of [the repo](https://github.com/tendermint/tendermint/blob/v0.34.x/Makefile) and run:
 
 ```sh
 make build-linux

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ contact us [over email](mailto:hello@interchain.berlin) or [join the chat](https
 ## Security
 
 To report a security vulnerability, see our [bug bounty
-program](https://hackerone.com/tendermint). 
+program](https://hackerone.com/tendermint).
 For examples of the kinds of bugs we're looking for, see [our security policy](SECURITY.md)
 
 We also maintain a dedicated mailing list for security updates. We will only ever use this mailing list
@@ -121,7 +121,7 @@ In an effort to avoid accumulating technical debt prior to 1.0.0,
 we do not guarantee that breaking changes (ie. bumps in the MINOR version)
 will work with existing Tendermint blockchains. In these cases you will
 have to start a new blockchain, or write something custom to get the old
-data into the new chain. However, any bump in the PATCH version should be 
+data into the new chain. However, any bump in the PATCH version should be
 compatible with existing blockchain histories.
 
 
@@ -139,7 +139,7 @@ in [UPGRADING.md](./UPGRADING.md).
 ### Tendermint Core
 
 For details about the blockchain data structures and the p2p protocols, see the
-[Tendermint specification](https://docs.tendermint.com/v0.34/spec/).
+[Tendermint specification](./spec/).
 
 For details on using the software, see the [documentation](/docs/) which is also
 hosted at: <https://docs.tendermint.com/v0.34/>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Or [Blockchain](<https://en.wikipedia.org/wiki/Blockchain_(database)>), for shor
 [![API Reference](https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667)](https://pkg.go.dev/github.com/tendermint/tendermint)
 [![Go version](https://img.shields.io/badge/go-1.15-blue.svg)](https://github.com/moovweb/gvm)
 [![Discord chat](https://img.shields.io/discord/669268347736686612.svg)](https://discord.gg/AzefAFd)
-[![license](https://img.shields.io/github/license/tendermint/tendermint.svg)](https://github.com/tendermint/tendermint/blob/master/LICENSE)
+[![license](https://img.shields.io/github/license/tendermint/tendermint.svg)](https://github.com/tendermint/tendermint/blob/main/LICENSE)
 [![tendermint/tendermint](https://tokei.rs/b1/github/tendermint/tendermint?category=lines)](https://github.com/tendermint/tendermint)
 [![Sourcegraph](https://sourcegraph.com/github.com/tendermint/tendermint/-/badge.svg)](https://sourcegraph.com/github.com/tendermint/tendermint?badge)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Or [Blockchain](<https://en.wikipedia.org/wiki/Blockchain_(database)>), for shor
 Tendermint Core is Byzantine Fault Tolerant (BFT) middleware that takes a state transition machine - written in any programming language -
 and securely replicates it on many machines.
 
-For protocol details, see [the specification](https://github.com/tendermint/spec).
+For protocol details, see [the
+specification](https://github.com/tendermint/tendermint/tree/v0.34.x/spec).
 
 For detailed analysis of the consensus protocol, including safety and liveness proofs,
 see our recent paper, "[The latest gossip on BFT consensus](https://arxiv.org/abs/1807.04938)".
@@ -72,11 +73,12 @@ See the [install instructions](/docs/introduction/install.md).
 
 Please abide by the [Code of Conduct](CODE_OF_CONDUCT.md) in all interactions.
 
-Before contributing to the project, please take a look at the [contributing guidelines](CONTRIBUTING.md)
-and the [style guide](STYLE_GUIDE.md). You may also find it helpful to read the
-[specifications](https://github.com/tendermint/spec), watch the [Developer Sessions](/docs/DEV_SESSIONS.md), 
-and familiarize yourself with our
-[Architectural Decision Records](https://github.com/tendermint/tendermint/tree/master/docs/architecture).
+Before contributing to the project, please take a look at the [contributing
+guidelines](CONTRIBUTING.md) and the [style guide](STYLE_GUIDE.md). You may also
+find it helpful to read the [specifications](./spec/), watch the [Developer
+Sessions](/docs/DEV_SESSIONS.md), and familiarize yourself with our
+[Architectural Decision
+Records](https://github.com/tendermint/tendermint/tree/main/docs/architecture).
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ to notify you of vulnerabilities and fixes in Tendermint Core. You can subscribe
 
 ## Documentation
 
-Complete documentation can be found on the [website](https://docs.tendermint.com/master/).
+Complete documentation can be found on the [website](https://docs.tendermint.com/main/).
 
 ### Install
 
@@ -137,10 +137,10 @@ in [UPGRADING.md](./UPGRADING.md).
 ### Tendermint Core
 
 For details about the blockchain data structures and the p2p protocols, see the
-[Tendermint specification](https://docs.tendermint.com/master/spec/).
+[Tendermint specification](https://docs.tendermint.com/main/spec/).
 
 For details on using the software, see the [documentation](/docs/) which is also
-hosted at: <https://docs.tendermint.com/master/>
+hosted at: <https://docs.tendermint.com/main/>
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ to notify you of vulnerabilities and fixes in Tendermint Core. You can subscribe
 
 ## Documentation
 
-Complete documentation can be found on the [website](https://docs.tendermint.com/main/).
+Complete documentation can be found on the [website](https://docs.tendermint.com/v0.34/).
 
 ### Install
 
@@ -137,10 +137,10 @@ in [UPGRADING.md](./UPGRADING.md).
 ### Tendermint Core
 
 For details about the blockchain data structures and the p2p protocols, see the
-[Tendermint specification](https://docs.tendermint.com/main/spec/).
+[Tendermint specification](https://docs.tendermint.com/v0.34/spec/).
 
 For details on using the software, see the [documentation](/docs/) which is also
-hosted at: <https://docs.tendermint.com/main/>
+hosted at: <https://docs.tendermint.com/v0.34/>
 
 ### Tools
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,7 +15,7 @@ and gas cost).
 Operators can enable the priority mempool by setting `mempool.version` to
 `"v1"` in the `config.toml`. For more technical details about the priority
 mempool, see [ADR 067: Mempool
-Refactor](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-067-mempool-refactor.md).
+Refactor](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-067-mempool-refactor.md).
 
 ## v0.34.0
 
@@ -49,7 +49,7 @@ Note also that Tendermint 0.34 also requires Go 1.15 or higher.
   Applications should be able to handle these evidence types
   (i.e., through slashing or other accountability measures).
 
-* The [`PublicKey` type](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/crypto/keys.proto#L13-L15)
+* The [`PublicKey` type](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/crypto/keys.proto#L13-L15)
   (used in ABCI as part of `ValidatorUpdate`) now uses a `oneof` protobuf type.
   Note that since Tendermint only supports ed25519 validator keys, there's only one
   option in the `oneof`.  For more, see "Protocol Buffers," below.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -33,7 +33,7 @@ Note also that Tendermint 0.34 also requires Go 1.15 or higher.
   were added to support the new State Sync feature.
   Previously, syncing a new node to a preexisting network could take days; but with State Sync,
   new nodes are able to join a network in a matter of seconds.
-  Read [the spec](https://docs.tendermint.com/main/spec/abci/apps.html#state-sync)
+  Read [the spec](https://docs.tendermint.com/v0.34/spec/abci/apps.html#state-sync)
   if you want to learn more about State Sync, or if you'd like your application to use it.
   (If you don't want to support State Sync in your application, you can just implement these new
   ABCI methods as no-ops, leaving them empty.)
@@ -159,7 +159,7 @@ The `bech32` package has moved to the Cosmos SDK:
 ### CLI
 
 The `tendermint lite` command has been renamed to `tendermint light` and has a slightly different API.
-See [the docs](https://docs.tendermint.com/main/tendermint-core/light-client-protocol.html#http-proxy) for details.
+See [the docs](https://docs.tendermint.com/v0.34/tendermint-core/light-client-protocol.html#http-proxy) for details.
 
 ### Light Client
 
@@ -314,7 +314,7 @@ Evidence Params has been changed to include duration.
 ### RPC Changes
 
 * `/validators` is now paginated (default: 30 vals per page)
-* `/block_results` response format updated [see RPC docs for details](https://docs.tendermint.com/main/rpc/#/Info/block_results)
+* `/block_results` response format updated [see RPC docs for details](https://docs.tendermint.com/v0.34/rpc/#/Info/block_results)
 * Event suffix has been removed from the ID in event responses
 * IDs are now integers not `json-client-XYZ`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -33,7 +33,7 @@ Note also that Tendermint 0.34 also requires Go 1.15 or higher.
   were added to support the new State Sync feature.
   Previously, syncing a new node to a preexisting network could take days; but with State Sync,
   new nodes are able to join a network in a matter of seconds.
-  Read [the spec](https://docs.tendermint.com/master/spec/abci/apps.html#state-sync)
+  Read [the spec](https://docs.tendermint.com/main/spec/abci/apps.html#state-sync)
   if you want to learn more about State Sync, or if you'd like your application to use it.
   (If you don't want to support State Sync in your application, you can just implement these new
   ABCI methods as no-ops, leaving them empty.)
@@ -159,7 +159,7 @@ The `bech32` package has moved to the Cosmos SDK:
 ### CLI
 
 The `tendermint lite` command has been renamed to `tendermint light` and has a slightly different API.
-See [the docs](https://docs.tendermint.com/master/tendermint-core/light-client-protocol.html#http-proxy) for details.
+See [the docs](https://docs.tendermint.com/main/tendermint-core/light-client-protocol.html#http-proxy) for details.
 
 ### Light Client
 
@@ -314,7 +314,7 @@ Evidence Params has been changed to include duration.
 ### RPC Changes
 
 * `/validators` is now paginated (default: 30 vals per page)
-* `/block_results` response format updated [see RPC docs for details](https://docs.tendermint.com/master/rpc/#/Info/block_results)
+* `/block_results` response format updated [see RPC docs for details](https://docs.tendermint.com/main/rpc/#/Info/block_results)
 * Event suffix has been removed from the ID in event responses
 * IDs are now integers not `json-client-XYZ`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -33,7 +33,7 @@ Note also that Tendermint 0.34 also requires Go 1.15 or higher.
   were added to support the new State Sync feature.
   Previously, syncing a new node to a preexisting network could take days; but with State Sync,
   new nodes are able to join a network in a matter of seconds.
-  Read [the spec](https://docs.tendermint.com/v0.34/spec/abci/apps.html#state-sync)
+  Read [the spec](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/apps.md#state-sync)
   if you want to learn more about State Sync, or if you'd like your application to use it.
   (If you don't want to support State Sync in your application, you can just implement these new
   ABCI methods as no-ops, leaving them empty.)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -49,7 +49,7 @@ Note also that Tendermint 0.34 also requires Go 1.15 or higher.
   Applications should be able to handle these evidence types
   (i.e., through slashing or other accountability measures).
 
-* The [`PublicKey` type](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/crypto/keys.proto#L13-L15)
+* The [`PublicKey` type](https://github.com/tendermint/tendermint/blob/v0.34.x/proto/tendermint/crypto/keys.proto#L13-L15)
   (used in ABCI as part of `ValidatorUpdate`) now uses a `oneof` protobuf type.
   Note that since Tendermint only supports ed25519 validator keys, there's only one
   option in the `oneof`.  For more, see "Protocol Buffers," below.
@@ -508,14 +508,14 @@ due to changes in how various data structures are hashed.
 Any implementations of Tendermint blockchain verification, including lite clients,
 will need to be updated. For specific details:
 
-* [Merkle tree](https://github.com/tendermint/spec/blob/master/spec/blockchain/encoding.md#merkle-trees)
-* [ConsensusParams](https://github.com/tendermint/spec/blob/master/spec/blockchain/state.md#consensusparams)
+* [Merkle tree](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/encoding.md#merkle-trees)
+* [ConsensusParams](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/state.md#consensusparams)
 
 There was also a small change to field ordering in the vote struct. Any
 implementations of an out-of-process validator (like a Key-Management Server)
 will need to be updated. For specific details:
 
-* [Vote](https://github.com/tendermint/spec/blob/master/spec/consensus/signing.md#votes)
+* [Vote](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/consensus/signing.md#votes)
 
 Finally, the proposer selection algorithm continues to evolve. See the
 [work-in-progress

--- a/abci/README.md
+++ b/abci/README.md
@@ -19,7 +19,7 @@ To get up and running quickly, see the [getting started guide](../docs/app-dev/g
 
 A detailed description of the ABCI methods and message types is contained in:
 
-- [The main spec](https://github.com/tendermint/spec/blob/master/spec/abci/abci.md)
+- [The main spec](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/abci.md)
 - [A protobuf file](./types/types.proto)
 - [A Go interface](./types/application.go)
 

--- a/consensus/README.md
+++ b/consensus/README.md
@@ -1,3 +1,3 @@
 # Consensus 
 
-See the [consensus spec](https://github.com/tendermint/spec/tree/master/spec/consensus) and the [reactor consensus spec](https://github.com/tendermint/spec/tree/master/spec/reactors/consensus) for more information.
+See the [consensus spec](https://github.com/tendermint/tendermint/tree/v0.34.x/spec/consensus) and the [reactor consensus spec](https://github.com/tendermint/tendermint/tree/v0.34.x/spec/reactors/consensus) for more information.

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2212,10 +2212,11 @@ func (cs *State) voteTime() time.Time {
 	now := tmtime.Now()
 	minVoteTime := now
 	// TODO: We should remove next line in case we don't vote for v in case cs.ProposalBlock == nil,
-	// even if cs.LockedBlock != nil. See https://docs.tendermint.com/v0.34/spec/.
+	// even if cs.LockedBlock != nil. See https://github.com/tendermint/tendermint/tree/v0.34.x/spec/.
 	timeIota := time.Duration(cs.state.ConsensusParams.Block.TimeIotaMs) * time.Millisecond
 	if cs.LockedBlock != nil {
-		// See the BFT time spec https://docs.tendermint.com/v0.34/spec/consensus/bft-time.html
+		// See the BFT time spec
+		// https://github.com/tendermint/tendermint/blob/v0.34.x/spec/consensus/bft-time.md
 		minVoteTime = cs.LockedBlock.Time.Add(timeIota)
 	} else if cs.ProposalBlock != nil {
 		minVoteTime = cs.ProposalBlock.Time.Add(timeIota)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2212,10 +2212,10 @@ func (cs *State) voteTime() time.Time {
 	now := tmtime.Now()
 	minVoteTime := now
 	// TODO: We should remove next line in case we don't vote for v in case cs.ProposalBlock == nil,
-	// even if cs.LockedBlock != nil. See https://docs.tendermint.com/master/spec/.
+	// even if cs.LockedBlock != nil. See https://docs.tendermint.com/main/spec/.
 	timeIota := time.Duration(cs.state.ConsensusParams.Block.TimeIotaMs) * time.Millisecond
 	if cs.LockedBlock != nil {
-		// See the BFT time spec https://docs.tendermint.com/master/spec/consensus/bft-time.html
+		// See the BFT time spec https://docs.tendermint.com/main/spec/consensus/bft-time.html
 		minVoteTime = cs.LockedBlock.Time.Add(timeIota)
 	} else if cs.ProposalBlock != nil {
 		minVoteTime = cs.ProposalBlock.Time.Add(timeIota)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2212,10 +2212,10 @@ func (cs *State) voteTime() time.Time {
 	now := tmtime.Now()
 	minVoteTime := now
 	// TODO: We should remove next line in case we don't vote for v in case cs.ProposalBlock == nil,
-	// even if cs.LockedBlock != nil. See https://docs.tendermint.com/main/spec/.
+	// even if cs.LockedBlock != nil. See https://docs.tendermint.com/v0.34/spec/.
 	timeIota := time.Duration(cs.state.ConsensusParams.Block.TimeIotaMs) * time.Millisecond
 	if cs.LockedBlock != nil {
-		// See the BFT time spec https://docs.tendermint.com/main/spec/consensus/bft-time.html
+		// See the BFT time spec https://docs.tendermint.com/v0.34/spec/consensus/bft-time.html
 		minVoteTime = cs.LockedBlock.Time.Add(timeIota)
 	} else if cs.ProposalBlock != nil {
 		minVoteTime = cs.ProposalBlock.Time.Add(timeIota)

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -12,7 +12,7 @@ For any specific algorithm, use its specific module e.g.
 
 ## Binary encoding
 
-For Binary encoding, please refer to the [Tendermint encoding specification](https://docs.tendermint.com/v0.34/spec/blockchain/encoding.html).
+For Binary encoding, please refer to the [Tendermint encoding specification](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/core/encoding.md).
 
 ## JSON Encoding
 

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -12,7 +12,7 @@ For any specific algorithm, use its specific module e.g.
 
 ## Binary encoding
 
-For Binary encoding, please refer to the [Tendermint encoding specification](https://docs.tendermint.com/main/spec/blockchain/encoding.html).
+For Binary encoding, please refer to the [Tendermint encoding specification](https://docs.tendermint.com/v0.34/spec/blockchain/encoding.html).
 
 ## JSON Encoding
 

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -12,7 +12,7 @@ For any specific algorithm, use its specific module e.g.
 
 ## Binary encoding
 
-For Binary encoding, please refer to the [Tendermint encoding specification](https://docs.tendermint.com/master/spec/blockchain/encoding.html).
+For Binary encoding, please refer to the [Tendermint encoding specification](https://docs.tendermint.com/main/spec/blockchain/encoding.html).
 
 ## JSON Encoding
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -19,8 +19,8 @@ module.exports = {
         "key": "v0.33"
       },
       {
-        "label": "v0.34",
-        "key": "v0.34"
+        "label": "v0.34 (latest)",
+        "key": "latest"
       }
     ],
     topbar: {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -15,16 +15,12 @@ module.exports = {
     },
     versions: [
       {
-        "label": "main (unstable)",
-        "key": "main"
+        "label": "v0.34 (latest)",
+        "key": "v0.34"
       },
       {
         "label": "v0.33",
         "key": "v0.33"
-      },
-      {
-        "label": "v0.34 (latest)",
-        "key": "latest"
       }
     ],
     topbar: {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -15,6 +15,10 @@ module.exports = {
     },
     versions: [
       {
+        "label": "main (unstable)",
+        "key": "main"
+      },
+      {
         "label": "v0.33",
         "key": "v0.33"
       },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,14 +1,6 @@
 module.exports = {
   theme: 'cosmos',
   title: 'Tendermint Core',
-  // locales: {
-  //   "/": {
-  //     lang: "en-US"
-  //   },
-  //   "/ru/": {
-  //     lang: "ru"
-  //   }
-  // },
   base: process.env.VUEPRESS_BASE,
   themeConfig: {
     repo: 'tendermint/tendermint',
@@ -29,10 +21,6 @@ module.exports = {
       {
         "label": "v0.34",
         "key": "v0.34"
-      },
-      {
-        "label": "v0.35",
-        "key": "v0.35"
       }
     ],
     topbar: {
@@ -45,10 +33,8 @@ module.exports = {
           title: 'Resources',
           children: [
             {
-              // TODO(creachadair): Figure out how to make this per-branch.
-              // See: https://github.com/tendermint/tendermint/issues/7908
               title: 'RPC',
-              path: 'https://docs.tendermint.com/v0.35/rpc/',
+              path: (process.env.VUEPRESS_BASE ? process.env.VUEPRESS_BASE : '/')+'rpc/',
               static: true
             },
           ]
@@ -59,9 +45,9 @@ module.exports = {
       title: 'Help & Support',
       editLink: true,
       forum: {
-        title: 'Tendermint Forum',
-        text: 'Join the Tendermint forum to learn more',
-        url: 'https://forum.cosmos.network/c/tendermint',
+        title: 'Tendermint Discussions',
+        text: 'Join the Tendermint discussions to learn more',
+        url: 'https://github.com/tendermint/tendermint/discussions',
         bg: '#0B7E0B',
         logo: 'tendermint'
       },
@@ -72,7 +58,7 @@ module.exports = {
     },
     footer: {
       question: {
-        text: 'Chat with Tendermint developers in <a href=\'https://discord.gg/vcExX9T\' target=\'_blank\'>Discord</a> or reach out on the <a href=\'https://forum.cosmos.network/c/tendermint\' target=\'_blank\'>Tendermint Forum</a> to learn more.'
+        text: 'Chat with Tendermint developers in <a href=\'https://discord.gg/vcExX9T\' target=\'_blank\'>Discord</a> or reach out on <a href=\'https://github.com/tendermint/tendermint/discussions\' target=\'_blank\'>GitHub</a> to learn more.'
       },
       logo: '/logo-bw.svg',
       textLink: {
@@ -129,8 +115,8 @@ module.exports = {
               url: 'https://medium.com/@tendermint'
             },
             {
-              title: 'Forum',
-              url: 'https://forum.cosmos.network/c/tendermint'
+              title: 'GitHub Discussions',
+              url: 'https://github.com/tendermint/tendermint/discussions'
             }
           ]
         },

--- a/docs/.vuepress/redirects
+++ b/docs/.vuepress/redirects
@@ -1,1 +1,1 @@
-/master/ /v0.35/
+/master/ /main/

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -2,7 +2,7 @@
 
 The documentation for Tendermint Core is hosted at:
 
-- <https://docs.tendermint.com/main/>
+- <https://docs.tendermint.com/v0.34/>
 
 built from the files in this (`/docs`) directory for
 [main](https://github.com/tendermint/tendermint/tree/main/docs) respectively.

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -2,10 +2,9 @@
 
 The documentation for Tendermint Core is hosted at:
 
-- <https://docs.tendermint.com/v0.34/>
+- <https://docs.tendermint.com/>
 
-built from the files in this (`/docs`) directory for
-[main](https://github.com/tendermint/tendermint/tree/main/docs) respectively.
+built from the files in this (`/docs`) directory.
 
 ## How It Works
 

--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -2,39 +2,39 @@
 
 The documentation for Tendermint Core is hosted at:
 
-- <https://docs.tendermint.com/master/>
+- <https://docs.tendermint.com/main/>
 
 built from the files in this (`/docs`) directory for
-[master](https://github.com/tendermint/tendermint/tree/master/docs) respectively.
+[main](https://github.com/tendermint/tendermint/tree/main/docs) respectively.
 
 ## How It Works
 
-There is a CircleCI job listening for changes in the `/docs` directory, on both
-the `master` branch. Any updates to files in this directory
-on those branches will automatically trigger a website deployment. Under the hood,
-the private website repository has a `make build-docs` target consumed by a CircleCI job in that repo.
+There is a [GitHub Action](../.github/workflows/docs-deployment.yml) that is
+triggered by changes in the `/docs` directory on `main` as well as the branch of
+each major supported version (e.g. `v0.34.x`). Any updates to files in this
+directory on those branches will automatically trigger a website deployment.
 
 ## README
 
-The [README.md](./README.md) is also the landing page for the documentation
-on the website. During the Jenkins build, the current commit is added to the bottom
-of the README.
+The [README.md](./README.md) is also the landing page for the documentation on
+the website.
 
 ## Config.js
 
-The [config.js](./.vuepress/config.js) generates the sidebar and Table of Contents
-on the website docs. Note the use of relative links and the omission of
-file extensions. Additional features are available to improve the look
-of the sidebar.
+The [config.js](./.vuepress/config.js) generates the sidebar and Table of
+Contents on the website docs. Note the use of relative links and the omission of
+file extensions. Additional features are available to improve the look of the
+sidebar.
 
 ## Links
 
-**NOTE:** Strongly consider the existing links - both within this directory
-and to the website docs - when moving or deleting files.
+**NOTE:** Strongly consider the existing links - both within this directory and
+to the website docs - when moving or deleting files.
 
 Links to directories _MUST_ end in a `/`.
 
-Relative links should be used nearly everywhere, having discovered and weighed the following:
+Relative links should be used nearly everywhere, having discovered and weighed
+the following:
 
 ### Relative
 
@@ -65,7 +65,8 @@ Make sure you are in the `docs` directory and run the following commands:
 rm -rf node_modules
 ```
 
-This command will remove old version of the visual theme and required packages. This step is optional.
+This command will remove old version of the visual theme and required packages.
+This step is optional.
 
 ```bash
 npm install
@@ -79,17 +80,24 @@ npm run serve
 
 <!-- markdown-link-check-disable -->
 
-Run `pre` and `post` hooks and start a hot-reloading web-server. See output of this command for the URL (it is often <https://localhost:8080>).
+Run `pre` and `post` hooks and start a hot-reloading web-server. See output of
+this command for the URL (it is often <https://localhost:8080>).
 
 <!-- markdown-link-check-enable -->
 
-To build documentation as a static website run `npm run build`. You will find the website in `.vuepress/dist` directory.
+To build documentation as a static website run `npm run build`. You will find
+the website in `.vuepress/dist` directory.
 
 ## Search
 
-We are using [Algolia](https://www.algolia.com) to power full-text search. This uses a public API search-only key in the `config.js` as well as a [tendermint.json](https://github.com/algolia/docsearch-configs/blob/master/configs/tendermint.json) configuration file that we can update with PRs.
+We are using [Algolia](https://www.algolia.com) to power full-text search. This
+uses a public API search-only key in the `config.js` as well as a
+[tendermint.json](https://github.com/algolia/docsearch-configs/blob/master/configs/tendermint.json)
+configuration file that we can update with PRs.
 
 ## Consistency
 
-Because the build processes are identical (as is the information contained herein), this file should be kept in sync as
-much as possible with its [counterpart in the Cosmos SDK repo](https://github.com/cosmos/cosmos-sdk/blob/master/docs/DOCS_README.md).
+Because the build processes are identical (as is the information contained
+herein), this file should be kept in sync as much as possible with its
+[counterpart in the Cosmos SDK
+repo](https://github.com/cosmos/cosmos-sdk/blob/master/docs/DOCS_README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,4 +30,4 @@ To find out about the Tendermint ecosystem you can go [here](https://github.com/
 
 ## Contribute
 
-To contribute to the documentation, see [this file](https://github.com/tendermint/tendermint/blob/master/docs/DOCS_README.md) for details of the build process and considerations when making changes.
+To contribute to the documentation, see [this file](https://github.com/tendermint/tendermint/blob/main/docs/DOCS_README.md) for details of the build process and considerations when making changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,20 +14,29 @@ of a web-server, database, and supporting libraries for blockchain applications
 written in any programming language. Like a web-server serving web applications,
 Tendermint serves blockchain applications.
 
-More formally, Tendermint Core performs Byzantine Fault Tolerant (BFT)
-State Machine Replication (SMR) for arbitrary deterministic, finite state machines.
+More formally, Tendermint Core performs Byzantine Fault Tolerant (BFT) State
+Machine Replication (SMR) for arbitrary deterministic, finite state machines.
 For more background, see [What is
 Tendermint?](introduction/what-is-tendermint.md).
 
-To get started quickly with an example application, see the [quick start guide](introduction/quick-start.md).
+To get started quickly with an example application, see the [quick start
+guide](introduction/quick-start.md).
 
-To learn about application development on Tendermint, see the [Application Blockchain Interface](https://github.com/tendermint/spec/tree/master/spec/abci).
+To learn about application development on Tendermint, see the [Application
+Blockchain
+Interface](https://github.com/tendermint/tendermint/tree/v0.34.x/spec/abci).
 
 For more details on using Tendermint, see the respective documentation for
-[Tendermint Core](tendermint-core/), [benchmarking and monitoring](tools/), and [network deployments](networks/).
+[Tendermint Core](tendermint-core/), [benchmarking and monitoring](tools/), and
+[network deployments](networks/).
 
-To find out about the Tendermint ecosystem you can go [here](https://github.com/tendermint/awesome#ecosystem). If you are a project that is using Tendermint you are welcome to make a PR to add your project to the list.
+To find out about the Tendermint ecosystem you can go
+[here](https://github.com/tendermint/awesome#ecosystem). If you are a project
+that is using Tendermint you are welcome to make a PR to add your project to the
+list.
 
 ## Contribute
 
-To contribute to the documentation, see [this file](https://github.com/tendermint/tendermint/blob/main/docs/DOCS_README.md) for details of the build process and considerations when making changes.
+To contribute to the documentation, see [this
+file](https://github.com/tendermint/tendermint/blob/main/docs/DOCS_README.md)
+for details of the build process and considerations when making changes.

--- a/docs/app-dev/abci-cli.md
+++ b/docs/app-dev/abci-cli.md
@@ -138,7 +138,7 @@ response.
 
 The server may be generic for a particular language, and we provide a
 [reference implementation in
-Golang](https://github.com/tendermint/tendermint/tree/master/abci/server). See the
+Golang](https://github.com/tendermint/tendermint/tree/v0.34.x/abci/server). See the
 [list of other ABCI implementations](https://github.com/tendermint/awesome#ecosystem) for servers in
 other languages.
 
@@ -325,7 +325,7 @@ But the ultimate flexibility comes from being able to write the
 application easily in any language.
 
 We have implemented the counter in a number of languages [see the
-example directory](https://github.com/tendermint/tendermint/tree/master/abci/example).
+example directory](https://github.com/tendermint/tendermint/tree/v0.34.x/abci/example).
 
 To run the Node.js version, fist download & install [the Javascript ABCI server](https://github.com/tendermint/js-abci):
 

--- a/docs/app-dev/app-architecture.md
+++ b/docs/app-dev/app-architecture.md
@@ -55,6 +55,6 @@ Tendermint.
 See the following for more extensive documentation:
 
 - [Interchain Standard for the Light-Client REST API](https://github.com/cosmos/cosmos-sdk/pull/1028)
-- [Tendermint RPC Docs](https://docs.tendermint.com/master/rpc/)
+- [Tendermint RPC Docs](https://docs.tendermint.com/main/rpc/)
 - [Tendermint in Production](../tendermint-core/running-in-production.md)
 - [ABCI spec](https://github.com/tendermint/spec/tree/95cf253b6df623066ff7cd4074a94e7a3f147c7a/spec/abci)

--- a/docs/app-dev/app-architecture.md
+++ b/docs/app-dev/app-architecture.md
@@ -55,6 +55,6 @@ Tendermint.
 See the following for more extensive documentation:
 
 - [Interchain Standard for the Light-Client REST API](https://github.com/cosmos/cosmos-sdk/pull/1028)
-- [Tendermint RPC Docs](https://docs.tendermint.com/main/rpc/)
+- [Tendermint RPC Docs](https://docs.tendermint.com/v0.34/rpc/)
 - [Tendermint in Production](../tendermint-core/running-in-production.md)
 - [ABCI spec](https://github.com/tendermint/spec/tree/95cf253b6df623066ff7cd4074a94e7a3f147c7a/spec/abci)

--- a/docs/app-dev/indexing-transactions.md
+++ b/docs/app-dev/indexing-transactions.md
@@ -146,7 +146,7 @@ You can query for a paginated set of transaction by their events by calling the
 curl "localhost:26657/tx_search?query=\"message.sender='cosmos1...'\"&prove=true"
 ```
 
-Check out [API docs](https://docs.tendermint.com/main/rpc/#/Info/tx_search)
+Check out [API docs](https://docs.tendermint.com/v0.34/rpc/#/Info/tx_search)
 for more information on query syntax and other options.
 
 ## Subscribing to Transactions
@@ -165,7 +165,7 @@ a query to `/subscribe` RPC endpoint.
 }
 ```
 
-Check out [API docs](https://docs.tendermint.com/main/rpc/#subscribe) for more information
+Check out [API docs](https://docs.tendermint.com/v0.34/rpc/#subscribe) for more information
 on query syntax and other options.
 
 ## Querying Blocks Events
@@ -177,5 +177,5 @@ You can query for a paginated set of blocks by their events by calling the
 curl "localhost:26657/block_search?query=\"block.height > 10 AND val_set.num_changed > 0\""
 ```
 
-Check out [API docs](https://docs.tendermint.com/main/rpc/#/Info/block_search)
+Check out [API docs](https://docs.tendermint.com/v0.34/rpc/#/Info/block_search)
 for more information on query syntax and other options.

--- a/docs/app-dev/indexing-transactions.md
+++ b/docs/app-dev/indexing-transactions.md
@@ -15,7 +15,7 @@ the block itself is never stored.
 Each event contains a type and a list of attributes, which are key-value pairs
 denoting something about what happened during the method's execution. For more
 details on `Events`, see the
-[ABCI](https://github.com/tendermint/spec/blob/master/spec/abci/abci.md#events)
+[ABCI](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/abci.md#events)
 documentation.
 
 An `Event` has a composite key associated with it. A `compositeKey` is

--- a/docs/app-dev/indexing-transactions.md
+++ b/docs/app-dev/indexing-transactions.md
@@ -146,7 +146,7 @@ You can query for a paginated set of transaction by their events by calling the
 curl "localhost:26657/tx_search?query=\"message.sender='cosmos1...'\"&prove=true"
 ```
 
-Check out [API docs](https://docs.tendermint.com/master/rpc/#/Info/tx_search)
+Check out [API docs](https://docs.tendermint.com/main/rpc/#/Info/tx_search)
 for more information on query syntax and other options.
 
 ## Subscribing to Transactions
@@ -165,7 +165,7 @@ a query to `/subscribe` RPC endpoint.
 }
 ```
 
-Check out [API docs](https://docs.tendermint.com/master/rpc/#subscribe) for more information
+Check out [API docs](https://docs.tendermint.com/main/rpc/#subscribe) for more information
 on query syntax and other options.
 
 ## Querying Blocks Events
@@ -177,5 +177,5 @@ You can query for a paginated set of blocks by their events by calling the
 curl "localhost:26657/block_search?query=\"block.height > 10 AND val_set.num_changed > 0\""
 ```
 
-Check out [API docs](https://docs.tendermint.com/master/rpc/#/Info/block_search)
+Check out [API docs](https://docs.tendermint.com/main/rpc/#/Info/block_search)
 for more information on query syntax and other options.

--- a/docs/introduction/what-is-tendermint.md
+++ b/docs/introduction/what-is-tendermint.md
@@ -120,7 +120,7 @@ consensus engine, and provides a particular application state.
 ## ABCI Overview
 
 The [Application BlockChain Interface
-(ABCI)](https://github.com/tendermint/tendermint/tree/master/abci)
+(ABCI)](https://github.com/tendermint/tendermint/tree/v0.34.x/abci)
 allows for Byzantine Fault Tolerant replication of applications
 written in any programming language.
 
@@ -180,15 +180,15 @@ The application will be responsible for
 - Allowing clients to query the UTXO database.
 
 Tendermint is able to decompose the blockchain design by offering a very
-simple API (ie. the ABCI) between the application process and consensus
+simple API (i.e. the ABCI) between the application process and consensus
 process.
 
 The ABCI consists of 3 primary message types that get delivered from the
 core to the application. The application replies with corresponding
 response messages.
 
-The messages are specified here: [ABCI Message
-Types](https://github.com/tendermint/tendermint/blob/main/abci/README.md#message-types).
+The messages are specified in the [ABCI
+specification](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/abci.md).
 
 The **DeliverTx** message is the work horse of the application. Each
 transaction in the blockchain is delivered with this message. The

--- a/docs/introduction/what-is-tendermint.md
+++ b/docs/introduction/what-is-tendermint.md
@@ -188,7 +188,7 @@ core to the application. The application replies with corresponding
 response messages.
 
 The messages are specified here: [ABCI Message
-Types](https://github.com/tendermint/tendermint/blob/master/abci/README.md#message-types).
+Types](https://github.com/tendermint/tendermint/blob/main/abci/README.md#message-types).
 
 The **DeliverTx** message is the work horse of the application. Each
 transaction in the blockchain is delivered with this message. The

--- a/docs/networks/terraform-and-ansible.md
+++ b/docs/networks/terraform-and-ansible.md
@@ -14,7 +14,7 @@ testnets on those servers.
 ## Install
 
 NOTE: see the [integration bash
-script](https://github.com/tendermint/tendermint/blob/master/networks/remote/integration.sh)
+script](https://github.com/tendermint/tendermint/blob/main/networks/remote/integration.sh)
 that can be run on a fresh DO droplet and will automatically spin up a 4
 node testnet. The script more or less does everything described below.
 

--- a/docs/networks/terraform-and-ansible.md
+++ b/docs/networks/terraform-and-ansible.md
@@ -14,7 +14,7 @@ testnets on those servers.
 ## Install
 
 NOTE: see the [integration bash
-script](https://github.com/tendermint/tendermint/blob/main/networks/remote/integration.sh)
+script](https://github.com/tendermint/tendermint/blob/v0.34.x/networks/remote/integration.sh)
 that can be run on a fresh DO droplet and will automatically spin up a 4
 node testnet. The script more or less does everything described below.
 
@@ -58,7 +58,7 @@ With the droplets created and running, let's setup Ansible.
 ## Ansible
 
 The playbooks in [the ansible
-directory](https://github.com/tendermint/tendermint/tree/master/networks/remote/ansible)
+directory](https://github.com/tendermint/tendermint/tree/v0.34.x/networks/remote/ansible)
 run ansible roles to configure the sentry node architecture. You must
 switch to this directory to run ansible
 (`cd $GOPATH/src/github.com/tendermint/tendermint/networks/remote/ansible`).

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8876,9 +8876,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mississippi": {
       "version": "3.0.0",
@@ -13045,9 +13045,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.7.tgz",
-      "integrity": "sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -21113,9 +21113,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -24536,9 +24536,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.7.tgz",
-      "integrity": "sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/docs/tendermint-core/how-to-read-logs.md
+++ b/docs/tendermint-core/how-to-read-logs.md
@@ -67,7 +67,7 @@ Next follows a standard block creation cycle, where we enter a new
 round, propose a block, receive more than 2/3 of prevotes, then
 precommits and finally have a chance to commit a block. For details,
 please refer to [Byzantine Consensus
-Algorithm](https://github.com/tendermint/spec/blob/master/spec/consensus/consensus.md).
+Algorithm](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/consensus/consensus.md).
 
 ```sh
 I[10-04|13:54:30.393] enterNewRound(91/0). Current: 91/0/RoundStepNewHeight module=consensus

--- a/docs/tendermint-core/rpc.md
+++ b/docs/tendermint-core/rpc.md
@@ -6,6 +6,6 @@ order: 9
 
 The RPC documentation is hosted here:
 
-- [https://docs.tendermint.com/master/rpc/](https://docs.tendermint.com/master/rpc/)
+- [https://docs.tendermint.com/main/rpc/](https://docs.tendermint.com/main/rpc/)
 
 To update the documentation, edit the relevant `godoc` comments in the [rpc/core directory](https://github.com/tendermint/tendermint/blob/v0.34.x/rpc/core).

--- a/docs/tendermint-core/rpc.md
+++ b/docs/tendermint-core/rpc.md
@@ -6,6 +6,6 @@ order: 9
 
 The RPC documentation is hosted here:
 
-- [https://docs.tendermint.com/main/rpc/](https://docs.tendermint.com/main/rpc/)
+- [https://docs.tendermint.com/v0.34/rpc/](https://docs.tendermint.com/v0.34/rpc/)
 
 To update the documentation, edit the relevant `godoc` comments in the [rpc/core directory](https://github.com/tendermint/tendermint/blob/v0.34.x/rpc/core).

--- a/docs/tendermint-core/running-in-production.md
+++ b/docs/tendermint-core/running-in-production.md
@@ -95,7 +95,7 @@ mechanisms.
 ### RPC
 
 Endpoints returning multiple entries are limited by default to return 30
-elements (100 max). See the [RPC Documentation](https://docs.tendermint.com/master/rpc/)
+elements (100 max). See the [RPC Documentation](https://docs.tendermint.com/main/rpc/)
 for more information.
 
 Rate-limiting and authentication are another key aspects to help protect

--- a/docs/tendermint-core/running-in-production.md
+++ b/docs/tendermint-core/running-in-production.md
@@ -95,7 +95,7 @@ mechanisms.
 ### RPC
 
 Endpoints returning multiple entries are limited by default to return 30
-elements (100 max). See the [RPC Documentation](https://docs.tendermint.com/main/rpc/)
+elements (100 max). See the [RPC Documentation](https://docs.tendermint.com/v0.34/rpc/)
 for more information.
 
 Rate-limiting and authentication are another key aspects to help protect

--- a/docs/tendermint-core/subscription.md
+++ b/docs/tendermint-core/subscription.md
@@ -43,7 +43,7 @@ transactions](./indexing-transactions.md) for details.
 When validator set changes, ValidatorSetUpdates event is published. The
 event carries a list of pubkey/power pairs. The list is the same
 Tendermint receives from ABCI application (see [EndBlock
-section](https://github.com/tendermint/spec/blob/master/spec/abci/abci.md#endblock) in
+section](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/abci.md#endblock) in
 the ABCI spec).
 
 Response:

--- a/docs/tendermint-core/subscription.md
+++ b/docs/tendermint-core/subscription.md
@@ -31,7 +31,7 @@ method via Websocket along with a valid query.
 }
 ```
 
-Check out [API docs](https://docs.tendermint.com/main/rpc/) for
+Check out [API docs](https://docs.tendermint.com/v0.34/rpc/) for
 more information on query syntax and other options.
 
 You can also use tags, given you had included them into DeliverTx

--- a/docs/tendermint-core/subscription.md
+++ b/docs/tendermint-core/subscription.md
@@ -31,7 +31,7 @@ method via Websocket along with a valid query.
 }
 ```
 
-Check out [API docs](https://docs.tendermint.com/master/rpc/) for
+Check out [API docs](https://docs.tendermint.com/main/rpc/) for
 more information on query syntax and other options.
 
 You can also use tags, given you had included them into DeliverTx

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -39,7 +39,7 @@ tendermint testnet --help
 
 The `genesis.json` file in `$TMHOME/config/` defines the initial
 TendermintCore state upon genesis of the blockchain ([see
-definition](https://github.com/tendermint/tendermint/blob/master/types/genesis.go)).
+definition](https://github.com/tendermint/tendermint/blob/main/types/genesis.go)).
 
 #### Fields
 
@@ -183,7 +183,7 @@ endpoints. Some take no arguments (like `/status`), while others specify
 the argument name and use `_` as a placeholder.
 
 
-> TIP: Find the RPC Documentation [here](https://docs.tendermint.com/master/rpc/)
+> TIP: Find the RPC Documentation [here](https://docs.tendermint.com/main/rpc/)
 
 ### Formatting
 

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -183,7 +183,7 @@ endpoints. Some take no arguments (like `/status`), while others specify
 the argument name and use `_` as a placeholder.
 
 
-> TIP: Find the RPC Documentation [here](https://docs.tendermint.com/main/rpc/)
+> TIP: Find the RPC Documentation [here](https://docs.tendermint.com/v0.34/rpc/)
 
 ### Formatting
 

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -39,7 +39,7 @@ tendermint testnet --help
 
 The `genesis.json` file in `$TMHOME/config/` defines the initial
 TendermintCore state upon genesis of the blockchain ([see
-definition](https://github.com/tendermint/tendermint/blob/main/types/genesis.go)).
+definition](https://github.com/tendermint/tendermint/blob/v0.34.x/types/genesis.go)).
 
 #### Fields
 
@@ -49,7 +49,7 @@ definition](https://github.com/tendermint/tendermint/blob/main/types/genesis.go)
   chain IDs, you will have a bad time. The ChainID must be less than 50 symbols.
 - `initial_height`: Height at which Tendermint should begin at. If a blockchain is conducting a network upgrade, 
     starting from the stopped height brings uniqueness to previous heights. 
-- `consensus_params` [spec](https://github.com/tendermint/spec/blob/master/spec/core/state.md#consensusparams)
+- `consensus_params` [spec](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/core/data_structures.md#consensusparams)
     - `block`
         - `max_bytes`: Max block size, in bytes.
         - `max_gas`: Max gas per block.

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -218,7 +218,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/main/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/v0.34/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -337,7 +337,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/main/spec/abci/).
+[here](https://docs.tendermint.com/v0.34/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instance in the same process
 
@@ -610,7 +610,7 @@ go build
 To create a default configuration, nodeKey and private validator files, let's
 execute `tendermint init`. But before we do that, we will need to install
 Tendermint Core. Please refer to [the official
-guide](https://docs.tendermint.com/main/introduction/install.html). If you're
+guide](https://docs.tendermint.com/v0.34/introduction/install.html). If you're
 installing from source, don't forget to checkout the latest release (`git checkout vX.Y.Z`).
 
 ```bash
@@ -680,4 +680,4 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/main/).
+deeper, read [the docs](https://docs.tendermint.com/v0.34/).

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -84,7 +84,7 @@ Hello, Tendermint Core
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
+file](https://github.com/tendermint/tendermint/blob/v0.34.x/proto/tendermint/abci/types.proto).
 This allows Tendermint Core to run applications written in any programming
 language.
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -218,7 +218,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/v0.34/spec/abci/apps.html#gas).
+specification"](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/apps.md#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -337,7 +337,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/v0.34/spec/abci/).
+[here](https://github.com/tendermint/tendermint/tree/v0.34.x/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instance in the same process
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -84,7 +84,7 @@ Hello, Tendermint Core
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/abci/types.proto).
+file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
 This allows Tendermint Core to run applications written in any programming
 language.
 
@@ -218,7 +218,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/main/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -337,7 +337,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/master/spec/abci/).
+[here](https://docs.tendermint.com/main/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instance in the same process
 
@@ -610,7 +610,7 @@ go build
 To create a default configuration, nodeKey and private validator files, let's
 execute `tendermint init`. But before we do that, we will need to install
 Tendermint Core. Please refer to [the official
-guide](https://docs.tendermint.com/master/introduction/install.html). If you're
+guide](https://docs.tendermint.com/main/introduction/install.html). If you're
 installing from source, don't forget to checkout the latest release (`git checkout vX.Y.Z`).
 
 ```bash
@@ -680,4 +680,4 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/master/).
+deeper, read [the docs](https://docs.tendermint.com/main/).

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -221,7 +221,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/main/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/v0.34/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -340,7 +340,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/main/spec/abci/).
+[here](https://docs.tendermint.com/v0.34/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -468,7 +468,7 @@ go build
 To create a default configuration, nodeKey and private validator files, let's
 execute `tendermint init`. But before we do that, we will need to install
 Tendermint Core. Please refer to [the official
-guide](https://docs.tendermint.com/main/introduction/install.html). If you're
+guide](https://docs.tendermint.com/v0.34/introduction/install.html). If you're
 installing from source, don't forget to checkout the latest release (`git checkout vX.Y.Z`).
 
 ```bash
@@ -482,7 +482,7 @@ I[2019-07-16|18:20:36.482] Generated genesis file                       module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://docs.tendermint.com/main/tendermint-core/configuration.html).
+[here](https://docs.tendermint.com/v0.34/tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -565,4 +565,4 @@ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/main/).
+deeper, read [the docs](https://docs.tendermint.com/v0.34/).

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -221,7 +221,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/v0.34/spec/abci/apps.html#gas).
+specification"](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/apps.md#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -340,7 +340,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/v0.34/spec/abci/).
+[here](https://github.com/tendermint/tendermint/tree/v0.34.x/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -87,7 +87,7 @@ Hello, Tendermint Core
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/abci/types.proto).
+file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
 This allows Tendermint Core to run applications written in any programming
 language.
 
@@ -221,7 +221,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/main/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -340,7 +340,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/master/spec/abci/).
+[here](https://docs.tendermint.com/main/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -468,7 +468,7 @@ go build
 To create a default configuration, nodeKey and private validator files, let's
 execute `tendermint init`. But before we do that, we will need to install
 Tendermint Core. Please refer to [the official
-guide](https://docs.tendermint.com/master/introduction/install.html). If you're
+guide](https://docs.tendermint.com/main/introduction/install.html). If you're
 installing from source, don't forget to checkout the latest release (`git checkout vX.Y.Z`).
 
 ```bash
@@ -482,7 +482,7 @@ I[2019-07-16|18:20:36.482] Generated genesis file                       module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://docs.tendermint.com/master/tendermint-core/configuration.html).
+[here](https://docs.tendermint.com/main/tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -565,4 +565,4 @@ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/master/).
+deeper, read [the docs](https://docs.tendermint.com/main/).

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -87,7 +87,7 @@ Hello, Tendermint Core
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
+file](https://github.com/tendermint/tendermint/blob/v0.34.x/proto/tendermint/abci/types.proto).
 This allows Tendermint Core to run applications written in any programming
 language.
 

--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -115,7 +115,7 @@ Hello world.
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/abci/types.proto).
+file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
 This allows Tendermint Core to run applications written in any programming
 language.
 
@@ -323,7 +323,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/main/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [JetBrains Xodus](https://github.com/JetBrains/xodus), which is a transactional schema-less embedded high-performance database written in Java.
@@ -467,7 +467,7 @@ public void query(RequestQuery req, StreamObserver<ResponseQuery> responseObserv
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/master/spec/abci/).
+[here](https://docs.tendermint.com/main/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -559,7 +559,7 @@ I[2019-07-16|18:20:36.482] Generated genesis file                       module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://docs.tendermint.com/master/tendermint-core/configuration.html).
+[here](https://docs.tendermint.com/main/tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -625,6 +625,6 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/master/).
+deeper, read [the docs](https://docs.tendermint.com/main/).
 
 The full source code of this example project can be found [here](https://github.com/climber73/tendermint-abci-grpc-java).

--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -323,7 +323,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/main/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/v0.34/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [JetBrains Xodus](https://github.com/JetBrains/xodus), which is a transactional schema-less embedded high-performance database written in Java.
@@ -467,7 +467,7 @@ public void query(RequestQuery req, StreamObserver<ResponseQuery> responseObserv
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/main/spec/abci/).
+[here](https://docs.tendermint.com/v0.34/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -559,7 +559,7 @@ I[2019-07-16|18:20:36.482] Generated genesis file                       module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://docs.tendermint.com/main/tendermint-core/configuration.html).
+[here](https://docs.tendermint.com/v0.34/tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -625,6 +625,6 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/main/).
+deeper, read [the docs](https://docs.tendermint.com/v0.34/).
 
 The full source code of this example project can be found [here](https://github.com/climber73/tendermint-abci-grpc-java).

--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -115,7 +115,7 @@ Hello world.
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
+file](https://github.com/tendermint/tendermint/blob/v0.34.x/proto/tendermint/abci/types.proto).
 This allows Tendermint Core to run applications written in any programming
 language.
 

--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -323,7 +323,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/v0.34/spec/abci/apps.html#gas).
+specification"](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/apps.md#gas).
 
 For the underlying key-value store we'll use
 [JetBrains Xodus](https://github.com/JetBrains/xodus), which is a transactional schema-less embedded high-performance database written in Java.
@@ -467,7 +467,7 @@ public void query(RequestQuery req, StreamObserver<ResponseQuery> responseObserv
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/v0.34/spec/abci/).
+[here](https://github.com/tendermint/tendermint/tree/v0.34.x/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 

--- a/docs/tutorials/kotlin.md
+++ b/docs/tutorials/kotlin.md
@@ -115,7 +115,7 @@ Hello world.
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/abci/types.proto).
+file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
 This allows Tendermint Core to run applications written in any programming
 language.
 
@@ -314,7 +314,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/master/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/main/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [JetBrains Xodus](https://github.com/JetBrains/xodus), which is a transactional schema-less embedded high-performance database written in Java.
@@ -446,7 +446,7 @@ override fun query(req: RequestQuery, responseObserver: StreamObserver<ResponseQ
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/master/spec/abci/).
+[here](https://docs.tendermint.com/main/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -533,7 +533,7 @@ I[2019-07-16|18:20:36.482] Generated genesis file                       module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://docs.tendermint.com/master/tendermint-core/configuration.html).
+[here](https://docs.tendermint.com/main/tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -599,6 +599,6 @@ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/master/).
+deeper, read [the docs](https://docs.tendermint.com/main/).
 
 The full source code of this example project can be found [here](https://github.com/climber73/tendermint-abci-grpc-kotlin).

--- a/docs/tutorials/kotlin.md
+++ b/docs/tutorials/kotlin.md
@@ -314,7 +314,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/main/spec/abci/apps.html#gas).
+specification"](https://docs.tendermint.com/v0.34/spec/abci/apps.html#gas).
 
 For the underlying key-value store we'll use
 [JetBrains Xodus](https://github.com/JetBrains/xodus), which is a transactional schema-less embedded high-performance database written in Java.
@@ -446,7 +446,7 @@ override fun query(req: RequestQuery, responseObserver: StreamObserver<ResponseQ
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/main/spec/abci/).
+[here](https://docs.tendermint.com/v0.34/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -533,7 +533,7 @@ I[2019-07-16|18:20:36.482] Generated genesis file                       module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://docs.tendermint.com/main/tendermint-core/configuration.html).
+[here](https://docs.tendermint.com/v0.34/tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -599,6 +599,6 @@ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/main/).
+deeper, read [the docs](https://docs.tendermint.com/v0.34/).
 
 The full source code of this example project can be found [here](https://github.com/climber73/tendermint-abci-grpc-kotlin).

--- a/docs/tutorials/kotlin.md
+++ b/docs/tutorials/kotlin.md
@@ -314,7 +314,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://docs.tendermint.com/v0.34/spec/abci/apps.html#gas).
+specification"](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/apps.md#gas).
 
 For the underlying key-value store we'll use
 [JetBrains Xodus](https://github.com/JetBrains/xodus), which is a transactional schema-less embedded high-performance database written in Java.
@@ -446,7 +446,7 @@ override fun query(req: RequestQuery, responseObserver: StreamObserver<ResponseQ
 ```
 
 The complete specification can be found
-[here](https://docs.tendermint.com/v0.34/spec/abci/).
+[here](https://github.com/tendermint/tendermint/tree/v0.34.x/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 

--- a/docs/tutorials/kotlin.md
+++ b/docs/tutorials/kotlin.md
@@ -115,7 +115,7 @@ Hello world.
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
+file](https://github.com/tendermint/tendermint/blob/v0.34.x/proto/tendermint/abci/types.proto).
 This allows Tendermint Core to run applications written in any programming
 language.
 

--- a/docs/versions
+++ b/docs/versions
@@ -1,4 +1,3 @@
-master                  master
+main                    main
 v0.33.x                 v0.33
 v0.34.x                 v0.34
-v0.35.x                 v0.35

--- a/docs/versions
+++ b/docs/versions
@@ -1,4 +1,3 @@
 main                    main
 v0.33.x                 v0.33
 v0.34.x                 v0.34
-v0.34.x                 latest

--- a/docs/versions
+++ b/docs/versions
@@ -1,3 +1,4 @@
 main                    main
 v0.33.x                 v0.33
 v0.34.x                 v0.34
+v0.34.x                 latest

--- a/evidence/doc.go
+++ b/evidence/doc.go
@@ -1,7 +1,7 @@
 /*
 Package evidence handles all evidence storage and gossiping from detection to block proposal.
 For the different types of evidence refer to the `evidence.go` file in the types package
-or https://github.com/tendermint/spec/blob/master/spec/consensus/light-client/accountability.md.
+or https://github.com/tendermint/tendermint/blob/v0.34.x/spec/consensus/light-client/accountability.md.
 
 # Gossiping
 

--- a/light/client.go
+++ b/light/client.go
@@ -506,7 +506,7 @@ func (c *Client) VerifyLightBlockAtHeight(ctx context.Context, height int64, now
 // headers are not adjacent, verifySkipping is performed and necessary (not all)
 // intermediate headers will be requested. See the specification for details.
 // Intermediate headers are not saved to database.
-// https://github.com/tendermint/spec/blob/master/spec/consensus/light-client.md
+// https://github.com/tendermint/tendermint/blob/v0.34.x/spec/consensus/light-client.md
 //
 // If the header, which is older than the currently trusted header, is
 // requested and the light client does not have it, VerifyHeader will perform:

--- a/light/doc.go
+++ b/light/doc.go
@@ -118,7 +118,7 @@ as a wrapper, which verifies all the headers, using a light client connected to
 some other node.
 
 See
-https://docs.tendermint.com/main/tendermint-core/light-client-protocol.html
+https://docs.tendermint.com/v0.34/tendermint-core/light-client-protocol.html
 for usage example.
 Or see
 https://github.com/tendermint/spec/tree/master/spec/consensus/light-client

--- a/light/doc.go
+++ b/light/doc.go
@@ -94,7 +94,7 @@ Check out other examples in example_test.go
 ## 2. Pure functions to verify a new header (see verifier.go)
 
 Verify function verifies a new header against some trusted header. See
-https://github.com/tendermint/spec/blob/master/spec/consensus/light-client/verification.md
+https://github.com/tendermint/tendermint/blob/v0.34.x/spec/consensus/light-client/verification.md
 for details.
 
 There are two methods of verification: sequential and bisection
@@ -121,7 +121,7 @@ See
 https://docs.tendermint.com/v0.34/tendermint-core/light-client-protocol.html
 for usage example.
 Or see
-https://github.com/tendermint/spec/tree/master/spec/consensus/light-client
+https://github.com/tendermint/tendermint/tree/v0.34.x/spec/consensus/light-client
 for the full spec
 */
 package light

--- a/light/doc.go
+++ b/light/doc.go
@@ -118,7 +118,7 @@ as a wrapper, which verifies all the headers, using a light client connected to
 some other node.
 
 See
-https://docs.tendermint.com/master/tendermint-core/light-client-protocol.html
+https://docs.tendermint.com/main/tendermint-core/light-client-protocol.html
 for usage example.
 Or see
 https://github.com/tendermint/spec/tree/master/spec/consensus/light-client

--- a/networks/local/README.md
+++ b/networks/local/README.md
@@ -1,3 +1,3 @@
 # Local Cluster with Docker Compose
 
-See the [docs](https://docs.tendermint.com/master/networks/docker-compose.html).
+See the [docs](https://docs.tendermint.com/main/networks/docker-compose.html).

--- a/networks/local/README.md
+++ b/networks/local/README.md
@@ -1,3 +1,3 @@
 # Local Cluster with Docker Compose
 
-See the [docs](https://docs.tendermint.com/main/networks/docker-compose.html).
+See the [docs](https://docs.tendermint.com/v0.34/networks/docker-compose.html).

--- a/networks/remote/README.md
+++ b/networks/remote/README.md
@@ -1,3 +1,3 @@
 # Remote Cluster with Terraform and Ansible
 
-See the [docs](https://docs.tendermint.com/main/networks/terraform-and-ansible.html).
+See the [docs](https://docs.tendermint.com/v0.34/networks/terraform-and-ansible.html).

--- a/networks/remote/README.md
+++ b/networks/remote/README.md
@@ -1,3 +1,3 @@
 # Remote Cluster with Terraform and Ansible
 
-See the [docs](https://docs.tendermint.com/master/networks/terraform-and-ansible.html).
+See the [docs](https://docs.tendermint.com/main/networks/terraform-and-ansible.html).

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -4,8 +4,8 @@ The p2p package provides an abstraction around peer-to-peer communication.
 
 Docs:
 
-- [Connection](https://docs.tendermint.com/main/spec/p2p/connection.html) for details on how connections and multiplexing work
-- [Peer](https://docs.tendermint.com/main/spec/p2p/node.html) for details on peer ID, handshakes, and peer exchange
-- [Node](https://docs.tendermint.com/main/spec/p2p/node.html) for details about different types of nodes and how they should work
-- [Pex](https://docs.tendermint.com/main/spec/reactors/pex/pex.html) for details on peer discovery and exchange
-- [Config](https://docs.tendermint.com/main/spec/p2p/config.html) for details on some config option
+- [Connection](https://docs.tendermint.com/v0.34/spec/p2p/connection.html) for details on how connections and multiplexing work
+- [Peer](https://docs.tendermint.com/v0.34/spec/p2p/node.html) for details on peer ID, handshakes, and peer exchange
+- [Node](https://docs.tendermint.com/v0.34/spec/p2p/node.html) for details about different types of nodes and how they should work
+- [Pex](https://docs.tendermint.com/v0.34/spec/reactors/pex/pex.html) for details on peer discovery and exchange
+- [Config](https://docs.tendermint.com/v0.34/spec/p2p/config.html) for details on some config option

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -4,8 +4,8 @@ The p2p package provides an abstraction around peer-to-peer communication.
 
 Docs:
 
-- [Connection](https://docs.tendermint.com/master/spec/p2p/connection.html) for details on how connections and multiplexing work
-- [Peer](https://docs.tendermint.com/master/spec/p2p/node.html) for details on peer ID, handshakes, and peer exchange
-- [Node](https://docs.tendermint.com/master/spec/p2p/node.html) for details about different types of nodes and how they should work
-- [Pex](https://docs.tendermint.com/master/spec/reactors/pex/pex.html) for details on peer discovery and exchange
-- [Config](https://docs.tendermint.com/master/spec/p2p/config.html) for details on some config option
+- [Connection](https://docs.tendermint.com/main/spec/p2p/connection.html) for details on how connections and multiplexing work
+- [Peer](https://docs.tendermint.com/main/spec/p2p/node.html) for details on peer ID, handshakes, and peer exchange
+- [Node](https://docs.tendermint.com/main/spec/p2p/node.html) for details about different types of nodes and how they should work
+- [Pex](https://docs.tendermint.com/main/spec/reactors/pex/pex.html) for details on peer discovery and exchange
+- [Config](https://docs.tendermint.com/main/spec/p2p/config.html) for details on some config option

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -4,8 +4,8 @@ The p2p package provides an abstraction around peer-to-peer communication.
 
 Docs:
 
-- [Connection](https://docs.tendermint.com/v0.34/spec/p2p/connection.html) for details on how connections and multiplexing work
-- [Peer](https://docs.tendermint.com/v0.34/spec/p2p/node.html) for details on peer ID, handshakes, and peer exchange
-- [Node](https://docs.tendermint.com/v0.34/spec/p2p/node.html) for details about different types of nodes and how they should work
-- [Pex](https://docs.tendermint.com/v0.34/spec/reactors/pex/pex.html) for details on peer discovery and exchange
-- [Config](https://docs.tendermint.com/v0.34/spec/p2p/config.html) for details on some config option
+- [Connection](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/connection.md) for details on how connections and multiplexing work
+- [Peer](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/node.md) for details on peer ID, handshakes, and peer exchange
+- [Node](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/node.md) for details about different types of nodes and how they should work
+- [Pex](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/reactors/pex/pex.md) for details on peer discovery and exchange
+- [Config](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/config.md) for details on some config option

--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ABCIQuery queries the application for some information.
-// More: https://docs.tendermint.com/master/rpc/#/ABCI/abci_query
+// More: https://docs.tendermint.com/main/rpc/#/ABCI/abci_query
 func ABCIQuery(
 	ctx *rpctypes.Context,
 	path string,
@@ -31,7 +31,7 @@ func ABCIQuery(
 }
 
 // ABCIInfo gets some info about the application.
-// More: https://docs.tendermint.com/master/rpc/#/ABCI/abci_info
+// More: https://docs.tendermint.com/main/rpc/#/ABCI/abci_info
 func ABCIInfo(ctx *rpctypes.Context) (*ctypes.ResultABCIInfo, error) {
 	resInfo, err := env.ProxyAppQuery.InfoSync(proxy.RequestInfo)
 	if err != nil {

--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ABCIQuery queries the application for some information.
-// More: https://docs.tendermint.com/main/rpc/#/ABCI/abci_query
+// More: https://docs.tendermint.com/v0.34/rpc/#/ABCI/abci_query
 func ABCIQuery(
 	ctx *rpctypes.Context,
 	path string,
@@ -31,7 +31,7 @@ func ABCIQuery(
 }
 
 // ABCIInfo gets some info about the application.
-// More: https://docs.tendermint.com/main/rpc/#/ABCI/abci_info
+// More: https://docs.tendermint.com/v0.34/rpc/#/ABCI/abci_info
 func ABCIInfo(ctx *rpctypes.Context) (*ctypes.ResultABCIInfo, error) {
 	resInfo, err := env.ProxyAppQuery.InfoSync(proxy.RequestInfo)
 	if err != nil {

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -15,7 +15,7 @@ import (
 
 // BlockchainInfo gets block headers for minHeight <= height <= maxHeight.
 // Block headers are returned in descending order (highest first).
-// More: https://docs.tendermint.com/master/rpc/#/Info/blockchain
+// More: https://docs.tendermint.com/main/rpc/#/Info/blockchain
 func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error) {
 	// maximum 20 block metas
 	const limit int64 = 20
@@ -77,7 +77,7 @@ func filterMinMax(base, height, min, max, limit int64) (int64, int64, error) {
 
 // Block gets block at a given height.
 // If no height is provided, it will fetch the latest block.
-// More: https://docs.tendermint.com/master/rpc/#/Info/block
+// More: https://docs.tendermint.com/main/rpc/#/Info/block
 func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error) {
 	height, err := getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
@@ -93,7 +93,7 @@ func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error)
 }
 
 // BlockByHash gets block by hash.
-// More: https://docs.tendermint.com/master/rpc/#/Info/block_by_hash
+// More: https://docs.tendermint.com/main/rpc/#/Info/block_by_hash
 func BlockByHash(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error) {
 	block := env.BlockStore.LoadBlockByHash(hash)
 	if block == nil {
@@ -106,7 +106,7 @@ func BlockByHash(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error
 
 // Commit gets block commit at a given height.
 // If no height is provided, it will fetch the commit for the latest block.
-// More: https://docs.tendermint.com/master/rpc/#/Info/commit
+// More: https://docs.tendermint.com/main/rpc/#/Info/commit
 func Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, error) {
 	height, err := getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
@@ -138,7 +138,7 @@ func Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, erro
 // Results are for the height of the block containing the txs.
 // Thus response.results.deliver_tx[5] is the results of executing
 // getBlock(h).Txs[5]
-// More: https://docs.tendermint.com/master/rpc/#/Info/block_results
+// More: https://docs.tendermint.com/main/rpc/#/Info/block_results
 func BlockResults(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlockResults, error) {
 	height, err := getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -15,7 +15,7 @@ import (
 
 // BlockchainInfo gets block headers for minHeight <= height <= maxHeight.
 // Block headers are returned in descending order (highest first).
-// More: https://docs.tendermint.com/main/rpc/#/Info/blockchain
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/blockchain
 func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error) {
 	// maximum 20 block metas
 	const limit int64 = 20
@@ -77,7 +77,7 @@ func filterMinMax(base, height, min, max, limit int64) (int64, int64, error) {
 
 // Block gets block at a given height.
 // If no height is provided, it will fetch the latest block.
-// More: https://docs.tendermint.com/main/rpc/#/Info/block
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/block
 func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error) {
 	height, err := getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
@@ -93,7 +93,7 @@ func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error)
 }
 
 // BlockByHash gets block by hash.
-// More: https://docs.tendermint.com/main/rpc/#/Info/block_by_hash
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/block_by_hash
 func BlockByHash(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error) {
 	block := env.BlockStore.LoadBlockByHash(hash)
 	if block == nil {
@@ -106,7 +106,7 @@ func BlockByHash(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error
 
 // Commit gets block commit at a given height.
 // If no height is provided, it will fetch the commit for the latest block.
-// More: https://docs.tendermint.com/main/rpc/#/Info/commit
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/commit
 func Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, error) {
 	height, err := getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
@@ -138,7 +138,7 @@ func Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, erro
 // Results are for the height of the block containing the txs.
 // Thus response.results.deliver_tx[5] is the results of executing
 // getBlock(h).Txs[5]
-// More: https://docs.tendermint.com/main/rpc/#/Info/block_results
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/block_results
 func BlockResults(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlockResults, error) {
 	height, err := getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -14,7 +14,7 @@ import (
 // validators are sorted by their voting power - this is the canonical order
 // for the validators in the set as used in computing their Merkle root.
 //
-// More: https://docs.tendermint.com/main/rpc/#/Info/validators
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/validators
 func Validators(ctx *rpctypes.Context, heightPtr *int64, pagePtr, perPagePtr *int) (*ctypes.ResultValidators, error) {
 	// The latest validator that we know is the NextValidator of the last block.
 	height, err := getHeight(latestUncommittedHeight(), heightPtr)
@@ -47,7 +47,7 @@ func Validators(ctx *rpctypes.Context, heightPtr *int64, pagePtr, perPagePtr *in
 
 // DumpConsensusState dumps consensus state.
 // UNSTABLE
-// More: https://docs.tendermint.com/main/rpc/#/Info/dump_consensus_state
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/dump_consensus_state
 func DumpConsensusState(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState, error) {
 	// Get Peer consensus states.
 	peers := env.P2PPeers.Peers().List()
@@ -80,7 +80,7 @@ func DumpConsensusState(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState
 
 // ConsensusState returns a concise summary of the consensus state.
 // UNSTABLE
-// More: https://docs.tendermint.com/main/rpc/#/Info/consensus_state
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/consensus_state
 func ConsensusState(ctx *rpctypes.Context) (*ctypes.ResultConsensusState, error) {
 	// Get self round state.
 	bz, err := env.ConsensusState.GetRoundStateSimpleJSON()
@@ -89,7 +89,7 @@ func ConsensusState(ctx *rpctypes.Context) (*ctypes.ResultConsensusState, error)
 
 // ConsensusParams gets the consensus parameters at the given block height.
 // If no height is provided, it will fetch the latest consensus params.
-// More: https://docs.tendermint.com/main/rpc/#/Info/consensus_params
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/consensus_params
 func ConsensusParams(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultConsensusParams, error) {
 	// The latest consensus params that we know is the consensus params after the
 	// last block.

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -14,7 +14,7 @@ import (
 // validators are sorted by their voting power - this is the canonical order
 // for the validators in the set as used in computing their Merkle root.
 //
-// More: https://docs.tendermint.com/master/rpc/#/Info/validators
+// More: https://docs.tendermint.com/main/rpc/#/Info/validators
 func Validators(ctx *rpctypes.Context, heightPtr *int64, pagePtr, perPagePtr *int) (*ctypes.ResultValidators, error) {
 	// The latest validator that we know is the NextValidator of the last block.
 	height, err := getHeight(latestUncommittedHeight(), heightPtr)
@@ -47,7 +47,7 @@ func Validators(ctx *rpctypes.Context, heightPtr *int64, pagePtr, perPagePtr *in
 
 // DumpConsensusState dumps consensus state.
 // UNSTABLE
-// More: https://docs.tendermint.com/master/rpc/#/Info/dump_consensus_state
+// More: https://docs.tendermint.com/main/rpc/#/Info/dump_consensus_state
 func DumpConsensusState(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState, error) {
 	// Get Peer consensus states.
 	peers := env.P2PPeers.Peers().List()
@@ -80,7 +80,7 @@ func DumpConsensusState(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState
 
 // ConsensusState returns a concise summary of the consensus state.
 // UNSTABLE
-// More: https://docs.tendermint.com/master/rpc/#/Info/consensus_state
+// More: https://docs.tendermint.com/main/rpc/#/Info/consensus_state
 func ConsensusState(ctx *rpctypes.Context) (*ctypes.ResultConsensusState, error) {
 	// Get self round state.
 	bz, err := env.ConsensusState.GetRoundStateSimpleJSON()
@@ -89,7 +89,7 @@ func ConsensusState(ctx *rpctypes.Context) (*ctypes.ResultConsensusState, error)
 
 // ConsensusParams gets the consensus parameters at the given block height.
 // If no height is provided, it will fetch the latest consensus params.
-// More: https://docs.tendermint.com/master/rpc/#/Info/consensus_params
+// More: https://docs.tendermint.com/main/rpc/#/Info/consensus_params
 func ConsensusParams(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultConsensusParams, error) {
 	// The latest consensus params that we know is the consensus params after the
 	// last block.

--- a/rpc/core/doc.go
+++ b/rpc/core/doc.go
@@ -2,7 +2,7 @@
 Package core defines the Tendermint RPC endpoints.
 
 Tendermint ships with its own JSONRPC library -
-https://github.com/tendermint/tendermint/tree/master/rpc/jsonrpc.
+https://github.com/tendermint/tendermint/tree/v0.34.x/rpc/jsonrpc.
 
 ## Get the list
 

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Subscribe for events via WebSocket.
-// More: https://docs.tendermint.com/master/rpc/#/Websocket/subscribe
+// More: https://docs.tendermint.com/main/rpc/#/Websocket/subscribe
 func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, error) {
 	addr := ctx.RemoteAddr()
 
@@ -102,7 +102,7 @@ func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, er
 }
 
 // Unsubscribe from events via WebSocket.
-// More: https://docs.tendermint.com/master/rpc/#/Websocket/unsubscribe
+// More: https://docs.tendermint.com/main/rpc/#/Websocket/unsubscribe
 func Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe, error) {
 	addr := ctx.RemoteAddr()
 	env.Logger.Info("Unsubscribe from query", "remote", addr, "query", query)
@@ -118,7 +118,7 @@ func Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe
 }
 
 // UnsubscribeAll from all events via WebSocket.
-// More: https://docs.tendermint.com/master/rpc/#/Websocket/unsubscribe_all
+// More: https://docs.tendermint.com/main/rpc/#/Websocket/unsubscribe_all
 func UnsubscribeAll(ctx *rpctypes.Context) (*ctypes.ResultUnsubscribe, error) {
 	addr := ctx.RemoteAddr()
 	env.Logger.Info("Unsubscribe from all", "remote", addr)

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Subscribe for events via WebSocket.
-// More: https://docs.tendermint.com/main/rpc/#/Websocket/subscribe
+// More: https://docs.tendermint.com/v0.34/rpc/#/Websocket/subscribe
 func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, error) {
 	addr := ctx.RemoteAddr()
 
@@ -102,7 +102,7 @@ func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, er
 }
 
 // Unsubscribe from events via WebSocket.
-// More: https://docs.tendermint.com/main/rpc/#/Websocket/unsubscribe
+// More: https://docs.tendermint.com/v0.34/rpc/#/Websocket/unsubscribe
 func Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe, error) {
 	addr := ctx.RemoteAddr()
 	env.Logger.Info("Unsubscribe from query", "remote", addr, "query", query)
@@ -118,7 +118,7 @@ func Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe
 }
 
 // UnsubscribeAll from all events via WebSocket.
-// More: https://docs.tendermint.com/main/rpc/#/Websocket/unsubscribe_all
+// More: https://docs.tendermint.com/v0.34/rpc/#/Websocket/unsubscribe_all
 func UnsubscribeAll(ctx *rpctypes.Context) (*ctypes.ResultUnsubscribe, error) {
 	addr := ctx.RemoteAddr()
 	env.Logger.Info("Unsubscribe from all", "remote", addr)

--- a/rpc/core/evidence.go
+++ b/rpc/core/evidence.go
@@ -10,7 +10,7 @@ import (
 )
 
 // BroadcastEvidence broadcasts evidence of the misbehavior.
-// More: https://docs.tendermint.com/main/rpc/#/Info/broadcast_evidence
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/broadcast_evidence
 func BroadcastEvidence(ctx *rpctypes.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
 	if ev == nil {
 		return nil, errors.New("no evidence was provided")

--- a/rpc/core/evidence.go
+++ b/rpc/core/evidence.go
@@ -10,7 +10,7 @@ import (
 )
 
 // BroadcastEvidence broadcasts evidence of the misbehavior.
-// More: https://docs.tendermint.com/master/rpc/#/Info/broadcast_evidence
+// More: https://docs.tendermint.com/main/rpc/#/Info/broadcast_evidence
 func BroadcastEvidence(ctx *rpctypes.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
 	if ev == nil {
 		return nil, errors.New("no evidence was provided")

--- a/rpc/core/health.go
+++ b/rpc/core/health.go
@@ -7,7 +7,7 @@ import (
 
 // Health gets node health. Returns empty result (200 OK) on success, no
 // response - in case of an error.
-// More: https://docs.tendermint.com/master/rpc/#/Info/health
+// More: https://docs.tendermint.com/main/rpc/#/Info/health
 func Health(ctx *rpctypes.Context) (*ctypes.ResultHealth, error) {
 	return &ctypes.ResultHealth{}, nil
 }

--- a/rpc/core/health.go
+++ b/rpc/core/health.go
@@ -7,7 +7,7 @@ import (
 
 // Health gets node health. Returns empty result (200 OK) on success, no
 // response - in case of an error.
-// More: https://docs.tendermint.com/main/rpc/#/Info/health
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/health
 func Health(ctx *rpctypes.Context) (*ctypes.ResultHealth, error) {
 	return &ctypes.ResultHealth{}, nil
 }

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -18,7 +18,7 @@ import (
 
 // BroadcastTxAsync returns right away, with no response. Does not wait for
 // CheckTx nor DeliverTx results.
-// More: https://docs.tendermint.com/main/rpc/#/Tx/broadcast_tx_async
+// More: https://docs.tendermint.com/v0.34/rpc/#/Tx/broadcast_tx_async
 func BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 	err := env.Mempool.CheckTx(tx, nil, mempl.TxInfo{})
 
@@ -30,7 +30,7 @@ func BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadca
 
 // BroadcastTxSync returns with the response from CheckTx. Does not wait for
 // DeliverTx result.
-// More: https://docs.tendermint.com/main/rpc/#/Tx/broadcast_tx_sync
+// More: https://docs.tendermint.com/v0.34/rpc/#/Tx/broadcast_tx_sync
 func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 	resCh := make(chan *abci.Response, 1)
 	err := env.Mempool.CheckTx(tx, func(res *abci.Response) {
@@ -60,7 +60,7 @@ func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcas
 }
 
 // BroadcastTxCommit returns with the responses from CheckTx and DeliverTx.
-// More: https://docs.tendermint.com/main/rpc/#/Tx/broadcast_tx_commit
+// More: https://docs.tendermint.com/v0.34/rpc/#/Tx/broadcast_tx_commit
 func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
 	subscriber := ctx.RemoteAddr()
 
@@ -149,7 +149,7 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadc
 
 // UnconfirmedTxs gets unconfirmed transactions (maximum ?limit entries)
 // including their number.
-// More: https://docs.tendermint.com/main/rpc/#/Info/unconfirmed_txs
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/unconfirmed_txs
 func UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*ctypes.ResultUnconfirmedTxs, error) {
 	// reuse per_page validator
 	limit := validatePerPage(limitPtr)
@@ -163,7 +163,7 @@ func UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*ctypes.ResultUnconfi
 }
 
 // NumUnconfirmedTxs gets number of unconfirmed transactions.
-// More: https://docs.tendermint.com/main/rpc/#/Info/num_unconfirmed_txs
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/num_unconfirmed_txs
 func NumUnconfirmedTxs(ctx *rpctypes.Context) (*ctypes.ResultUnconfirmedTxs, error) {
 	return &ctypes.ResultUnconfirmedTxs{
 		Count:      env.Mempool.Size(),
@@ -173,7 +173,7 @@ func NumUnconfirmedTxs(ctx *rpctypes.Context) (*ctypes.ResultUnconfirmedTxs, err
 
 // CheckTx checks the transaction without executing it. The transaction won't
 // be added to the mempool either.
-// More: https://docs.tendermint.com/main/rpc/#/Tx/check_tx
+// More: https://docs.tendermint.com/v0.34/rpc/#/Tx/check_tx
 func CheckTx(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
 	res, err := env.ProxyAppMempool.CheckTxSync(abci.RequestCheckTx{Tx: tx})
 	if err != nil {

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -18,7 +18,7 @@ import (
 
 // BroadcastTxAsync returns right away, with no response. Does not wait for
 // CheckTx nor DeliverTx results.
-// More: https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_async
+// More: https://docs.tendermint.com/main/rpc/#/Tx/broadcast_tx_async
 func BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 	err := env.Mempool.CheckTx(tx, nil, mempl.TxInfo{})
 
@@ -30,7 +30,7 @@ func BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadca
 
 // BroadcastTxSync returns with the response from CheckTx. Does not wait for
 // DeliverTx result.
-// More: https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_sync
+// More: https://docs.tendermint.com/main/rpc/#/Tx/broadcast_tx_sync
 func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 	resCh := make(chan *abci.Response, 1)
 	err := env.Mempool.CheckTx(tx, func(res *abci.Response) {
@@ -60,7 +60,7 @@ func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcas
 }
 
 // BroadcastTxCommit returns with the responses from CheckTx and DeliverTx.
-// More: https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_commit
+// More: https://docs.tendermint.com/main/rpc/#/Tx/broadcast_tx_commit
 func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
 	subscriber := ctx.RemoteAddr()
 
@@ -149,7 +149,7 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadc
 
 // UnconfirmedTxs gets unconfirmed transactions (maximum ?limit entries)
 // including their number.
-// More: https://docs.tendermint.com/master/rpc/#/Info/unconfirmed_txs
+// More: https://docs.tendermint.com/main/rpc/#/Info/unconfirmed_txs
 func UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*ctypes.ResultUnconfirmedTxs, error) {
 	// reuse per_page validator
 	limit := validatePerPage(limitPtr)
@@ -163,7 +163,7 @@ func UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*ctypes.ResultUnconfi
 }
 
 // NumUnconfirmedTxs gets number of unconfirmed transactions.
-// More: https://docs.tendermint.com/master/rpc/#/Info/num_unconfirmed_txs
+// More: https://docs.tendermint.com/main/rpc/#/Info/num_unconfirmed_txs
 func NumUnconfirmedTxs(ctx *rpctypes.Context) (*ctypes.ResultUnconfirmedTxs, error) {
 	return &ctypes.ResultUnconfirmedTxs{
 		Count:      env.Mempool.Size(),
@@ -173,7 +173,7 @@ func NumUnconfirmedTxs(ctx *rpctypes.Context) (*ctypes.ResultUnconfirmedTxs, err
 
 // CheckTx checks the transaction without executing it. The transaction won't
 // be added to the mempool either.
-// More: https://docs.tendermint.com/master/rpc/#/Tx/check_tx
+// More: https://docs.tendermint.com/main/rpc/#/Tx/check_tx
 func CheckTx(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
 	res, err := env.ProxyAppMempool.CheckTxSync(abci.RequestCheckTx{Tx: tx})
 	if err != nil {

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NetInfo returns network info.
-// More: https://docs.tendermint.com/master/rpc/#/Info/net_info
+// More: https://docs.tendermint.com/main/rpc/#/Info/net_info
 func NetInfo(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error) {
 	peersList := env.P2PPeers.Peers().List()
 	peers := make([]ctypes.Peer, 0, len(peersList))
@@ -92,7 +92,7 @@ func UnsafeDialPeers(ctx *rpctypes.Context, peers []string, persistent, uncondit
 }
 
 // Genesis returns genesis file.
-// More: https://docs.tendermint.com/master/rpc/#/Info/genesis
+// More: https://docs.tendermint.com/main/rpc/#/Info/genesis
 func Genesis(ctx *rpctypes.Context) (*ctypes.ResultGenesis, error) {
 	if len(env.genChunks) > 1 {
 		return nil, errors.New("genesis response is large, please use the genesis_chunked API instead")

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NetInfo returns network info.
-// More: https://docs.tendermint.com/main/rpc/#/Info/net_info
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/net_info
 func NetInfo(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error) {
 	peersList := env.P2PPeers.Peers().List()
 	peers := make([]ctypes.Peer, 0, len(peersList))
@@ -92,7 +92,7 @@ func UnsafeDialPeers(ctx *rpctypes.Context, peers []string, persistent, uncondit
 }
 
 // Genesis returns genesis file.
-// More: https://docs.tendermint.com/main/rpc/#/Info/genesis
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/genesis
 func Genesis(ctx *rpctypes.Context) (*ctypes.ResultGenesis, error) {
 	if len(env.genChunks) > 1 {
 		return nil, errors.New("genesis response is large, please use the genesis_chunked API instead")

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -12,7 +12,7 @@ import (
 
 // Status returns Tendermint status including node info, pubkey, latest block
 // hash, app hash, block height and time.
-// More: https://docs.tendermint.com/master/rpc/#/Info/status
+// More: https://docs.tendermint.com/main/rpc/#/Info/status
 func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 	var (
 		earliestBlockHeight   int64

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -12,7 +12,7 @@ import (
 
 // Status returns Tendermint status including node info, pubkey, latest block
 // hash, app hash, block height and time.
-// More: https://docs.tendermint.com/main/rpc/#/Info/status
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/status
 func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 	var (
 		earliestBlockHeight   int64

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -16,7 +16,7 @@ import (
 // Tx allows you to query the transaction results. `nil` could mean the
 // transaction is in the mempool, invalidated, or was not sent in the first
 // place.
-// More: https://docs.tendermint.com/main/rpc/#/Info/tx
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/tx
 func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error) {
 	// if index is disabled, return error
 	if _, ok := env.TxIndexer.(*null.TxIndex); ok {
@@ -53,7 +53,7 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 
 // TxSearch allows you to query for multiple transactions results. It returns a
 // list of transactions (maximum ?per_page entries) and the total count.
-// More: https://docs.tendermint.com/main/rpc/#/Info/tx_search
+// More: https://docs.tendermint.com/v0.34/rpc/#/Info/tx_search
 func TxSearch(
 	ctx *rpctypes.Context,
 	query string,

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -16,7 +16,7 @@ import (
 // Tx allows you to query the transaction results. `nil` could mean the
 // transaction is in the mempool, invalidated, or was not sent in the first
 // place.
-// More: https://docs.tendermint.com/master/rpc/#/Info/tx
+// More: https://docs.tendermint.com/main/rpc/#/Info/tx
 func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error) {
 	// if index is disabled, return error
 	if _, ok := env.TxIndexer.(*null.TxIndex); ok {
@@ -53,7 +53,7 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 
 // TxSearch allows you to query for multiple transactions results. It returns a
 // list of transactions (maximum ?per_page entries) and the total count.
-// More: https://docs.tendermint.com/master/rpc/#/Info/tx_search
+// More: https://docs.tendermint.com/main/rpc/#/Info/tx_search
 func TxSearch(
 	ctx *rpctypes.Context,
 	query string,

--- a/rpc/jsonrpc/doc.go
+++ b/rpc/jsonrpc/doc.go
@@ -80,5 +80,5 @@
 //
 // # Examples
 //
-// - [Tendermint](https://github.com/tendermint/tendermint/blob/main/rpc/core/routes.go)
+// - [Tendermint](https://github.com/tendermint/tendermint/blob/v0.34.x/rpc/core/routes.go)
 package jsonrpc

--- a/rpc/jsonrpc/doc.go
+++ b/rpc/jsonrpc/doc.go
@@ -80,5 +80,5 @@
 //
 // # Examples
 //
-// - [Tendermint](https://github.com/tendermint/tendermint/blob/master/rpc/core/routes.go)
+// - [Tendermint](https://github.com/tendermint/tendermint/blob/main/rpc/core/routes.go)
 package jsonrpc

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -51,7 +51,7 @@ info:
 
         ws ws://localhost:26657/websocket
         > { "jsonrpc": "2.0", "method": "subscribe", "params": ["tm.event='NewBlock'"], "id": 1 }
-  version: "Master"
+  version: "v0.34"
   license:
     name: Apache 2.0
     url: https://github.com/tendermint/tendermint/blob/master/LICENSE

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -54,7 +54,7 @@ info:
   version: "v0.34"
   license:
     name: Apache 2.0
-    url: https://github.com/tendermint/tendermint/blob/master/LICENSE
+    url: https://github.com/tendermint/tendermint/blob/main/LICENSE
 servers:
   - url: https://rpc.cosmos.network
     description: Cosmos mainnet node to interact with the Tendermint RPC
@@ -83,7 +83,7 @@ paths:
       description: |
         If you want to be sure that the transaction is included in a block, you can
         subscribe for the result using JSONRPC via a websocket. See
-        https://docs.tendermint.com/master/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/main/app-dev/subscribing-to-events-via-websocket.html
         If you haven't received anything after a couple of blocks, resend it. If the
         same happens again, send it to some other node. A few reasons why it could
         happen:
@@ -95,7 +95,7 @@ paths:
 
 
         Please refer to
-        https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -127,7 +127,7 @@ paths:
       description: |
         If you want to be sure that the transaction is included in a block, you can
         subscribe for the result using JSONRPC via a websocket. See
-        https://docs.tendermint.com/master/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/main/app-dev/subscribing-to-events-via-websocket.html
         If you haven't received anything after a couple of blocks, resend it. If the
         same happens again, send it to some other node. A few reasons why it could
         happen:
@@ -139,7 +139,7 @@ paths:
         3. node can be offline
 
         Please refer to
-        https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -172,7 +172,7 @@ paths:
         IMPORTANT: use only for testing and development. In production, use
         BroadcastTxSync or BroadcastTxAsync. You can subscribe for the transaction
         result using JSONRPC via a websocket. See
-        https://docs.tendermint.com/master/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/main/app-dev/subscribing-to-events-via-websocket.html
 
         CONTRACT: only returns error if mempool.CheckTx() errs or if we timeout
         waiting for tx to commit.
@@ -181,7 +181,7 @@ paths:
         will contain a non-OK ABCI code.
 
         Please refer to
-        https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -214,7 +214,7 @@ paths:
         The transaction won't be added to the mempool.
 
         Please refer to
-        https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -83,7 +83,7 @@ paths:
       description: |
         If you want to be sure that the transaction is included in a block, you can
         subscribe for the result using JSONRPC via a websocket. See
-        https://docs.tendermint.com/main/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/v0.34/app-dev/subscribing-to-events-via-websocket.html
         If you haven't received anything after a couple of blocks, resend it. If the
         same happens again, send it to some other node. A few reasons why it could
         happen:
@@ -95,7 +95,7 @@ paths:
 
 
         Please refer to
-        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/v0.34/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -127,7 +127,7 @@ paths:
       description: |
         If you want to be sure that the transaction is included in a block, you can
         subscribe for the result using JSONRPC via a websocket. See
-        https://docs.tendermint.com/main/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/v0.34/app-dev/subscribing-to-events-via-websocket.html
         If you haven't received anything after a couple of blocks, resend it. If the
         same happens again, send it to some other node. A few reasons why it could
         happen:
@@ -139,7 +139,7 @@ paths:
         3. node can be offline
 
         Please refer to
-        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/v0.34/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -172,7 +172,7 @@ paths:
         IMPORTANT: use only for testing and development. In production, use
         BroadcastTxSync or BroadcastTxAsync. You can subscribe for the transaction
         result using JSONRPC via a websocket. See
-        https://docs.tendermint.com/main/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/v0.34/app-dev/subscribing-to-events-via-websocket.html
 
         CONTRACT: only returns error if mempool.CheckTx() errs or if we timeout
         waiting for tx to commit.
@@ -181,7 +181,7 @@ paths:
         will contain a non-OK ABCI code.
 
         Please refer to
-        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/v0.34/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -214,7 +214,7 @@ paths:
         The transaction won't be added to the mempool.
 
         Please refer to
-        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/v0.34/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query

--- a/spec/abci/README.md
+++ b/spec/abci/README.md
@@ -14,7 +14,7 @@ _methods_, each with a corresponding `Request` and `Response`message type.
 To perform state-machine replication, Tendermint calls the ABCI methods on the 
 ABCI application by sending the `Request*` messages and receiving the `Response*` messages in return.
 
-All ABCI messages and methods are defined in [protocol buffers](https://github.com/tendermint/spec/blob/master/proto/abci/types.proto). 
+All ABCI messages and methods are defined in [protocol buffers](https://github.com/tendermint/tendermint/blob/v0.34.x/proto/abci/types.proto). 
 This allows Tendermint to run with applications written in many programming languages.
 
 This specification is split as follows:

--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -179,8 +179,8 @@ enum EvidenceType {
 ```
 
 There are two forms of evidence: Duplicate Vote and Light Client Attack. More
-information can be found in either [data structures](https://github.com/tendermint/spec/blob/master/spec/core/data_structures.md)
-or [accountability](https://github.com/tendermint/spec/blob/master/spec/light-client/accountability/)
+information can be found in either [data structures](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/core/data_structures.md)
+or [accountability](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/light-client/accountability/)
 
 ## Determinism
 

--- a/spec/abci/client-server.md
+++ b/spec/abci/client-server.md
@@ -14,7 +14,7 @@ Applications](./apps.md).
 ## Message Protocol
 
 The message protocol consists of pairs of requests and responses defined in the
-[protobuf file](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/abci/types.proto).
+[protobuf file](https://github.com/tendermint/tendermint/blob/v0.34.x/proto/tendermint/abci/types.proto).
 
 Some messages have no fields, while others may include byte-arrays, strings, integers,
 or custom protobuf types.
@@ -30,7 +30,7 @@ responses.
 To use ABCI in your programming language of choice, there must be a ABCI
 server in that language. Tendermint supports three implementations of the ABCI, written in Go:
 
-- In-process ([Golang](https://github.com/tendermint/tendermint/tree/master/abci), [Rust](https://github.com/tendermint/rust-abci))
+- In-process ([Golang](https://github.com/tendermint/tendermint/tree/v0.34.x/abci), [Rust](https://github.com/tendermint/rust-abci))
 - ABCI-socket
 - GRPC
 
@@ -38,7 +38,7 @@ The latter two can be tested using the `abci-cli` by setting the `--abci` flag
 appropriately (ie. to `socket` or `grpc`).
 
 See examples, in various stages of maintenance, in
-[Go](https://github.com/tendermint/tendermint/tree/master/abci/server),
+[Go](https://github.com/tendermint/tendermint/tree/v0.34.x/abci/server),
 [JavaScript](https://github.com/tendermint/js-abci),
 [C++](https://github.com/mdyring/cpp-tmsp), and
 [Java](https://github.com/jTendermint/jabci).
@@ -54,7 +54,7 @@ If GRPC is available in your language, this is the easiest approach,
 though it will have significant performance overhead.
 
 To get started with GRPC, copy in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/master/proto/tendermint/abci/types.proto)
+file](https://github.com/tendermint/tendermint/blob/v0.34.x/proto/tendermint/abci/types.proto)
 and compile it using the GRPC plugin for your language. For instance,
 for golang, the command is `protoc --go_out=plugins=grpc:. types.proto`.
 See the [grpc documentation for more details](http://www.grpc.io/docs/).
@@ -110,4 +110,4 @@ received or a block is committed.
 
 It is unlikely that you will need to implement a client. For details of
 our client, see
-[here](https://github.com/tendermint/tendermint/tree/master/abci/client).
+[here](https://github.com/tendermint/tendermint/tree/v0.34.x/abci/client).

--- a/spec/consensus/consensus.md
+++ b/spec/consensus/consensus.md
@@ -123,7 +123,7 @@ A proposal is signed and published by the designated proposer at each
 round. The proposer is chosen by a deterministic and non-choking round
 robin selection algorithm that selects proposers in proportion to their
 voting power (see
-[implementation](https://github.com/tendermint/tendermint/blob/master/types/validator_set.go)).
+[implementation](https://github.com/tendermint/tendermint/blob/v0.34.x/types/validator_set.go)).
 
 A proposal at `(H,R)` is composed of a block and an optional latest
 `PoLC-Round < R` which is included iff the proposer knows of one. This
@@ -295,7 +295,7 @@ may make JSet verification/gossip logic easier to implement.
 ### Censorship Attacks
 
 Due to the definition of a block
-[commit](https://github.com/tendermint/tendermint/blob/master/docs/tendermint-core/validators.md), any 1/3+ coalition of
+[commit](https://github.com/tendermint/tendermint/blob/v0.34.x/docs/tendermint-core/validators.md), any 1/3+ coalition of
 validators can halt the blockchain by not broadcasting their votes. Such
 a coalition can also censor particular transactions by rejecting blocks
 that include these transactions, though this would result in a

--- a/spec/consensus/proposer-based-timestamp/tla/TendermintPBT_001_draft.tla
+++ b/spec/consensus/proposer-based-timestamp/tla/TendermintPBT_001_draft.tla
@@ -3,7 +3,7 @@
  A TLA+ specification of a simplified Tendermint consensus, with added clocks 
  and proposer-based timestamps. This TLA+ specification extends and modifies 
  the Tendermint TLA+ specification for fork accountability: 
-    https://github.com/tendermint/spec/blob/master/spec/light-client/accountability/TendermintAcc_004_draft.tla
+    https://github.com/tendermint/tendermint/blob/v0.34.x/spec/light-client/accountability/TendermintAcc_004_draft.tla
  
  * Version 1. A preliminary specification.
 

--- a/spec/consensus/wal.md
+++ b/spec/consensus/wal.md
@@ -28,5 +28,5 @@ WAL. Then it will go to precommit, and that time it will work because the
 private validator contains the `LastSignBytes` and then we’ll replay the
 precommit from the WAL.
 
-Make sure to read about [WAL corruption](https://github.com/tendermint/tendermint/blob/master/docs/tendermint-core/running-in-production.md#wal-corruption)
+Make sure to read about [WAL corruption](https://github.com/tendermint/tendermint/blob/v0.34.x/docs/tendermint-core/running-in-production.md#wal-corruption)
 and recovery strategies.

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -210,7 +210,7 @@ to reconstruct the vote set given the validator set.
 | Signature        | [Signature](#signature)     | Signature corresponding to the validators participation in consensus.                                                                                           | The length of the signature must be > 0 and < than  64            |
 
 NOTE: `ValidatorAddress` and `Timestamp` fields may be removed in the future
-(see [ADR-25](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-025-commit.md)).
+(see [ADR-25](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-025-commit.md)).
 
 ## BlockIDFlag
 

--- a/spec/light-client/README.md
+++ b/spec/light-client/README.md
@@ -10,7 +10,7 @@ parent:
 This directory contains work-in-progress English and TLA+ specifications for the Light Client
 protocol. Implementations of the light client can be found in
 [Rust](https://github.com/informalsystems/tendermint-rs/tree/master/light-client) and
-[Go](https://github.com/tendermint/tendermint/tree/master/light).
+[Go](https://github.com/tendermint/tendermint/tree/v0.34.x/light).
 
 Light clients are assumed to be initialized once from a trusted source
 with a trusted header and validator set. The light client

--- a/spec/light-client/supervisor/supervisor_001_draft.md
+++ b/spec/light-client/supervisor/supervisor_001_draft.md
@@ -307,7 +307,7 @@ type LCInitData struct {
 
 where only one of the components must be provided. `GenesisDoc` is
 defined in the [Tendermint
-Types](https://github.com/tendermint/tendermint/blob/master/types/genesis.go).
+Types](https://github.com/tendermint/tendermint/blob/v0.34.x/types/genesis.go).
 
 #### **[LC-DATA-GENESIS.1]**
 

--- a/spec/light-client/supervisor/supervisor_002_draft.md
+++ b/spec/light-client/supervisor/supervisor_002_draft.md
@@ -17,7 +17,7 @@ type LCInitData struct {
 
 where only one of the components must be provided. `GenesisDoc` is
 defined in the [Tendermint
-Types](https://github.com/tendermint/tendermint/blob/master/types/genesis.go).
+Types](https://github.com/tendermint/tendermint/blob/v0.34.x/types/genesis.go).
 
 
 ### Initialization
@@ -45,8 +45,8 @@ able to verify anything.
 Cross-checking this trusted block with providers upon initialization is helpful
 for ensuring that the node is responsive and correctly configured but does not
 increase trust since proving a conflicting block is a
-[light client attack](https://github.com/tendermint/spec/blob/master/spec/light-client/detection/detection_003_reviewed.md#tmbc-lc-attack1)
-and not just a [bogus](https://github.com/tendermint/spec/blob/master/spec/light-client/detection/detection_003_reviewed.md#tmbc-bogus1) block could result in
+[light client attack](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/light-client/detection/detection_003_reviewed.md#tmbc-lc-attack1)
+and not just a [bogus](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/light-client/detection/detection_003_reviewed.md#tmbc-bogus1) block could result in
 performing backwards verification beyond the trusted period, thus a fruitless
 endeavour.
 

--- a/spec/light-client/verification/verification_001_published.md
+++ b/spec/light-client/verification/verification_001_published.md
@@ -1148,7 +1148,7 @@ func Main (primary PeerID, lightStore LightStore, targetHeight Height)
 
 [[lightclient]] The light client ADR [77d2651 on Dec 27, 2019].
 
-[RPC]: https://docs.tendermint.com/master/rpc/
+[RPC]: https://docs.tendermint.com/v0.34/rpc/
 
 [block]: https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md
 
@@ -1164,15 +1164,15 @@ func Main (primary PeerID, lightStore LightStore, targetHeight Height)
 
 [lightclient]: https://github.com/interchainio/tendermint-rs/blob/e2cb9aca0b95430fca2eac154edddc9588038982/docs/architecture/adr-002-lite-client.md
 [fork-detector]: https://github.com/informalsystems/tendermint-rs/blob/master/docs/spec/lightclient/detection.md
-[fullnode]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md
+[fullnode]: https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/fullnode.md
 
 [ibc-rs]:https://github.com/informalsystems/ibc-rs
 
-[FN-LuckyCase-link]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#fn-luckycase
+[FN-LuckyCase-link]: https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/fullnode.md#fn-luckycase
 
-[blockchain-validator-set]: https://github.com/tendermint/spec/blob/master/spec/blockchain/blockchain.md#data-structures
-[fullnode-data-structures]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#data-structures
+[blockchain-validator-set]: https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/blockchain.md#data-structures
+[fullnode-data-structures]: https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/fullnode.md#data-structures
 
-[FN-ManifestFaulty-link]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#fn-manifestfaulty
+[FN-ManifestFaulty-link]: https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/fullnode.md#fn-manifestfaulty
 
 [arXiv]: https://arxiv.org/abs/1807.04938

--- a/spec/light-client/verification/verification_002_draft.md
+++ b/spec/light-client/verification/verification_002_draft.md
@@ -1033,7 +1033,7 @@ func Backwards (primary PeerID, root LightBlock, targetHeight Height)
 
 [[lightclient]] The light client ADR [77d2651 on Dec 27, 2019].
 
-[RPC]: https://docs.tendermint.com/master/rpc/
+[RPC]: https://docs.tendermint.com/v0.34/rpc/
 
 [block]: https://github.com/tendermint/spec/blob/d46cd7f573a2c6a2399fcab2cde981330aa63f37/spec/core/data_structures.md
 
@@ -1049,13 +1049,13 @@ func Backwards (primary PeerID, root LightBlock, targetHeight Height)
 
 [lightclient]: https://github.com/interchainio/tendermint-rs/blob/e2cb9aca0b95430fca2eac154edddc9588038982/docs/architecture/adr-002-lite-client.md
 [attack-detector]: https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/detection/detection_001_reviewed.md
-[fullnode]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md
+[fullnode]: https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/fullnode.md
 
 [ibc-rs]:https://github.com/informalsystems/ibc-rs
 
-[blockchain-validator-set]: https://github.com/tendermint/spec/blob/master/spec/blockchain/blockchain.md#data-structures
-[fullnode-data-structures]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#data-structures
+[blockchain-validator-set]: https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/blockchain.md#data-structures
+[fullnode-data-structures]: https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/fullnode.md#data-structures
 
-[FN-ManifestFaulty-link]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#fn-manifestfaulty
+[FN-ManifestFaulty-link]: https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/fullnode.md#fn-manifestfaulty
 
 [arXiv]: https://arxiv.org/abs/1807.04938

--- a/spec/p2p/messages/consensus.md
+++ b/spec/p2p/messages/consensus.md
@@ -30,7 +30,7 @@ next block in the blockchain should be.
 
 Vote is sent to vote for some block (or to inform others that a process does not vote in the
 current round). Vote is defined in the
-[Blockchain](https://github.com/tendermint/spec/blob/master/spec/core/data_structures.md#blockidd)
+[Blockchain](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/core/data_structures.md#blockidd)
 section and contains validator's
 information (validator address and index), height and round for which the vote is sent, vote type,
 blockID if process vote for some block (`nil` otherwise) and a timestamp when the vote is sent. The

--- a/spec/p2p/node.md
+++ b/spec/p2p/node.md
@@ -12,7 +12,7 @@ Seeds should operate full nodes with the PEX reactor in a "crawler" mode
 that continuously explores to validate the availability of peers.
 
 Seeds should only respond with some top percentile of the best peers it knows about.
-See [the peer-exchange docs](https://github.com/tendermint/spec/blob/master/spec/reactors/pex/pex.md) for
+See [the peer-exchange docs](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/reactors/pex/pex.md) for
  details on peer quality.
 
 ## New Full Node

--- a/spec/p2p/peer.md
+++ b/spec/p2p/peer.md
@@ -2,7 +2,7 @@
 
 This document explains how Tendermint Peers are identified and how they connect to one another.
 
-For details on peer discovery, see the [peer exchange (PEX) reactor doc](https://github.com/tendermint/spec/blob/master/spec/reactors/pex/pex.md).
+For details on peer discovery, see the [peer exchange (PEX) reactor doc](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/reactors/pex/pex.md).
 
 ## Peer Identity
 

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -1853,10 +1853,11 @@ func (cs *State) voteTime() time.Time {
 	now := tmtime.Now()
 	minVoteTime := now
 	// TODO: We should remove next line in case we don't vote for v in case cs.ProposalBlock == nil,
-	// even if cs.LockedBlock != nil. See https://docs.tendermint.com/v0.34/spec/.
+	// even if cs.LockedBlock != nil. See https://github.com/tendermint/tendermint/tree/v0.34.x/spec/.
 	timeIota := time.Duration(cs.state.ConsensusParams.Block.TimeIotaMs) * time.Millisecond
 	if cs.LockedBlock != nil {
-		// See the BFT time spec https://docs.tendermint.com/v0.34/spec/consensus/bft-time.html
+		// See the BFT time spec
+		// https://github.com/tendermint/tendermint/blob/v0.34.x/spec/consensus/bft-time.md
 		minVoteTime = cs.LockedBlock.Time.Add(timeIota)
 	} else if cs.ProposalBlock != nil {
 		minVoteTime = cs.ProposalBlock.Time.Add(timeIota)

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -1853,10 +1853,10 @@ func (cs *State) voteTime() time.Time {
 	now := tmtime.Now()
 	minVoteTime := now
 	// TODO: We should remove next line in case we don't vote for v in case cs.ProposalBlock == nil,
-	// even if cs.LockedBlock != nil. See https://docs.tendermint.com/main/spec/.
+	// even if cs.LockedBlock != nil. See https://docs.tendermint.com/v0.34/spec/.
 	timeIota := time.Duration(cs.state.ConsensusParams.Block.TimeIotaMs) * time.Millisecond
 	if cs.LockedBlock != nil {
-		// See the BFT time spec https://docs.tendermint.com/main/spec/consensus/bft-time.html
+		// See the BFT time spec https://docs.tendermint.com/v0.34/spec/consensus/bft-time.html
 		minVoteTime = cs.LockedBlock.Time.Add(timeIota)
 	} else if cs.ProposalBlock != nil {
 		minVoteTime = cs.ProposalBlock.Time.Add(timeIota)

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -1853,10 +1853,10 @@ func (cs *State) voteTime() time.Time {
 	now := tmtime.Now()
 	minVoteTime := now
 	// TODO: We should remove next line in case we don't vote for v in case cs.ProposalBlock == nil,
-	// even if cs.LockedBlock != nil. See https://docs.tendermint.com/master/spec/.
+	// even if cs.LockedBlock != nil. See https://docs.tendermint.com/main/spec/.
 	timeIota := time.Duration(cs.state.ConsensusParams.Block.TimeIotaMs) * time.Millisecond
 	if cs.LockedBlock != nil {
-		// See the BFT time spec https://docs.tendermint.com/master/spec/consensus/bft-time.html
+		// See the BFT time spec https://docs.tendermint.com/main/spec/consensus/bft-time.html
 		minVoteTime = cs.LockedBlock.Time.Add(timeIota)
 	} else if cs.ProposalBlock != nil {
 		minVoteTime = cs.ProposalBlock.Time.Add(timeIota)

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,4 +2,4 @@
 
 Tools for working with Tendermint and associated technologies. Documentation for
 these tools can be found online in the [Tendermint tools
-documentation](https://docs.tendermint.com/master/tools/).
+documentation](https://docs.tendermint.com/main/tools/).

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,4 +2,4 @@
 
 Tools for working with Tendermint and associated technologies. Documentation for
 these tools can be found online in the [Tendermint tools
-documentation](https://docs.tendermint.com/main/tools/).
+documentation](https://docs.tendermint.com/v0.34/tools/).

--- a/types/block.go
+++ b/types/block.go
@@ -321,7 +321,7 @@ func MaxDataBytesNoEvidence(maxBytes int64, valsCount int) int64 {
 // NOTE: changes to the Header should be duplicated in:
 // - header.Hash()
 // - abci.Header
-// - https://github.com/tendermint/spec/blob/master/spec/blockchain/blockchain.md
+// - https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/blockchain.md
 type Header struct {
 	// basic block info
 	Version tmversion.Consensus `json:"version"`


### PR DESCRIPTION
Partially addresses #9096.

Similar to #9243, but targets the `v0.34.x` branch.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

