### PR TITLE
chore: Sync `CODEOWNERS` on `v0.33.x` branch with `main`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,10 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
-# Everything goes through Bucky, Anton, Tess. For now.
-*       @ebuchman @melekes @tessr
-
-# Precious documentation
-/docs/README.md  @zramsay
-/docs/DOCS_README.md  @zramsay
-/docs/.vuepress/  @zramsay
+# Everything goes through the following "global owners" by default.
+# Unless a later match takes precedence, these three will be
+# requested for review when someone opens a PR.
+# Note that the last matching pattern takes precedence, so
+# global owners are only requested if there isn't a more specific
+# codeowner specified below. For this reason, the global codeowners
+# are often repeated in package-level definitions.
+*     @ebuchman @tendermint/tendermint-engineering


### PR DESCRIPTION
Relates to #9245 and #9243

We should strongly consider dropping our documentation support for v0.33.x once we release v0.37.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

