### PR TITLE
config: add bootstrap peers

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,6 +23,9 @@
 
 ### FEATURES
 
+- [config] \#9680 Introduce `BootstrapPeers` to the config to allow nodes to list peers to be added to
+  the addressbook upon start up (@cmwaters)
+
 ### IMPROVEMENTS
 
 - [pubsub] \#7319 Performance improvements for the event query API (@creachadair)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,6 +5,15 @@ Tendermint Core.
 
 ## Unreleased
 
+## Config Changes
+
+* A new config field, `BootstrapPeers` has been introduced as a means of
+  adding a list of addresses to the addressbook upon initializing a node. This is an
+  alternative to `PersistentPeers`. `PersistentPeers` shold be only used for
+  nodes that you want to keep a constant connection with i.e. sentry nodes
+
+----
+
 ### ABCI Changes
 
 * The `ABCIVersion` is now `1.0.0`.

--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -66,6 +66,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("p2p.external-address", config.P2P.ExternalAddress, "ip:port address to advertise to peers for them to dial")
 	cmd.Flags().String("p2p.seeds", config.P2P.Seeds, "comma-delimited ID@host:port seed nodes")
 	cmd.Flags().String("p2p.persistent_peers", config.P2P.PersistentPeers, "comma-delimited ID@host:port persistent peers")
+	cmd.Flags().String("p2p.bootstrap_peers", config.P2P.BootstrapPeers, "comma-delimited ID@host:port peers to be added to the addressbook on startup")
 	cmd.Flags().String("p2p.unconditional_peer_ids",
 		config.P2P.UnconditionalPeerIDs, "comma-delimited IDs of unconditional peers")
 	cmd.Flags().Bool("p2p.upnp", config.P2P.UPNP, "enable/disable UPNP port forwarding")

