### PR TITLE
cli: Enable reindex-event cmd

### DIFF
--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -18,6 +18,7 @@ func main() {
 		cmd.InitFilesCmd,
 		cmd.ProbeUpnpCmd,
 		cmd.LightCmd,
+		cmd.ReIndexEventCmd,
 		cmd.ReplayCmd,
 		cmd.ReplayConsoleCmd,
 		cmd.ResetAllCmd,


### PR DESCRIPTION
I noticed today that this wasn't enabled.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

