### PR TITLE
docs: Update to reference v0.37 branch instead of main where applicable

### DIFF
--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -20,9 +20,9 @@ Respective versioned files can be found <https://raw.githubusercontent.com/tende
 
 Tendermint Core is Byzantine Fault Tolerant (BFT) middleware that takes a state transition machine, written in any programming language, and securely replicates it on many machines.
 
-For more background, see the [the docs](https://docs.tendermint.com/main/introduction/#quick-start).
+For more background, see the [the docs](https://docs.tendermint.com/v0.37/introduction/#quick-start).
 
-To get started developing applications, see the [application developers guide](https://docs.tendermint.com/main/introduction/quick-start.html).
+To get started developing applications, see the [application developers guide](https://docs.tendermint.com/v0.37/introduction/quick-start.html).
 
 ## How to use this image
 
@@ -37,7 +37,7 @@ docker run -it --rm -v "/tmp:/tendermint" tendermint/tendermint node --proxy_app
 
 ## Local cluster
 
-To run a 4-node network, see the `Makefile` in the root of [the repo](https://github.com/tendermint/tendermint/blob/main/Makefile) and run:
+To run a 4-node network, see the `Makefile` in the root of [the repo](https://github.com/tendermint/tendermint/blob/v0.37.x/Makefile) and run:
 
 ```sh
 make build-linux
@@ -53,4 +53,4 @@ Note that this will build and use a different image than the ones provided here.
 
 ## Contributing
 
-Contributions are most welcome! See the [contributing file](https://github.com/tendermint/tendermint/blob/main/CONTRIBUTING.md) for more information.
+Contributions are most welcome! See the [contributing file](https://github.com/tendermint/tendermint/blob/v0.37.x/CONTRIBUTING.md) for more information.

--- a/abci/README.md
+++ b/abci/README.md
@@ -19,7 +19,7 @@ To get up and running quickly, see the [getting started guide](../docs/app-dev/g
 
 A detailed description of the ABCI methods and message types is contained in:
 
-- [The main spec](https://github.com/tendermint/tendermint/blob/main/spec/abci/abci.md)
+- [The main spec](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/abci/abci.md)
 - [A protobuf file](./types/types.proto)
 - [A Go interface](./types/application.go)
 

--- a/consensus/README.md
+++ b/consensus/README.md
@@ -1,3 +1,3 @@
 # Consensus 
 
-See the [consensus spec](https://github.com/tendermint/tendermint/tree/main/spec/consensus) and the [reactor consensus spec](https://github.com/tendermint/tendermint/tree/main/spec/reactors/consensus) for more information.
+See the [consensus spec](https://github.com/tendermint/tendermint/tree/v0.37.x/spec/consensus) and the [reactor consensus spec](https://github.com/tendermint/tendermint/tree/v0.37.x/spec/reactors/consensus) for more information.

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -468,7 +468,6 @@ func (cs *State) AddVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 
 // SetProposal inputs a proposal.
 func (cs *State) SetProposal(proposal *types.Proposal, peerID p2p.ID) error {
-
 	if peerID == "" {
 		cs.internalMsgQueue <- msgInfo{&ProposalMessage{proposal}, ""}
 	} else {
@@ -481,7 +480,6 @@ func (cs *State) SetProposal(proposal *types.Proposal, peerID p2p.ID) error {
 
 // AddProposalBlockPart inputs a part of the proposal block.
 func (cs *State) AddProposalBlockPart(height int64, round int32, part *types.Part, peerID p2p.ID) error {
-
 	if peerID == "" {
 		cs.internalMsgQueue <- msgInfo{&BlockPartMessage{height, round, part}, ""}
 	} else {
@@ -499,7 +497,6 @@ func (cs *State) SetProposalAndBlock(
 	parts *types.PartSet,
 	peerID p2p.ID,
 ) error {
-
 	if err := cs.SetProposal(proposal, peerID); err != nil {
 		return err
 	}
@@ -945,7 +942,6 @@ func (cs *State) handleTimeout(ti timeoutInfo, rs cstypes.RoundState) {
 	default:
 		panic(fmt.Sprintf("invalid timeout step: %v", ti.Step))
 	}
-
 }
 
 func (cs *State) handleTxsAvailable() {
@@ -1196,7 +1192,6 @@ func (cs *State) isProposalComplete() bool {
 	}
 	// if this is false the proposer is lying or we haven't received the POL yet
 	return cs.Votes.Prevotes(cs.Proposal.POLRound).HasTwoThirdsMajority()
-
 }
 
 // Create the next block to propose and return it. Returns nil block upon error.
@@ -1941,7 +1936,7 @@ func (cs *State) addProposalBlockPart(msg *BlockPartMessage, peerID p2p.ID) (add
 			return added, err
 		}
 
-		var pbb = new(tmproto.Block)
+		pbb := new(tmproto.Block)
 		err = proto.Unmarshal(bz, pbb)
 		if err != nil {
 			return added, err
@@ -2274,10 +2269,10 @@ func (cs *State) voteTime() time.Time {
 	// Minimum time increment between blocks
 	const timeIota = time.Millisecond
 	// TODO: We should remove next line in case we don't vote for v in case cs.ProposalBlock == nil,
-	// even if cs.LockedBlock != nil. See https://github.com/tendermint/tendermint/tree/main/spec/.
+	// even if cs.LockedBlock != nil. See https://github.com/tendermint/tendermint/tree/v0.37.x/spec/.
 	if cs.LockedBlock != nil {
 		// See the BFT time spec
-		// https://github.com/tendermint/tendermint/blob/main/spec/consensus/bft-time.md
+		// https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/bft-time.md
 		minVoteTime = cs.LockedBlock.Time.Add(timeIota)
 	} else if cs.ProposalBlock != nil {
 		minVoteTime = cs.ProposalBlock.Time.Add(timeIota)

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -12,7 +12,7 @@ For any specific algorithm, use its specific module e.g.
 
 ## Binary encoding
 
-For Binary encoding, please refer to the [Tendermint encoding specification](https://github.com/tendermint/tendermint/blob/main/spec/core/encoding.md).
+For Binary encoding, please refer to the [Tendermint encoding specification](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/core/encoding.md).
 
 ## JSON Encoding
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Tendermint?](introduction/what-is-tendermint.md).
 
 To get started quickly with an example application, see the [quick start guide](introduction/quick-start.md).
 
-To learn about application development on Tendermint, see the [Application Blockchain Interface](https://github.com/tendermint/tendermint/tree/main/spec/abci).
+To learn about application development on Tendermint, see the [Application Blockchain Interface](https://github.com/tendermint/tendermint/tree/v0.37.x/spec/abci).
 
 For more details on using Tendermint, see the respective documentation for
 [Tendermint Core](tendermint-core/), [benchmarking and monitoring](tools/), and [network deployments](networks/).
@@ -30,4 +30,4 @@ To find out about the Tendermint ecosystem you can go [here](https://github.com/
 
 ## Contribute
 
-To contribute to the documentation, see [this file](https://github.com/tendermint/tendermint/blob/main/docs/DOCS_README.md) for details of the build process and considerations when making changes.
+To contribute to the documentation, see [this file](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/DOCS_README.md) for details of the build process and considerations when making changes.

--- a/docs/app-dev/abci-cli.md
+++ b/docs/app-dev/abci-cli.md
@@ -136,7 +136,7 @@ response.
 
 The server may be generic for a particular language, and we provide a
 [reference implementation in
-Golang](https://github.com/tendermint/tendermint/tree/main/abci/server). See the
+Golang](https://github.com/tendermint/tendermint/tree/v0.37.x/abci/server). See the
 [list of other ABCI implementations](https://github.com/tendermint/awesome#ecosystem) for servers in
 other languages.
 

--- a/docs/app-dev/app-architecture.md
+++ b/docs/app-dev/app-architecture.md
@@ -55,6 +55,6 @@ Tendermint.
 See the following for more extensive documentation:
 
 - [Interchain Standard for the Light-Client REST API](https://github.com/cosmos/cosmos-sdk/pull/1028)
-- [Tendermint RPC Docs](https://docs.tendermint.com/main/rpc/)
+- [Tendermint RPC Docs](https://docs.tendermint.com/v0.37/rpc/)
 - [Tendermint in Production](../tendermint-core/running-in-production.md)
 - [ABCI spec](https://github.com/tendermint/spec/tree/95cf253b6df623066ff7cd4074a94e7a3f147c7a/spec/abci)

--- a/docs/app-dev/indexing-transactions.md
+++ b/docs/app-dev/indexing-transactions.md
@@ -15,7 +15,7 @@ the block itself is never stored.
 Each event contains a type and a list of attributes, which are key-value pairs
 denoting something about what happened during the method's execution. For more
 details on `Events`, see the
-[ABCI](https://github.com/tendermint/tendermint/blob/main/spec/abci/abci.md#events)
+[ABCI](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/abci/abci.md#events)
 documentation.
 
 An `Event` has a composite key associated with it. A `compositeKey` is
@@ -146,7 +146,7 @@ You can query for a paginated set of transaction by their events by calling the
 curl "localhost:26657/tx_search?query=\"message.sender='cosmos1...'\"&prove=true"
 ```
 
-Check out [API docs](https://docs.tendermint.com/main/rpc/#/Info/tx_search)
+Check out [API docs](https://docs.tendermint.com/v0.37/rpc/#/Info/tx_search)
 for more information on query syntax and other options.
 
 ## Subscribing to Transactions
@@ -165,7 +165,7 @@ a query to `/subscribe` RPC endpoint.
 }
 ```
 
-Check out [API docs](https://docs.tendermint.com/main/rpc/#subscribe) for more information
+Check out [API docs](https://docs.tendermint.com/v0.37/rpc/#subscribe) for more information
 on query syntax and other options.
 
 ## Querying Blocks Events
@@ -177,5 +177,5 @@ You can query for a paginated set of blocks by their events by calling the
 curl "localhost:26657/block_search?query=\"block.height > 10 AND val_set.num_changed > 0\""
 ```
 
-Check out [API docs](https://docs.tendermint.com/main/rpc/#/Info/block_search)
+Check out [API docs](https://docs.tendermint.com/v0.37/rpc/#/Info/block_search)
 for more information on query syntax and other options.

--- a/docs/architecture/adr-021-abci-events.md
+++ b/docs/architecture/adr-021-abci-events.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-ABCI tags were first described in [ADR 002](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-002-event-subscription.md).
+ABCI tags were first described in [ADR 002](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-002-event-subscription.md).
 They are key-value pairs that can be used to index transactions.
 
 Currently, ABCI messages return a list of tags to describe an

--- a/docs/architecture/adr-024-sign-bytes.md
+++ b/docs/architecture/adr-024-sign-bytes.md
@@ -16,7 +16,7 @@ The messages exchanged between tendermint and a remote signer currently live in
 
 [privval/socket.go]: https://github.com/tendermint/tendermint/blob/d419fffe18531317c28c29a292ad7d253f6cafdf/privval/socket.go#L496-L502
 [issue#1622]: https://github.com/tendermint/tendermint/issues/1622
-[types]: https://github.com/tendermint/tendermint/tree/main/types
+[types]: https://github.com/tendermint/tendermint/tree/v0.37.x/types
  
 
 ## Decision

--- a/docs/architecture/adr-043-blockchain-riri-org.md
+++ b/docs/architecture/adr-043-blockchain-riri-org.md
@@ -9,7 +9,7 @@
 
 ## Context
 
-The blockchain reactor is responsible for two high level processes:sending/receiving blocks from peers and FastSync-ing blocks to catch upnode who is far behind. The goal of [ADR-40](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-040-blockchain-reactor-refactor.md) was to refactor these two processes by separating business logic currently wrapped up in go-channels into pure `handle*` functions. While the ADR specified what the final form of the reactor might look like it lacked guidance on intermediary steps to get there.
+The blockchain reactor is responsible for two high level processes:sending/receiving blocks from peers and FastSync-ing blocks to catch upnode who is far behind. The goal of [ADR-40](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-040-blockchain-reactor-refactor.md) was to refactor these two processes by separating business logic currently wrapped up in go-channels into pure `handle*` functions. While the ADR specified what the final form of the reactor might look like it lacked guidance on intermediary steps to get there.
 The following diagram illustrates the state of the [blockchain-reorg](https://github.com/tendermint/tendermint/pull/3561) reactor which will be referred to as `v1`.
 
 ![v1 Blockchain Reactor Architecture
@@ -22,7 +22,7 @@ While `v1` of the blockchain reactor has shown significant improvements in terms
 - Peer communication is spread over multiple components creating complex dependency graph which must be mocked out during testing.
 - Timeouts modeled as stateful tickers introduce non-determinism in tests
 
-This ADR is meant to specify the missing components and control necessary to achieve [ADR-40](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-040-blockchain-reactor-refactor.md).
+This ADR is meant to specify the missing components and control necessary to achieve [ADR-40](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-040-blockchain-reactor-refactor.md).
 
 ## Decision
 
@@ -41,7 +41,7 @@ Diagram](https://github.com/tendermint/tendermint/blob/5cf570690f989646fb3b615b7
 
 ### Reactor changes in detail
 
-The reactor will include a demultiplexing routine which will send each message to each sub routine for independent processing. Each sub routine will then select the messages it's interested in and call the handle specific function specified in [ADR-40](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-040-blockchain-reactor-refactor.md). The demuxRoutine acts as "pacemaker" setting the time in which events are expected to be handled.
+The reactor will include a demultiplexing routine which will send each message to each sub routine for independent processing. Each sub routine will then select the messages it's interested in and call the handle specific function specified in [ADR-40](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-040-blockchain-reactor-refactor.md). The demuxRoutine acts as "pacemaker" setting the time in which events are expected to be handled.
 
 ```go
 func demuxRoutine(msgs, scheduleMsgs, processorMsgs, ioMsgs) {
@@ -400,5 +400,5 @@ Implemented
 
 ## References
 
-- [ADR-40](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-040-blockchain-reactor-refactor.md): The original blockchain reactor re-org proposal
+- [ADR-40](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-040-blockchain-reactor-refactor.md): The original blockchain reactor re-org proposal
 - [Blockchain re-org](https://github.com/tendermint/tendermint/pull/3561): The current blockchain reactor re-org implementation (v1)

--- a/docs/architecture/adr-044-lite-client-with-weak-subjectivity.md
+++ b/docs/architecture/adr-044-lite-client-with-weak-subjectivity.md
@@ -32,7 +32,7 @@ fork the network at some point in its prior history. See Vitalik’s post at
 Subjectivity](https://blog.ethereum.org/2014/11/25/proof-stake-learned-love-weak-subjectivity/).
 
 Currently, Tendermint provides a lite client implementation in the
-[light](https://github.com/tendermint/tendermint/tree/main/light) package. This
+[light](https://github.com/tendermint/tendermint/tree/v0.37.x/light) package. This
 lite client implements a bisection algorithm that tries to use a binary search
 to find the minimum number of block headers where the validator set voting
 power changes are less than < 1/3rd. This interface does not support weak
@@ -84,7 +84,7 @@ The linear verification algorithm requires downloading all headers
 between the `TrustHeight` and the `LatestHeight`. The lite client downloads the
 full header for the provided `TrustHeight` and then proceeds to download `N+1`
 headers and applies the [Tendermint validation
-rules](https://github.com/tendermint/tendermint/tree/main/spec/light-client/verification/README.md)
+rules](https://github.com/tendermint/tendermint/tree/v0.37.x/spec/light-client/verification/README.md)
 to each block.
 
 ### Bisecting Verification
@@ -119,7 +119,7 @@ network usage.
 ---
 
 Check out the formal specification
-[here](https://github.com/tendermint/tendermint/tree/main/spec/light-client).
+[here](https://github.com/tendermint/tendermint/tree/v0.37.x/spec/light-client).
 
 ## Status
 

--- a/docs/architecture/adr-045-abci-evidence.md
+++ b/docs/architecture/adr-045-abci-evidence.md
@@ -18,7 +18,7 @@ graceful here, but that's for another day.
 
 It's possible to fool lite clients without there being a fork on the
 main chain - so called Fork-Lite. See the
-[fork accountability](https://github.com/tendermint/tendermint/blob/main/spec/light-client/accountability/README.md)
+[fork accountability](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/light-client/accountability/README.md)
 document for more details. For a sequential lite client, this can happen via
 equivocation or amnesia attacks. For a skipping lite client this can also happen
 via lunatic validator attacks. There must be some way for applications to punish
@@ -31,7 +31,7 @@ checking).
 
 Currently, evidence verification is handled by Tendermint. Once committed,
 [evidence is passed over
-ABCI](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto#L354)
+ABCI](https://github.com/tendermint/tendermint/blob/v0.37.x/proto/tendermint/abci/types.proto#L354)
 in BeginBlock in a reduced form that includes only
 the type of evidence, its height and timestamp, the validator it's from, and the
 total voting power of the validator set at the height. The app trusts Tendermint

--- a/docs/architecture/adr-047-handling-evidence-from-light-client.md
+++ b/docs/architecture/adr-047-handling-evidence-from-light-client.md
@@ -179,13 +179,13 @@ This then ends the process and the verify function that was called at the start 
 the user.
 
 For a detailed overview of how each of these three attacks can be conducted please refer to the
-[fork accountability spec](https://github.com/tendermint/tendermint/blob/main/spec/consensus/light-client/accountability.md).
+[fork accountability spec](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/light-client/accountability.md).
 
 ## Full Node Verification
 
 When a full node receives evidence from the light client it will need to verify
 it for itself before gossiping it to peers and trying to commit it on chain. This process is outlined
- in [ADR-059](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-059-evidence-composition-and-lifecycle.md).
+ in [ADR-059](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-059-evidence-composition-and-lifecycle.md).
 
 ## Status
 
@@ -212,9 +212,9 @@ clear from the current information which nodes behaved maliciously.
 
 ## References
 
-* [Fork accountability spec](https://github.com/tendermint/tendermint/blob/main/spec/consensus/light-client/accountability.md)
-* [ADR 056: Light client amnesia attacks](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-056-light-client-amnesia-attacks.md)
-* [ADR-059: Evidence Composition and Lifecycle](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-059-evidence-composition-and-lifecycle.md)
+* [Fork accountability spec](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/light-client/accountability.md)
+* [ADR 056: Light client amnesia attacks](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-056-light-client-amnesia-attacks.md)
+* [ADR-059: Evidence Composition and Lifecycle](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-059-evidence-composition-and-lifecycle.md)
 * [Informal's Light Client Detector](https://github.com/informalsystems/tendermint-rs/blob/master/docs/spec/lightclient/detection/detection.md)
 
 

--- a/docs/architecture/adr-056-light-client-amnesia-attacks.md
+++ b/docs/architecture/adr-056-light-client-amnesia-attacks.md
@@ -10,7 +10,7 @@
 
 ## Context
 
-Whilst most created evidence of malicious behavior is self evident such that any individual can verify them independently there are types of evidence, known collectively as global evidence, that require further collaboration from the network in order to accumulate enough information to create evidence that is individually verifiable and can therefore be processed through consensus. [Fork Accountability](https://github.com/tendermint/tendermint/blob/main/spec/consensus/light-client/accountability.md) has been coined to describe the entire process of detection, proving and punishing of malicious behavior. This ADR addresses specifically what a light client amnesia attack is and how it can be proven and the current decision around handling light client amnesia attacks. For information on evidence handling by the light client, it is recommended to read [ADR 47](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-047-handling-evidence-from-light-client.md).
+Whilst most created evidence of malicious behavior is self evident such that any individual can verify them independently there are types of evidence, known collectively as global evidence, that require further collaboration from the network in order to accumulate enough information to create evidence that is individually verifiable and can therefore be processed through consensus. [Fork Accountability](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/light-client/accountability.md) has been coined to describe the entire process of detection, proving and punishing of malicious behavior. This ADR addresses specifically what a light client amnesia attack is and how it can be proven and the current decision around handling light client amnesia attacks. For information on evidence handling by the light client, it is recommended to read [ADR 47](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-047-handling-evidence-from-light-client.md).
 
 ### Amnesia Attack
 
@@ -33,7 +33,7 @@ The decision surrounding amnesia attacks has both a short term and long term com
 
 The latter of the two options meant storing a record of all votes in any height with which there was more than one round. This information would then be accessible for applications if they wanted to perform some off-chain verification and punishment.
 
-In summary, this seemed like too much to ask of the application to implement only on a temporary basis, whilst not having the domain specific knowledge and considering such a difficult and unlikely attack. Therefore the short term decision is to identify when the attack has occurred and implement the detector algorithm highlighted in [ADR 47](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-047-handling-evidence-from-light-client.md) but to not implement any accountability protocol that would identify malicious validators and allow applications to punish them. This will hopefully change in the long term with the focus on eventually reaching a concrete and secure protocol with identifying and dealing with these attacks.
+In summary, this seemed like too much to ask of the application to implement only on a temporary basis, whilst not having the dov0.37.x specific knowledge and considering such a difficult and unlikely attack. Therefore the short term decision is to identify when the attack has occurred and implement the detector algorithm highlighted in [ADR 47](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-047-handling-evidence-from-light-client.md) but to not implement any accountability protocol that would identify malicious validators and allow applications to punish them. This will hopefully change in the long term with the focus on eventually reaching a concrete and secure protocol with identifying and dealing with these attacks.
 
 ## Implications
 
@@ -65,7 +65,7 @@ Light clients where all witnesses are faulty can be subject to an amnesia attack
 ## References
 
 - [Fork accountability algorithm](https://docs.google.com/document/d/11ZhMsCj3y7zIZz4udO9l25xqb0kl7gmWqNpGVRzOeyY/edit)
-- [Fork accountability spec](https://github.com/tendermint/tendermint/blob/main/spec/consensus/light-client/accountability.md)
+- [Fork accountability spec](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/light-client/accountability.md)
 
 ## Appendix A: Detailed Walkthrough of Performing a Light Client Amnesia Attack
 
@@ -107,7 +107,7 @@ As the distinction between these two attacks (amnesia and back to the past) can 
 
 Currently, the evidence reactor is used to simply broadcast and store evidence. The idea of creating a new reactor for the specific task of verifying these attacks was briefly discussed, but it is decided that the current evidence reactor will be extended.
 
-The process begins with a light client receiving conflicting headers (in the future this could also be a full node during fast sync or state sync), which it sends to a full node to analyze. As part of [evidence handling](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-047-handling-evidence-from-light-client.md), this is extracted into potential amnesia evidence when the validator voted in more than one round for a different block.
+The process begins with a light client receiving conflicting headers (in the future this could also be a full node during fast sync or state sync), which it sends to a full node to analyze. As part of [evidence handling](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-047-handling-evidence-from-light-client.md), this is extracted into potential amnesia evidence when the validator voted in more than one round for a different block.
 
 ```golang
 type PotentialAmnesiaEvidence struct {
@@ -128,7 +128,7 @@ This trial period will be discussed later.
 
 Returning to the event of an amnesia attack, if we were to examine the behavior of the honest nodes, C1 and C2, in the schematic, C2 will not PRECOMMIT an earlier round, but it is likely, if a node in C1 were to receive +2/3 PREVOTE's or PRECOMMIT's for a higher round, that it would remove the lock and PREVOTE and PRECOMMIT for the later round. Therefore, unfortunately it is not a case of simply punishing all nodes that have double voted in the `PotentialAmnesiaEvidence`.
 
-Instead we use the Proof of Lock Change (PoLC) referred to in the [consensus spec](https://github.com/tendermint/tendermint/blob/main/spec/consensus/consensus.md#terms). When an honest node votes again for a different block in a later round
+Instead we use the Proof of Lock Change (PoLC) referred to in the [consensus spec](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/consensus.md#terms). When an honest node votes again for a different block in a later round
 (which will only occur in very rare cases), it will generate the PoLC and store it in the evidence reactor for a time equal to the `MaxEvidenceAge`
 
 ```golang

--- a/docs/architecture/adr-067-mempool-refactor.md
+++ b/docs/architecture/adr-067-mempool-refactor.md
@@ -106,7 +106,7 @@ invasive in the required  set of protocol and implementation changes, which
 simply extends the existing `CheckTx` ABCI method. The second candidate essentially
 involves the introduction of new ABCI method(s) and would require a higher degree
 of complexity in protocol and implementation changes, some of which may either
-overlap or conflict with the upcoming introduction of [ABCI++](https://github.com/tendermint/tendermint/blob/main/docs/rfc/rfc-013-abci%2B%2B.md).
+overlap or conflict with the upcoming introduction of [ABCI++](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/rfc/rfc-013-abci%2B%2B.md).
 
 For more information on the various approaches and proposals, please see the
 [mempool discussion](https://github.com/tendermint/tendermint/discussions/6295).
@@ -299,5 +299,5 @@ non-contentious and backwards compatible manner.
 
 ## References
 
-- [ABCI++](https://github.com/tendermint/tendermint/blob/main/docs/rfc/rfc-013-abci%2B%2B.md)
+- [ABCI++](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/rfc/rfc-013-abci%2B%2B.md)
 - [Mempool Discussion](https://github.com/tendermint/tendermint/discussions/6295)

--- a/docs/architecture/adr-068-reverse-sync.md
+++ b/docs/architecture/adr-068-reverse-sync.md
@@ -12,7 +12,7 @@ Accepted
 
 The advent of state sync and block pruning gave rise to the opportunity for full nodes to participate in consensus without needing complete block history. This also introduced a problem with respect to evidence handling. Nodes that didn't have all the blocks within the evidence age were incapable of validating evidence, thus halting if that evidence was committed on chain.
 
-[ADR 068](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-068-reverse-sync.md) was published in response to this problem and modified the spec to add a minimum block history invariant. This predominantly sought to extend state sync so that it was capable of fetching and storing the `Header`, `Commit` and `ValidatorSet` (essentially a `LightBlock`) of the last `n` heights, where `n` was calculated based from the evidence age.
+[ADR 068](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-068-reverse-sync.md) was published in response to this problem and modified the spec to add a minimum block history invariant. This predominantly sought to extend state sync so that it was capable of fetching and storing the `Header`, `Commit` and `ValidatorSet` (essentially a `LightBlock`) of the last `n` heights, where `n` was calculated based from the evidence age.
 
 This ADR sets out to describe the design of this state sync extension as well as modifications to the light client provider and the merging of tm store.
 
@@ -93,5 +93,5 @@ This ADR tries to remain within the scope of extending state sync, however the c
 
 ## References
 
-- [Reverse Sync RFC](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-068-reverse-sync.md)
+- [Reverse Sync RFC](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-068-reverse-sync.md)
 - [Original Issue](https://github.com/tendermint/tendermint/issues/5617)

--- a/docs/architecture/adr-069-flexible-node-initialization.md
+++ b/docs/architecture/adr-069-flexible-node-initialization.md
@@ -126,13 +126,13 @@ would probably be overly-abstract at this stage.
 ## Detailed Design
 
 The [current
-nodeImpl](https://github.com/tendermint/tendermint/blob/main/node/node.go#L47)
+nodeImpl](https://github.com/tendermint/tendermint/blob/v0.37.x/node/node.go#L47)
 includes direct references to the implementations of each of the
 reactors, which should be replaced by references to `service.Service`
 objects. This will require moving construction of the [rpc
-service](https://github.com/tendermint/tendermint/blob/main/node/node.go#L771)
+service](https://github.com/tendermint/tendermint/blob/v0.37.x/node/node.go#L771)
 into the constructor of
-[makeNode](https://github.com/tendermint/tendermint/blob/main/node/node.go#L126). One
+[makeNode](https://github.com/tendermint/tendermint/blob/v0.37.x/node/node.go#L126). One
 possible implementation of this would be to eliminate the current
 `ConfigureRPC` method on the node package and instead [configure it
 here](https://github.com/tendermint/tendermint/pull/6798/files#diff-375d57e386f20eaa5f09f02bb9d28bfc48ac3dca18d0325f59492208219e5618R441).

--- a/docs/architecture/adr-071-proposer-based-timestamps.md
+++ b/docs/architecture/adr-071-proposer-based-timestamps.md
@@ -16,7 +16,7 @@
 
 ## Context
 
-Tendermint currently provides a monotonically increasing source of time known as [BFTTime](https://github.com/tendermint/tendermint/blob/main/spec/consensus/bft-time.md).
+Tendermint currently provides a monotonically increasing source of time known as [BFTTime](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/bft-time.md).
 This mechanism for producing a source of time is reasonably simple.
 Each correct validator adds a timestamp to each `Precommit` message it sends.
 The timestamp it sends is either the validator's current known Unix time or one millisecond greater than the previous block time, depending on which value is greater.
@@ -41,7 +41,7 @@ Proposer-based timestamps alter the current mechanism for producing block timest
 1. Correct validators only approve the proposed block timestamp if it is close enough to their own currently known Unix time.
 
 The result of these changes is a more meaningful timestamp that cannot be controlled by `<= 2/3` of the validator voting power.
-This document outlines the necessary code changes in Tendermint to implement the corresponding [proposer-based timestamps specification](https://github.com/tendermint/tendermint/tree/main/spec/consensus/proposer-based-timestamp).
+This document outlines the necessary code changes in Tendermint to implement the corresponding [proposer-based timestamps specification](https://github.com/tendermint/tendermint/tree/v0.37.x/spec/consensus/proposer-based-timestamp).
 
 ## Alternative Approaches
 
@@ -58,7 +58,7 @@ We therefore decided not to remove the timestamp.
 Applications often wish for some transactions to occur on a certain day, on a regular period, or after some time following a different event.
 All of these require some meaningful representation of agreed upon time.
 The following protocols and application features require a reliable source of time:
-* Tendermint Light Clients [rely on correspondence between their known time](https://github.com/tendermint/tendermint/blob/main/spec/light-client/verification/README.md#definitions-1) and the block time for block verification.
+* Tendermint Light Clients [rely on correspondence between their known time](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/light-client/verification/README.md#definitions-1) and the block time for block verification.
 * Tendermint Evidence validity is determined [either in terms of heights or in terms of time](https://github.com/tendermint/tendermint/blob/8029cf7a0fcc89a5004e173ec065aa48ad5ba3c8/spec/consensus/evidence.md#verification).
 * Unbonding of staked assets in the Cosmos Hub [occurs after a period of 21 days](https://github.com/cosmos/governance/blob/ce75de4019b0129f6efcbb0e752cd2cc9e6136d3/params-change/Staking.md#unbondingtime).
 * IBC packets can use either a [timestamp or a height to timeout packet delivery](https://docs.cosmos.network/v0.44/ibc/overview.html#acknowledgements)
@@ -135,7 +135,7 @@ A validator will only Prevote a proposal if the proposal timestamp is considered
 A proposal timestamp is considered `timely` if it is within `PRECISION` and `MSGDELAY` of the Unix time known to the validator.
 More specifically, a proposal timestamp is `timely` if `proposalTimestamp - PRECISION ≤ validatorLocalTime ≤ proposalTimestamp + PRECISION + MSGDELAY`.
 
-Because the `PRECISION` and `MSGDELAY` parameters must be the same across all validators, they will be added to the [consensus parameters](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/types/params.proto#L11) as [durations](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration).
+Because the `PRECISION` and `MSGDELAY` parameters must be the same across all validators, they will be added to the [consensus parameters](https://github.com/tendermint/tendermint/blob/v0.37.x/proto/tendermint/types/params.proto#L11) as [durations](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration).
 
 The consensus parameters will be updated to include this `Synchrony` field as follows:
 
@@ -328,6 +328,6 @@ This skew will be bound by the `PRECISION` value, so it is unlikely to be too la
 
 ## References
 
-* [PBTS Spec](https://github.com/tendermint/tendermint/tree/main/spec/consensus/proposer-based-timestamp)
-* [BFTTime spec](https://github.com/tendermint/tendermint/blob/main/spec/consensus/bft-time.md)
+* [PBTS Spec](https://github.com/tendermint/tendermint/tree/v0.37.x/spec/consensus/proposer-based-timestamp)
+* [BFTTime spec](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/bft-time.md)
 * [Issue 371](https://github.com/tendermint/spec/issues/371)

--- a/docs/architecture/adr-075-rpc-subscription.md
+++ b/docs/architecture/adr-075-rpc-subscription.md
@@ -664,8 +664,8 @@ The following alternative approaches were considered:
    - [indexer: unbuffered event subscription slow down the consensus][i7247] (#7247)
    - [rpc: remove duplication of events when querying][i7273] (#7273)
 
-[rfc006]:        https://github.com/tendermint/tendermint/blob/main/docs/rfc/rfc-006-event-subscription.md
-[rpc-service]:   https://github.com/tendermint/tendermint/blob/main/rpc/openapi/openapi.yaml
+[rfc006]:        https://github.com/tendermint/tendermint/blob/v0.37.x/docs/rfc/rfc-006-event-subscription.md
+[rpc-service]:   https://github.com/tendermint/tendermint/blob/v0.37.x/rpc/openapi/openapi.yaml
 [query-grammar]: https://pkg.go.dev/github.com/tendermint/tendermint@master/internal/pubsub/query/syntax
 [ws]:            https://datatracker.ietf.org/doc/html/rfc6455
 [jsonrpc2]:      https://www.jsonrpc.org/specification
@@ -675,8 +675,8 @@ The following alternative approaches were considered:
 <!-- markdown-link-check-disable-next-line -->
 [ng-xm]:         https://www.nginx.com/resources/wiki/extending/
 [abci-event]:    https://pkg.go.dev/github.com/tendermint/tendermint/abci/types#Event
-[rfc001]:        https://github.com/tendermint/tendermint/blob/main/docs/rfc/rfc-001-storage-engine.rst
-[rfc002]:        https://github.com/tendermint/tendermint/blob/main/docs/rfc/rfc-002-ipc-ecosystem.md
+[rfc001]:        https://github.com/tendermint/tendermint/blob/v0.37.x/docs/rfc/rfc-001-storage-engine.rst
+[rfc002]:        https://github.com/tendermint/tendermint/blob/v0.37.x/docs/rfc/rfc-002-ipc-ecosystem.md
 [i3380]:         https://github.com/tendermint/tendermint/issues/3380
 [i6439]:         https://github.com/tendermint/tendermint/issues/6439
 [i6729]:         https://github.com/tendermint/tendermint/issues/6729

--- a/docs/architecture/adr-077-block-retention.md
+++ b/docs/architecture/adr-077-block-retention.md
@@ -102,7 +102,7 @@ Accepted
 
 ## References
 
-- State sync ADR: <https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-053-state-sync-prototype.md>
+- State sync ADR: <https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-053-state-sync-prototype.md>
 
 - State sync issue: <https://github.com/tendermint/tendermint/issues/828>
 

--- a/docs/architecture/adr-080-reverse-sync.md
+++ b/docs/architecture/adr-080-reverse-sync.md
@@ -16,10 +16,10 @@
 ## Context
 
 Two new features: [Block pruning](https://github.com/tendermint/tendermint/issues/3652)
-and [State sync](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-042-state-sync.md)
+and [State sync](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-042-state-sync.md)
 meant nodes no longer needed a complete history of the blockchain. This
 introduced some challenges of its own which were covered and subsequently
-tackled with [RFC-001](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-077-block-retention.md).
+tackled with [RFC-001](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-077-block-retention.md).
 The RFC allowed applications to set a block retention height; an upper bound on
 what blocks would be pruned. However nodes who state sync past this upper bound
 (which is necessary as snapshots must be saved within the trusting period for
@@ -199,5 +199,5 @@ nodes to freely fetch and verify prior blocks
 
 ## References
 
-- [RFC-001: Block retention](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-077-block-retention.md)
+- [RFC-001: Block retention](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-077-block-retention.md)
 - [Original issue](https://github.com/tendermint/tendermint/issues/4629)

--- a/docs/introduction/what-is-tendermint.md
+++ b/docs/introduction/what-is-tendermint.md
@@ -120,7 +120,7 @@ consensus engine, and provides a particular application state.
 ## ABCI Overview
 
 The [Application BlockChain Interface
-(ABCI)](https://github.com/tendermint/tendermint/tree/main/abci)
+(ABCI)](https://github.com/tendermint/tendermint/tree/v0.37.x/abci)
 allows for Byzantine Fault Tolerant replication of applications
 written in any programming language.
 
@@ -188,7 +188,7 @@ core to the application. The application replies with corresponding
 response messages.
 
 The messages are specified here: [ABCI Message
-Types](https://github.com/tendermint/tendermint/blob/main/abci/README.md#message-types).
+Types](https://github.com/tendermint/tendermint/blob/v0.37.x/abci/README.md#message-types).
 
 The **DeliverTx** message is the work horse of the application. Each
 transaction in the blockchain is delivered with this message. The

--- a/docs/networks/terraform-and-ansible.md
+++ b/docs/networks/terraform-and-ansible.md
@@ -14,7 +14,7 @@ testnets on those servers.
 ## Install
 
 NOTE: see the [integration bash
-script](https://github.com/tendermint/tendermint/blob/main/networks/remote/integration.sh)
+script](https://github.com/tendermint/tendermint/blob/v0.37.x/networks/remote/integration.sh)
 that can be run on a fresh DO droplet and will automatically spin up a 4
 node testnet. The script more or less does everything described below.
 
@@ -58,7 +58,7 @@ With the droplets created and running, let's setup Ansible.
 ## Ansible
 
 The playbooks in [the ansible
-directory](https://github.com/tendermint/tendermint/tree/main/networks/remote/ansible)
+directory](https://github.com/tendermint/tendermint/tree/v0.37.x/networks/remote/ansible)
 run ansible roles to configure the sentry node architecture. You must
 switch to this directory to run ansible
 (`cd $GOPATH/src/github.com/tendermint/tendermint/networks/remote/ansible`).

--- a/docs/rfc/rfc-002-ipc-ecosystem.md
+++ b/docs/rfc/rfc-002-ipc-ecosystem.md
@@ -407,14 +407,14 @@ discussed.
 
 ## References
 
-[abci]: https://github.com/tendermint/tendermint/tree/main/spec/abci
+[abci]: https://github.com/tendermint/tendermint/tree/v0.37.x/spec/abci
 [rpc-service]: https://docs.tendermint.com/v0.34/rpc/
 [light-client]: https://docs.tendermint.com/v0.34/tendermint-core/light-client.html
-[tm-cli]: https://github.com/tendermint/tendermint/tree/main/cmd/tendermint
+[tm-cli]: https://github.com/tendermint/tendermint/tree/v0.37.x/cmd/tendermint
 [cosmos-sdk]: https://github.com/cosmos/cosmos-sdk/
-[local-client]: https://github.com/tendermint/tendermint/blob/main/abci/client/local_client.go
-[socket-server]: https://github.com/tendermint/tendermint/blob/main/abci/server/socket_server.go
+[local-client]: https://github.com/tendermint/tendermint/blob/v0.37.x/abci/client/local_client.go
+[socket-server]: https://github.com/tendermint/tendermint/blob/v0.37.x/abci/server/socket_server.go
 [sdk-grpc]: https://pkg.go.dev/github.com/cosmos/cosmos-sdk/types/tx#ServiceServer
 [json-rpc]: https://www.jsonrpc.org/specification
-[abci-conn]: https://github.com/tendermint/tendermint/blob/main/spec/abci/apps.md#state
-[adr-57]: https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-057-RPC.md
+[abci-conn]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/abci/apps.md#state
+[adr-57]: https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-057-RPC.md

--- a/docs/rfc/rfc-003-performance-questions.md
+++ b/docs/rfc/rfc-003-performance-questions.md
@@ -270,9 +270,9 @@ event sends. The following metrics would be a good start for tracking this perfo
 [issue-2186]: https://github.com/tendermint/tendermint/issues/2186
 [issue-2187]: https://github.com/tendermint/tendermint/issues/2187
 [rfc-002]: https://github.com/tendermint/tendermint/pull/6913
-[adr-57]: https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-057-RPC.md
+[adr-57]: https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-057-RPC.md
 [issue-1319]: https://github.com/tendermint/tendermint/issues/1319
-[abci-commit-description]: https://github.com/tendermint/tendermint/blob/main/spec/abci/apps.md#commit
+[abci-commit-description]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/abci/apps.md#commit
 [abci-local-client-code]: https://github.com/tendermint/tendermint/blob/511bd3eb7f037855a793a27ff4c53c12f085b570/abci/client/local_client.go#L84
 [hub-signature]: https://github.com/cosmos/gaia/blob/0ecb6ed8a244d835807f1ced49217d54a9ca2070/docs/resources/genesis.md#consensus-parameters
 [ed25519-bench]: https://github.com/oasisprotocol/curve25519-voi/blob/d2e7fc59fe38c18ca990c84c4186cba2cc45b1f9/PERFORMANCE.md

--- a/docs/rfc/rfc-004-e2e-framework.rst
+++ b/docs/rfc/rfc-004-e2e-framework.rst
@@ -59,7 +59,7 @@ Configurable Generator
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The nightly e2e suite is defined by the `testnet generator
-<https://github.com/tendermint/tendermint/blob/main/test/e2e/generator/generate.go#L13-L65>`_,
+<https://github.com/tendermint/tendermint/blob/v0.37.x/test/e2e/generator/generate.go#L13-L65>`_,
 and it's difficult to add dimensions or change the focus of the test suite in
 any way without modifying the implementation of the generator. If the
 generator were more configurable, potentially via a file rather than in

--- a/docs/rfc/rfc-005-event-system.rst
+++ b/docs/rfc/rfc-005-event-system.rst
@@ -55,9 +55,9 @@ References
 ~~~~~~~~~~
 
 - Legacy Implementation
-  - `publication of events <https://github.com/tendermint/tendermint/blob/main/libs/pubsub/pubsub.go#L333-L345>`_ 
-  - `send operation <https://github.com/tendermint/tendermint/blob/main/libs/pubsub/pubsub.go#L489-L527>`_ 
-  - `send loop <https://github.com/tendermint/tendermint/blob/main/libs/pubsub/pubsub.go#L381-L402>`_
+  - `publication of events <https://github.com/tendermint/tendermint/blob/v0.37.x/libs/pubsub/pubsub.go#L333-L345>`_ 
+  - `send operation <https://github.com/tendermint/tendermint/blob/v0.37.x/libs/pubsub/pubsub.go#L489-L527>`_ 
+  - `send loop <https://github.com/tendermint/tendermint/blob/v0.37.x/libs/pubsub/pubsub.go#L381-L402>`_
 - Related RFCs 
   - `RFC 002: IPC Ecosystem <./rfc-002-ipc-ecosystem.md>`_ 
   - `RFC 003: Performance Questions <./rfc-003-performance-questions.md>`_ 

--- a/docs/rfc/rfc-006-event-subscription.md
+++ b/docs/rfc/rfc-006-event-subscription.md
@@ -195,7 +195,7 @@ mutually exclusive.
 - [JSON-RPC 2.0 Specification](https://www.jsonrpc.org/specification)
 
 [rpc-service]: https://docs.tendermint.com/v0.34/rpc/
-[rpc-methods]: https://github.com/tendermint/tendermint/blob/main/internal/rpc/core/routes.go#L12
+[rpc-methods]: https://github.com/tendermint/tendermint/blob/v0.37.x/internal/rpc/core/routes.go#L12
 [events]: ./rfc-005-event-system.rst
 [rpc-transport]: ./rfc-002-ipc-ecosystem.md#rpc-transport
 [ws]: https://datatracker.ietf.org/doc/html/rfc6455

--- a/docs/rfc/rfc-012-custom-indexing.md
+++ b/docs/rfc/rfc-012-custom-indexing.md
@@ -336,17 +336,17 @@ something like this (subject to refinement):
 - [`EventSink` interface][esink]
 - [`tm-db` library][tmdb]
 
-[adr065]: https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-065-custom-event-indexing.md
-[adr075]: https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-075-rpc-subscription.md
+[adr065]: https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-065-custom-event-indexing.md
+[adr075]: https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-075-rpc-subscription.md
 [esink]: https://pkg.go.dev/github.com/tendermint/tendermint/internal/state/indexer#EventSink
 [event-rpc]: https://docs.tendermint.com/v0.34/rpc/#/Websocket/subscribe
 [i1161]: https://github.com/tendermint/tendermint/issues/1161
 [i7135]: https://github.com/tendermint/tendermint/issues/7135
 [i7247]: https://github.com/tendermint/tendermint/issues/7247
-[kv-index]: https://github.com/tendermint/tendermint/blob/main/internal/state/indexer/tx/kv
+[kv-index]: https://github.com/tendermint/tendermint/blob/v0.37.x/internal/state/indexer/tx/kv
 [postgres]: https://postgresql.org/
-[psql]: https://github.com/tendermint/tendermint/blob/main/internal/state/indexer/sink/psql
-[psql]: https://github.com/tendermint/tendermint/blob/main/internal/state/indexer/sink/psql
+[psql]: https://github.com/tendermint/tendermint/blob/v0.37.x/internal/state/indexer/sink/psql
+[psql]: https://github.com/tendermint/tendermint/blob/v0.37.x/internal/state/indexer/sink/psql
 [query]: https://pkg.go.dev/github.com/tendermint/tendermint/internal/pubsub/query/syntax
 [sdk]: https://github.com/cosmos/cosmos-sdk
 [tmdb]: https://pkg.go.dev/github.com/tendermint/tm-db#DB

--- a/docs/rfc/rfc-019-config-version.md
+++ b/docs/rfc/rfc-019-config-version.md
@@ -289,11 +289,11 @@ balance:
 - [ADR 075: RPC Event Subscription Interface][adr075]
 
 [config-pkg]: https://godoc.org/github.com/tendermint/tendermint/config
-[confix]: https://github.com/tendermint/tendermint/blob/main/scripts/confix
-[condiff]: https://github.com/tendermint/tendermint/blob/main/scripts/confix/condiff
-[plan]: https://github.com/tendermint/tendermint/blob/main/scripts/confix/plan.go
-[testdata]: https://github.com/tendermint/tendermint/blob/main/scripts/confix/testdata
-[adr075]: https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-075-rpc-subscription.md
+[confix]: https://github.com/tendermint/tendermint/blob/v0.37.x/scripts/confix
+[condiff]: https://github.com/tendermint/tendermint/blob/v0.37.x/scripts/confix/condiff
+[plan]: https://github.com/tendermint/tendermint/blob/v0.37.x/scripts/confix/plan.go
+[testdata]: https://github.com/tendermint/tendermint/blob/v0.37.x/scripts/confix/testdata
+[adr075]: https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-075-rpc-subscription.md
 
 ## Appendix: Research Notes
 

--- a/docs/rfc/rfc-020-onboarding-projects.rst
+++ b/docs/rfc/rfc-020-onboarding-projects.rst
@@ -159,7 +159,7 @@ in many cases the panics were just added to simplify downstream error
 checking, and could easily be converted to errors.
 
 The `Don't Panic RFC
-<https://github.com/tendermint/tendermint/blob/main/docs/rfc/rfc-008-do-not-panic.MD>`_
+<https://github.com/tendermint/tendermint/blob/v0.37.x/docs/rfc/rfc-008-do-not-panic.MD>`_
 covers some of the background and approach.
 
 While the changes are in this project are relatively rote, this will provide

--- a/docs/rfc/rfc-021-socket-protocol.md
+++ b/docs/rfc/rfc-021-socket-protocol.md
@@ -73,7 +73,7 @@ applications using it. In particular:
   server to understand which operation is requested is to dispatch on the type
   of the request and response payloads. For responses, this means that [any
   error condition is terminal not only to the request, but to the entire ABCI
-  client](https://github.com/tendermint/tendermint/blob/main/abci/client/socket_client.go#L149).
+  client](https://github.com/tendermint/tendermint/blob/v0.37.x/abci/client/socket_client.go#L149).
 
   The historical intent of terminating for any error seems to have been that
   all ABCI errors are unrecoverable and hence protocol fatal <!-- markdown-link-check-disable-next-line -->
@@ -221,10 +221,10 @@ design.
 - [Tendermint ABCI gRPC client][grpc-client]
 - [Initial commit of gRPC client][abci-start]
 
-[abci]: https://github.com/tendermint/tendermint/tree/main/spec/abci
-[socket-client]: https://github.com/tendermint/tendermint/blob/main/abci/client/socket_client.go
-[socket-server]: https://github.com/tendermint/tendermint/blob/main/abci/server/socket_server.go
-[grpc-client]: https://github.com/tendermint/tendermint/blob/main/abci/client/grpc_client.go
+[abci]: https://github.com/tendermint/tendermint/tree/v0.37.x/spec/abci
+[socket-client]: https://github.com/tendermint/tendermint/blob/v0.37.x/abci/client/socket_client.go
+[socket-server]: https://github.com/tendermint/tendermint/blob/v0.37.x/abci/server/socket_server.go
+[grpc-client]: https://github.com/tendermint/tendermint/blob/v0.37.x/abci/client/grpc_client.go
 [abci-start]: https://github.com/tendermint/abci/commit/1ab3c747182aaa38418258679c667090c2bb1e0d
 
 ## Notes

--- a/docs/tendermint-core/how-to-read-logs.md
+++ b/docs/tendermint-core/how-to-read-logs.md
@@ -67,7 +67,7 @@ Next follows a standard block creation cycle, where we enter a new
 round, propose a block, receive more than 2/3 of prevotes, then
 precommits and finally have a chance to commit a block. For details,
 please refer to [Byzantine Consensus
-Algorithm](https://github.com/tendermint/tendermint/blob/main/spec/consensus/consensus.md).
+Algorithm](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/consensus.md).
 
 ```sh
 I[10-04|13:54:30.393] enterNewRound(91/0). Current: 91/0/RoundStepNewHeight module=consensus

--- a/docs/tendermint-core/rpc.md
+++ b/docs/tendermint-core/rpc.md
@@ -6,6 +6,6 @@ order: 9
 
 The RPC documentation is hosted here:
 
-- [https://docs.tendermint.com/main/rpc/](https://docs.tendermint.com/main/rpc/)
+- [https://docs.tendermint.com/v0.37/rpc/](https://docs.tendermint.com/v0.37/rpc/)
 
 To update the documentation, edit the relevant `godoc` comments in the [rpc/core directory](https://github.com/tendermint/tendermint/blob/v0.34.x/rpc/core).

--- a/docs/tendermint-core/running-in-production.md
+++ b/docs/tendermint-core/running-in-production.md
@@ -95,7 +95,7 @@ mechanisms.
 ### RPC
 
 Endpoints returning multiple entries are limited by default to return 30
-elements (100 max). See the [RPC Documentation](https://docs.tendermint.com/main/rpc/)
+elements (100 max). See the [RPC Documentation](https://docs.tendermint.com/v0.37/rpc/)
 for more information.
 
 Rate-limiting and authentication are another key aspects to help protect

--- a/docs/tendermint-core/subscription.md
+++ b/docs/tendermint-core/subscription.md
@@ -31,7 +31,7 @@ method via Websocket along with a valid query.
 }
 ```
 
-Check out [API docs](https://docs.tendermint.com/main/rpc/) for
+Check out [API docs](https://docs.tendermint.com/v0.37/rpc/) for
 more information on query syntax and other options.
 
 You can also use tags, given you had included them into DeliverTx
@@ -43,7 +43,7 @@ transactions](./indexing-transactions.md) for details.
 When validator set changes, ValidatorSetUpdates event is published. The
 event carries a list of pubkey/power pairs. The list is the same
 Tendermint receives from ABCI application (see [EndBlock
-section](https://github.com/tendermint/tendermint/blob/main/spec/abci/abci.md#endblock) in
+section](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/abci/abci.md#endblock) in
 the ABCI spec).
 
 Response:

--- a/docs/tendermint-core/using-tendermint.md
+++ b/docs/tendermint-core/using-tendermint.md
@@ -39,7 +39,7 @@ tendermint testnet --help
 
 The `genesis.json` file in `$TMHOME/config/` defines the initial
 TendermintCore state upon genesis of the blockchain ([see
-definition](https://github.com/tendermint/tendermint/blob/main/types/genesis.go)).
+definition](https://github.com/tendermint/tendermint/blob/v0.37.x/types/genesis.go)).
 
 #### Fields
 
@@ -49,7 +49,7 @@ definition](https://github.com/tendermint/tendermint/blob/main/types/genesis.go)
   chain IDs, you will have a bad time. The ChainID must be less than 50 symbols.
 - `initial_height`: Height at which Tendermint should begin at. If a blockchain is conducting a network upgrade, 
     starting from the stopped height brings uniqueness to previous heights. 
-- `consensus_params` [spec](https://github.com/tendermint/tendermint/blob/main/spec/core/state.md#consensusparams)
+- `consensus_params` [spec](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/core/state.md#consensusparams)
     - `block`
         - `max_bytes`: Max block size, in bytes.
         - `max_gas`: Max gas per block.
@@ -183,7 +183,7 @@ endpoints. Some take no arguments (like `/status`), while others specify
 the argument name and use `_` as a placeholder.
 
 
-> TIP: Find the RPC Documentation [here](https://docs.tendermint.com/main/rpc/)
+> TIP: Find the RPC Documentation [here](https://docs.tendermint.com/v0.37/rpc/)
 
 ### Formatting
 

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -84,7 +84,7 @@ Hello, Tendermint Core
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
+file](https://github.com/tendermint/tendermint/blob/v0.37.x/proto/tendermint/abci/types.proto).
 This allows Tendermint Core to run applications written in any programming
 language.
 
@@ -214,7 +214,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://github.com/tendermint/tendermint/blob/main/spec/abci/apps.md#gas).
+specification"](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/abci/apps.md#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -333,7 +333,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 ```
 
 The complete specification can be found
-[here](https://github.com/tendermint/tendermint/tree/main/spec/abci/).
+[here](https://github.com/tendermint/tendermint/tree/v0.37.x/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instance in the same process
 
@@ -606,7 +606,7 @@ go build
 To create a default configuration, nodeKey and private validator files, let's
 execute `tendermint init`. But before we do that, we will need to install
 Tendermint Core. Please refer to [the official
-guide](https://docs.tendermint.com/main/introduction/install.html). If you're
+guide](https://docs.tendermint.com/v0.37/introduction/install.html). If you're
 installing from source, don't forget to checkout the latest release (`git checkout vX.Y.Z`).
 
 ```bash
@@ -676,4 +676,4 @@ $ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/main/).
+deeper, read [the docs](https://docs.tendermint.com/v0.37/).

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -87,7 +87,7 @@ Hello, Tendermint Core
 
 Tendermint Core communicates with the application through the Application
 BlockChain Interface (ABCI). All message types are defined in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
+file](https://github.com/tendermint/tendermint/blob/v0.37.x/proto/tendermint/abci/types.proto).
 This allows Tendermint Core to run applications written in any programming
 language.
 
@@ -216,7 +216,7 @@ etc.) by Tendermint Core.
 
 Valid transactions will eventually be committed given they are not too big and
 have enough gas. To learn more about gas, check out ["the
-specification"](https://github.com/tendermint/tendermint/blob/main/spec/abci/apps.md#gas).
+specification"](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/abci/apps.md#gas).
 
 For the underlying key-value store we'll use
 [badger](https://github.com/dgraph-io/badger), which is an embeddable,
@@ -335,7 +335,7 @@ func (app *KVStoreApplication) Query(reqQuery abcitypes.RequestQuery) (resQuery 
 ```
 
 The complete specification can be found
-[here](https://github.com/tendermint/tendermint/tree/main/spec/abci/).
+[here](https://github.com/tendermint/tendermint/tree/v0.37.x/spec/abci/).
 
 ## 1.4 Starting an application and a Tendermint Core instances
 
@@ -463,7 +463,7 @@ go build
 To create a default configuration, nodeKey and private validator files, let's
 execute `tendermint init`. But before we do that, we will need to install
 Tendermint Core. Please refer to [the official
-guide](https://docs.tendermint.com/main/introduction/install.html). If you're
+guide](https://docs.tendermint.com/v0.37/introduction/install.html). If you're
 installing from source, don't forget to checkout the latest release (`git checkout vX.Y.Z`).
 
 ```bash
@@ -477,7 +477,7 @@ I[2019-07-16|18:20:36.482] Generated genesis file                       module=m
 
 Feel free to explore the generated files, which can be found at
 `/tmp/example/config` directory. Documentation on the config can be found
-[here](https://docs.tendermint.com/main/tendermint-core/configuration.html).
+[here](https://docs.tendermint.com/v0.37/tendermint-core/configuration.html).
 
 We are ready to start our application:
 
@@ -560,4 +560,4 @@ curl -s 'localhost:26657/abci_query?data="tendermint"'
 I hope everything went smoothly and your first, but hopefully not the last,
 Tendermint Core application is up and running. If not, please [open an issue on
 Github](https://github.com/tendermint/tendermint/issues/new/choose). To dig
-deeper, read [the docs](https://docs.tendermint.com/main/).
+deeper, read [the docs](https://docs.tendermint.com/v0.37/).

--- a/evidence/doc.go
+++ b/evidence/doc.go
@@ -1,7 +1,7 @@
 /*
 Package evidence handles all evidence storage and gossiping from detection to block proposal.
 For the different types of evidence refer to the `evidence.go` file in the types package
-or https://github.com/tendermint/tendermint/blob/main/spec/consensus/light-client/accountability.md.
+or https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/light-client/accountability.md.
 
 # Gossiping
 

--- a/light/client.go
+++ b/light/client.go
@@ -178,8 +178,8 @@ func NewClient(
 	primary provider.Provider,
 	witnesses []provider.Provider,
 	trustedStore store.Store,
-	options ...Option) (*Client, error) {
-
+	options ...Option,
+) (*Client, error) {
 	if err := trustOptions.ValidateBasic(); err != nil {
 		return nil, fmt.Errorf("invalid TrustOptions: %w", err)
 	}
@@ -215,8 +215,8 @@ func NewClientFromTrustedStore(
 	primary provider.Provider,
 	witnesses []provider.Provider,
 	trustedStore store.Store,
-	options ...Option) (*Client, error) {
-
+	options ...Option,
+) (*Client, error) {
 	c := &Client{
 		chainID:          chainID,
 		trustingPeriod:   trustingPeriod,
@@ -506,7 +506,7 @@ func (c *Client) VerifyLightBlockAtHeight(ctx context.Context, height int64, now
 // headers are not adjacent, verifySkipping is performed and necessary (not all)
 // intermediate headers will be requested. See the specification for details.
 // Intermediate headers are not saved to database.
-// https://github.com/tendermint/tendermint/blob/main/spec/consensus/light-client.md
+// https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/light-client.md
 //
 // If the header, which is older than the currently trusted header, is
 // requested and the light client does not have it, VerifyHeader will perform:
@@ -614,8 +614,8 @@ func (c *Client) verifySequential(
 	ctx context.Context,
 	trustedBlock *types.LightBlock,
 	newLightBlock *types.LightBlock,
-	now time.Time) error {
-
+	now time.Time,
+) error {
 	var (
 		verifiedBlock = trustedBlock
 		interimBlock  *types.LightBlock
@@ -708,8 +708,8 @@ func (c *Client) verifySkipping(
 	source provider.Provider,
 	trustedBlock *types.LightBlock,
 	newLightBlock *types.LightBlock,
-	now time.Time) ([]*types.LightBlock, error) {
-
+	now time.Time,
+) ([]*types.LightBlock, error) {
 	var (
 		blockCache = []*types.LightBlock{newLightBlock}
 		depth      = 0
@@ -778,8 +778,8 @@ func (c *Client) verifySkippingAgainstPrimary(
 	ctx context.Context,
 	trustedBlock *types.LightBlock,
 	newLightBlock *types.LightBlock,
-	now time.Time) error {
-
+	now time.Time,
+) error {
 	trace, err := c.verifySkipping(ctx, c.primary, trustedBlock, newLightBlock, now)
 
 	switch errors.Unwrap(err).(type) {
@@ -933,8 +933,8 @@ func (c *Client) updateTrustedLightBlock(l *types.LightBlock) error {
 func (c *Client) backwards(
 	ctx context.Context,
 	trustedHeader *types.Header,
-	newHeader *types.Header) error {
-
+	newHeader *types.Header,
+) error {
 	var (
 		verifiedHeader = trustedHeader
 		interimHeader  *types.Header

--- a/light/doc.go
+++ b/light/doc.go
@@ -94,7 +94,7 @@ Check out other examples in example_test.go
 ## 2. Pure functions to verify a new header (see verifier.go)
 
 Verify function verifies a new header against some trusted header. See
-https://github.com/tendermint/tendermint/blob/main/spec/consensus/light-client/verification.md
+https://github.com/tendermint/tendermint/blob/v0.37.x/spec/consensus/light-client/verification.md
 for details.
 
 There are two methods of verification: sequential and bisection
@@ -118,10 +118,10 @@ as a wrapper, which verifies all the headers, using a light client connected to
 some other node.
 
 See
-https://docs.tendermint.com/main/tendermint-core/light-client-protocol.html
+https://docs.tendermint.com/v0.37/tendermint-core/light-client-protocol.html
 for usage example.
 Or see
-https://github.com/tendermint/tendermint/tree/main/spec/consensus/light-client
+https://github.com/tendermint/tendermint/tree/v0.37.x/spec/consensus/light-client
 for the full spec
 */
 package light

--- a/networks/local/README.md
+++ b/networks/local/README.md
@@ -1,3 +1,3 @@
 # Local Cluster with Docker Compose
 
-See the [docs](https://docs.tendermint.com/main/networks/docker-compose.html).
+See the [docs](https://docs.tendermint.com/v0.37/networks/docker-compose.html).

--- a/networks/remote/README.md
+++ b/networks/remote/README.md
@@ -1,3 +1,3 @@
 # Remote Cluster with Terraform and Ansible
 
-See the [docs](https://docs.tendermint.com/main/networks/terraform-and-ansible.html).
+See the [docs](https://docs.tendermint.com/v0.37/networks/terraform-and-ansible.html).

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -4,7 +4,7 @@ The p2p package provides an abstraction around peer-to-peer communication.
 
 Docs:
 
-- [Connection](https://github.com/tendermint/tendermint/blob/main/spec/p2p/connection.md) for details on how connections and multiplexing work
-- [Peer](https://github.com/tendermint/tendermint/blob/main/spec/p2p/node.md) for details on peer ID, handshakes, and peer exchange
-- [Node](https://github.com/tendermint/tendermint/blob/main/spec/p2p/node.md) for details about different types of nodes and how they should work
-- [Config](https://github.com/tendermint/tendermint/blob/main/spec/p2p/config.md) for details on some config option
+- [Connection](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/p2p/connection.md) for details on how connections and multiplexing work
+- [Peer](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/p2p/node.md) for details on peer ID, handshakes, and peer exchange
+- [Node](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/p2p/node.md) for details about different types of nodes and how they should work
+- [Config](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/p2p/config.md) for details on some config option

--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ABCIQuery queries the application for some information.
-// More: https://docs.tendermint.com/main/rpc/#/ABCI/abci_query
+// More: https://docs.tendermint.com/v0.37/rpc/#/ABCI/abci_query
 func ABCIQuery(
 	ctx *rpctypes.Context,
 	path string,
@@ -31,7 +31,7 @@ func ABCIQuery(
 }
 
 // ABCIInfo gets some info about the application.
-// More: https://docs.tendermint.com/main/rpc/#/ABCI/abci_info
+// More: https://docs.tendermint.com/v0.37/rpc/#/ABCI/abci_info
 func ABCIInfo(ctx *rpctypes.Context) (*ctypes.ResultABCIInfo, error) {
 	resInfo, err := env.ProxyAppQuery.InfoSync(proxy.RequestInfo)
 	if err != nil {

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -15,7 +15,7 @@ import (
 
 // BlockchainInfo gets block headers for minHeight <= height <= maxHeight.
 // Block headers are returned in descending order (highest first).
-// More: https://docs.tendermint.com/main/rpc/#/Info/blockchain
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/blockchain
 func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.ResultBlockchainInfo, error) {
 	// maximum 20 block metas
 	const limit int64 = 20
@@ -39,7 +39,8 @@ func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.
 
 	return &ctypes.ResultBlockchainInfo{
 		LastHeight: env.BlockStore.Height(),
-		BlockMetas: blockMetas}, nil
+		BlockMetas: blockMetas,
+	}, nil
 }
 
 // error if either min or max are negative or min > max
@@ -77,7 +78,7 @@ func filterMinMax(base, height, min, max, limit int64) (int64, int64, error) {
 
 // Block gets block at a given height.
 // If no height is provided, it will fetch the latest block.
-// More: https://docs.tendermint.com/main/rpc/#/Info/block
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/block
 func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error) {
 	height, err := getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
@@ -93,7 +94,7 @@ func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error)
 }
 
 // BlockByHash gets block by hash.
-// More: https://docs.tendermint.com/main/rpc/#/Info/block_by_hash
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/block_by_hash
 func BlockByHash(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error) {
 	block := env.BlockStore.LoadBlockByHash(hash)
 	if block == nil {
@@ -106,7 +107,7 @@ func BlockByHash(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error
 
 // Commit gets block commit at a given height.
 // If no height is provided, it will fetch the commit for the latest block.
-// More: https://docs.tendermint.com/main/rpc/#/Info/commit
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/commit
 func Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, error) {
 	height, err := getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
@@ -137,7 +138,7 @@ func Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, erro
 // Results are for the height of the block containing the txs.
 // Thus response.results.deliver_tx[5] is the results of executing
 // getBlock(h).Txs[5]
-// More: https://docs.tendermint.com/main/rpc/#/Info/block_results
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/block_results
 func BlockResults(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlockResults, error) {
 	height, err := getHeight(env.BlockStore.Height(), heightPtr)
 	if err != nil {
@@ -167,7 +168,6 @@ func BlockSearch(
 	pagePtr, perPagePtr *int,
 	orderBy string,
 ) (*ctypes.ResultBlockSearch, error) {
-
 	// skip if block indexing is disabled
 	if _, ok := env.BlockIndexer.(*blockidxnull.BlockerIndexer); ok {
 		return nil, errors.New("block indexing is disabled")

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -14,7 +14,7 @@ import (
 // validators are sorted by their voting power - this is the canonical order
 // for the validators in the set as used in computing their Merkle root.
 //
-// More: https://docs.tendermint.com/main/rpc/#/Info/validators
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/validators
 func Validators(ctx *rpctypes.Context, heightPtr *int64, pagePtr, perPagePtr *int) (*ctypes.ResultValidators, error) {
 	// The latest validator that we know is the NextValidator of the last block.
 	height, err := getHeight(latestUncommittedHeight(), heightPtr)
@@ -42,12 +42,13 @@ func Validators(ctx *rpctypes.Context, heightPtr *int64, pagePtr, perPagePtr *in
 		BlockHeight: height,
 		Validators:  v,
 		Count:       len(v),
-		Total:       totalCount}, nil
+		Total:       totalCount,
+	}, nil
 }
 
 // DumpConsensusState dumps consensus state.
 // UNSTABLE
-// More: https://docs.tendermint.com/main/rpc/#/Info/dump_consensus_state
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/dump_consensus_state
 func DumpConsensusState(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState, error) {
 	// Get Peer consensus states.
 	peers := env.P2PPeers.Peers().List()
@@ -75,12 +76,13 @@ func DumpConsensusState(ctx *rpctypes.Context) (*ctypes.ResultDumpConsensusState
 	}
 	return &ctypes.ResultDumpConsensusState{
 		RoundState: roundState,
-		Peers:      peerStates}, nil
+		Peers:      peerStates,
+	}, nil
 }
 
 // ConsensusState returns a concise summary of the consensus state.
 // UNSTABLE
-// More: https://docs.tendermint.com/main/rpc/#/Info/consensus_state
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/consensus_state
 func ConsensusState(ctx *rpctypes.Context) (*ctypes.ResultConsensusState, error) {
 	// Get self round state.
 	bz, err := env.ConsensusState.GetRoundStateSimpleJSON()
@@ -89,7 +91,7 @@ func ConsensusState(ctx *rpctypes.Context) (*ctypes.ResultConsensusState, error)
 
 // ConsensusParams gets the consensus parameters at the given block height.
 // If no height is provided, it will fetch the latest consensus params.
-// More: https://docs.tendermint.com/main/rpc/#/Info/consensus_params
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/consensus_params
 func ConsensusParams(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultConsensusParams, error) {
 	// The latest consensus params that we know is the consensus params after the
 	// last block.
@@ -104,5 +106,6 @@ func ConsensusParams(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCon
 	}
 	return &ctypes.ResultConsensusParams{
 		BlockHeight:     height,
-		ConsensusParams: consensusParams}, nil
+		ConsensusParams: consensusParams,
+	}, nil
 }

--- a/rpc/core/doc.go
+++ b/rpc/core/doc.go
@@ -2,7 +2,7 @@
 Package core defines the Tendermint RPC endpoints.
 
 Tendermint ships with its own JSONRPC library -
-https://github.com/tendermint/tendermint/tree/main/rpc/jsonrpc.
+https://github.com/tendermint/tendermint/tree/v0.37.x/rpc/jsonrpc.
 
 ## Get the list
 

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Subscribe for events via WebSocket.
-// More: https://docs.tendermint.com/main/rpc/#/Websocket/subscribe
+// More: https://docs.tendermint.com/v0.37/rpc/#/Websocket/subscribe
 func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, error) {
 	addr := ctx.RemoteAddr()
 
@@ -102,7 +102,7 @@ func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, er
 }
 
 // Unsubscribe from events via WebSocket.
-// More: https://docs.tendermint.com/main/rpc/#/Websocket/unsubscribe
+// More: https://docs.tendermint.com/v0.37/rpc/#/Websocket/unsubscribe
 func Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe, error) {
 	addr := ctx.RemoteAddr()
 	env.Logger.Info("Unsubscribe from query", "remote", addr, "query", query)
@@ -118,7 +118,7 @@ func Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe
 }
 
 // UnsubscribeAll from all events via WebSocket.
-// More: https://docs.tendermint.com/main/rpc/#/Websocket/unsubscribe_all
+// More: https://docs.tendermint.com/v0.37/rpc/#/Websocket/unsubscribe_all
 func UnsubscribeAll(ctx *rpctypes.Context) (*ctypes.ResultUnsubscribe, error) {
 	addr := ctx.RemoteAddr()
 	env.Logger.Info("Unsubscribe from all", "remote", addr)

--- a/rpc/core/evidence.go
+++ b/rpc/core/evidence.go
@@ -10,7 +10,7 @@ import (
 )
 
 // BroadcastEvidence broadcasts evidence of the misbehavior.
-// More: https://docs.tendermint.com/main/rpc/#/Info/broadcast_evidence
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/broadcast_evidence
 func BroadcastEvidence(ctx *rpctypes.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
 	if ev == nil {
 		return nil, errors.New("no evidence was provided")

--- a/rpc/core/health.go
+++ b/rpc/core/health.go
@@ -7,7 +7,7 @@ import (
 
 // Health gets node health. Returns empty result (200 OK) on success, no
 // response - in case of an error.
-// More: https://docs.tendermint.com/main/rpc/#/Info/health
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/health
 func Health(ctx *rpctypes.Context) (*ctypes.ResultHealth, error) {
 	return &ctypes.ResultHealth{}, nil
 }

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -18,10 +18,9 @@ import (
 
 // BroadcastTxAsync returns right away, with no response. Does not wait for
 // CheckTx nor DeliverTx results.
-// More: https://docs.tendermint.com/main/rpc/#/Tx/broadcast_tx_async
+// More: https://docs.tendermint.com/v0.37/rpc/#/Tx/broadcast_tx_async
 func BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 	err := env.Mempool.CheckTx(tx, nil, mempl.TxInfo{})
-
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +29,7 @@ func BroadcastTxAsync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadca
 
 // BroadcastTxSync returns with the response from CheckTx. Does not wait for
 // DeliverTx result.
-// More: https://docs.tendermint.com/main/rpc/#/Tx/broadcast_tx_sync
+// More: https://docs.tendermint.com/v0.37/rpc/#/Tx/broadcast_tx_sync
 func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 	resCh := make(chan *abci.Response, 1)
 	err := env.Mempool.CheckTx(tx, func(res *abci.Response) {
@@ -38,7 +37,6 @@ func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcas
 		case <-ctx.Context().Done():
 		case resCh <- res:
 		}
-
 	}, mempl.TxInfo{})
 	if err != nil {
 		return nil, err
@@ -60,7 +58,7 @@ func BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcas
 }
 
 // BroadcastTxCommit returns with the responses from CheckTx and DeliverTx.
-// More: https://docs.tendermint.com/main/rpc/#/Tx/broadcast_tx_commit
+// More: https://docs.tendermint.com/v0.37/rpc/#/Tx/broadcast_tx_commit
 func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
 	subscriber := ctx.RemoteAddr()
 
@@ -149,7 +147,7 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultBroadc
 
 // UnconfirmedTxs gets unconfirmed transactions (maximum ?limit entries)
 // including their number.
-// More: https://docs.tendermint.com/main/rpc/#/Info/unconfirmed_txs
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/unconfirmed_txs
 func UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*ctypes.ResultUnconfirmedTxs, error) {
 	// reuse per_page validator
 	limit := validatePerPage(limitPtr)
@@ -159,21 +157,23 @@ func UnconfirmedTxs(ctx *rpctypes.Context, limitPtr *int) (*ctypes.ResultUnconfi
 		Count:      len(txs),
 		Total:      env.Mempool.Size(),
 		TotalBytes: env.Mempool.SizeBytes(),
-		Txs:        txs}, nil
+		Txs:        txs,
+	}, nil
 }
 
 // NumUnconfirmedTxs gets number of unconfirmed transactions.
-// More: https://docs.tendermint.com/main/rpc/#/Info/num_unconfirmed_txs
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/num_unconfirmed_txs
 func NumUnconfirmedTxs(ctx *rpctypes.Context) (*ctypes.ResultUnconfirmedTxs, error) {
 	return &ctypes.ResultUnconfirmedTxs{
 		Count:      env.Mempool.Size(),
 		Total:      env.Mempool.Size(),
-		TotalBytes: env.Mempool.SizeBytes()}, nil
+		TotalBytes: env.Mempool.SizeBytes(),
+	}, nil
 }
 
 // CheckTx checks the transaction without executing it. The transaction won't
 // be added to the mempool either.
-// More: https://docs.tendermint.com/main/rpc/#/Tx/check_tx
+// More: https://docs.tendermint.com/v0.37/rpc/#/Tx/check_tx
 func CheckTx(ctx *rpctypes.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
 	res, err := env.ProxyAppMempool.CheckTxSync(abci.RequestCheckTx{Tx: tx})
 	if err != nil {

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NetInfo returns network info.
-// More: https://docs.tendermint.com/main/rpc/#/Info/net_info
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/net_info
 func NetInfo(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error) {
 	peersList := env.P2PPeers.Peers().List()
 	peers := make([]ctypes.Peer, 0, len(peersList))
@@ -53,7 +53,8 @@ func UnsafeDialSeeds(ctx *rpctypes.Context, seeds []string) (*ctypes.ResultDialS
 // UnsafeDialPeers dials the given peers (comma-separated id@IP:PORT),
 // optionally making them persistent.
 func UnsafeDialPeers(ctx *rpctypes.Context, peers []string, persistent, unconditional, private bool) (
-	*ctypes.ResultDialPeers, error) {
+	*ctypes.ResultDialPeers, error,
+) {
 	if len(peers) == 0 {
 		return &ctypes.ResultDialPeers{}, errors.New("no peers provided")
 	}
@@ -92,7 +93,7 @@ func UnsafeDialPeers(ctx *rpctypes.Context, peers []string, persistent, uncondit
 }
 
 // Genesis returns genesis file.
-// More: https://docs.tendermint.com/main/rpc/#/Info/genesis
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/genesis
 func Genesis(ctx *rpctypes.Context) (*ctypes.ResultGenesis, error) {
 	if len(env.genChunks) > 1 {
 		return nil, errors.New("genesis response is large, please use the genesis_chunked API instead")

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -12,7 +12,7 @@ import (
 
 // Status returns Tendermint status including node info, pubkey, latest block
 // hash, app hash, block height and time.
-// More: https://docs.tendermint.com/main/rpc/#/Info/status
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/status
 func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 	var (
 		earliestBlockHeight   int64

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -16,7 +16,7 @@ import (
 // Tx allows you to query the transaction results. `nil` could mean the
 // transaction is in the mempool, invalidated, or was not sent in the first
 // place.
-// More: https://docs.tendermint.com/main/rpc/#/Info/tx
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/tx
 func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error) {
 	// if index is disabled, return error
 	if _, ok := env.TxIndexer.(*null.TxIndex); ok {
@@ -50,7 +50,7 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 
 // TxSearch allows you to query for multiple transactions results. It returns a
 // list of transactions (maximum ?per_page entries) and the total count.
-// More: https://docs.tendermint.com/main/rpc/#/Info/tx_search
+// More: https://docs.tendermint.com/v0.37/rpc/#/Info/tx_search
 func TxSearch(
 	ctx *rpctypes.Context,
 	query string,
@@ -58,7 +58,6 @@ func TxSearch(
 	pagePtr, perPagePtr *int,
 	orderBy string,
 ) (*ctypes.ResultTxSearch, error) {
-
 	// if index is disabled, return error
 	if _, ok := env.TxIndexer.(*null.TxIndex); ok {
 		return nil, errors.New("transaction indexing is disabled")

--- a/rpc/jsonrpc/doc.go
+++ b/rpc/jsonrpc/doc.go
@@ -80,5 +80,5 @@
 //
 // # Examples
 //
-// - [Tendermint](https://github.com/tendermint/tendermint/blob/main/rpc/core/routes.go)
+// - [Tendermint](https://github.com/tendermint/tendermint/blob/v0.37.x/rpc/core/routes.go)
 package jsonrpc

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -83,7 +83,7 @@ paths:
       description: |
         If you want to be sure that the transaction is included in a block, you can
         subscribe for the result using JSONRPC via a websocket. See
-        https://docs.tendermint.com/main/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/v0.37/app-dev/subscribing-to-events-via-websocket.html
         If you haven't received anything after a couple of blocks, resend it. If the
         same happens again, send it to some other node. A few reasons why it could
         happen:
@@ -95,7 +95,7 @@ paths:
 
 
         Please refer to
-        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/v0.37/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -127,7 +127,7 @@ paths:
       description: |
         If you want to be sure that the transaction is included in a block, you can
         subscribe for the result using JSONRPC via a websocket. See
-        https://docs.tendermint.com/main/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/v0.37/app-dev/subscribing-to-events-via-websocket.html
         If you haven't received anything after a couple of blocks, resend it. If the
         same happens again, send it to some other node. A few reasons why it could
         happen:
@@ -139,7 +139,7 @@ paths:
         3. node can be offline
 
         Please refer to
-        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/v0.37/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -172,7 +172,7 @@ paths:
         IMPORTANT: use only for testing and development. In production, use
         BroadcastTxSync or BroadcastTxAsync. You can subscribe for the transaction
         result using JSONRPC via a websocket. See
-        https://docs.tendermint.com/main/app-dev/subscribing-to-events-via-websocket.html
+        https://docs.tendermint.com/v0.37/app-dev/subscribing-to-events-via-websocket.html
 
         CONTRACT: only returns error if mempool.CheckTx() errs or if we timeout
         waiting for tx to commit.
@@ -181,7 +181,7 @@ paths:
         will contain a non-OK ABCI code.
 
         Please refer to
-        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/v0.37/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query
@@ -214,7 +214,7 @@ paths:
         The transaction won't be added to the mempool.
 
         Please refer to
-        https://docs.tendermint.com/main/tendermint-core/using-tendermint.html#formatting
+        https://docs.tendermint.com/v0.37/tendermint-core/using-tendermint.html#formatting
         for formatting/encoding rules.
       parameters:
         - in: query

--- a/spec/abci/README.md
+++ b/spec/abci/README.md
@@ -15,7 +15,7 @@ To perform state-machine replication, Tendermint calls the ABCI methods on the
 ABCI application by sending the `Request*` messages and receiving the `Response*` messages in return.
 
 All ABCI messages and methods are defined in [protocol
-buffers](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
+buffers](https://github.com/tendermint/tendermint/blob/v0.37.x/proto/tendermint/abci/types.proto).
 This allows Tendermint to run with applications written in many programming
 languages.
 

--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -179,8 +179,8 @@ enum EvidenceType {
 ```
 
 There are two forms of evidence: Duplicate Vote and Light Client Attack. More
-information can be found in either [data structures](https://github.com/tendermint/tendermint/blob/main/spec/core/data_structures.md)
-or [accountability](https://github.com/tendermint/tendermint/blob/main/spec/light-client/accountability/)
+information can be found in either [data structures](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/core/data_structures.md)
+or [accountability](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/light-client/accountability/)
 
 ## Determinism
 

--- a/spec/abci/client-server.md
+++ b/spec/abci/client-server.md
@@ -14,7 +14,7 @@ Applications](./apps.md).
 ## Message Protocol
 
 The message protocol consists of pairs of requests and responses defined in the
-[protobuf file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto).
+[protobuf file](https://github.com/tendermint/tendermint/blob/v0.37.x/proto/tendermint/abci/types.proto).
 
 Some messages have no fields, while others may include byte-arrays, strings, integers,
 or custom protobuf types.
@@ -30,7 +30,7 @@ responses.
 To use ABCI in your programming language of choice, there must be a ABCI
 server in that language. Tendermint supports three implementations of the ABCI, written in Go:
 
-- In-process ([Golang](https://github.com/tendermint/tendermint/tree/main/abci),
+- In-process ([Golang](https://github.com/tendermint/tendermint/tree/v0.37.x/abci),
   [Rust](https://github.com/informalsystems/tendermint-rs/tree/main/abci))
 - ABCI-socket
 - GRPC
@@ -39,7 +39,7 @@ The latter two can be tested using the `abci-cli` by setting the `--abci` flag
 appropriately (ie. to `socket` or `grpc`).
 
 See examples, in various stages of maintenance, in
-[Go](https://github.com/tendermint/tendermint/tree/main/abci/server),
+[Go](https://github.com/tendermint/tendermint/tree/v0.37.x/abci/server),
 [JavaScript](https://github.com/tendermint/js-abci),
 [C++](https://github.com/mdyring/cpp-tmsp), and
 [Java](https://github.com/jTendermint/jabci).
@@ -55,7 +55,7 @@ If GRPC is available in your language, this is the easiest approach,
 though it will have significant performance overhead.
 
 To get started with GRPC, copy in the [protobuf
-file](https://github.com/tendermint/tendermint/blob/main/proto/tendermint/abci/types.proto)
+file](https://github.com/tendermint/tendermint/blob/v0.37.x/proto/tendermint/abci/types.proto)
 and compile it using the GRPC plugin for your language. For instance,
 for golang, the command is `protoc --go_out=plugins=grpc:. types.proto`.
 See the [grpc documentation for more details](http://www.grpc.io/docs/).
@@ -114,4 +114,4 @@ received or a block is committed.
 
 It is unlikely that you will need to implement a client. For details of
 our client, see
-[here](https://github.com/tendermint/tendermint/tree/main/abci/client).
+[here](https://github.com/tendermint/tendermint/tree/v0.37.x/abci/client).

--- a/spec/consensus/consensus.md
+++ b/spec/consensus/consensus.md
@@ -123,7 +123,7 @@ A proposal is signed and published by the designated proposer at each
 round. The proposer is chosen by a deterministic and non-choking round
 robin selection algorithm that selects proposers in proportion to their
 voting power (see
-[implementation](https://github.com/tendermint/tendermint/blob/main/types/validator_set.go)).
+[implementation](https://github.com/tendermint/tendermint/blob/v0.37.x/types/validator_set.go)).
 
 A proposal at `(H,R)` is composed of a block and an optional latest
 `PoLC-Round < R` which is included iff the proposer knows of one. This
@@ -295,7 +295,7 @@ may make JSet verification/gossip logic easier to implement.
 ### Censorship Attacks
 
 Due to the definition of a block
-[commit](https://github.com/tendermint/tendermint/blob/main/docs/tendermint-core/validators.md), any 1/3+ coalition of
+[commit](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/tendermint-core/validators.md), any 1/3+ coalition of
 validators can halt the blockchain by not broadcasting their votes. Such
 a coalition can also censor particular transactions by rejecting blocks
 that include these transactions, though this would result in a

--- a/spec/consensus/proposer-based-timestamp/tla/TendermintPBT_001_draft.tla
+++ b/spec/consensus/proposer-based-timestamp/tla/TendermintPBT_001_draft.tla
@@ -3,7 +3,7 @@
  A TLA+ specification of a simplified Tendermint consensus, with added clocks 
  and proposer-based timestamps. This TLA+ specification extends and modifies 
  the Tendermint TLA+ specification for fork accountability: 
-    https://github.com/tendermint/tendermint/blob/main/spec/light-client/accountability/TendermintAcc_004_draft.tla
+    https://github.com/tendermint/tendermint/blob/v0.37.x/spec/light-client/accountability/TendermintAcc_004_draft.tla
  
  * Version 1. A preliminary specification.
 

--- a/spec/consensus/wal.md
+++ b/spec/consensus/wal.md
@@ -28,5 +28,5 @@ WAL. Then it will go to precommit, and that time it will work because the
 private validator contains the `LastSignBytes` and then we’ll replay the
 precommit from the WAL.
 
-Make sure to read about [WAL corruption](https://github.com/tendermint/tendermint/blob/main/docs/tendermint-core/running-in-production.md#wal-corruption)
+Make sure to read about [WAL corruption](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/tendermint-core/running-in-production.md#wal-corruption)
 and recovery strategies.

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -210,7 +210,7 @@ to reconstruct the vote set given the validator set.
 | Signature        | [Signature](#signature)     | Signature corresponding to the validators participation in consensus.                                                                                           | The length of the signature must be > 0 and < than  64            |
 
 NOTE: `ValidatorAddress` and `Timestamp` fields may be removed in the future
-(see [ADR-25](https://github.com/tendermint/tendermint/blob/main/docs/architecture/adr-025-commit.md)).
+(see [ADR-25](https://github.com/tendermint/tendermint/blob/v0.37.x/docs/architecture/adr-025-commit.md)).
 
 ## BlockIDFlag
 

--- a/spec/light-client/README.md
+++ b/spec/light-client/README.md
@@ -10,7 +10,7 @@ parent:
 This directory contains work-in-progress English and TLA+ specifications for the Light Client
 protocol. Implementations of the light client can be found in
 [Rust](https://github.com/informalsystems/tendermint-rs/tree/master/light-client) and
-[Go](https://github.com/tendermint/tendermint/tree/main/light).
+[Go](https://github.com/tendermint/tendermint/tree/v0.37.x/light).
 
 Light clients are assumed to be initialized once from a trusted source
 with a trusted header and validator set. The light client

--- a/spec/light-client/supervisor/supervisor_001_draft.md
+++ b/spec/light-client/supervisor/supervisor_001_draft.md
@@ -307,7 +307,7 @@ type LCInitData struct {
 
 where only one of the components must be provided. `GenesisDoc` is
 defined in the [Tendermint
-Types](https://github.com/tendermint/tendermint/blob/main/types/genesis.go).
+Types](https://github.com/tendermint/tendermint/blob/v0.37.x/types/genesis.go).
 
 #### **[LC-DATA-GENESIS.1]**
 

--- a/spec/light-client/supervisor/supervisor_002_draft.md
+++ b/spec/light-client/supervisor/supervisor_002_draft.md
@@ -17,7 +17,7 @@ type LCInitData struct {
 
 where only one of the components must be provided. `GenesisDoc` is
 defined in the [Tendermint
-Types](https://github.com/tendermint/tendermint/blob/main/types/genesis.go).
+Types](https://github.com/tendermint/tendermint/blob/v0.37.x/types/genesis.go).
 
 
 ### Initialization
@@ -45,8 +45,8 @@ able to verify anything.
 Cross-checking this trusted block with providers upon initialization is helpful
 for ensuring that the node is responsive and correctly configured but does not
 increase trust since proving a conflicting block is a
-[light client attack](https://github.com/tendermint/tendermint/blob/main/spec/light-client/detection/detection_003_reviewed.md#tmbc-lc-attack1)
-and not just a [bogus](https://github.com/tendermint/tendermint/blob/main/spec/light-client/detection/detection_003_reviewed.md#tmbc-bogus1) block could result in
+[light client attack](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/light-client/detection/detection_003_reviewed.md#tmbc-lc-attack1)
+and not just a [bogus](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/light-client/detection/detection_003_reviewed.md#tmbc-bogus1) block could result in
 performing backwards verification beyond the trusted period, thus a fruitless
 endeavour.
 

--- a/spec/light-client/verification/verification_001_published.md
+++ b/spec/light-client/verification/verification_001_published.md
@@ -1164,15 +1164,15 @@ func Main (primary PeerID, lightStore LightStore, targetHeight Height)
 
 [lightclient]: https://github.com/interchainio/tendermint-rs/blob/e2cb9aca0b95430fca2eac154edddc9588038982/docs/architecture/adr-002-lite-client.md
 [fork-detector]: https://github.com/informalsystems/tendermint-rs/blob/master/docs/spec/lightclient/detection.md
-[fullnode]: https://github.com/tendermint/tendermint/blob/main/spec/blockchain/fullnode.md
+[fullnode]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/blockchain/fullnode.md
 
 [ibc-rs]:https://github.com/informalsystems/ibc-rs
 
-[FN-LuckyCase-link]: https://github.com/tendermint/tendermint/blob/main/spec/blockchain/fullnode.md#fn-luckycase
+[FN-LuckyCase-link]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/blockchain/fullnode.md#fn-luckycase
 
-[blockchain-validator-set]: https://github.com/tendermint/tendermint/blob/main/spec/blockchain/blockchain.md#data-structures
-[fullnode-data-structures]: https://github.com/tendermint/tendermint/blob/main/spec/blockchain/fullnode.md#data-structures
+[blockchain-validator-set]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/blockchain/blockchain.md#data-structures
+[fullnode-data-structures]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/blockchain/fullnode.md#data-structures
 
-[FN-ManifestFaulty-link]: https://github.com/tendermint/tendermint/blob/main/spec/blockchain/fullnode.md#fn-manifestfaulty
+[FN-ManifestFaulty-link]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/blockchain/fullnode.md#fn-manifestfaulty
 
 [arXiv]: https://arxiv.org/abs/1807.04938

--- a/spec/light-client/verification/verification_002_draft.md
+++ b/spec/light-client/verification/verification_002_draft.md
@@ -1049,13 +1049,13 @@ func Backwards (primary PeerID, root LightBlock, targetHeight Height)
 
 [lightclient]: https://github.com/interchainio/tendermint-rs/blob/e2cb9aca0b95430fca2eac154edddc9588038982/docs/architecture/adr-002-lite-client.md
 [attack-detector]: https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/detection/detection_001_reviewed.md
-[fullnode]: https://github.com/tendermint/tendermint/blob/main/spec/blockchain/fullnode.md
+[fullnode]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/blockchain/fullnode.md
 
 [ibc-rs]:https://github.com/informalsystems/ibc-rs
 
-[blockchain-validator-set]: https://github.com/tendermint/tendermint/blob/main/spec/blockchain/blockchain.md#data-structures
-[fullnode-data-structures]: https://github.com/tendermint/tendermint/blob/main/spec/blockchain/fullnode.md#data-structures
+[blockchain-validator-set]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/blockchain/blockchain.md#data-structures
+[fullnode-data-structures]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/blockchain/fullnode.md#data-structures
 
-[FN-ManifestFaulty-link]: https://github.com/tendermint/tendermint/blob/main/spec/blockchain/fullnode.md#fn-manifestfaulty
+[FN-ManifestFaulty-link]: https://github.com/tendermint/tendermint/blob/v0.37.x/spec/blockchain/fullnode.md#fn-manifestfaulty
 
 [arXiv]: https://arxiv.org/abs/1807.04938

--- a/spec/p2p/messages/consensus.md
+++ b/spec/p2p/messages/consensus.md
@@ -30,7 +30,7 @@ next block in the blockchain should be.
 
 Vote is sent to vote for some block (or to inform others that a process does not vote in the
 current round). Vote is defined in the
-[Blockchain](https://github.com/tendermint/tendermint/blob/main/spec/core/data_structures.md#blockidd)
+[Blockchain](https://github.com/tendermint/tendermint/blob/v0.37.x/spec/core/data_structures.md#blockidd)
 section and contains validator's
 information (validator address and index), height and round for which the vote is sent, vote type,
 blockID if process vote for some block (`nil` otherwise) and a timestamp when the vote is sent. The

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,4 +2,4 @@
 
 Tools for working with Tendermint and associated technologies. Documentation for
 these tools can be found online in the [Tendermint tools
-documentation](https://docs.tendermint.com/main/tools/).
+documentation](https://docs.tendermint.com/v0.37/tools/).

--- a/types/block.go
+++ b/types/block.go
@@ -321,7 +321,7 @@ func MaxDataBytesNoEvidence(maxBytes int64, valsCount int) int64 {
 // NOTE: changes to the Header should be duplicated in:
 // - header.Hash()
 // - abci.Header
-// - https://github.com/tendermint/tendermint/blob/main/spec/blockchain/blockchain.md
+// - https://github.com/tendermint/tendermint/blob/v0.37.x/spec/blockchain/blockchain.md
 type Header struct {
 	// basic block info
 	Version tmversion.Consensus `json:"version"`
@@ -722,7 +722,6 @@ func (cs *CommitSig) ToProto() *tmproto.CommitSig {
 // FromProto sets a protobuf CommitSig to the given pointer.
 // It returns an error if the CommitSig is invalid.
 func (cs *CommitSig) FromProto(csp tmproto.CommitSig) error {
-
 	cs.BlockIDFlag = BlockIDFlag(csp.BlockIdFlag)
 	cs.ValidatorAddress = csp.ValidatorAddress
 	cs.Timestamp = csp.Timestamp
@@ -963,9 +962,7 @@ func CommitFromProto(cp *tmproto.Commit) (*Commit, error) {
 		return nil, errors.New("nil Commit")
 	}
 
-	var (
-		commit = new(Commit)
-	)
+	commit := new(Commit)
 
 	bi, err := BlockIDFromProto(&cp.BlockID)
 	if err != nil {
@@ -991,7 +988,6 @@ func CommitFromProto(cp *tmproto.Commit) (*Commit, error) {
 
 // Data contains the set of transactions included in the block
 type Data struct {
-
 	// Txs that will be applied by state @ block.Height+1.
 	// NOTE: not all txs here are valid.  We're just agreeing on the order first.
 	// This means that block.AppHash does not include these txs.


### PR DESCRIPTION
In preparation for cutting a v0.37 release candidate, we need to update all of our documentation references on the `v0.37.x` branch from `main` to `v0.37.x` for GitHub references, and `v0.37` for **docs.tendermint.com** references.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