--- a/config/config.go
+++ b/config/config.go
@@ -548,6 +548,11 @@ type P2PConfig struct { //nolint: maligned
 	// We only use these if we can’t connect to peers in the addrbook
 	Seeds string `mapstructure:"seeds"`
 
+	// Comma separated list of peers to be added to the peer store
+	// on startup. Either BootstrapPeers or PersistentPeers are
+	// needed for peer discovery
+	BootstrapPeers string `mapstructure:"bootstrap_peers"`
+
 	// Comma separated list of nodes to keep persistent connections to
 	PersistentPeers string `mapstructure:"persistent_peers"`
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -283,6 +283,11 @@ external_address = "{{ .P2P.ExternalAddress }}"
 # Comma separated list of seed nodes to connect to
 seeds = "{{ .P2P.Seeds }}"
 
+# Comma separated list of peers to be added to the peer store
+# on startup. Either BootstrapPeers or PersistentPeers are
+# needed for peer discovery
+bootstrap_peers = "{{ .P2P.BootstrapPeers }}"
+
 # Comma separated list of nodes to keep persistent connections to
 persistent_peers = "{{ .P2P.PersistentPeers }}"
 

--- a/node/node.go
+++ b/node/node.go
@@ -308,6 +308,17 @@ func NewNode(config *cfg.Config,
 		return nil, fmt.Errorf("could not create addrbook: %w", err)
 	}
 
+	for _, addr := range splitAndTrimEmpty(config.P2P.BootstrapPeers, ",", " ") {
+		netAddrs, err := p2p.NewNetAddressString(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bootstrap peer address: %w", err)
+		}
+		err = addrBook.AddAddress(netAddrs, netAddrs)
+		if err != nil {
+			return nil, fmt.Errorf("adding bootstrap address to addressbook: %w", err)
+		}
+	}
+
 	// Optionally, start the pex reactor
 	//
 	// TODO:

--- a/spec/p2p/config.md
+++ b/spec/p2p/config.md
@@ -17,6 +17,14 @@ and upon incoming connection shares some peers and disconnects.
 Dials these seeds when we need more peers. They should return a list of peers and then disconnect.
 If we already have enough peers in the address book, we may never need to dial them.
 
+## Bootstrap Peers
+
+`--p2p.bootstrap_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”`
+
+A list of peers to be added to the addressbook upon startup to ensure that the node has some peers to initially dial.
+Unlike persistent peers, these addresses don't have any extra privileges. The node may not necessarily connect on redial
+these peers.
+
 ## Persistent Peers
 
 `--p2p.persistent_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”`

--- a/spec/p2p/v0.34/configuration.md
+++ b/spec/p2p/v0.34/configuration.md
@@ -7,7 +7,6 @@ This document contains configurable parameters a node operator can use to tune t
 |   ListenAddress               |   "tcp://0.0.0.0:26656" |   Address to listen for incoming connections (0.0.0.0:0 means any interface, any port)  |
 |   ExternalAddress             |  ""                 |  Address to advertise to peers for them to dial |
 |   [Seeds](pex-protocol.md#seed-nodes) | empty               | Comma separated list of seed nodes to connect to (ID@host:port )| 
-|   BootstrapPeers | empty | Comma separated list of nodes to add to the address book on startup (ID@host:port) |
 |   [Persistent peers](peer_manager.md#persistent-peers)            | empty               | Comma separated list of nodes to keep persistent connections to (ID@host:port )  |
 |	UPNP                        | false               | UPNP port forwarding enabled |
 |	[AddrBook](addressbook.md)                    | defaultAddrBookPath | Path do address book |
@@ -34,7 +33,6 @@ These parameters can be set using the `$TMHOME/config/config.toml` file. A subse
 | --- | --- | ---|
 | Listen address|  `p2p.laddr` |  "tcp://0.0.0.0:26656" |
 | Seed nodes | `p2p.seeds` | `--p2p.seeds “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:4444”` |
-| Bootstrap peers | `p2p.bootstrap_peers` | `--p2p.bootstrap_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”` |
 | Persistent peers | `p2p.persistent_peers` | `--p2p.persistent_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”` | 
 | Unconditional peers | `p2p.unconditional_peer_ids` | `--p2p.unconditional_peer_ids “id100000000000000000000000000000000,id200000000000000000000000000000000”` |
  | UPNP  | `p2p.upnp` | `--p2p.upnp` | 

--- a/spec/p2p/v0.34/configuration.md
+++ b/spec/p2p/v0.34/configuration.md
@@ -7,6 +7,7 @@ This document contains configurable parameters a node operator can use to tune t
 |   ListenAddress               |   "tcp://0.0.0.0:26656" |   Address to listen for incoming connections (0.0.0.0:0 means any interface, any port)  |
 |   ExternalAddress             |  ""                 |  Address to advertise to peers for them to dial |
 |   [Seeds](pex-protocol.md#seed-nodes) | empty               | Comma separated list of seed nodes to connect to (ID@host:port )| 
+|   BootstrapPeers | empty | Comma separated list of nodes to add to the address book on startup (ID@host:port) |
 |   [Persistent peers](peer_manager.md#persistent-peers)            | empty               | Comma separated list of nodes to keep persistent connections to (ID@host:port )  |
 |	UPNP                        | false               | UPNP port forwarding enabled |
 |	[AddrBook](addressbook.md)                    | defaultAddrBookPath | Path do address book |
@@ -33,6 +34,7 @@ These parameters can be set using the `$TMHOME/config/config.toml` file. A subse
 | --- | --- | ---|
 | Listen address|  `p2p.laddr` |  "tcp://0.0.0.0:26656" |
 | Seed nodes | `p2p.seeds` | `--p2p.seeds “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:4444”` |
+| Bootstrap peers | `p2p.bootstrap_peers` | `--p2p.bootstrap_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”` |
 | Persistent peers | `p2p.persistent_peers` | `--p2p.persistent_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”` | 
 | Unconditional peers | `p2p.unconditional_peer_ids` | `--p2p.unconditional_peer_ids “id100000000000000000000000000000000,id200000000000000000000000000000000”` |
  | UPNP  | `p2p.upnp` | `--p2p.upnp` | 


### PR DESCRIPTION
This PR adds a new config field: bootstrap peers, a comma separated string of addresses to be added to the addressbook upon node startup. Currently, some node operators misuse persistent peers as a way of adding addresses to dial. Persistent peers has the characteristic of always redialing that peer to keep a consistent connection (designed for sentries) which might not be what node operators intended for. 

This feature is ported across from v0.35.x

---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

