### PR TITLE
loadtime: add block time to the data point

### DIFF
--- a/test/loadtime/cmd/report/main.go
+++ b/test/loadtime/cmd/report/main.go
@@ -87,7 +87,7 @@ func toCSVRecords(rs []report.Report) [][]string {
 	}
 	res := make([][]string, total+1)
 
-	res[0] = []string{"experiment_id", "duration_ns", "connections", "rate", "size"}
+	res[0] = []string{"experiment_id", "duration_ns", "block_time", "connections", "rate", "size"}
 	offset := 1
 	for _, r := range rs {
 		idStr := r.ID.String()
@@ -95,7 +95,7 @@ func toCSVRecords(rs []report.Report) [][]string {
 		rateStr := strconv.FormatInt(int64(r.Rate), 10)
 		sizeStr := strconv.FormatInt(int64(r.Size), 10)
 		for i, v := range r.All {
-			res[offset+i] = []string{idStr, strconv.FormatInt(int64(v), 10), connStr, rateStr, sizeStr}
+			res[offset+i] = []string{idStr, strconv.FormatInt(int64(v.Duration), 10), strconv.FormatInt(v.BlockTime.UnixNano(), 10), connStr, rateStr, sizeStr}
 		}
 		offset += len(r.All)
 	}

--- a/test/loadtime/report/report.go
+++ b/test/loadtime/report/report.go
@@ -21,6 +21,12 @@ type BlockStore interface {
 	LoadBlock(int64) *types.Block
 }
 
+// DataPoint contains the set of data collected for each transaction.
+type DataPoint struct {
+	Duration  time.Duration
+	BlockTime time.Time
+}
+
 // Report contains the data calculated from reading the timestamped transactions
 // of each block found in the blockstore.
 type Report struct {
@@ -38,7 +44,7 @@ type Report struct {
 	// All contains all data points gathered from all valid transactions.
 	// The order of the contents of All is not guaranteed to be match the order of transactions
 	// in the chain.
-	All []time.Duration
+	All []DataPoint
 
 	// used for calculating average during report creation.
 	sum int64
@@ -62,7 +68,7 @@ func (rs *Reports) ErrorCount() int {
 	return rs.errorCount
 }
 
-func (rs *Reports) addDataPoint(id uuid.UUID, l time.Duration, conns, rate, size uint64) {
+func (rs *Reports) addDataPoint(id uuid.UUID, l time.Duration, bt time.Time, conns, rate, size uint64) {
 	r, ok := rs.s[id]
 	if !ok {
 		r = Report{
@@ -75,7 +81,7 @@ func (rs *Reports) addDataPoint(id uuid.UUID, l time.Duration, conns, rate, size
 		}
 		rs.s[id] = r
 	}
-	r.All = append(r.All, l)
+	r.All = append(r.All, DataPoint{Duration: l, BlockTime: bt})
 	if l > r.Max {
 		r.Max = l
 	}
@@ -116,6 +122,7 @@ func GenerateFromBlockStore(s BlockStore) (*Reports, error) {
 	type payloadData struct {
 		id                      uuid.UUID
 		l                       time.Duration
+		bt                      time.Time
 		connections, rate, size uint64
 		err                     error
 	}
@@ -150,10 +157,11 @@ func GenerateFromBlockStore(s BlockStore) (*Reports, error) {
 				}
 
 				l := b.bt.Sub(p.Time.AsTime())
-				b := (*[16]byte)(p.Id)
+				idb := (*[16]byte)(p.Id)
 				pdc <- payloadData{
 					l:           l,
-					id:          uuid.UUID(*b),
+					bt:          b.bt,
+					id:          uuid.UUID(*idb),
 					connections: p.Connections,
 					rate:        p.Rate,
 					size:        p.Size,
@@ -194,16 +202,16 @@ func GenerateFromBlockStore(s BlockStore) (*Reports, error) {
 			reports.addError()
 			continue
 		}
-		reports.addDataPoint(pd.id, pd.l, pd.connections, pd.rate, pd.size)
+		reports.addDataPoint(pd.id, pd.l, pd.bt, pd.connections, pd.rate, pd.size)
 	}
 	reports.calculateAll()
 	return reports, nil
 }
 
-func toFloat(in []time.Duration) []float64 {
+func toFloat(in []DataPoint) []float64 {
 	r := make([]float64, len(in))
 	for i, v := range in {
-		r[i] = float64(int64(v))
+		r[i] = float64(int64(v.Duration))
 	}
 	return r
 }


### PR DESCRIPTION
This pull request adds the block time as the unix time since the epoch to the `report` tool's csv output.

```csv
...
a7a8b903-1136-4da1-97aa-d25da7b4094f,1614226790,1663707084905417366,4,200,1024
a7a8b903-1136-4da1-97aa-d25da7b4094f,1614196724,1663707084905417366,4,200,1024
a7a8b903-1136-4da1-97aa-d25da7b4094f,1613097336,1663707084905417366,4,200,1024
a7a8b903-1136-4da1-97aa-d25da7b4094f,1609365168,1663707084905417366,4,200,1024
a7a8b903-1136-4da1-97aa-d25da7b4094f,1617199169,1663707084905417366,4,200,1024
a7a8b903-1136-4da1-97aa-d25da7b4094f,1615197134,1663707084905417366,4,200,1024
a7a8b903-1136-4da1-97aa-d25da7b4094f,1610399447,1663707084905417366,4,200,1024
...
```

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

