### PR TITLE
ci: Remove "(WARNING: BETA SOFTWARE)" tagline from all upcoming releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ checksum:
 
 release:
   prerelease: auto
-  name_template: "{{.Version}} (WARNING: BETA SOFTWARE)"
+  name_template: "{{.Version}}"
 
 archives:
   - files:


### PR DESCRIPTION
This is by no means a signal that we offer any additional guarantees with our software. This warning seems somewhat pointless given that:
1. Our open source license clearly states that we offer no warranties with this software.
2. We are clearly still pre-1.0.

It also doesn't make sense to append "(WARNING: BETA SOFTWARE)" to pre-releases such as alpha releases, which are to be considered _more_ unstable than beta releases.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

