### PR TITLE
Fix TX payload for DO testnets

### DIFF
--- a/test/loadtime/payload/payload.go
+++ b/test/loadtime/payload/payload.go
@@ -51,12 +51,22 @@ func NewBytes(p *Payload) ([]byte, error) {
 // FromBytes leaves the padding untouched, returning it to the caller to handle
 // or discard per their preference.
 func FromBytes(b []byte) (*Payload, error) {
-	p := &Payload{}
-	tr := bytes.TrimPrefix(b, []byte(keyPrefix))
-	if bytes.Equal(b, tr) {
+	tr_h := bytes.TrimPrefix(b, []byte(keyPrefix))
+	if bytes.Equal(b, tr_h) {
 		return nil, errors.New("payload bytes missing key prefix")
 	}
-	err := proto.Unmarshal(tr, p)
+
+	var tr_b string
+	n, err := fmt.Sscanf("%X", string(tr_h), tr_b)
+	if err != nil {
+		return nil, err
+	}
+	if n != 1 {
+		return nil, fmt.Errorf("Invalid # of elements in TX payload (1 != %d)", n)
+	}
+
+	p := &Payload{}
+	err = proto.Unmarshal(tr_h, p)
 	if err != nil {
 		return nil, err
 	}

--- a/test/loadtime/payload/payload.go
+++ b/test/loadtime/payload/payload.go
@@ -56,8 +56,8 @@ func FromBytes(b []byte) (*Payload, error) {
 		return nil, errors.New("payload bytes missing key prefix")
 	}
 
-	var tr_b string
-	n, err := fmt.Sscanf("%X", string(tr_h), tr_b)
+	tr_b := make([]byte, (len(tr_h)+1)/2)
+	n, err := fmt.Sscanf(string(tr_h), "%X", &tr_b)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func FromBytes(b []byte) (*Payload, error) {
 	}
 
 	p := &Payload{}
-	err = proto.Unmarshal(tr_h, p)
+	err = proto.Unmarshal(tr_b, p)
 	if err != nil {
 		return nil, err
 	}

--- a/test/loadtime/payload/payload.go
+++ b/test/loadtime/payload/payload.go
@@ -1,9 +1,7 @@
 package payload
 
 import (
-	"bytes"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"math"
 
@@ -51,13 +49,8 @@ func NewBytes(p *Payload) ([]byte, error) {
 // FromBytes leaves the padding untouched, returning it to the caller to handle
 // or discard per their preference.
 func FromBytes(b []byte) (*Payload, error) {
-	tr_h := bytes.TrimPrefix(b, []byte(keyPrefix))
-	if bytes.Equal(b, tr_h) {
-		return nil, errors.New("payload bytes missing key prefix")
-	}
-
-	tr_b := make([]byte, (len(tr_h)+1)/2)
-	n, err := fmt.Sscanf(string(tr_h), "%X", &tr_b)
+	tr_b := make([]byte, (len(b)-len(keyPrefix)+1)/2)
+	n, err := fmt.Sscanf(string(b), keyPrefix+"%X", &tr_b)
 	if err != nil {
 		return nil, err
 	}

--- a/test/loadtime/payload/payload.go
+++ b/test/loadtime/payload/payload.go
@@ -29,7 +29,7 @@ func NewBytes(p *Payload) ([]byte, error) {
 
 	// We halve the padding size because we transform the TX to hex
 	// We add 1 to account for the initial padding byte
-	p.Padding = make([]byte, (p.Size-uint64(us))/2+1) //
+	p.Padding = make([]byte, (p.Size-uint64(us))/2+1)
 	_, err = rand.Read(p.Padding)
 	if err != nil {
 		return nil, err

--- a/test/loadtime/payload/payload.go
+++ b/test/loadtime/payload/payload.go
@@ -50,17 +50,17 @@ func NewBytes(p *Payload) ([]byte, error) {
 // FromBytes leaves the padding untouched, returning it to the caller to handle
 // or discard per their preference.
 func FromBytes(b []byte) (*Payload, error) {
-	tr_h := bytes.TrimPrefix(b, []byte(keyPrefix))
-	if bytes.Equal(b, tr_h) {
+	trH := bytes.TrimPrefix(b, []byte(keyPrefix))
+	if bytes.Equal(b, trH) {
 		return nil, fmt.Errorf("payload bytes missing key prefix '%s'", keyPrefix)
 	}
-	tr_b, err := hex.DecodeString(string(tr_h))
+	trB, err := hex.DecodeString(string(trH))
 	if err != nil {
 		return nil, err
 	}
 
 	p := &Payload{}
-	err = proto.Unmarshal(tr_b, p)
+	err = proto.Unmarshal(trB, p)
 	if err != nil {
 		return nil, err
 	}

--- a/test/loadtime/payload/payload.go
+++ b/test/loadtime/payload/payload.go
@@ -30,7 +30,7 @@ func NewBytes(p *Payload) ([]byte, error) {
 	}
 
 	// We halve the padding size because we transform the TX to hex
-	p.Padding = make([]byte, (p.Size-uint64(us))/2)
+	p.Padding = make([]byte, (p.Size-uint64(us))/uint64(2))
 	_, err = rand.Read(p.Padding)
 	if err != nil {
 		return nil, err

--- a/test/loadtime/payload/payload.go
+++ b/test/loadtime/payload/payload.go
@@ -29,7 +29,7 @@ func NewBytes(p *Payload) ([]byte, error) {
 	if p.Size > maxPayloadSize {
 		return nil, fmt.Errorf("configured size %d is too large (>%d)", p.Size, maxPayloadSize)
 	}
-	pSize := int(p.Size)
+	pSize := int(p.Size) // #nosec -- The "if" above makes this cast safe
 	if pSize < us {
 		return nil, fmt.Errorf("configured size %d not large enough to fit unpadded transaction of size %d", pSize, us)
 	}

--- a/test/loadtime/payload/payload.go
+++ b/test/loadtime/payload/payload.go
@@ -12,6 +12,7 @@ import (
 )
 
 const keyPrefix = "a="
+const maxPayloadSize = 4 * 1024 * 1024
 
 // NewBytes generates a new payload and returns the encoded representation of
 // the payload as a slice of bytes. NewBytes uses the fields on the Options
@@ -25,12 +26,16 @@ func NewBytes(p *Payload) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if p.Size < uint64(us) {
-		return nil, fmt.Errorf("configured size %d not large enough to fit unpadded transaction of size %d", p.Size, us)
+	if p.Size > maxPayloadSize {
+		return nil, fmt.Errorf("configured size %d is too large (>%d)", p.Size, maxPayloadSize)
+	}
+	pSize := int(p.Size)
+	if pSize < us {
+		return nil, fmt.Errorf("configured size %d not large enough to fit unpadded transaction of size %d", pSize, us)
 	}
 
 	// We halve the padding size because we transform the TX to hex
-	p.Padding = make([]byte, (p.Size-uint64(us))/uint64(2))
+	p.Padding = make([]byte, (pSize-us)/2)
 	_, err = rand.Read(p.Padding)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #9539

This PR changes the way the payload is encoded and decoded in the `loadtime` tool.
To make sure only one "=" character appears in the transaction's payload, we:
* First we use protobufs to encode the `Payload` structure
* Then we encode those bytes in (uppercase) hex

As this encoding is less efficient, we need to adjust the padding length in order to obtain the desired transaction length.

The tradeoff here is that the minimum transaction payload is doubled (the space required to store a transaction without padding); but we are not likely to hit this limit anytime soon.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

