### PR TITLE
e2e: configurable IP addresses for e2e testnet generator

### DIFF
--- a/test/e2e/pkg/infra/docker/docker.go
+++ b/test/e2e/pkg/infra/docker/docker.go
@@ -1,0 +1,100 @@
+package docker
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"text/template"
+
+	e2e "github.com/tendermint/tendermint/test/e2e/pkg"
+	"github.com/tendermint/tendermint/test/e2e/pkg/infra"
+)
+
+var _ infra.Provider = &Provider{}
+
+// Provider implements a docker-compose backed infrastructure provider.
+type Provider struct {
+	Testnet *e2e.Testnet
+}
+
+// Setup generates the docker-compose file and write it to disk, erroring if
+// any of these operations fail.
+func (p *Provider) Setup() error {
+	compose, err := dockerComposeBytes(p.Testnet)
+	if err != nil {
+		return err
+	}
+	// nolint: gosec
+	// G306: Expect WriteFile permissions to be 0600 or less
+	err = os.WriteFile(filepath.Join(p.Testnet.Dir, "docker-compose.yml"), compose, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// dockerComposeBytes generates a Docker Compose config file for a testnet and returns the
+// file as bytes to be written out to disk.
+func dockerComposeBytes(testnet *e2e.Testnet) ([]byte, error) {
+	// Must use version 2 Docker Compose format, to support IPv6.
+	tmpl, err := template.New("docker-compose").Funcs(template.FuncMap{
+		"misbehaviorsToString": func(misbehaviors map[int64]string) string {
+			str := ""
+			for height, misbehavior := range misbehaviors {
+				// after the first behavior set, a comma must be prepended
+				if str != "" {
+					str += ","
+				}
+				heightString := strconv.Itoa(int(height))
+				str += misbehavior + "," + heightString
+			}
+			return str
+		},
+	}).Parse(`version: '2.4'
+
+networks:
+  {{ .Name }}:
+    labels:
+      e2e: true
+    driver: bridge
+{{- if .IPv6 }}
+    enable_ipv6: true
+{{- end }}
+    ipam:
+      driver: default
+      config:
+      - subnet: {{ .IP }}
+
+services:
+{{- range .Nodes }}
+  {{ .Name }}:
+    labels:
+      e2e: true
+    container_name: {{ .Name }}
+    image: tendermint/e2e-node
+{{- if eq .ABCIProtocol "builtin" }}
+    entrypoint: /usr/bin/entrypoint-builtin
+{{- end }}
+    init: true
+    ports:
+    - 26656
+    - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657
+    - 6060
+    volumes:
+    - ./{{ .Name }}:/tendermint
+    networks:
+      {{ $.Name }}:
+        ipv{{ if $.IPv6 }}6{{ else }}4{{ end}}_address: {{ .IP }}
+
+{{end}}`)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, testnet)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/test/e2e/pkg/infra/provider.go
+++ b/test/e2e/pkg/infra/provider.go
@@ -1,0 +1,20 @@
+package infra
+
+// Provider defines an API for manipulating the infrastructure of a
+// specific set of testnet infrastructure.
+type Provider interface {
+
+	// Setup generates any necessary configuration for the infrastructure
+	// provider during testnet setup.
+	Setup() error
+}
+
+// NoopProvider implements the provider interface by performing noops for every
+// interface method. This may be useful if the infrastructure is managed by a
+// separate process.
+type NoopProvider struct {
+}
+
+func (_ NoopProvider) Setup() error { return nil }
+
+var _ Provider = NoopProvider{}

--- a/test/e2e/pkg/infrastructure.go
+++ b/test/e2e/pkg/infrastructure.go
@@ -1,0 +1,20 @@
+package e2e
+
+import "net"
+
+// InfrastructureData contains the relevant information for a set of existing
+// infrastructure that is to be used for running a testnet.
+type InfrastructureData struct {
+
+	// Instances is a map of all of the machine instances on which to run
+	// processes for a testnet.
+	// The key of the map is the name of the instance, which each must correspond
+	// to the names of one of the testnet nodes defined in the testnet manifest.
+	Instances map[string]InstanceData `json:"instances"`
+}
+
+// InstanceData contains the relevant information for a machine instance backing
+// one of the nodes in the testnet.
+type InstanceData struct {
+	IPAddress net.IP `json:"ip_address"`
+}

--- a/test/e2e/pkg/infrastructure.go
+++ b/test/e2e/pkg/infrastructure.go
@@ -22,7 +22,7 @@ type InstanceData struct {
 	IPAddress net.IP `json:"ip_address"`
 }
 
-func NewDockerInfrastructure(m Manifest) (InfrastructureData, error) {
+func NewDockerInfrastructureData(m Manifest) (InfrastructureData, error) {
 	netAddress := networkIPv4
 	if m.IPv6 {
 		netAddress = networkIPv6

--- a/test/e2e/pkg/infrastructure.go
+++ b/test/e2e/pkg/infrastructure.go
@@ -1,8 +1,10 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 )
 
 // InfrastructureData contains the relevant information for a set of existing
@@ -39,6 +41,16 @@ func NewDockerInfrastructureData(m Manifest) (InfrastructureData, error) {
 		ifd.Instances[name] = InstanceData{
 			IPAddress: ipGen.Next(),
 		}
+	}
+	return ifd, nil
+}
+
+func InfrastructureDataFromFile(p string) (InfrastructureData, error) {
+	ifd := InfrastructureData{}
+	b, err := os.ReadFile(p)
+	err = json.Unmarshal(b, &ifd)
+	if err != nil {
+		return InfrastructureData{}, err
 	}
 	return ifd, nil
 }

--- a/test/e2e/pkg/infrastructure.go
+++ b/test/e2e/pkg/infrastructure.go
@@ -11,6 +11,11 @@ import (
 // infrastructure that is to be used for running a testnet.
 type InfrastructureData struct {
 
+	// Provider is the name of infrastructure provider backing the testnet.
+	// For example, 'docker' if it is running locally in a docker network or
+	// 'digital-ocean', 'aws', 'google', etc. if it is from a cloud provider.
+	Provider string `json:"provider"`
+
 	// Instances is a map of all of the machine instances on which to run
 	// processes for a testnet.
 	// The key of the map is the name of the instance, which each must correspond
@@ -25,9 +30,9 @@ type InstanceData struct {
 }
 
 func NewDockerInfrastructureData(m Manifest) (InfrastructureData, error) {
-	netAddress := networkIPv4
+	netAddress := dockerIPv4CIDR
 	if m.IPv6 {
-		netAddress = networkIPv6
+		netAddress = dockerIPv6CIDR
 	}
 	_, ipNet, err := net.ParseCIDR(netAddress)
 	if err != nil {
@@ -35,6 +40,7 @@ func NewDockerInfrastructureData(m Manifest) (InfrastructureData, error) {
 	}
 	ipGen := newIPGenerator(ipNet)
 	ifd := InfrastructureData{
+		Provider:  "docker",
 		Instances: make(map[string]InstanceData),
 	}
 	for name := range m.Nodes {

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -156,12 +156,16 @@ func LoadTestnet(file string, ifd InfrastructureData) (*Testnet, error) {
 
 	for _, name := range nodeNames {
 		nodeManifest := manifest.Nodes[name]
+		ind, ok := ifd.Instances[name]
+		if !ok {
+			return nil, fmt.Errorf("information for node '%s' missing from infrastucture data", name)
+		}
 		node := &Node{
 			Name:             name,
 			Testnet:          testnet,
 			PrivvalKey:       keyGen.Generate(manifest.KeyType),
 			NodeKey:          keyGen.Generate("ed25519"),
-			IP:               ipGen.Next(),
+			IP:               ind.IPAddress,
 			ProxyPort:        proxyPortGen.Next(),
 			Mode:             ModeValidator,
 			Database:         "goleveldb",

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -21,8 +21,11 @@ import (
 const (
 	randomSeed     int64  = 2308084734268
 	proxyPortFirst uint32 = 5701
-	networkIPv4           = "10.186.73.0/24"
-	networkIPv6           = "fd80:b10c::/48"
+	dockerIPv4CIDR        = "10.186.73.0/24"
+	dockerIPv6CIDR        = "fd80:b10c::/48"
+
+	globalIPv4CIDR = "0.0.0.0/0"
+	globalIPv6CIDR = "0:0::/0"
 )
 
 type (
@@ -108,9 +111,20 @@ func LoadTestnet(file string, ifd InfrastructureData) (*Testnet, error) {
 	dir := strings.TrimSuffix(file, filepath.Ext(file))
 
 	// Set up resource generators. These must be deterministic.
-	netAddress := networkIPv4
-	if manifest.IPv6 {
-		netAddress = networkIPv6
+	var netAddress string
+	switch ifd.Provider {
+	case "docker":
+		netAddress = dockerIPv4CIDR
+		if manifest.IPv6 {
+			netAddress = dockerIPv6CIDR
+		}
+	default:
+		// TODO(williambanfield): add list of CIDR blocks to the infrastructure
+		// data struct to allow tighter validation of IP addresses.
+		netAddress = globalIPv4CIDR
+		if manifest.IPv6 {
+			netAddress = globalIPv6CIDR
+		}
 	}
 	_, ipNet, err := net.ParseCIDR(netAddress)
 	if err != nil {

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -100,7 +100,7 @@ type Node struct {
 // The testnet generation must be deterministic, since it is generated
 // separately by the runner and the test cases. For this reason, testnets use a
 // random seed to generate e.g. keys.
-func LoadTestnet(file string) (*Testnet, error) {
+func LoadTestnet(file string, ifd InfrastructureData) (*Testnet, error) {
 	manifest, err := LoadManifest(file)
 	if err != nil {
 		return nil, err

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -53,7 +53,7 @@ func NewCLI() *CLI {
 			if err := Cleanup(cli.testnet); err != nil {
 				return err
 			}
-			if err := Setup(cli.testnet); err != nil {
+			if err := Setup(cli.testnet, e2e.InfrastructureData{}); err != nil {
 				return err
 			}
 
@@ -125,7 +125,7 @@ func NewCLI() *CLI {
 		Use:   "setup",
 		Short: "Generates the testnet directory and configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return Setup(cli.testnet)
+			return Setup(cli.testnet, e2e.InfrastructureData{})
 		},
 	})
 
@@ -135,7 +135,7 @@ func NewCLI() *CLI {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, err := os.Stat(cli.testnet.Dir)
 			if os.IsNotExist(err) {
-				err = Setup(cli.testnet)
+				err = Setup(cli.testnet, e2e.InfrastructureData{})
 			}
 			if err != nil {
 				return err
@@ -258,7 +258,7 @@ Does not run any perbutations.
 			if err := Cleanup(cli.testnet); err != nil {
 				return err
 			}
-			if err := Setup(cli.testnet); err != nil {
+			if err := Setup(cli.testnet, e2e.InfrastructureData{}); err != nil {
 				return err
 			}
 

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -41,7 +41,15 @@ func NewCLI() *CLI {
 			if err != nil {
 				return err
 			}
-			testnet, err := e2e.LoadTestnet(file, e2e.InfrastructureData{})
+			m, err := e2e.LoadManifest(file)
+			if err != nil {
+				return err
+			}
+			ifd, err := e2e.NewDockerInfrastructure(m)
+			if err != nil {
+				return err
+			}
+			testnet, err := e2e.LoadTestnet(file, ifd)
 			if err != nil {
 				return err
 			}

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -45,10 +45,25 @@ func NewCLI() *CLI {
 			if err != nil {
 				return err
 			}
-			ifd, err := e2e.NewDockerInfrastructure(m)
+
+			t, err := cmd.Flags().GetString("infrastructure-type")
 			if err != nil {
 				return err
 			}
+
+			var ifd e2e.InfrastructureData
+			switch t {
+			case "docker":
+				var err error
+				ifd, err = e2e.NewDockerInfrastructure(m)
+				if err != nil {
+					return err
+				}
+			// TODO(williambanfield): add a section that implements the 'digital-ocean' infrastructure-type
+			default:
+				return fmt.Errorf("unknown infrastructure type '%s'", t)
+			}
+
 			testnet, err := e2e.LoadTestnet(file, ifd)
 			if err != nil {
 				return err
@@ -125,6 +140,10 @@ func NewCLI() *CLI {
 
 	cli.root.PersistentFlags().StringP("file", "f", "", "Testnet TOML manifest")
 	_ = cli.root.MarkPersistentFlagRequired("file")
+
+	cli.root.PersistentFlags().StringP("infrastructure-type", "", "docker", "Backing infrastructure used to run the testnet. Either 'digital-ocean' or 'docker'")
+
+	cli.root.PersistentFlags().StringP("infrastructure-data", "", "", "path to the json file containing the infrastructure data. Only used if the 'infrastructure-type' is set to a value other than 'docker'")
 
 	cli.root.Flags().BoolVarP(&cli.preserve, "preserve", "p", false,
 		"Preserves the running of the test net after tests are completed")

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -55,7 +55,7 @@ func NewCLI() *CLI {
 			switch t {
 			case "docker":
 				var err error
-				ifd, err = e2e.NewDockerInfrastructure(m)
+				ifd, err = e2e.NewDockerInfrastructureData(m)
 				if err != nil {
 					return err
 				}

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -69,6 +69,9 @@ func NewCLI() *CLI {
 					return errors.New("'--infrastructure-data' must be set when using the 'digital-ocean' infrastructure-type")
 				}
 				ifd, err = e2e.InfrastructureDataFromFile(p)
+				if err != nil {
+					return err
+				}
 			default:
 				return fmt.Errorf("unknown infrastructure type '%s'", t)
 			}

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -88,7 +88,7 @@ func NewCLI() *CLI {
 			if err := Cleanup(cli.testnet); err != nil {
 				return err
 			}
-			if err := Setup(cli.testnet, e2e.InfrastructureData{}); err != nil {
+			if err := Setup(cli.testnet); err != nil {
 				return err
 			}
 
@@ -164,7 +164,7 @@ func NewCLI() *CLI {
 		Use:   "setup",
 		Short: "Generates the testnet directory and configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return Setup(cli.testnet, e2e.InfrastructureData{})
+			return Setup(cli.testnet)
 		},
 	})
 
@@ -174,7 +174,7 @@ func NewCLI() *CLI {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, err := os.Stat(cli.testnet.Dir)
 			if os.IsNotExist(err) {
-				err = Setup(cli.testnet, e2e.InfrastructureData{})
+				err = Setup(cli.testnet)
 			}
 			if err != nil {
 				return err
@@ -297,7 +297,7 @@ Does not run any perbutations.
 			if err := Cleanup(cli.testnet); err != nil {
 				return err
 			}
-			if err := Setup(cli.testnet, e2e.InfrastructureData{}); err != nil {
+			if err := Setup(cli.testnet); err != nil {
 				return err
 			}
 

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -69,7 +69,6 @@ func NewCLI() *CLI {
 					return errors.New("'--infrastructure-data' must be set when using the 'digital-ocean' infrastructure-type")
 				}
 				ifd, err = e2e.InfrastructureDataFromFile(p)
-			// TODO(williambanfield): add a section that implements the 'digital-ocean' infrastructure-type
 			default:
 				return fmt.Errorf("unknown infrastructure type '%s'", t)
 			}

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -59,6 +60,15 @@ func NewCLI() *CLI {
 				if err != nil {
 					return err
 				}
+			case "digital-ocean":
+				p, err := cmd.Flags().GetString("infrastructure-data")
+				if err != nil {
+					return err
+				}
+				if p == "" {
+					return errors.New("'--infrastructure-data' must be set when using the 'digital-ocean' infrastructure-type")
+				}
+				ifd, err = e2e.InfrastructureDataFromFile(p)
 			// TODO(williambanfield): add a section that implements the 'digital-ocean' infrastructure-type
 			default:
 				return fmt.Errorf("unknown infrastructure type '%s'", t)

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -41,7 +41,7 @@ func NewCLI() *CLI {
 			if err != nil {
 				return err
 			}
-			testnet, err := e2e.LoadTestnet(file)
+			testnet, err := e2e.LoadTestnet(file, e2e.InfrastructureData{})
 			if err != nil {
 				return err
 			}

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -39,7 +39,7 @@ const (
 )
 
 // Setup sets up the testnet configuration.
-func Setup(testnet *e2e.Testnet, ifd e2e.InfrastructureData) error {
+func Setup(testnet *e2e.Testnet) error {
 	logger.Info("setup", "msg", log.NewLazySprintf("Generating testnet files in %q", testnet.Dir))
 
 	err := os.MkdirAll(testnet.Dir, os.ModePerm)

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -10,9 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -23,6 +21,7 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/privval"
 	e2e "github.com/tendermint/tendermint/test/e2e/pkg"
+	"github.com/tendermint/tendermint/test/e2e/pkg/infra"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -39,7 +38,7 @@ const (
 )
 
 // Setup sets up the testnet configuration.
-func Setup(testnet *e2e.Testnet) error {
+func Setup(testnet *e2e.Testnet, infp infra.Provider) error {
 	logger.Info("setup", "msg", log.NewLazySprintf("Generating testnet files in %q", testnet.Dir))
 
 	err := os.MkdirAll(testnet.Dir, os.ModePerm)
@@ -47,11 +46,7 @@ func Setup(testnet *e2e.Testnet) error {
 		return err
 	}
 
-	compose, err := MakeDockerCompose(testnet)
-	if err != nil {
-		return err
-	}
-	err = os.WriteFile(filepath.Join(testnet.Dir, "docker-compose.yml"), compose, 0o644) //nolint:gosec
+	err = infp.Setup()
 	if err != nil {
 		return err
 	}
@@ -124,70 +119,6 @@ func Setup(testnet *e2e.Testnet) error {
 	}
 
 	return nil
-}
-
-// MakeDockerCompose generates a Docker Compose config for a testnet.
-func MakeDockerCompose(testnet *e2e.Testnet) ([]byte, error) {
-	// Must use version 2 Docker Compose format, to support IPv6.
-	tmpl, err := template.New("docker-compose").Funcs(template.FuncMap{
-		"misbehaviorsToString": func(misbehaviors map[int64]string) string {
-			str := ""
-			for height, misbehavior := range misbehaviors {
-				// after the first behavior set, a comma must be prepended
-				if str != "" {
-					str += ","
-				}
-				heightString := strconv.Itoa(int(height))
-				str += misbehavior + "," + heightString
-			}
-			return str
-		},
-	}).Parse(`version: '2.4'
-
-networks:
-  {{ .Name }}:
-    labels:
-      e2e: true
-    driver: bridge
-{{- if .IPv6 }}
-    enable_ipv6: true
-{{- end }}
-    ipam:
-      driver: default
-      config:
-      - subnet: {{ .IP }}
-
-services:
-{{- range .Nodes }}
-  {{ .Name }}:
-    labels:
-      e2e: true
-    container_name: {{ .Name }}
-    image: tendermint/e2e-node
-{{- if eq .ABCIProtocol "builtin" }}
-    entrypoint: /usr/bin/entrypoint-builtin
-{{- end }}
-    init: true
-    ports:
-    - 26656
-    - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657
-    - 6060
-    volumes:
-    - ./{{ .Name }}:/tendermint
-    networks:
-      {{ $.Name }}:
-        ipv{{ if $.IPv6 }}6{{ else }}4{{ end}}_address: {{ .IP }}
-
-{{end}}`)
-	if err != nil {
-		return nil, err
-	}
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, testnet)
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
 }
 
 // MakeGenesis generates a genesis document.

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -39,7 +39,7 @@ const (
 )
 
 // Setup sets up the testnet configuration.
-func Setup(testnet *e2e.Testnet) error {
+func Setup(testnet *e2e.Testnet, ifd e2e.InfrastructureData) error {
 	logger.Info("setup", "msg", log.NewLazySprintf("Generating testnet files in %q", testnet.Dir))
 
 	err := os.MkdirAll(testnet.Dir, os.ModePerm)

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -81,7 +81,7 @@ func loadTestnet(t *testing.T) e2e.Testnet {
 	}
 	m, err := e2e.LoadManifest(manifest)
 	require.NoError(t, err)
-	ifd, err := e2e.NewDockerInfrastructure(m)
+	ifd, err := e2e.NewDockerInfrastructureData(m)
 	require.NoError(t, err)
 
 	testnet, err := e2e.LoadTestnet(manifest, ifd)

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -79,8 +79,12 @@ func loadTestnet(t *testing.T) e2e.Testnet {
 	if testnet, ok := testnetCache[manifest]; ok {
 		return testnet
 	}
+	m, err := e2e.LoadManifest(manifest)
+	require.NoError(t, err)
+	ifd, err := e2e.NewDockerInfrastructure(m)
+	require.NoError(t, err)
 
-	testnet, err := e2e.LoadTestnet(manifest)
+	testnet, err := e2e.LoadTestnet(manifest, ifd)
 	require.NoError(t, err)
 	testnetCache[manifest] = *testnet
 	return *testnet


### PR DESCRIPTION
This change updates the e2e `Setup` logic and all other parts of the runner that use its code to accept list of IP addresses from already existing infrastructure to be used when generating the testnet configuration. 

The change adds two new flags

1. `--infrastructure-type`: The type of the backing infrastructure, either 'digital-ocean' or docker
2. `--infrastructure-data`: The path to a file containing information on already existing infrastructure. 

This new `infrastructure-data` flag selects the path to a json file whose contents can be deserialized into the new `InfrastructureData` type. This type contains a  map of node name to IP address. The map is then used when constructing the testnet. Instead of generating a new IP address for each Tendermint node, the code reaches into the map to determine what the IP address is. A docker variant of this is also defined that, instead of reading data from disk, generates a new set of IP addresses per the already existing logic for IP generation.

This change also adds a new `infra.Provider` interface type. The `Provider` currently only has one method, `Setup` that sets up any configuration files for the specific infrastructure being used. For `docker`, this method generates the `docker-compose.yaml` file. For `digital-ocean`, the method is a Noop. This type borrows from the [TestnetInfra](https://github.com/tendermint/tendermint/pull/8754/files#diff-233eb196e2baa372d36b7ce09a41b252ce51d9a492a5f14467092929374ce3b9R11) type created for the runner in the now defunct `v0.36.x` code as part of #8754. The hope would be to gradually add more functionality to the `infra.Provider` until it is much closer to what is implemented previously.

Closes: #9857

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

