### PR TITLE
spec:p2p v0.34 introduction

### DIFF
--- a/spec/p2p/v0.34/README.md
+++ b/spec/p2p/v0.34/README.md
@@ -1,6 +1,6 @@
 # v0.34 P2P Communicaton layer
 
-Within a Tendermint network, nodes can communicate with one another using a p2p protocol. The goal of this document is to specify the the p2p layer in Tendermint v0.34 including: Peer discovery, peer management, connection handling and message types. 
+Within a Tendermint network, nodes can communicate with one another using a p2p protocol. The goal of this document is to specify the p2p layer in Tendermint v0.34 including: Peer discovery, peer management, connection handling and message types. 
 
 This documentation aims at separating the logical components on a protocol level from the implementation details of each protocol. 
 At a high level, the p2p layer in Tendermint has the following main functionalities:

--- a/spec/p2p/v0.34/README.md
+++ b/spec/p2p/v0.34/README.md
@@ -1,46 +1,46 @@
 # v0.34 P2P Communicaton layer
 
-## Intro
+Within a Tendermint network, nodes can communicate with one another using a p2p protocol. The goal of this document is to specify the the p2p layer in Tendermint v0.34 including: Peer discovery, peer management, connection handling and message types. 
 
-The goal of this document is to specify the behaviour of the p2p layer in Tenderming v0.34. The existing documents aiming to describe the p2p layer are:
-
-- https://github.com/tendermint/tendermint/tree/master/spec/p2p : Peer information (handshake and addresses); Mconn package;
-Tendermint nodes can connect and communicate via p2p to one another. The main high level responsibilities of the p2p layer are  1) establishing and maintaining connections between peers and 2) managing the state of peers. 
-- https://github.com/tendermint/tendermint/tree/master/docs/tendermint-core/pex : PEX reactor (*Note* I am not sure that the peer exchange section is valid anymore)
-
-## p2p main concepts
-The main components that manage these two broad categories are:
-- The Switch
-- The PEX reactor 
-- Transport
-- Different reactors in Tendermint implementing p2p reactor interface
-
-The tables below gives a high level overview of the main functionalities provided by the p2p implementation of Tendermint and the components responsible for each functionality. 
+This documentation aims at separating the logical components on a protocol level from the implementation details of each protocol. 
+At a high level, the p2p layer in Tendermint has the following main functionalities:
+1. Peer management: peer discovery and peer ranking
+2. Peer connection handling: dialing and accepting connections
+3. Message transfer
+   
+The implementation of these three functionalities is split between different Tendermint components as shown in the tables below. 
+<!--
+ToDo Check that the split in tables corresponds to what is actually in the files. 
+-->
 
 ### **Peer communication** 
