### PR TITLE
Fix ABCI specification (TXs added in `PrepareProposal` are not added to the mempool)

### DIFF
--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -431,8 +431,8 @@ title: Methods
               there are other transactions with higher priority, then it should not include it in
               `ResponsePrepareProposal.txs`. However, this will not remove `tx` from the mempool.
             * If the Application wants to add a new transaction to the proposed block, then the
-              Application includes it in `ResponsePrepareProposal.txs`. In this case, Tendermint
-              will also add the transaction to the mempool.
+              Application includes it in `ResponsePrepareProposal.txs`. Tendermint will not add
+              the transaction to the mempool.
         * The Application should be aware that removing and adding transactions may compromise
           _traceability_.
           > Consider the following example: the Application transforms a client-submitted


### PR DESCRIPTION
Contributes to #9201

As per title, fixed paragraph that was stating the contrary.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

