### PR TITLE
state: restore previous error message

### DIFF
--- a/state/store.go
+++ b/state/store.go
@@ -531,7 +531,7 @@ func loadValidatorsInfo(db dbm.DB, height int64) (*tmstate.ValidatorsInfo, error
 	}
 
 	if len(buf) == 0 {
-		return nil, errors.New("no last ABCI response has been persisted")
+		return nil, errors.New("value retrieved from db is empty")
 	}
 
 	v := new(tmstate.ValidatorsInfo)
@@ -619,7 +619,7 @@ func (store dbStore) loadConsensusParamsInfo(height int64) (*tmstate.ConsensusPa
 		return nil, err
 	}
 	if len(buf) == 0 {
-		return nil, errors.New("no last ABCI response has been persisted")
+		return nil, errors.New("value retrieved from db is empty")
 	}
 
 	paramsInfo := new(tmstate.ConsensusParamsInfo)


### PR DESCRIPTION
Error message was incorrectly changed in https://github.com/tendermint/tendermint/pull/9286. This restores it to the previous one. 