-| Peer discovery | Peer dialing | Accepting connections from peers | Connection management (processing msgs) |
+| [Peer discovery](peer_manager.md) | [Peer dialing](switch.md#dialing-peers) | [Accepting connections from peers](switch.md#accepting-peers) | Connection management (processing msgs) |
 | ---| ---| ---| --- | 
 | PEX / config | PEX / Switch | Reactors / Switch | Reactors| 
 
 
 ### **Peer management**
-| Peer ranking | Connection upgrading | Evicting| 
+| [Peer ranking](addressbook.md#pick-address) | Connection upgrading | [Evicting](pex-protocol.md#misbehavior)| 
 | --- | --- | --- |
-| PEX / reactors (only marking peers as good/bad) | - | Switch| 
+| PEX / reactors (only marking peers as good/bad); address book (actual ranking)| - | PEX reactor| 
 
 
-The main states a node can be in are:
-- 'Candidate': peers that we have not connected to yet but are discovered. (no explicit list)
-- 'Dialing' : peers who are currently being dialed. ( I did not see where this is of particular use. )
-- 'Peers' : Connected peers (effectivley a connected state)
-- 'Reconnecting': Peers to whom a node is currently reconnecting. The node is trying to establosh a connectiong to these peers and is failing to do so. After a certain amount of time, the peer is simply dropped to be discovered again by the PEX reactor. 
-- 'BadPeers' : This is the only list not kept by the switch. It is stored within the address book of the PEX reactor. 
+## Peer lifecycle
 
-The diagram below shows the lifecycle of an outbound peer:
-
+A Node can pass through various states before becoming the peer of another node as demonstrated below in the example of an outbound peer:
 <img src="img/p2p_state.png" width="50%" title="Outgoing peers lifecycle">Outgoing peers lifecycle</img>
 
+A node can thus be in the following states before connecting to its peer:
+- 'Candidate': peers that we have not connected to yet but are discovered. (no explicit list)
+- ['Dialing'](switch.md#dialing-peers) : peers who are currently being dialed. ( I did not see where this is of particular use. )
+- 'Peers' : Connected peers (effectivley a connected state)
+- ['Reconnecting'](switch.md#reconnect-to-peer): Peers to whom a node is currently reconnecting. The node is trying to establosh a connectiong to these peers and is failing to do so. After a certain amount of time, the peer is simply dropped to be discovered again by the PEX reactor. 
+- 'BadPeers' : This is the only list not kept by the switch. It is stored within the [address](addressbook.md#bad-peers) book of the PEX reactor. 
 
+This specification explains the conditions that need to be satisfied for a node to transition into between these state.
+
+<!--
+ToDo check if smething can be moved to existing sections Daniel wrote, otherwise delete
 ### Peer discovery
 
 Peers are discovered by adding addresses provided in the config file or triggering dials to seed nodes or nodes in the address book. 
@@ -126,7 +126,15 @@ In case of `PexRequest` messages the reactor provides the requesting peer with k
 - The address is private 
 
 A node has a requests map where it stores all requets it issued to a peer asking it for more peer addresses. If a `PexAddress` message returns an error, a node marks the sending peer as bad. 
+-->
+## References 
 
+Documents that describe some of the functionality of the p2p layer prior to this specification:
+
+- https://github.com/tendermint/tendermint/tree/master/spec/p2p : Peer information (handshake and addresses); Mconn package;
+Tendermint nodes can connect and communicate via p2p to one another. The main high level responsibilities of the p2p layer are  1) establishing and maintaining connections between peers and 2) managing the state of peers. 
+- https://github.com/tendermint/tendermint/tree/master/docs/tendermint-core/pex : PEX reactor (*Note* I am not sure that the peer exchange section is valid anymore)
+- 
 
 ## Notes on diff v0.35+ and v0.34
 
@@ -141,3 +149,5 @@ A node has a requests map where it stores all requets it issued to a peer asking
 *Bug v0.36* p2p router l722 - this increment hgappens twice (once for in and once for out )
 
 *v0.36 p2p statesync* If the statesyncing node has only two peers and one of those does not have the requested light block (has not created a snapshot yet for example), statesync will not look for additional peers but will fail to initialize the `StateProvider` and halt. 
+
+

--- a/spec/p2p/v0.34/addressbook.md
+++ b/spec/p2p/v0.34/addressbook.md
@@ -111,6 +111,9 @@ bucket is moved (downgraded) to a bucket of new addresses.
 Moving the peer address to a bucket of old addresses has the effect of
 upgrading, or increasing the ranking of a peer in the address book.
 
+**Note** In v0.34 a peers is currently marked good only from the consensus reactor 
+whenever it delivers a correct consensus message.
+
 ## Bad peers
 
 The `MarkBad` method marks a peer as bad and bans it for a period of time.

--- a/spec/p2p/v0.34/addressbook.md
+++ b/spec/p2p/v0.34/addressbook.md
@@ -115,7 +115,7 @@ upgrading, or increasing the ranking of a peer in the address book.
 
 The `MarkBad` method marks a peer as bad and bans it for a period of time.
 
-It is invoked by the PEX reactor, with banning time of 24 hours, in the following cases:
+It is invoked by the [PEX reactor](pex-protocol.md#misbehavior), with banning time of 24 hours, in the following cases:
 
 - When PEX requests are received too often from a peer
 - When an invalid PEX response is received from a peer

--- a/spec/p2p/v0.34/peer_manager.md
+++ b/spec/p2p/v0.34/peer_manager.md
@@ -82,7 +82,7 @@ received from a peer that is locally configured as a seed node.
 
 > FIXME: The current logic was introduced in [#3762](https://github.com/tendermint/tendermint/pull/3762).
 > Although it fix the issue, the delay between receiving an address and dialing
-> the peer, it does not impose ant limit on how many addresses are dialed in this
+> the peer, it does not impose and limit on how many addresses are dialed in this
 > scenario.
 > So, all addresses received from a seed node are dialed, regardless of the
 > current number of outbound peers, the number of dialing routines, or the

--- a/spec/p2p/v0.34/peer_manager.md
+++ b/spec/p2p/v0.34/peer_manager.md
@@ -1,5 +1,14 @@
 # Peer Manager
 
+## Dialing peers on startup
+
+The node configuration file can contain a list of *persistent peers*. Those peers
+have preferential treatment compared to regular peers and the node is always trying to 
+connect to them - they are not removed on errors. If, on startup, the list of empty peers 
+is not empty, the node immediately tries to dial them by calling the 
+[`DialPeersAsync`](switch.md#dialpeersasync)
+within the switch directly from its setup method. 
+
 ## Ensure peers
 
 The `ensurePeersRoutine` is a persistent routine intended to ensure that a node
@@ -113,3 +122,19 @@ TODO:
 ## AttemptsToDial - PEX reactor
 
 Not invoked in the code, except for tests.
+
+## Peer types
+
+Tendermint distignuishes between three types of peers:
+1. Regular peers
+2. Persistent peers
+3. Unconditional peers
+
+Unlike regular peers, persistent and unconditional peers are treated differently by the peer manager.
+
+*Persistent peers* are provided via the config file on startup and are considered more trustworthy. When 
+dialing these peers errors, or a reactor reports an error on this peer, Tendermint will always try to
+reconnect to a persistent peer. Regular peers will be removed and disconnected from.
+
+*Unconditional peers* are not subjected to the limits of maximum inbound and outbound connections and Tendermint
+always attempts to connect to them, even if the maximum number of connections is reached. 

--- a/spec/p2p/v0.34/pex-protocol.md
+++ b/spec/p2p/v0.34/pex-protocol.md
@@ -122,7 +122,7 @@ More specifically, a node operating in seed mode sends PEX requests in two cases
 
 1. When a outbound peer is added, and the seed node needs more peer addresses,
    it requests peer addresses to the new peer
-1. Periodically, the `crawlPeersRoutine` sends PEX requests to a random set of
+2. Periodically, the `crawlPeersRoutine` sends PEX requests to a random set of
    peers, whose addresses are registered in the Address Book
 
 The first case also applies for nodes not operating in seed mode.

--- a/spec/p2p/v0.34/pex-protocol.md
+++ b/spec/p2p/v0.34/pex-protocol.md
@@ -25,7 +25,7 @@ the node *needs* peers addresses, a condition checked:
 
 1. When an *outbound* peer is added, causing the node to request addresses from
    the new peer
-1. Periodically, by the `ensurePeersRoutine`, causing the node to request peer
+2. Periodically, by the `ensurePeersRoutine`, causing the node to request peer
    addresses to a randomly selected peer
 
 A node needs more peer addresses when its addresses book has

--- a/spec/p2p/v0.34/pex-protocol.md
+++ b/spec/p2p/v0.34/pex-protocol.md
@@ -78,7 +78,7 @@ Sending a PEX response to a peer that has not requested peer addresses
 is also considered a misbehavior.
 So, if a PEX response is received from a peer that is not registered in
 the `requestsSent` set, a `ErrUnsolicitedList` error is produced.
-This leads the peer to be disconnected and marked as a bad peer.
+This leads the peer to be disconnected and [marked as a bad peer](addressbook.md#bad-peers).
 
 ## Providing Addresses
 
@@ -102,7 +102,7 @@ The `receiveRequest` method is responsible for verifying this condition.
 The node keeps a `lastReceivedRequests` map with the time of the last PEX
 request received from every peer.
 If the interval between successive requests is less than the minimum accepted
-one, the peer is disconnected and marked as a bad peer.
+one, the peer is disconnected and [marked as a bad peer](addressbook.md#bad-peers).
 An exception is made for the first two PEX requests received from a peer.
 
 > The probably reason is that, when a new peer is added, the two conditions for
@@ -150,7 +150,7 @@ peers, the seed node sends a PEX request.
 
 Dialing a selected peer address can fail for multiple reasons.
 The seed node might have attempted to dial the peer too many times.
-In this case, the peer address is marked as bad in the address book.
+In this case, the peer address is marked as [bad in the address book](addressbook.md#bad-peers).
 The seed node might have attempted to dial the peer recently, without success,
 and the exponential `backoffDuration` has not yet passed.
 Or the current connection attempt might fail, which is registered in the address book.

--- a/spec/p2p/v0.34/switch.md
+++ b/spec/p2p/v0.34/switch.md
@@ -218,7 +218,7 @@ reactor (`InitPeer` method).
 Next, the peer's sending and receiving routines are started, and the peer is
 added to set of connected peers.
 These two operations can fail, causing `addPeer` to return an error.
-Then, in the absence of previous errors, the peer is added to every reactor (`AdPeer` method).
+Then, in the absence of previous errors, the peer is added to every reactor (`AddPeer` method).
 
 > Adding the peer to the peer set returns a `ErrSwitchDuplicatePeerID` error
 > when a peer with the same ID is already presented.


### PR DESCRIPTION
This PR aims to create an introduction to the p2p specification and fills up some information in the rest of the documentation. 