### PR TITLE
ci: Run Markdown link checker nightly

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
-      - uses: creachadair/github-action-markdown-link-check@master
+      - uses: informalsystems/github-action-markdown-link-check@main
         with:
           config-file: '.md-link-check.json'

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -1,23 +1,20 @@
 name: Check Markdown links
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches: [main]
+  schedule:
+    # 2am UTC daily
+    - cron: '0 2 * * *'
 
 jobs:
   markdown-link-check:
+    strategy:
+      matrix:
+        branch: ['main', 'v0.37.x', 'v0.34.x']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: technote-space/get-diff-action@v6
         with:
-          PATTERNS: |
-            **/**.md
+          ref: ${{ matrix.branch }}
       - uses: creachadair/github-action-markdown-link-check@master
         with:
-          check-modified-files-only: 'yes'
           config-file: '.md-link-check.json'
-        if: env.GIT_DIFF

--- a/.md-link-check.json
+++ b/.md-link-check.json
@@ -2,5 +2,16 @@
     "retryOn429": true,
     "retryCount": 5,
     "fallbackRetryDelay": "30s",
-    "aliveStatusCodes": [200, 206, 503]
+    "aliveStatusCodes": [200, 206, 503],
+    "httpHeaders": [
+        {
+            "urls": [
+                "https://docs.github.com/",
+                "https://help.github.com/"
+            ],
+            "headers": {
+                "Accept-Encoding": "zstd, br, gzip, deflate"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
The Markdown link checker takes ages to run, and often fails spuriously with many false positives. This makes it run nightly for `main` and the `v0.37.x` and `v0.34.x` branches.

This does not enable Slack notifications. Let me know if anyone wants Slack notifications for this, otherwise we'll just end up getting GitHub notifications for failures.

Also, we could consider reducing this to run only once per week if it's too noisy. Let me know if anyone has any preferences.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

