### PR TITLE
ci: Only notify on nightly E2E failures

### DIFF
--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -77,28 +77,3 @@ jobs:
                 }
               ]
             }
-
-  e2e-nightly-success:  # may turn this off once they seem to pass consistently
-    needs: e2e-nightly-test
-    if: ${{ success() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack on success
-        uses: slackapi/slack-github-action@v1.22.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          BRANCH: ${{ needs.e2e-nightly-test.outputs.git-branch }}
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":white_check_mark: Nightly E2E tests for `${{ env.BRANCH }}` passed."
-                  }
-                }
-              ]
-            }

--- a/.github/workflows/e2e-nightly-37x.yml
+++ b/.github/workflows/e2e-nightly-37x.yml
@@ -77,28 +77,3 @@ jobs:
                 }
               ]
             }
-
-  e2e-nightly-success:  # may turn this off once they seem to pass consistently
-    needs: e2e-nightly-test
-    if: ${{ success() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack on success
-        uses: slackapi/slack-github-action@v1.22.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          BRANCH: ${{ needs.e2e-nightly-test.outputs.git-branch }}
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":white_check_mark: Nightly E2E tests for `${{ env.BRANCH }}` passed."
-                  }
-                }
-              ]
-            }

--- a/.github/workflows/e2e-nightly-main.yml
+++ b/.github/workflows/e2e-nightly-main.yml
@@ -66,28 +66,3 @@ jobs:
                 }
               ]
             }
-
-  e2e-nightly-success:  # may turn this off once they seem to pass consistently
-    needs: e2e-nightly-test
-    if: ${{ success() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack on success
-        uses: slackapi/slack-github-action@v1.22.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          BRANCH: ${{ github.ref_name }}
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":white_check_mark: Nightly E2E tests for `${{ env.BRANCH }}` passed."
-                  }
-                }
-              ]
-            }


### PR DESCRIPTION
As discussed in the team, let's only be notified when there's a failure in the nightly E2E tests. All of them for `main`, `v0.34.x` and `v0.37.x` seem to be passing pretty consistently at present.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

