### PR TITLE
rfc: Banning peers based on ResponseCheckTx

### DIFF
--- a/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
+++ b/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
@@ -356,7 +356,10 @@ The previous code snippets do not incroporate these in peer banning. If we adopt
 - Handling of transactions failing `CheckTx`: Keeping track of how often transactions from a particular peer have failed
   and banning them if the conditions for a ban are met.
 
+### Impact on ABCI 
 
+- Introduction of new response codes for CheckTx
+- Altering the specification to reflect this change
 
 ### References
 

--- a/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
+++ b/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
@@ -2,7 +2,7 @@
 
 ## Changelog
 - Nov 4, 2022: Initial draft (jmalicevic)
-- Nov 7, 2022: Updated draft (jmalicevic)
+- Nov 8, 2022: Updated draft (jmalicevic)
 
 ## Abstract
 
@@ -11,7 +11,7 @@ in case the transaction fails an application specific check.
 
 Note that there are valid scenarios in which a transaction will not
 pass this check (including nodes getting different transactions at different times, meaning some
-of them might be obsolete at the time of the check, state changes upon block execution etc.). 
+of them might be obsolete at the time of the check; state changes upon block execution etc.). 
 However, Tendermint users observed that
 there are transactions that can never have been or will never be valid. They thus propose
 to introduce a special response code for `CheckTx` to indicate this behaviour, and ban the peers
@@ -48,16 +48,15 @@ this behaviour and explaining their needs.
   [avoid overloading the p2p/mempool system](https://github.com/cosmos/ibc-go/issues/853#issuecomment-1032211020)
  (ToDo check with Adi what is this about, what are valid reasons this can happen and when should we disconnect)
   (relevant code [here](https://github.com/cosmos/ibc-go/blob/a0e59b8e7a2e1305b7b168962e20516ca8c98fad/modules/core/ante/ante.go#L23)) 
-- From  Adi: Nodes allow transactions with a wrong `minGas` transaction and gossip them, and other nodes keep rejecting them. (Problem seen
-  with relayers)
+- From  Adi: Nodes allow transactions with a wrong `minGas` transaction and gossip them, and other nodes keep rejecting them. (Problem seen with relayers)
 
 ### Current state of mempool/p2p interaction
 
-Transactions received from a peer are handled within the [`handleMempoolMessage`](https://github.com/tendermint/tendermint/blob/85a584dd2ee3437b117d9f5e894eac70bf09aeef/internal/mempool/reactor.go#L120) routine. 
+Transactions received from a peer are handled within the [`Receive`](https://github.com/tendermint/tendermint/blob/ff0f98892f24aac11e46aeff2b6d2c0ad816701a/mempool/v0/reactor.go#L158) routine. 
 
-Currently, the mempool can trigger a disconnect from a peer in the case of the following errors:
+Currently, the mempool triggers a disconnect from a peer in the case of the following errors:
 
-  - [Unknown message type](https://github.com/tendermint/tendermint/blob/d704c0a0b6fbc042dcb260dbb766bd83bb140cb7/mempool/v0/reactor.go#L182)
+  - [Unknown message type](https://github.com/tendermint/tendermint/blob/ff0f98892f24aac11e46aeff2b6d2c0ad816701a/mempool/v0/reactor.go#L184)
 
 However, disconnecting from a peer is not the same as banning the peer. The p2p layer will close the connecton but 
 the peer can reconnect without any penalty, and if it as a persistent peer, a reconnect will be initiated
@@ -69,7 +68,7 @@ Currently, the p2p layer implements only banning peers for an indefinite amount 
 as bad (calling the `MarkBad` routine implemented by the `Switch`). The peers are reinstated to the list 
 of good peers only if the node requires more peers. They can also not be marked as bad forever (blacklisted). 
 
-The application can also blacklist peers if the 
+The application can blacklist peers via ABCI if the 
 [`filterPeers`](../../spec/abci/abci%2B%2B_app_requirements.md#peer-filtering) 
 config flag is set, by providing a set of peers to ban to Tendermint. 
 
@@ -82,40 +81,29 @@ specific design considerations.
 ## Discussion
 
 If this feature is to be implemented we need to clearly define the following:
-1. If `CheckTx` signals a peer should be banned, how do we know which peer(s) to ban?
-2. What does banning a peer mean:
+1. What does banning a peer mean:
    1. A peer can be simply disconnected from. 
    2. Peer is disconnected from and banned.
    3. Conditions for the peer to be banned.
+2. If `CheckTx` signals a peer should be banned, how do we know which peer(s) to ban?
 3. Are there possible attack scenarios by allowing this. 
 
 Any further mentions of `banning` will be agnostic to the actual way banning is implemented by the p2p layer. 
 
-### 1. Choosing the peer to ban
 
-Each transaction gossiped contains the ID of the peer that sent that transaction. Upon receiving a transaction,
-a node saves the peer ID of the peer(s) that have sent it. As each peer had to have
-run `CheckTx` on this transaction before adding it to its own mempool, we can assume this peer
-can be held accountable for the validity of transactions it gossips. 
-
-For transactions submitted via `boradcastTxCommit`, this field is empty. 
-
-**Note**  Do we have mechanisms in place to handle cases when `broadcastTxCommit` submits
-failing transactions (can this be a form of attack?)?
-
-### 2. What does banning a peer mean 
+### 1. What does banning a peer mean 
 
 Tendermint recognizes that peers can accept transactions into their mempool as valid but then those transactions
 become invalid, or were valid at some point. 
 But, if a transaction could never have been valid, how can it pass a `CheckTx` at any node? What are the valid
 (non malicious reasons for such failures). 
-This differentiates two scenarios - a) where `CheckTx` fails due to reasons already 
+We thus differentiate two scenarios - a) where `CheckTx` fails due to reasons already 
 known and b) where `CheckTx` deems a transactions could never have been valid.
 
 For the sake of simplicity, in the remainder of the text we will distinguish the failures due to a) with failures 
-signaled with `responseCode = 1` and the failures described in b), failures with `responseCode > 1`.
+signaled with `ResponseCheckTx.code = 1` and the failures described in b), failures with `ResponseCheckTx.code > 1`.
 
-For a) a peer sends transactions that repeatedly fail CheckTx with `ResponseCheckTx.code = 1`, and is banned or disconnected from to avoid this. 
+For a), a peer sends transactions that **repeatedly** fail CheckTx with `ResponseCheckTx.code = 1`, and is banned or disconnected from to avoid this. In this case we need to define what repeadetly means. 
 
 For b) we need to understand what is the potential reason a transaction could never have been valid on one node, but passes `CheckTx` on another node. 
 We need to understand all the possible scenarios in which this can happen:
