### PR TITLE
test: generate uuid on startup for load tool

### DIFF
--- a/test/loadtime/cmd/load/main.go
+++ b/test/loadtime/cmd/load/main.go
@@ -15,7 +15,9 @@ var (
 )
 
 // ClientFactory implements the loadtest.ClientFactory interface.
-type ClientFactory struct{}
+type ClientFactory struct {
+	Id []byte
+}
 
 // TxGenerator is responsible for generating transactions.
 // TxGenerator holds the set of information that will be used to generate
@@ -28,7 +30,8 @@ type TxGenerator struct {
 }
 
 func main() {
-	if err := loadtest.RegisterClientFactory("loadtime-client", &ClientFactory{}); err != nil {
+	u := [16]byte(uuid.New()) // generate run ID on startup
+	if err := loadtest.RegisterClientFactory("loadtime-client", &ClientFactory{Id: u[:]}); err != nil {
 		panic(err)
 	}
 	loadtest.Run(&loadtest.CLIConfig{
@@ -51,9 +54,8 @@ func (f *ClientFactory) ValidateConfig(cfg loadtest.Config) error {
 }
 
 func (f *ClientFactory) NewClient(cfg loadtest.Config) (loadtest.Client, error) {
-	u := [16]byte(uuid.New())
 	return &TxGenerator{
-		id:    u[:],
+		id:    f.Id,
 		conns: uint64(cfg.Connections),
 		rate:  uint64(cfg.Rate),
 		size:  uint64(cfg.Size),

--- a/test/loadtime/cmd/load/main.go
+++ b/test/loadtime/cmd/load/main.go
@@ -16,7 +16,7 @@ var (
 
 // ClientFactory implements the loadtest.ClientFactory interface.
 type ClientFactory struct {
-	Id []byte
+	ID []byte
 }
 
 // TxGenerator is responsible for generating transactions.
@@ -31,7 +31,7 @@ type TxGenerator struct {
 
 func main() {
 	u := [16]byte(uuid.New()) // generate run ID on startup
-	if err := loadtest.RegisterClientFactory("loadtime-client", &ClientFactory{Id: u[:]}); err != nil {
+	if err := loadtest.RegisterClientFactory("loadtime-client", &ClientFactory{ID: u[:]}); err != nil {
 		panic(err)
 	}
 	loadtest.Run(&loadtest.CLIConfig{
@@ -55,7 +55,7 @@ func (f *ClientFactory) ValidateConfig(cfg loadtest.Config) error {
 
 func (f *ClientFactory) NewClient(cfg loadtest.Config) (loadtest.Client, error) {
 	return &TxGenerator{
-		id:    f.Id,
+		id:    f.ID,
 		conns: uint64(cfg.Connections),
 		rate:  uint64(cfg.Rate),
 		size:  uint64(cfg.Size),


### PR DESCRIPTION
the `NewClient` method is called by the load test framework for each connection. This means that if multiple connections are instantiated, each connection will erroneously have its own UUID. This PR changes the UUID generation to happen at the _beginning_ of the script instead of on client creation so that each experimental run shares a UUID.

Caught while preparing the script for production readiness.

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

