### PR TITLE
Add redirect link for tutorial

### DIFF
--- a/docs/.vuepress/redirects
+++ b/docs/.vuepress/redirects
@@ -63,3 +63,4 @@
 /redirects/master/spec/blockchain/encoding.html https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/encoding.md
 /redirects/master/spec/blockchain/blockchain.html https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/blockchain.md
 /redirects/master/spec/blockchain/index.html https://github.com/tendermint/tendermint/blob/v0.34.x/spec/blockchain/readme.md
+/redirects/master/tutorials/go.html /v0.34/tutorials/go.html


### PR DESCRIPTION
Small issue, https://tendermint.com/core/ pointing to /master/tutorials/go.html rather than /v0.34/tutorials/go.html
