### PR TITLE
Disable markdown-link-check for some links reported as broken

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -369,4 +369,5 @@ the total stake. The remaining 33% of the stake is configured to belong to
 a validator that is never actually run in the test network. The network is run
 for multiple days, ensuring that it is able to produce blocks without issue.
 
+<!-- markdown-link-check-disable-next-line -->
 [bpr]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -44,7 +44,7 @@ the 0.38.x line.
 
 1. Start on `main`
 
-2. Ensure that there is a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule) for the
+2. Ensure that there is a [branch protection rule][bpr] for the
    branch you are about to create (you will need admin access to the repository
    in order to do this).
 
@@ -368,3 +368,5 @@ of 150 validators is configured to only possess a cumulative stake of 67% of
 the total stake. The remaining 33% of the stake is configured to belong to
 a validator that is never actually run in the test network. The network is run
 for multiple days, ensuring that it is able to produce blocks without issue.
+
+[bpr]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -44,8 +44,7 @@ the 0.38.x line.
 
 1. Start on `main`
 
-2. Ensure that there is a [branch protection
-   rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule) for the
+2. Ensure that there is a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule) for the
    branch you are about to create (you will need admin access to the repository
    in order to do this).
 

--- a/docs/architecture/adr-075-rpc-subscription.md
+++ b/docs/architecture/adr-075-rpc-subscription.md
@@ -666,6 +666,7 @@ The following alternative approaches were considered:
 
 [rfc006]:        https://github.com/tendermint/tendermint/blob/main/docs/rfc/rfc-006-event-subscription.md
 [rpc-service]:   https://github.com/tendermint/tendermint/blob/main/rpc/openapi/openapi.yaml
+<!-- markdown-link-check-disable-next-line -->
 [query-grammar]: https://pkg.go.dev/github.com/tendermint/tendermint@master/internal/pubsub/query/syntax
 [ws]:            https://datatracker.ietf.org/doc/html/rfc6455
 [jsonrpc2]:      https://www.jsonrpc.org/specification

--- a/docs/introduction/what-is-tendermint.md
+++ b/docs/introduction/what-is-tendermint.md
@@ -103,6 +103,7 @@ Another example of a cryptocurrency application built on Tendermint is
 to Tendermint, but is more opinionated about how the state is managed,
 and requires that all application behavior runs in potentially many
 docker containers, modules it calls "chaincode". It uses an
+<!-- markdown-link-check-disable-next-line -->
 implementation of [PBFT](http://pmg.csail.mit.edu/papers/osdi99.pdf).
 from a team at IBM that is [augmented to handle potentially
 non-deterministic


### PR DESCRIPTION
This is a workaround for allowing outstanding PRs to be merged.

It addresses errors reported by the markdown link checker in this   [run](https://github.com/tendermint/tendermint/actions/runs/3321769389/jobs/5489869023#logs).