@@ -124,7 +112,9 @@ We need to understand all the possible scenarios in which this can happen:
 This node would then gossip these transactions and they would always fail on other nodes. 
 Is this a scenario where we want nodes to disconnect from this peer and ban it without this peer being neccessarily malicious?
 2. Are all other reasons for this to happen sign of malicious behaviour where a node explicitly lies? 
-In such cases, peers should not only be banned, but punished as well (if they are validators). 
+In such cases, peers should not only be banned, but punished as well (if they are validators). Note that 
+we cannot know whether a node is a validator. A proposal to gossip this behaviour to other peers pro-actively
+also entails a different set of problems with it - how do we know we can trust peers who tell us to ban other peers. 
 
 The later is most likely a potential future optimizations, where for now, we will disconnect and ban the peer regardless of the exact reason such a transaction 
 is never valid. 
@@ -135,14 +125,20 @@ If a node sends transactions that fail `CheckTx` with a response code of 1, ther
 A peer should not be banned the first time this happens, but rather if this happens a predefined number 
 of times (`numFailures`) within a time interval (`lastFailure`). This time interval should be reset every `failureResetInterval`ms.  
 
-For each peer, we should have a separate `numFailures` and `lastFailure` variable. There is no need to  have one per transaction. 
+For each peer, we should have a separate `numFailures` and `lastFailure` variable. There is no need to  have one per transaction. Whenever a transaction fails, if the `now - lastFailure <= failureResetInterval`, then we increment the `numFailures` for this particular peer and set the `lastFailure` to `now`. Otherwise, we set `lastFailure` to `now` but do not increment the `numFailures`  variable. Once the value for `numFailures` for a peer reaches `maxAllowedFailures`, the peer is disconnected from and banned. 
 
-Whenever a transaction fails, if the `now - lastFailure <= failureResetInterval`, then we increment the `numFailures` for this particular peer and set the `lastFailure` to `now`. Otherwise, we set `lastFailure` to `now` but do not increment the `numFailures`  variable. The reason behind confirming that not too much time
-has passed between two failures is that a node can be allowed to send an invalid transaction from time to time, but this change intends to avoid spam. 
+The reason for this logic is as follows: We deem it acceptable if every now and then a peer sends us an invalid transaction. But if this happens very frequently, then this behaviour can be considered as spamming and we want to disconnect from the peer.
 
-Once the value for `numFailures` for a peer reaches `maxAllowedFailures`, the peer is disconnected from and banned. 
 
-Currently the `ResponseCheckTx` code is check in `resCbFirstTime` of the mempool. 
+*Banning a peer in case of duplicate transactions*
+
+Currently, a peer can send the same valid (or invalid) transaction multiple times. Peers currently do not 
+gossip transactions to peers that have sent them that same transaction. But there is no check on whether 
+a node has alrady sent the same transaction to this peer before. There is also no check whether the transaction
+that is being gossiped was valid or not (assumint that invalid transactions could become valid).
+The transaction broadcast logic simply loops through the mempool and tries to send the transactions currently in the pool. 
+
+mempool/v0/mempool.go:L247 - ToDo note on punishing peers for duplicate transactions;
 
 
 #### **Banning in case of ResponseCheckTx.code > 1**
@@ -158,11 +154,37 @@ However, there might not be the need to store all the peers that have sent us th
 Now, if we want to differentiate further reasons of why this transaction is sent to a node (whether it is a sign of malice or not), 
 we might need more information on the actual reason for rejection. This could be done by an additional set of response codes provided by the application. 
 
+### 2. Choosing the peer to ban
+
+Each transaction gossiped contains the ID of the peer that sent that transaction. Upon receiving a transaction,
+a node saves the peer ID of the peer(s) that have sent it. As each peer had to have
+run `CheckTx` on this transaction before adding it to its own mempool, we can assume this peer
+can be held accountable for the validity of transactions it gossips. However, the current mempool logic 
+will store and gossip **all* transactions - those that pass as well as those that do not pass `CheckTx`. 
+
+Assuming nodes ban peers that send them failing transactions, but broadcast those very transactions, they 
+risk being banned themselves by their peers. 
+
+To avoid this, we propose that peers do not broadcast transactions that come from banned peers by 
+adapting the logic of the `broadcastTxRoutine`. 
+
+Assuming that peers sending too many transactions failing with `ResponseCheckTx.code = 1` are banned in a timely manner, we could optimistically 
+not apply any additional logic when it comes to those transactions, but not forward only transactions that have failed with `ResponseCheckTx.code > 1`. However, the only way to make sure a node is not
+banned itself by forwarding invalid transactions is to not forward **any** transaction received from banned peers. 
+This would require either: a) checking for each transaction whether a peer that gossiped it is banned; or b) keeping track of transactions gossiped by banned peers when they are received, and alter the code snippets above to keep track of those. Then the `braodcastTxRoutine` would simply make sure that these transactions are not gossiped. Option b) seems more feasible in terms of time it would take to verify the information.
+
+*Transactions received by users*
+
+For transactions submitted via `boradcastTxCommit`, the `SenderID` field is empty. 
+
+**Note**  Do we have mechanisms in place to handle cases when `broadcastTxCommit` submits
+failing transactions (can this be a form of attack)?
+
 
 ### Implementation considerations
 
