### PR TITLE
ci: Prepare for v0.37 release branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,16 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    target-branch: "v0.37.x"
+    open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+      - S:automerge
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
     target-branch: "v0.34.x"
     open-pull-requests-limit: 10
     labels:
@@ -35,6 +45,16 @@ updates:
     schedule:
       interval: weekly
     target-branch: "main"
+    open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+      - S:automerge
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: "v0.37.x"
     open-pull-requests-limit: 10
     labels:
       - T:dependencies

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,6 +17,14 @@ pull_request_rules:
           {{ title }} (#{{ number }})
 
           {{ body }}
+  - name: backport patches to v0.37.x branch
+    conditions:
+      - base=main
+      - label=S:backport-to-v0.37.x
+    actions:
+      backport:
+        branches:
+          - v0.37.x
   - name: backport patches to v0.34.x branch
     conditions:
       - base=main

--- a/.github/workflows/e2e-nightly-37x.yml
+++ b/.github/workflows/e2e-nightly-37x.yml
@@ -1,0 +1,104 @@
+# Runs randomly generated E2E testnets nightly on the v0.37.x branch.
+
+# !! This file should be kept in sync with the e2e-nightly-main.yml file,
+# modulo changes to the version labels.
+
+name: e2e-nightly-37x
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  e2e-nightly-test:
+    # Run parallel jobs for the listed testnet groups (must match the
+    # ./build/generator -g flag)
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ['00', '01', '02', '03', "04"]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+
+      - uses: actions/checkout@v3
+        with:
+          ref: 'v0.37.x'
+
+      - name: Capture git repo info
+        id: git-info
+        run: |
+          echo "::set-output name=branch::`git branch --show-current`"
+          echo "::set-output name=commit::`git rev-parse HEAD`"
+
+      - name: Build
+        working-directory: test/e2e
+        # Run make jobs in parallel, since we can't run steps in parallel.
+        run: make -j2 docker generator runner tests
+
+      - name: Generate testnets
+        working-directory: test/e2e
+        # When changing -g, also change the matrix groups above
+        run: ./build/generator -g 5 -d networks/nightly/
+
+      - name: Run ${{ matrix.p2p }} p2p testnets
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
+
+    outputs:
+      git-branch: ${{ steps.git-info.outputs.branch }}
+      git-commit: ${{ steps.git-info.outputs.commit }}
+
+  e2e-nightly-fail:
+    needs: e2e-nightly-test
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.21.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ needs.e2e-nightly-test.outputs.git-branch }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMIT_URL: "${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.e2e-nightly-test.outputs.git-commit }}"
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMIT_URL }}|commit> that caused the failure."
+                  }
+                }
+              ]
+            }
+
+  e2e-nightly-success:  # may turn this off once they seem to pass consistently
+    needs: e2e-nightly-test
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on success
+        uses: slackapi/slack-github-action@v1.21.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ needs.e2e-nightly-test.outputs.git-branch }}
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":white_check_mark: Nightly E2E tests for `${{ env.BRANCH }}` passed."
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
Depends on #9337.

Prepare the CI to handle the v0.37 development processes, as per our [release guidelines](https://github.com/tendermint/tendermint/blob/main/RELEASES.md#creating-a-backport-branch).

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

