### PR TITLE
Restore e2e nightly workflow on feature/abci++ppp branch

### DIFF
--- a/.github/workflows/e2e-nightly-main.yml
+++ b/.github/workflows/e2e-nightly-main.yml
@@ -1,0 +1,93 @@
+# Runs randomly generated E2E testnets nightly on main
+
+# !! Relevant changes to this file should be propagated to the e2e-nightly-<V>x
+# files for the supported backport branches, when appropriate, modulo version
+# markers.
+
+name: e2e-nightly-main
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  e2e-nightly-test:
+    # Run parallel jobs for the listed testnet groups (must match the
+    # ./build/generator -g flag)
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ['00', '01', '02', '03', "04"]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+
+      - uses: actions/checkout@v3
+
+      - name: Build
+        working-directory: test/e2e
+        # Run make jobs in parallel, since we can't run steps in parallel.
+        run: make -j2 docker generator runner tests
+
+      - name: Generate testnets
+        working-directory: test/e2e
+        # When changing -g, also change the matrix groups above
+        run: ./build/generator -g 5 -d networks/nightly/
+
+      - name: Run ${{ matrix.p2p }} p2p testnets
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
+
+  e2e-nightly-fail:
+    needs: e2e-nightly-test
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.21.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ github.ref_name }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMIT_URL: "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMIT_URL }}|commit> that caused the failure."
+                  }
+                }
+              ]
+            }
+
+  e2e-nightly-success:  # may turn this off once they seem to pass consistently
+    needs: e2e-nightly-test
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on success
+        uses: slackapi/slack-github-action@v1.21.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ github.ref_name }}
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":white_check_mark: Nightly E2E tests for `${{ env.BRANCH }}` passed."
+                  }
+                }
+              ]
+            }

--- a/libs/pubsub/pubsub.go
+++ b/libs/pubsub/pubsub.go
@@ -27,7 +27,7 @@
 //         select {
 //         case msg <- subscription.Out():
 //             // handle msg.Data() and msg.Events()
-//         case <-subscription.Canceled():
+//         case <-subscription.Cancelled():
 //             return subscription.Err()
 //         }
 //     }

--- a/libs/pubsub/subscription.go
+++ b/libs/pubsub/subscription.go
@@ -46,7 +46,7 @@ func (s *Subscription) Out() <-chan Message {
 // nolint: misspell
 // Cancelled returns a channel that's closed when the subscription is
 // terminated and supposed to be used in a select statement.
-func (s *Subscription) Cancelled() <-chan struct{} { // nolint: misspell
+func (s *Subscription) Cancelled() <-chan struct{} {
 	return s.canceled
 }
 


### PR DESCRIPTION
Closes #9277

This PR aligns the .github configuration in `feature/abci++ppp` with the one in `main` to avoid problems when carrying out the final merge of the feature branch back into `main`

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

