### PR TITLE
abci: Set version to 1.0.0

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,7 +7,7 @@ Tendermint Core.
 
 ### ABCI Changes
 
-* The `ABCIVersion` is now `0.18.0`.
+* The `ABCIVersion` is now `1.0.0`.
 
 * Added new ABCI methods `PrepareProposal` and `ProcessProposal`. For details,
   please see the [spec](spec/abci/README.md). Applications upgrading to

--- a/version/version.go
+++ b/version/version.go
@@ -1,15 +1,13 @@
 package version
 
-var (
-	TMCoreSemVer = TMVersionDefault
-)
+var TMCoreSemVer = TMVersionDefault
 
 const (
 	// TMVersionDefault is the used as the fallback version of Tendermint Core
 	// when not using git describe. It is formatted with semantic versioning.
 	TMVersionDefault = "0.34.20"
-	// ABCISemVer is the semantic version of the ABCI library
-	ABCISemVer = "0.18.0"
+	// ABCISemVer is the semantic version of the ABCI protocol
+	ABCISemVer = "1.0.0"
 
 	ABCIVersion = ABCISemVer
 )


### PR DESCRIPTION
After talking with the council, there's agreement that Tendermint v0.37 should release its ABCI protocol version as "1.0.0", and when vote extensions land it should be "2.0.0".

This PR can be automatically backported to `v0.37.x` once #9338 lands.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

