### PR TITLE
Enable local snapshot restore

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -796,6 +796,7 @@ type StateSyncConfig struct {
 	DiscoveryTime       time.Duration `mapstructure:"discovery_time"`
 	ChunkRequestTimeout time.Duration `mapstructure:"chunk_request_timeout"`
 	ChunkFetchers       int32         `mapstructure:"chunk_fetchers"`
+	RestoreHeight       uint64        `mapstructure:"restore_height"`
 }
 
 func (cfg *StateSyncConfig) TrustHashBytes() []byte {

--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -274,7 +274,19 @@ func (r *Reactor) Sync(stateProvider StateProvider, discoveryTime time.Duration)
 
 	hook()
 
-	state, commit, err := r.syncer.SyncAny(discoveryTime, hook)
+	var state sm.State
+	var commit *types.Commit
+	var err error
+
+	if r.cfg.RestoreHeight > 0 {
+		// Restore Height for Local Snapshot Specified
+		// cosmos-sdk has already restored the chunks
+		// finish up restoring stateStore and blockStore
+		r.Logger.Debug("Local Statesync - Update state and commit")
+		state, commit, err = r.syncer.LocalSync()
+	} else {
+		state, commit, err = r.syncer.SyncAny(discoveryTime, hook)
+	}
 
 	r.mtx.Lock()
 	r.syncer = nil

--- a/statesync/syncer.go
+++ b/statesync/syncer.go
@@ -59,6 +59,7 @@ type syncer struct {
 	tempDir       string
 	chunkFetchers int32
 	retryTimeout  time.Duration
+	restoreHeight uint64
 
 	mtx    tmsync.RWMutex
 	chunks *chunkQueue
@@ -83,6 +84,7 @@ func newSyncer(
 		tempDir:       tempDir,
 		chunkFetchers: cfg.ChunkFetchers,
 		retryTimeout:  cfg.ChunkRequestTimeout,
+		restoreHeight: cfg.RestoreHeight,
 	}
 }
 
@@ -309,6 +311,37 @@ func (s *syncer) Sync(snapshot *snapshot, chunks *chunkQueue) (sm.State, *types.
 	// Done! 🎉
 	s.logger.Info("Snapshot restored", "height", snapshot.Height, "format", snapshot.Format,
 		"hash", snapshot.Hash)
+
+	return state, commit, nil
+}
+
+// LocalSync restores stateStore and blockStore state which is not included in the snapshot
+// This function assumes that the implicit trusted local snapshot chunks have already been applied
+// State restoration depends on heights after the restored snapshot so the RPC dependency remains
+func (s *syncer) LocalSync() (sm.State, *types.Commit, error) {
+	pctx, pcancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer pcancel()
+
+	// Optimistically build new state, so we don't discover any light client failures at the end.
+	state, err := s.stateProvider.State(pctx, s.restoreHeight)
+	if err != nil {
+		s.logger.Info("failed to fetch and verify tendermint state", "err", err)
+		if err == light.ErrNoWitnesses {
+			return sm.State{}, nil, err
+		}
+		return sm.State{}, nil, errRejectSnapshot
+	}
+	commit, err := s.stateProvider.Commit(pctx, s.restoreHeight)
+	if err != nil {
+		s.logger.Info("failed to fetch and verify commit", "err", err)
+		if err == light.ErrNoWitnesses {
+			return sm.State{}, nil, err
+		}
+		return sm.State{}, nil, errRejectSnapshot
+	}
+
+	// Done! 🎉
+	s.logger.Info("🎉 Local Snapshot Restored", "height", s.restoreHeight)
 
 	return state, commit, nil
 }


### PR DESCRIPTION
Seeking guidance.  

This PR enables cosmos-sdk to initiate local snapshot restore with tendermint finishing up the stateStore and blockStore data restoration.

This development is based on juno's uni testnet (tendermint v0.34.20) and is the reason why it does not merge cleanly into main.  

This PR enables a validator quickly restore without needing to search for remote snapshot servers.  

The use case is to quickly reduce disk usage which normally grows over time to an arguably large size without the need to slowly prune IAVL trees.

Before further development, we'd like to ask:

Do you prefer such work to be done on the main branch, and if so how shall it be tested against a cosmwasm restore?

If testing is required, how shall it be done with cosmos-sdk's additional data stores such as cosmwasm or a sifchain style clp module?

Please take a look at the structure of code and indicate whether any rules regarding ABCI or API/Responsibilities have been broken.

The current code design is meant for ease of review/comment before adding multiple additional layers of abstraction to put each bit of code in the right place.

---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

