### PR TITLE
add allocate in Receive calls

### DIFF
--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -234,7 +234,7 @@ func (bcR *BlockchainReactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (bcR *BlockchainReactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	var msg *bcproto.Message
+	msg := &bcproto.Message{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)

--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/mempool/mock"
 	"github.com/tendermint/tendermint/p2p"
+	bcproto "github.com/tendermint/tendermint/proto/tendermint/blockchain"
 	"github.com/tendermint/tendermint/proxy"
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/store"
@@ -190,6 +192,25 @@ func TestNoBlockResponse(t *testing.T) {
 			assert.True(t, block == nil)
 		}
 	}
+}
+
+func TestLegacyReactorReceiveBasic(t *testing.T) {
+	config = cfg.ResetTestRoot("blockchain_reactor_test")
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	reactor := newBlockchainReactor(log.TestingLogger(), genDoc, privVals, 10).reactor
+	peer := p2p.CreateRandomPeer(false)
+
+	reactor.InitPeer(peer)
+	reactor.AddPeer(peer)
+	m := &bcproto.StatusRequest{}
+	wm := m.Wrap()
+	msg, err := proto.Marshal(wm)
+	assert.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		reactor.Receive(BlockchainChannel, peer, msg)
+	})
 }
 
 // NOTE: This is too hard to test without

--- a/blockchain/v1/reactor.go
+++ b/blockchain/v1/reactor.go
@@ -312,7 +312,7 @@ func (bcR *BlockchainReactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (bcR *BlockchainReactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	var msg *bcproto.Message
+	msg := &bcproto.Message{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)

--- a/blockchain/v1/reactor_test.go
+++ b/blockchain/v1/reactor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/mempool/mock"
 	"github.com/tendermint/tendermint/p2p"
+	bcproto "github.com/tendermint/tendermint/proto/tendermint/blockchain"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/proxy"
 	sm "github.com/tendermint/tendermint/state"
@@ -347,6 +349,25 @@ outerFor:
 	}
 
 	assert.True(t, lastReactorPair.bcR.Switch.Peers().Size() < len(reactorPairs)-1)
+}
+
+func TestLegacyReactorReceiveBasic(t *testing.T) {
+	config = cfg.ResetTestRoot("blockchain_reactor_test")
+	defer os.RemoveAll(config.RootDir)
+	genDoc, privVals := randGenesisDoc(1, false, 30)
+	reactor := newBlockchainReactor(t, log.TestingLogger(), genDoc, privVals, 10)
+	peer := p2p.CreateRandomPeer(false)
+
+	reactor.InitPeer(peer)
+	reactor.AddPeer(peer)
+	m := &bcproto.StatusRequest{}
+	wm := m.Wrap()
+	msg, err := proto.Marshal(wm)
+	assert.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		reactor.Receive(BlockchainChannel, peer, msg)
+	})
 }
 
 //----------------------------------------------

--- a/blockchain/v2/reactor.go
+++ b/blockchain/v2/reactor.go
@@ -518,7 +518,7 @@ func (r *BlockchainReactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (r *BlockchainReactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	var msg *bcproto.Message
+	msg := &bcproto.Message{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -393,7 +393,7 @@ func (conR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (conR *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	var msg *tmcons.Message
+	msg := &tmcons.Message{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)

--- a/evidence/reactor.go
+++ b/evidence/reactor.go
@@ -93,7 +93,7 @@ func (evR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (evR *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	var msg *tmproto.EvidenceList
+	msg := &tmproto.EvidenceList{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)

--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -384,6 +384,8 @@ func TestLegacyReactorReceiveBasic(t *testing.T) {
 		reactor = reactors[0]
 		peer    = &p2pmocks.Peer{}
 	)
+	quitChan := make(<-chan struct{})
+	peer.On("Quit").Return(quitChan)
 
 	reactor.InitPeer(peer)
 	reactor.AddPeer(peer)

--- a/mempool/v0/reactor.go
+++ b/mempool/v0/reactor.go
@@ -191,7 +191,7 @@ func (memR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (memR *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	var msg *protomem.Message
+	msg := &protomem.Message{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -190,7 +190,7 @@ func (memR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (memR *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	var msg *protomem.Message
+	msg := &protomem.Message{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -301,7 +301,7 @@ func (r *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (r *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	var msg *tmp2p.Message
+	msg := &tmp2p.Message{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -498,6 +498,22 @@ func TestPEXReactorDoesNotAddPrivatePeersToAddrBook(t *testing.T) {
 	assert.Equal(t, size, book.Size())
 }
 
+func TestLegacyReactorReceiveBasic(t *testing.T) {
+	pexR, _ := createReactor(&ReactorConfig{})
+	peer := p2p.CreateRandomPeer(false)
+
+	pexR.InitPeer(peer)
+	pexR.AddPeer(peer)
+	m := &tmp2p.PexAddrs{}
+	wm := m.Wrap()
+	msg, err := proto.Marshal(wm)
+	assert.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		pexR.Receive(PexChannel, peer, msg)
+	})
+}
+
 func TestPEXReactorDialPeer(t *testing.T) {
 	pexR, book := createReactor(&ReactorConfig{})
 	defer teardownReactor(book)

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -80,7 +80,7 @@ func (tr *TestReactor) ReceiveEnvelope(e Envelope) {
 }
 
 func (tr *TestReactor) Receive(chID byte, peer Peer, msgBytes []byte) {
-	var msg *p2pproto.Message
+	msg := &p2pproto.Message{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)

--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -226,7 +226,7 @@ func (r *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (r *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	var msg *ssproto.Message
+	msg := &ssproto.Message{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)

--- a/statesync/reactor_test.go
+++ b/statesync/reactor_test.go
@@ -183,3 +183,21 @@ func TestReactor_Receive_SnapshotsRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestLegacyReactorReceiveBasic(t *testing.T) {
+	cfg := config.DefaultStateSyncConfig()
+	conn := &proxymocks.AppConnSnapshot{}
+	reactor := NewReactor(*cfg, conn, nil, "")
+	peer := p2p.CreateRandomPeer(false)
+
+	reactor.InitPeer(peer)
+	reactor.AddPeer(peer)
+	m := &ssproto.ChunkRequest{Height: 1, Format: 1, Index: 1}
+	wm := m.Wrap()
+	msg, err := proto.Marshal(wm)
+	assert.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		reactor.Receive(ChunkChannel, peer, msg)
+	})
+}

--- a/test/maverick/consensus/reactor.go
+++ b/test/maverick/consensus/reactor.go
@@ -396,7 +396,7 @@ func (conR *Reactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (conR *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
-	var msg *tmcons.Message
+	msg := &tmcons.Message{}
 	err := proto.Unmarshal(msgBytes, msg)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
When implementing this, I had assumed that proto.Unmarshal would allocate for the top-level struct if only a pointer was passed. This assumption was incorrect, we have to explicitly allocate the value to pass to the unmarshal call.

---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

