### PR TITLE
ci: Only allow automated security-related updates until v0.37.0 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,9 @@ updates:
     schedule:
       interval: weekly
     target-branch: "v0.37.x"
-    open-pull-requests-limit: 10
+    # Only allow automated security-related dependency updates until we cut the
+    # final v0.37.0 release.
+    open-pull-requests-limit: 0
     labels:
       - T:dependencies
       - S:automerge


### PR DESCRIPTION
As per discussion with @sergio-mena, this should disable all automated dependency updates that are not security-related. We should make this part of our standard practice when cutting new major releases, given that our QA process for major releases is expensive at present and we cannot re-run it for every dependency update.

Once we have cut a final major release, we can consider re-enabling automated dependency updates here that can be rolled out in minor releases.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

