### PR TITLE
v0.37.x: Update codeowners to include Adi and Lásaro (backport #9697)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,6 @@
 # global owners are only requested if there isn't a more specific
 # codeowner specified below. For this reason, the global codeowners
 # are often repeated in package-level definitions.
-*     @ebuchman @tendermint/tendermint-engineering
+*     @ebuchman @tendermint/tendermint-engineering @adizere @lasarojc
 
-/spec @ebuchman @tendermint/tendermint-research @tendermint/tendermint-engineering
+/spec @ebuchman @tendermint/tendermint-research @tendermint/tendermint-engineering @adizere @lasarojc


### PR DESCRIPTION
Backports #9697 to `v0.37.x`.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

