### PR TITLE
docs: Remove dev base tagging from release branch creation process

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -93,22 +93,14 @@ the 0.38.x line.
 
 After doing these steps, go back to `main` and do the following:
 
-1. Tag `main` as the dev branch for the _next_ minor version release and push
-   it up to GitHub.
-   For example:
-   ```sh
-   git tag -a v0.39.0-dev -m "Development base for Tendermint v0.39."
-   git push origin v0.39.0-dev
-   ```
-
-2. Create a new workflow to run e2e nightlies for the new backport branch. (See
+1. Create a new workflow to run e2e nightlies for the new backport branch. (See
    [e2e-nightly-main.yml][e2e] for an example.)
 
-3. Add a new section to the Mergify config (`.github/mergify.yml`) to enable the
+2. Add a new section to the Mergify config (`.github/mergify.yml`) to enable the
    backport bot to work on this branch, and add a corresponding `S:backport-to-v0.38.x`
    [label](https://github.com/tendermint/tendermint/labels) so the bot can be triggered.
 
-4. Add a new section to the Dependabot config (`.github/dependabot.yml`) to
+3. Add a new section to the Dependabot config (`.github/dependabot.yml`) to
    enable automatic update of Go dependencies on this branch. Copy and edit one
    of the existing branch configurations to set the correct `target-branch`.
 


### PR DESCRIPTION
After discussion with @marbar3778, it seems that this process of creating `*-dev` tags interferes with the use of our pre-releases.

Also, it's not clear what value this really brings. Who needs these `-dev` tags and why? If nobody, we should really just remove this part of the process. If it's actually necessary, we should find a different tag naming scheme that doesn't interfere with use of our pre-releases.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

