### PR TITLE
config: Add missing storage section when generating config

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -487,6 +487,7 @@ peer_query_maj23_sleep_duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
 #######################################################
 ###         Storage Configuration Options           ###
 #######################################################
+[storage]
 
 # Set to true to discard ABCI responses from the state store, which can save a
 # considerable amount of disk space. Set to false to ensure ABCI responses are


### PR DESCRIPTION
In looking at adding support for the new `[storage]` section in tendermint-rs, I see that in #9275 I forgot to add the section to our TOML template that's used when generating new configuration files :facepalm: 

This doesn't affect users whose configuration files include the new `[storage]` section in any way: this just ensures that we generate the config file correctly when the user runs `tendermint init`.

This should go into `main`, `v0.37.x` and `v0.34.x` and won't affect the results of our v0.37 QA.

---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

