### PR TITLE
chore: Sync `CODEOWNERS` on `v0.34.x` branch with `main`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # global owners are only requested if there isn't a more specific
 # codeowner specified below. For this reason, the global codeowners
 # are often repeated in package-level definitions.
-*      @ebuchman @cmwaters @tychoish @williambanfield @creachadair
+*     @ebuchman @tendermint/tendermint-engineering


### PR DESCRIPTION
Synchronizes the `CODEOWNERS` file on the `v0.34.x` branch with `main`.

There's no spec on the `v0.34.x` branch, so we don't need the research team-related restriction on this branch.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

