### PR TITLE
backport:  rewrite the WaitForOneEvent helper for rpc/client (#7986)

### DIFF
--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -41,12 +41,12 @@ func TestHeaderEvents(t *testing.T) {
 					}
 				})
 			}
-
-			evtTyp := types.EventNewBlockHeader
-			evt, err := client.WaitForOneEvent(c, evtTyp, waitForEventTimeout)
+			ectx, cancel := context.WithTimeout(ctx, waitForEventTimeout)
+			defer cancel()
+			query := types.QueryForEvent(types.EventNewBlockHeader).String()
+			var evt types.EventDataNewBlockHeader
+			err := client.WaitForOneEvent(ectx, c, query, &evt)
 			require.Nil(t, err, "%d: %+v", i, err)
-			_, ok := evt.(types.EventDataNewBlockHeader)
-			require.True(t, ok, "%d: %#v", i, evt)
 			// TODO: more checks...
 		})
 	}
@@ -141,17 +141,15 @@ func testTxEventsSent(t *testing.T, broadcastMethod string) {
 				}
 			}()
 
-			// and wait for confirmation
-			evt, err := client.WaitForOneEvent(c, types.EventTx, waitForEventTimeout)
+			// Wait for the transaction we sent to be confirmed.
+			query := fmt.Sprintf(`tm.event = '%s' AND tx.hash = '%X'`, types.EventTx, types.Tx(tx).Hash())
+			var evt types.EventDataTx
+			err := client.WaitForOneEvent(ctx, c, query, &evt)
 			require.Nil(t, err)
 
-			// and make sure it has the proper info
-			txe, ok := evt.(types.EventDataTx)
-			require.True(t, ok)
-
 			// make sure this is the proper tx
-			require.EqualValues(t, tx, txe.Tx)
-			require.True(t, txe.Result.IsOK())
+			require.EqualValues(t, tx, evt.Tx)
+			require.True(t, evt.Result.IsOK())
 		})
 	}
 }


### PR DESCRIPTION
For the full description, see https://github.com/tendermint/tendermint/pull/7986

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #tendermint-core channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/tendermint/tendermint/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/tendermint/projects/15/views/5

-->

---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

