### PR TITLE
ABCI: Removed unused `votes` param

### DIFF
--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -214,7 +214,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		proposerAddr := lazyProposer.privValidatorPubKey.Address()
 
 		block, err := lazyProposer.blockExec.CreateProposalBlock(
-			lazyProposer.Height, lazyProposer.state, commit, proposerAddr, nil)
+			lazyProposer.Height, lazyProposer.state, commit, proposerAddr)
 		require.NoError(t, err)
 		blockParts, err := block.MakePartSet(types.BlockPartSizeBytes)
 		require.NoError(t, err)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1229,7 +1229,7 @@ func (cs *State) createProposalBlock() (*types.Block, error) {
 
 	proposerAddr := cs.privValidatorPubKey.Address()
 
-	ret, err := cs.blockExec.CreateProposalBlock(cs.Height, cs.state, commit, proposerAddr, cs.LastCommit.GetVotes())
+	ret, err := cs.blockExec.CreateProposalBlock(cs.Height, cs.state, commit, proposerAddr)
 	if err != nil {
 		panic(err)
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -312,7 +312,6 @@ func TestCreateProposalBlock(t *testing.T) {
 		height,
 		state, commit,
 		proposerAddr,
-		nil,
 	)
 	require.NoError(t, err)
 
@@ -395,7 +394,6 @@ func TestMaxProposalBlockSize(t *testing.T) {
 		height,
 		state, commit,
 		proposerAddr,
-		nil,
 	)
 	require.NoError(t, err)
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -97,7 +97,6 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	state State,
 	commit *types.Commit,
 	proposerAddr []byte,
-	votes []*types.Vote,
 ) (*types.Block, error) {
 
 	maxBytes := state.ConsensusParams.Block.MaxBytes
@@ -116,7 +115,7 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 		abci.RequestPrepareProposal{
 			MaxTxBytes:         maxDataBytes,
 			Txs:                block.Txs.ToSliceOfBytes(),
-			LocalLastCommit:    extendedCommitInfo(localLastCommit, votes),
+			LocalLastCommit:    extendedCommitInfo(localLastCommit),
 			Misbehavior:        block.Evidence.Evidence.ToABCI(),
 			Height:             block.Height,
 			Time:               block.Time,
@@ -432,7 +431,7 @@ func buildLastCommitInfo(block *types.Block, store Store, initialHeight int64) a
 	}
 }
 
-func extendedCommitInfo(c abci.CommitInfo, votes []*types.Vote) abci.ExtendedCommitInfo {
+func extendedCommitInfo(c abci.CommitInfo) abci.ExtendedCommitInfo {
 	vs := make([]abci.ExtendedVoteInfo, len(c.Votes))
 	for i := range vs {
 		vs[i] = abci.ExtendedVoteInfo{

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -624,7 +624,7 @@ func TestEmptyPrepareProposal(t *testing.T) {
 	pa, _ := state.Validators.GetByIndex(0)
 	commit, err := makeValidCommit(height, types.BlockID{}, state.Validators, privVals)
 	require.NoError(t, err)
-	_, err = blockExec.CreateProposalBlock(height, state, commit, pa, nil)
+	_, err = blockExec.CreateProposalBlock(height, state, commit, pa)
 	require.NoError(t, err)
 }
 
@@ -665,7 +665,7 @@ func TestPrepareProposalTxsAllIncluded(t *testing.T) {
 	pa, _ := state.Validators.GetByIndex(0)
 	commit, err := makeValidCommit(height, types.BlockID{}, state.Validators, privVals)
 	require.NoError(t, err)
-	block, err := blockExec.CreateProposalBlock(height, state, commit, pa, nil)
+	block, err := blockExec.CreateProposalBlock(height, state, commit, pa)
 	require.NoError(t, err)
 
 	for i, tx := range block.Data.Txs {
@@ -716,7 +716,7 @@ func TestPrepareProposalReorderTxs(t *testing.T) {
 	pa, _ := state.Validators.GetByIndex(0)
 	commit, err := makeValidCommit(height, types.BlockID{}, state.Validators, privVals)
 	require.NoError(t, err)
-	block, err := blockExec.CreateProposalBlock(height, state, commit, pa, nil)
+	block, err := blockExec.CreateProposalBlock(height, state, commit, pa)
 	require.NoError(t, err)
 	for i, tx := range block.Data.Txs {
 		require.Equal(t, txs[i], tx)
@@ -770,7 +770,7 @@ func TestPrepareProposalErrorOnTooManyTxs(t *testing.T) {
 	commit, err := makeValidCommit(height, types.BlockID{}, state.Validators, privVals)
 	require.NoError(t, err)
 
-	block, err := blockExec.CreateProposalBlock(height, state, commit, pa, nil)
+	block, err := blockExec.CreateProposalBlock(height, state, commit, pa)
 	require.Nil(t, block)
 	require.ErrorContains(t, err, "transaction data size exceeds maximum")
 
@@ -818,7 +818,7 @@ func TestPrepareProposalErrorOnPrepareProposalError(t *testing.T) {
 	commit, err := makeValidCommit(height, types.BlockID{}, state.Validators, privVals)
 	require.NoError(t, err)
 
-	block, err := blockExec.CreateProposalBlock(height, state, commit, pa, nil)
+	block, err := blockExec.CreateProposalBlock(height, state, commit, pa)
 	require.Nil(t, block)
 	require.ErrorContains(t, err, "an injected error")
 


### PR DESCRIPTION
Contributes to #9053 

The way this code is structured will minimize conflicts when backporting vote extensions to `main`.
However, on `v0.37.x`, there is no point in having the `votes` parameter, which is not used.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

