### PR TITLE
config: Move `discard_abci_responses` flag into its own storage section

### DIFF
--- a/cmd/tendermint/commands/rollback.go
+++ b/cmd/tendermint/commands/rollback.go
@@ -78,7 +78,7 @@ func loadStateAndBlockStore(config *cfg.Config) (*store.BlockStore, state.Store,
 		return nil, nil, err
 	}
 	stateStore := state.NewStore(stateDB, state.StoreOptions{
-		DiscardABCIResponses: config.RPC.DiscardABCIResponses,
+		DiscardABCIResponses: config.Storage.DiscardABCIResponses,
 	})
 
 	return blockStore, stateStore, nil

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,7 @@ type Config struct {
 	StateSync       *StateSyncConfig       `mapstructure:"statesync"`
 	FastSync        *FastSyncConfig        `mapstructure:"fastsync"`
 	Consensus       *ConsensusConfig       `mapstructure:"consensus"`
+	Storage         *StorageConfig         `mapstructure:"storage"`
 	TxIndex         *TxIndexConfig         `mapstructure:"tx_index"`
 	Instrumentation *InstrumentationConfig `mapstructure:"instrumentation"`
 }
@@ -88,6 +89,7 @@ func DefaultConfig() *Config {
 		StateSync:       DefaultStateSyncConfig(),
 		FastSync:        DefaultFastSyncConfig(),
 		Consensus:       DefaultConsensusConfig(),
+		Storage:         DefaultStorageConfig(),
 		TxIndex:         DefaultTxIndexConfig(),
 		Instrumentation: DefaultInstrumentationConfig(),
 	}
@@ -103,6 +105,7 @@ func TestConfig() *Config {
 		StateSync:       TestStateSyncConfig(),
 		FastSync:        TestFastSyncConfig(),
 		Consensus:       TestConsensusConfig(),
+		Storage:         TestStorageConfig(),
 		TxIndex:         TestTxIndexConfig(),
 		Instrumentation: TestInstrumentationConfig(),
 	}
@@ -405,11 +408,6 @@ type RPCConfig struct {
 
 	// pprof listen address (https://golang.org/pkg/net/http/pprof)
 	PprofListenAddress string `mapstructure:"pprof_laddr"`
-
-	// Set false to ensure ABCI responses are persisted.
-	// ABCI responses are required for /BlockResults RPC queries, and
-	// to reindex events in the command-line tool.
-	DiscardABCIResponses bool `mapstructure:"discard_abci_responses"`
 }
 
 // DefaultRPCConfig returns a default configuration for the RPC server
@@ -434,9 +432,8 @@ func DefaultRPCConfig() *RPCConfig {
 		MaxBodyBytes:   int64(1000000), // 1MB
 		MaxHeaderBytes: 1 << 20,        // same as the net/http default
 
-		TLSCertFile:          "",
-		TLSKeyFile:           "",
-		DiscardABCIResponses: false,
+		TLSCertFile: "",
+		TLSKeyFile:  "",
 	}
 }
 
@@ -1074,6 +1071,34 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 		return errors.New("double_sign_check_height can't be negative")
 	}
 	return nil
+}
+
+//-----------------------------------------------------------------------------
+// StorageConfig
+
+// StorageConfig allows more fine-grained control over certain storage-related
+// behavior.
+type StorageConfig struct {
+	// Set to false to ensure ABCI responses are persisted. ABCI responses are
+	// required for `/block_results` RPC queries, and to reindex events in the
+	// command-line tool.
+	DiscardABCIResponses bool `mapstructure:"discard_abci_responses"`
+}
+
+// DefaultStorageConfig returns the default configuration options relating to
+// Tendermint storage optimization.
+func DefaultStorageConfig() *StorageConfig {
+	return &StorageConfig{
+		DiscardABCIResponses: false,
+	}
+}
+
+// TestStorageConfig returns storage configuration that can be used for
+// testing.
+func TestStorageConfig() *StorageConfig {
+	return &StorageConfig{
+		DiscardABCIResponses: false,
+	}
 }
 
 // -----------------------------------------------------------------------------

--- a/config/toml.go
+++ b/config/toml.go
@@ -484,9 +484,10 @@ peer_query_maj23_sleep_duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
 ###         Storage Configuration Options           ###
 #######################################################
 
-# Set to false to ensure ABCI responses are persisted. ABCI responses are
-# required for /block_results RPC queries, and to reindex events in the
-# command-line tool.
+# Set to true to discard ABCI responses from the state store, which can save a
+# considerable amount of disk space. Set to false to ensure ABCI responses are
+# persisted. ABCI responses are required for /block_results RPC queries, and to
+# reindex events in the command-line tool.
 discard_abci_responses = {{ .Storage.DiscardABCIResponses}}
 
 #######################################################

--- a/config/toml.go
+++ b/config/toml.go
@@ -263,9 +263,6 @@ tls_key_file = "{{ .RPC.TLSKeyFile }}"
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
 pprof_laddr = "{{ .RPC.PprofListenAddress }}"
 
-# Flag that enables discarding of abci responses
-discard_abci_responses = {{ .RPC.DiscardABCIResponses}}
-
 #######################################################
 ###           P2P Configuration Options             ###
 #######################################################
@@ -482,6 +479,15 @@ create_empty_blocks_interval = "{{ .Consensus.CreateEmptyBlocksInterval }}"
 # Reactor sleep duration parameters
 peer_gossip_sleep_duration = "{{ .Consensus.PeerGossipSleepDuration }}"
 peer_query_maj23_sleep_duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
+
+#######################################################
+###         Storage Configuration Options           ###
+#######################################################
+
+# Set to false to ensure ABCI responses are persisted. ABCI responses are
+# required for /block_results RPC queries, and to reindex events in the
+# command-line tool.
+discard_abci_responses = {{ .Storage.DiscardABCIResponses}}
 
 #######################################################
 ###   Transaction Indexer Configuration Options     ###

--- a/node/node.go
+++ b/node/node.go
@@ -432,7 +432,7 @@ func createEvidenceReactor(config *cfg.Config, dbProvider DBProvider,
 	}
 	evidenceLogger := logger.With("module", "evidence")
 	evidencePool, err := evidence.NewPool(evidenceDB, sm.NewStore(stateDB, sm.StoreOptions{
-		DiscardABCIResponses: config.RPC.DiscardABCIResponses,
+		DiscardABCIResponses: config.Storage.DiscardABCIResponses,
 	}), blockStore)
 	if err != nil {
 		return nil, nil, err
@@ -720,7 +720,7 @@ func NewNode(config *cfg.Config,
 	}
 
 	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-		DiscardABCIResponses: config.RPC.DiscardABCIResponses,
+		DiscardABCIResponses: config.Storage.DiscardABCIResponses,
 	})
 
 	state, genDoc, err := LoadStateFromDBOrGenesisDocProvider(stateDB, genesisDocProvider)

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -442,7 +442,7 @@ func createEvidenceReactor(config *cfg.Config, dbProvider DBProvider,
 		return nil, nil, err
 	}
 	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-		DiscardABCIResponses: config.RPC.DiscardABCIResponses,
+		DiscardABCIResponses: config.Storage.DiscardABCIResponses,
 	})
 	evidenceLogger := logger.With("module", "evidence")
 	evidencePool, err := evidence.NewPool(evidenceDB, stateStore, blockStore)


### PR DESCRIPTION
Closes #9274 

Docs and `CHANGELOG_PENDING` entry will be added in #9267.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