-To implement this functionality, we need to keep track of the `CheckTx` response code for each transaction. However, the current implementation
-of the mempool, adds a transaction to the mempool only once and caches its signature, to avoid running `CheckTx` on transactions already checked. 
+To implement this functionality, we need to keep track of the `CheckTx` response code for each transaction. Currently the `ResponseCheckTx` code is checked in `resCbFirstTime` of the mempool. This code is ran only when a transaction is 
+seen for the first time. Afterwards, the  transaction is cached, to avoid running `CheckTx` on transactions already checked. 
 Thus when a transaction is received from a peer, if it is in the cache,
 `CheckTx` is not ran again, but the peers' ID is addded to the list of peers who sent this particular transaction.
 These transactions are rechecked once a block is committed to verify that they are still valid.
@@ -203,8 +225,8 @@ If a transaction fails `CheckTx` the [first time it is seen](https://github.com/
 
 ```					
 The `KeepInvalidTxsInCache` configuration parameter defines whether an invalid transaction stays in cache. 
-Currently, even transactions that never could have been valid are kept in the cache. This can be mitigating by 
-expanding the condititon in the code above by:
+Currently, even transactions that never could have been valid are kept in the cache. This can be mitigated by 
+expanding the condititon in the code above with:
 
 ```golang
 if !mem.config.KeepInvalidTxsInCache || r.CheckTx.Code == abci.NeverValid {
@@ -213,11 +235,13 @@ if !mem.config.KeepInvalidTxsInCache || r.CheckTx.Code == abci.NeverValid {
 }
 ```
 
-However, this code will [never be executed](https://github.com/tendermint/tendermint/blob/ff0f98892f24aac11e46aeff2b6d2c0ad816701a/mempool/v0/clist_mempool.go#L239) for transactions not seen for the first time. 
+However, this code will [never be executed](https://github.com/tendermint/tendermint/blob/ff0f98892f24aac11e46aeff2b6d2c0ad816701a/mempool/v0/clist_mempool.go#L239) for transactions whose signature is found
+in the cache. 
 One way to go around this is to implement a valid/invalit bit per transaction within the cache. Currently, transactions themselves do not
 store such information. As we expect this scenario to be unlikely, instead of increasing the footprint of all transactions in the cache, 
 we can keep a map of transactions that are in the cache, but are invalid. Alternatively, the cache could keep two lists, one for valid, and one for invalid transactions. 
-The former would modify the following pieces of code as follows:
+The former would modify the following pieces of code as follows (this is just a prototype and does not include 
+some obvious sanity checks):
 
 ```golang
 
@@ -227,7 +251,8 @@ type CListMempool struct {
 invalidCachedTx map[types.TxKey]bool
 }
 ```
-
+This data structure could keep track of invalid transactions, where the `bool` would be true if the transaction comes 
+from a peer that is banned.
 
 >>mempool/v0/clist_mempool.go#L239
 ```golang
@@ -245,49 +270,79 @@ if !mem.cache.Push(tx) { // if the transaction already exists in the cache
 			// but they can spam the same tx with little cost to them atm.
 		}
 
-    if _, ok := mem.invalidCachedTx.(tx); ok {
+    if _, ok := mem.invalidCachedTx.Load(tx.Key); ok {
 
+        // Check whether this peer has sent us transactions that fail
         if val , ok := lastFailure.Load(peerID); ok {
-          
+        
+        // if the failure was recent enough, update the number of failures and 
+        // ban peer if applicable
         if time.Since(val) <= failureResetInterval {
-          numFailures.(peerID) = numFailures.(peerID) + 1
-          if numFailures.(peerID) == maxAllowedFailures {
+          if numFailures.(peerID) == maxAllowedFailures - 1 {
               mem.banPeer(peerID)
             }
           }
-        }     
+        }
+        // Update the time of the last failure     
         lastFailure(peerID) = time.Now()
+        numFailures.(peerID) = numFailures.(peerID) + 1
     }
 		return mempool.ErrTxInCache
 	}
 
 ```
 If transactions with `ResponseCheckTx.code > 1` are not deleted from the cache and we want to ban them on the first offence,
-we can skip the second if in the code above.
+we can skip the second `if` in the code above but call `banPeer` immediately. The function `banPeer` should simply forward the `peerID` to the p2p layer. 
 
 **Implementing peer banning on recheck**
 
-Currently the only check within the recheck logic is confirming whether once valid transactions, 
+Currently the recheck logic confirmes whether once **valid** transactions, 
 , where `ResponseCheckTx.code == 0`, are still valid. 
 
 As this logic loops through the transactions in any case, we can leverage it to check whether we can ban peers. 
 However, this approach has several downsides:
 - It is not timely enough. Recheck is executed after a block is committed, leaving room for a bad peer to send 
 us transactions the entire time between two blocks. 
-- If we want to keep track of when peers sent usa traansaction and punish them only if the misbehaviour happens 
+- If we want to keep track of when peers sent us a traansaction and punish them only if the misbehaviour happens 
 frequently enough, this approach makes it hard to keep track of when exactly was a transaction submitted. 
 
+However, this would avoid adding new logic to the mempool caching mechanism and keeping additional information about
+transaction validity.
 
 
-### Impacted functionalities
+#### `PreCheck` and`PostCheck`
 
-- mempool caching
-- what happens on PreCheck and PostCheck
-- what happens on mempool.Recheck
+The `PreCheck` and `PostCheck` functions are optional functions that can be executed before or after `CheckTx`. 
+Following the design outlined in this RFC, their responses are not considered for banning. 
+
+
+#### Checks outside `CheckTx`
+
+There are a number of checks that the mempool performs on the transaction, that are not part of `CheckTx` itself. 
+Those checks, however, have been mentioned in the user issues described at the beginning of this document:
+
+- Transaction size
+- Proto checks
+
+The previous code snippets do not incroporate these in peer banning. If we adopt those as valid reasons for banning, we should put the corresponding logic in place. 
+
+### Impacted mempool functionalities
+
+- Mempool caching: remembering failed transactions and whether they come from banned peers
+- Transaction broadcast: not broadcasting transactions that came from banned peers. 
+
+### 3.Attack scenarios
+
+While an attack by simply banning peers on faling `CheckTx` is hard to imagine, as the incentive for doing so is not clear, there are considerations with regards to the current mempool gossip implementation.
+
+As discussed above, the mempool allows for gossip of invalid transaction. This is a concious decision to make sure peers have transactions that can become valid in the future, ready and not block on waiting for them. But if the sending of these transactions is a reason to get banned, peers have no incentive to blindly forward those transactions. 
+
+The current proposal includes not forwarding transactions coming from banned peers. 
+
+An open question is, if a transaction comes from a banned peer, and is invalid, should the other - good peers, be banned for having sent it. Our current proposal is no, as this would potentially open an attack vector for malicious nodes to disconnect a node form good peers by sending bad transactions. 
 
 ### References
 
-mempool/v0/mempool.go:L247 - ToDo note on punishing peers for duplicate transactions;
 
 > Links to external materials needed to follow the discussion may be added here.
 >

--- a/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
+++ b/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
@@ -1,4 +1,4 @@
-# RFC 26: Mark peers as bad based on ResponseCheckTx
+# RFC 26: Banning peers based on ResponseCheckTx
 
 ## Changelog
 - Nov 4, 2022: Initial draft (jmalicevic)

--- a/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
+++ b/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
@@ -1,0 +1,95 @@
+# RFC 26: Mark peers as bad based on ResponseCheckTx
+
+## Changelog
+- Nov 4, 2022: Initial draft (jmalicevic)
+
+
+## Abstract
+
+Before adding a transaction to its mempool, a node runs `CheckTx` on it. `CheckTx` returns a non-zero code
+in case `CheckTx` returns a non-zero code. Note that there are valid reasons a transaction will not
+pass this check (including nodes getting different transactions at different times, meaning some
+of them might be obsolete at the time of the check). However, Tendermint users observed that
+there are transactions that can never have been or will never be valid. They thus propose
+to introduce a special response code for `CheckTx` to indicate this behaviour. 
+
+The reason behind differentiating between this scenario and other failures is to 
+be able to ban and disconnect from peers who gossip such transactions.
+
+This documents outlies the potental scenarios around this behaviour, understanding when this 
+happens and its risks, along with potential implementation suggestions.  
+
+## Background
+
+This work was triggered by issue [#7918](https://github.com/tendermint/tendermint/issues/7918). It was 
+additionally discussed in [2018](https://github.com/tendermint/tendermint/issues/2185). Additionally,
+there was a [proposal](https://github.com/tendermint/tendermint/issues/6523) to disconnect from peers after they send us transactions that constantly fail `CheckTx`  While 
+the actual implementation of an additional response code for `CheckTx` is straight forward there 
+are certain things to consider. The questions to answer, along with idnetified risks will be outlined in 
+the discussion. 
+
+Before diving into the details, we collected a set of issues opened by various users, arguing for 
+this behaviour and explaining their needs. 
+
+- Celestia: [blacklisting peers that repeatedly send bad tx](https://github.com/celestiaorg/celestia-core/issues/867)
+  and investigating how [Tendermint treats large Txs](https://github.com/celestiaorg/celestia-core/issues/243)
+- BigChainDb: [Handling proposers that who propose bad blocks](https://github.com/bigchaindb/BEPs/issues/84)
+- IBC relayer: Simulate transactions in the mempool and detect whether they could ever have beein valid to 
+  [avoid overloading the p2p/mempool system](https://github.com/cosmos/ibc-go/issues/853#issuecomment-1032211020)
+ (ToDo check with Adi what is this about, what are valid reasons this can happen and when should we disconnect)
+  (relevant code [here](https://github.com/cosmos/ibc-go/blob/a0e59b8e7a2e1305b7b168962e20516ca8c98fad/modules/core/ante/ante.go#L23)) 
+
+
+Currently, the mempool can trigger a disconnect from a peer in the case of the following errors:
+    - [Unknown message type](https://github.com/tendermint/tendermint/blob/d704c0a0b6fbc042dcb260dbb766bd83bb140cb7/mempool/v0/reactor.go#L182)
+
+However, disconnecting from a peer is not the same as banning the peer. The p2p layer will close the connecton but 
+the peer can reconnect without any penalty, and if it as a persistent peer, a reconnect will be initiated
+from the node. 
+Note that, currently, the p2p layer implements only banning peers for an indefinite amount of time, by marking them
+as bad. Additionally, if the [`filterPeers`](../../spec/abci/abci%2B%2B_app_requirements.md#peer-filtering) config flag is set, the application can ban peers itself. 
+
+- Transaction handling from [peers](https://github.com/tendermint/tendermint/blob/85a584dd2ee3437b117d9f5e894eac70bf09aeef/internal/mempool/reactor.go#L120)
+
+## Discussion
+
+If this feature is to be implemented we need to clearly define the following:
+1. If `CheckTx` signals a peer should be banned, how do we know which peer(s) to ban?
+2. Should a peer be banned based on the first offense?
+3. What does banning a peer mean:
+   1. A peer can be simple disconnected from. 
+   2. Peer is disconnected from and banned by marking the peer as bad (calling `MarkBad`).
+   3. Peer is disconnected from and banned temporarily (currently not implemented). 
+4. Are there possible attack scenarios by allowing this. 
+
+Note that the actual peer banning will be discussed in a separate RFC as it relates to
+the p2p layer and should be designed in a way that is generic and usable by all reactors. 
+
+### 1. Which peer should be banned
+
+Each transaction gossiped contains the ID of the peer that sent us that transaction. As each peer had to have
+run `CheckTx` on this transaction before adding it to its own mempool, we can assume this peer
+can be held accountable for the validity of transactions it gossips. 
+
+As Tendermint recognizes that peers can accept transactions into their mempool as valid but then those transactions
+become invalid, what are the valid (non malicious) use cases a peers transaction can pass a local `CheckTx` but fail 
+`CheckTx` on another node? This differentiates two scenarios - a) where `CheckTx` fails due to reasons already 
+known and b) where `CheckTx` deems a transactions could never have been valid:
+
+For a) a peer sends transaction that repeadetly fail CheckTx (not neccessarily due to the reason discussed in the abstract), and is banned or disconnected from to avoid this. 
+Risks: What if this behaviour exists due to a bad confguration and we have all peers sending and accepting transactions that are for example too large? We will end up with no peers? 
+For b) we need to understand what is the potential reason a transaction could never have been valid on one node, but passes `CheckTx` on another node. It seems that the only reason this happens is if a node is malicious and explicitly lies. In such cases, peers should not only be banned, but punished as well. 
+
+For each transaction a peer keeps track of the peer it has received the transaction from so they can all be banned. 
+
+mempool/v0/mempool.go:L247 - ToDo note on punishing peers for duplicate transactions;
+TxInfo.sender contains the SenderID - for transactions added via broadcastTxCommit this is empty
+
+
+### References
+
+> Links to external materials needed to follow the discussion may be added here.
+>
+> In addition, if the discussion in a request for comments leads to any design
+> decisions, it may be helpful to add links to the ADR documents here after the
+> discussion has settled.

--- a/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
+++ b/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
@@ -2,132 +2,289 @@
 
 ## Changelog
 - Nov 4, 2022: Initial draft (jmalicevic)
-
+- Nov 7, 2022: Updated draft (jmalicevic)
 
 ## Abstract
 
 Before adding a transaction to its mempool, a node runs `CheckTx` on it. `CheckTx` returns a non-zero code
-in case `CheckTx` returns a non-zero code. Note that there are valid reasons a transaction will not
+in case the transaction fails an application specific check. 
+
+Note that there are valid scenarios in which a transaction will not
 pass this check (including nodes getting different transactions at different times, meaning some
-of them might be obsolete at the time of the check). However, Tendermint users observed that
+of them might be obsolete at the time of the check, state changes upon block execution etc.). 
+However, Tendermint users observed that
 there are transactions that can never have been or will never be valid. They thus propose
-to introduce a special response code for `CheckTx` to indicate this behaviour. 
+to introduce a special response code for `CheckTx` to indicate this behaviour, and ban the peers
+who gossip such transactions. Additionally, users expressed a need for banning peers who
+repeadetly send transactions failing `CheckTx`. 
 
-The reason behind differentiating between this scenario and other failures is to 
-be able to ban and disconnect from peers who gossip such transactions.
+The main goal of this document is to analyse the cases where peers could be banned when they send 
+transacations failing `CheckTx`, and provide the exact conditions that a peer and transaction have
+to satisfy in order to mark the peer as bad.
 
-This documents outlies the potental scenarios around this behaviour, understanding when this 
-happens and its risks, along with potential implementation suggestions.  
+This document will also include a proposal for implementing these changes within the mempool, including
+potential changes to the existing mempool logic and implementation.
+
 
 ## Background
 
-This work was triggered by issue [#7918](https://github.com/tendermint/tendermint/issues/7918). It was 
-additionally discussed in [2018](https://github.com/tendermint/tendermint/issues/2185). Additionally,
-there was a [proposal](https://github.com/tendermint/tendermint/issues/6523) to disconnect from peers after they send us transactions that constantly fail `CheckTx`  While 
+This work was triggered by issue [#7918](https://github.com/tendermint/tendermint/issues/7918) and a related
+discussion in [2018](https://github.com/tendermint/tendermint/issues/2185). Additionally,
+there was a [proposal](https://github.com/tendermint/tendermint/issues/6523) 
+to disconnect from peers after they send us transactions that constantly fail `CheckTx`.  While 
 the actual implementation of an additional response code for `CheckTx` is straight forward there 
-are certain things to consider. The questions to answer, along with idnetified risks will be outlined in 
+are certain things to consider. The questions to answer, along with identified risks will be outlined in 
 the discussion. 
+
+### Existing issues and concerns
 
 Before diving into the details, we collected a set of issues opened by various users, arguing for 
 this behaviour and explaining their needs. 
 
 - Celestia: [blacklisting peers that repeatedly send bad tx](https://github.com/celestiaorg/celestia-core/issues/867)
   and investigating how [Tendermint treats large Txs](https://github.com/celestiaorg/celestia-core/issues/243)
-- BigChainDb: [Handling proposers that who propose bad blocks](https://github.com/bigchaindb/BEPs/issues/84)
-- IBC relayer: Simulate transactions in the mempool and detect whether they could ever have beein valid to 
+- BigChainDb: [Handling proposers who propose bad blocks](https://github.com/bigchaindb/BEPs/issues/84)
+- IBC relayer: Simulate transactions in the mempool and detect whether they could ever have been valid to 
   [avoid overloading the p2p/mempool system](https://github.com/cosmos/ibc-go/issues/853#issuecomment-1032211020)
  (ToDo check with Adi what is this about, what are valid reasons this can happen and when should we disconnect)
   (relevant code [here](https://github.com/cosmos/ibc-go/blob/a0e59b8e7a2e1305b7b168962e20516ca8c98fad/modules/core/ante/ante.go#L23)) 
+- From  Adi: Nodes allow transactions with a wrong `minGas` transaction and gossip them, and other nodes keep rejecting them. (Problem seen
+  with relayers)
 
+### Current state of mempool/p2p interaction
+
+Transactions received from a peer are handled within the [`handleMempoolMessage`](https://github.com/tendermint/tendermint/blob/85a584dd2ee3437b117d9f5e894eac70bf09aeef/internal/mempool/reactor.go#L120) routine. 
 
 Currently, the mempool can trigger a disconnect from a peer in the case of the following errors:
-    - [Unknown message type](https://github.com/tendermint/tendermint/blob/d704c0a0b6fbc042dcb260dbb766bd83bb140cb7/mempool/v0/reactor.go#L182)
+
+  - [Unknown message type](https://github.com/tendermint/tendermint/blob/d704c0a0b6fbc042dcb260dbb766bd83bb140cb7/mempool/v0/reactor.go#L182)
 
 However, disconnecting from a peer is not the same as banning the peer. The p2p layer will close the connecton but 
 the peer can reconnect without any penalty, and if it as a persistent peer, a reconnect will be initiated
 from the node. 
 
-- Transaction handling from [peers](https://github.com/tendermint/tendermint/blob/85a584dd2ee3437b117d9f5e894eac70bf09aeef/internal/mempool/reactor.go#L120)
+### Current support for peer banning
+
+Currently, the p2p layer implements only banning peers for an indefinite amount of time, by marking them
+as bad (calling the `MarkBad` routine implemented by the `Switch`). The peers are reinstated to the list 
+of good peers only if the node requires more peers. They can also not be marked as bad forever (blacklisted). 
+
+The application can also blacklist peers if the 
+[`filterPeers`](../../spec/abci/abci%2B%2B_app_requirements.md#peer-filtering) 
+config flag is set, by providing a set of peers to ban to Tendermint. 
+
+If the discussion in this RFC deems a different banning schema is needed,
+the actual implementation and design of this mechanism will be discussed in a separate RFC.
+This mechanism should be generic, designed within the p2p layer and simply provide an interface
+for reactors to indicate peers to ban and for how long. It should not involve any mempool
+specific design considerations. 
 
 ## Discussion
 
 If this feature is to be implemented we need to clearly define the following:
 1. If `CheckTx` signals a peer should be banned, how do we know which peer(s) to ban?
 2. What does banning a peer mean:
-   1. A peer can be simple disconnected from. 
+   1. A peer can be simply disconnected from. 
    2. Peer is disconnected from and banned.
-   3. Should a peer be banned based on the first offense?
+   3. Conditions for the peer to be banned.
 3. Are there possible attack scenarios by allowing this. 
 
-Note that the actual implementation and design of peer banning will be discussed in a separate RFC 
-as it relates to the p2p layer and should be designed in a way that is 
-generic and usable by all reactors. This documment will therefore simply refer to peer banning 
-regardless of its actual implementation.
+Any further mentions of `banning` will be agnostic to the actual way banning is implemented by the p2p layer. 
 
-Currently, the p2p layer implements only banning peers for an indefinite amount of time, by marking them
-as bad (calling the `MarkBad` routine implemented by the `Switch`). The peers are reinstated to the list of good peers only if the node requires more peers. 
+### 1. Choosing the peer to ban
 
-Additionally, if the [`filterPeers`](../../spec/abci/abci%2B%2B_app_requirements.md#peer-filtering) config flag is set, the application can ban peers itself. 
-
-### 1. Which peer should be banned
-
-Each transaction gossiped contains the ID of the peer that sent us that transaction. Upon receiving a transaction,
+Each transaction gossiped contains the ID of the peer that sent that transaction. Upon receiving a transaction,
 a node saves the peer ID of the peer(s) that have sent it. As each peer had to have
 run `CheckTx` on this transaction before adding it to its own mempool, we can assume this peer
 can be held accountable for the validity of transactions it gossips. 
 
-However, for transactions received via `boradcastTxCommit`, this field is empty. 
+For transactions submitted via `boradcastTxCommit`, this field is empty. 
+
+**Note**  Do we have mechanisms in place to handle cases when `broadcastTxCommit` submits
+failing transactions (can this be a form of attack?)?
 
 ### 2. What does banning a peer mean 
 
 Tendermint recognizes that peers can accept transactions into their mempool as valid but then those transactions
-become invalid, what are the valid (non malicious) use cases a peers transaction that could never have been valid passes a local `CheckTx` but fails `CheckTx` on another node? This differentiates two scenarios - a) where `CheckTx` fails due to reasons already 
+become invalid, or were valid at some point. 
+But, if a transaction could never have been valid, how can it pass a `CheckTx` at any node? What are the valid
+(non malicious reasons for such failures). 
+This differentiates two scenarios - a) where `CheckTx` fails due to reasons already 
 known and b) where `CheckTx` deems a transactions could never have been valid.
 
 For the sake of simplicity, in the remainder of the text we will distinguish the failures due to a) with failures 
 signaled with `responseCode = 1` and the failures described in b), failures with `responseCode > 1`.
 
-For a) a peer sends transactions that repeadetly fail CheckTx with `ResponseCheckTx.code = 1`, and is banned or disconnected from to avoid this. 
+For a) a peer sends transactions that repeatedly fail CheckTx with `ResponseCheckTx.code = 1`, and is banned or disconnected from to avoid this. 
 
-For b) we need to understand what is the potential reason a transaction could never have been valid on one node, but passes `CheckTx` on another node. We need to understand all the possible scenarios in which this can happen:
+For b) we need to understand what is the potential reason a transaction could never have been valid on one node, but passes `CheckTx` on another node. 
+We need to understand all the possible scenarios in which this can happen:
 
-1. What happens if a node is misconfigured and allows, for example, very large transactions into the mempool. This node would then gossip these transactions and they would always fail on other nodes. Is this a scenario where we want nodes to disconnect from this peer and ban it without this peer being neccessarily malicious? 
-2. Are all other reasons for this to happen sign of malicious behaviour where a node explicitly lies? In such cases, peers should not only be banned, but punished as well (if they are validators). 
+1. What happens if a node is misconfigured and allows, for example, very large transactions into the mempool. 
+This node would then gossip these transactions and they would always fail on other nodes. 
+Is this a scenario where we want nodes to disconnect from this peer and ban it without this peer being neccessarily malicious?
+2. Are all other reasons for this to happen sign of malicious behaviour where a node explicitly lies? 
+In such cases, peers should not only be banned, but punished as well (if they are validators). 
 
+The later is most likely a potential future optimizations, where for now, we will disconnect and ban the peer regardless of the exact reason such a transaction 
+is never valid. 
 
 #### **Banning in case of ResponseCheckTx.code = 1**
 
-If a node sends transactions that fail CheckTx with a response code of 1, there might be a valid reason for this behaviour. A peer should be banned the first time this happens, but rather if this happens a predefined number 
-of times (`numFailures`) within a time interval (`lastFailure`). This time interval should be reset every `failureResetInterval`.  
+If a node sends transactions that fail `CheckTx` with a response code of 1, there might be a valid reason for this behaviour. 
+A peer should not be banned the first time this happens, but rather if this happens a predefined number 
+of times (`numFailures`) within a time interval (`lastFailure`). This time interval should be reset every `failureResetInterval`ms.  
 
 For each peer, we should have a separate `numFailures` and `lastFailure` variable. There is no need to  have one per transaction. 
 
-Whenever a transaction fails, if the `now - lastFailure <= failureResetInterval`, then we increment the `numFailures` for this particular peer and set the `lastFailure` to `now`. Otherwise, we set `lastFailure` to `now` but do not increment the `numFailures`  variable. 
+Whenever a transaction fails, if the `now - lastFailure <= failureResetInterval`, then we increment the `numFailures` for this particular peer and set the `lastFailure` to `now`. Otherwise, we set `lastFailure` to `now` but do not increment the `numFailures`  variable. The reason behind confirming that not too much time
+has passed between two failures is that a node can be allowed to send an invalid transaction from time to time, but this change intends to avoid spam. 
 
 Once the value for `numFailures` for a peer reaches `maxAllowedFailures`, the peer is disconnected from and banned. 
 
 Currently the `ResponseCheckTx` code is check in `resCbFirstTime` of the mempool. 
 
-Currently, invalid transactions are still kept in the cache. If a transaction is in cache, `CheckTx` is not ran for it again. Thus we will not discover subsequent offenses by the same peer or different peers submitting invalid transactions. 
-
-One way to go around this is to implement a valid/invalit bit per transaction within the cache and check this 
-[in case the transaction is already in the cache](https://github.com/tendermint/tendermint/blob/816c6bac00c63a421a1bdaeccbc081c5346cb0d8/mempool/v0/clist_mempool.go#L244).
-
 
 #### **Banning in case of ResponseCheckTx.code > 1**
 
-If a transaction fails since it could never have been valid, `CheckTx` returns a `ResponseCheckTx.code` value greater than 1. In this case, the peer should be disconnected from and banned immediately without keeping count on how often 
+If a transaction fails since it could never have been valid, `CheckTx` returns a `ResponseCheckTx.code` 
+value greater than 1. In this case, the peer should be disconnected from and banned immediately without keeping count on how often 
 this has happened. 
 
-The question is whether this transaction should be kept track of in the mempool? We can still store it in the cache so that we don't run `CheckTx` on it agan. However, there might not be the need to store all the peers that have sent us this transaction. 
+The question is whether this transaction should be kept track of in the mempool? We can still store it in 
+the cache so that we don't run `CheckTx` on it agan. 
+However, there might not be the need to store all the peers that have sent us this transaction. 
 
-Now, if we want to differentiate further reasons of why this transaction is sent to a node (whether it is a sign of malice or not), we might need more information on the actual reason for rejection. This could be done by an additional set of response codes provided by the application. 
+Now, if we want to differentiate further reasons of why this transaction is sent to a node (whether it is a sign of malice or not), 
+we might need more information on the actual reason for rejection. This could be done by an additional set of response codes provided by the application. 
+
+
+### Implementation considerations
+
+To implement this functionality, we need to keep track of the `CheckTx` response code for each transaction. However, the current implementation
+of the mempool, adds a transaction to the mempool only once and caches its signature, to avoid running `CheckTx` on transactions already checked. 
+Thus when a transaction is received from a peer, if it is in the cache,
+`CheckTx` is not ran again, but the peers' ID is addded to the list of peers who sent this particular transaction.
+These transactions are rechecked once a block is committed to verify that they are still valid.
+
+Currently there are two ways to implement peer banning based on the result of `CheckTx`:
+
+1. Introduce banning when transactions start to be processed
+2. Adapt the recheck logic to support this
+
+
+**Peer banning when transactions are received**
+
+If a transaction fails `CheckTx` the [first time it is seen](https://github.com/tendermint/tendermint/blob/ff0f98892f24aac11e46aeff2b6d2c0ad816701a/mempool/v0/clist_mempool.go#L409),  the peer can be banned right there:
+
+>>mempool/v0/clist_mempool.go#L409
+```golang
+
+      if (r.CheckTx.Code == abci.CodeTypeOK) && postCheckErr == nil {
+          // Check Tx passed
+      } else {
+			// ignore bad transaction
+          mem.logger.Debug(
+            "rejected bad transaction",
+            "tx", types.Tx(tx).Hash(),
+            "peerID", peerP2PID,
+            "res", r,
+            "err", postCheckErr,
+          )
+          mem.metrics.FailedTxs.Add(1)
+
+          mem.banPeer(peerP2PID)
+
+          if !mem.config.KeepInvalidTxsInCache {
+            // remove from cache (it might be good later)
+            mem.cache.Remove(tx)
+          }
+		}
+
+```					
+The `KeepInvalidTxsInCache` configuration parameter defines whether an invalid transaction stays in cache. 
+Currently, even transactions that never could have been valid are kept in the cache. This can be mitigating by 
+expanding the condititon in the code above by:
+
+```golang
+if !mem.config.KeepInvalidTxsInCache || r.CheckTx.Code == abci.NeverValid {
+            // remove from cache (it might be good later)
+    mem.cache.Remove(tx)
+}
+```
+
+However, this code will [never be executed](https://github.com/tendermint/tendermint/blob/ff0f98892f24aac11e46aeff2b6d2c0ad816701a/mempool/v0/clist_mempool.go#L239) for transactions not seen for the first time. 
+One way to go around this is to implement a valid/invalit bit per transaction within the cache. Currently, transactions themselves do not
+store such information. As we expect this scenario to be unlikely, instead of increasing the footprint of all transactions in the cache, 
+we can keep a map of transactions that are in the cache, but are invalid. Alternatively, the cache could keep two lists, one for valid, and one for invalid transactions. 
+The former would modify the following pieces of code as follows:
+
+```golang
+
+type CListMempool struct {
+ // ..existing fields
+
+invalidCachedTx map[types.TxKey]bool
+}
+```
+
+
+>>mempool/v0/clist_mempool.go#L239
+```golang
+
+if !mem.cache.Push(tx) { // if the transaction already exists in the cache
+		// Record a new sender for a tx we've already seen.
+		// Note it's possible a tx is still in the cache but no longer in the mempool
+		// (eg. after committing a block, txs are removed from mempool but not cache),
+		// so we only record the sender for txs still in the mempool.
+		if e, ok := mem.txsMap.Load(tx.Key()); ok {
+			memTx := e.(*clist.CElement).Value.(*mempoolTx)
+			memTx.senders.LoadOrStore(txInfo.SenderID, true)
+			// TODO: consider punishing peer for dups,
+			// its non-trivial since invalid txs can become valid,
+			// but they can spam the same tx with little cost to them atm.
+		}
+
+    if _, ok := mem.invalidCachedTx.(tx); ok {
+
+        if val , ok := lastFailure.Load(peerID); ok {
+          
+        if time.Since(val) <= failureResetInterval {
+          numFailures.(peerID) = numFailures.(peerID) + 1
+          if numFailures.(peerID) == maxAllowedFailures {
+              mem.banPeer(peerID)
+            }
+          }
+        }     
+        lastFailure(peerID) = time.Now()
+    }
+		return mempool.ErrTxInCache
+	}
+
+```
+If transactions with `ResponseCheckTx.code > 1` are not deleted from the cache and we want to ban them on the first offence,
+we can skip the second if in the code above.
+
+**Implementing peer banning on recheck**
+
+Currently the only check within the recheck logic is confirming whether once valid transactions, 
+, where `ResponseCheckTx.code == 0`, are still valid. 
+
+As this logic loops through the transactions in any case, we can leverage it to check whether we can ban peers. 
+However, this approach has several downsides:
+- It is not timely enough. Recheck is executed after a block is committed, leaving room for a bad peer to send 
+us transactions the entire time between two blocks. 
+- If we want to keep track of when peers sent usa traansaction and punish them only if the misbehaviour happens 
+frequently enough, this approach makes it hard to keep track of when exactly was a transaction submitted. 
 
 
 
+### Impacted functionalities
 
+- mempool caching
+- what happens on PreCheck and PostCheck
+- what happens on mempool.Recheck
 
-Questions : What is the rationale in adding the Tx to the cache before running checkTx on it? Why do we leave it in the cache it is invalid?
 ### References
 
 mempool/v0/mempool.go:L247 - ToDo note on punishing peers for duplicate transactions;
@@ -137,3 +294,7 @@ mempool/v0/mempool.go:L247 - ToDo note on punishing peers for duplicate transact
 > In addition, if the discussion in a request for comments leads to any design
 > decisions, it may be helpful to add links to the ADR documents here after the
 > discussion has settled.
+
+
+
+- 

--- a/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
+++ b/docs/rfc/rfc-026-p2p-bad-peers-checktx.md
@@ -326,6 +326,7 @@ However, this approach has several downsides:
 us transactions the entire time between two blocks. 
 - If we want to keep track of when peers sent us a traansaction and punish them only if the misbehaviour happens 
 frequently enough, this approach makes it hard to keep track of when exactly was a transaction submitted. 
+- Rechecking if optional and node operators can disable it. 
 
 On the plus side this would avoid adding new logic to the mempool caching mechanism and keeping additional information about
 transaction validity. But we would still have to keep the information on peers and the frequency at which they send us bad transactions.


### PR DESCRIPTION
This RFC captures the changes required to implement the proposals in #7918 , #2185, #6523. The gist of the document is that the mempool should be able to trigger baning of peers if they either send us transactions that fail too often, or transactions that fail due to a particular code that indicates that the application has determined a transaction to never be valid, in any state. 

 It closes #9546 and if accepted will be followed by implementing the proposed changes. 

:book: [Rendered](https://github.com/tendermint/tendermint/blob/jasmina/p2p-bad-peers/docs/rfc/rfc-026-p2p-bad-peers-checktx.md)
