### PR TITLE
rpc/websocket: configurable write timeout for websocket

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,7 +17,7 @@
 
 - Data Storage
   - [state] \#6541 Move pruneBlocks from consensus/state to state/execution. (@JayT106)
-  
+
 - Tooling
   - [tools/tm-signer-harness] \#6498 Set OS home dir to instead of the hardcoded PATH. (@JayT106)
   - [metrics] \#9682 move state-syncing and block-syncing metrics to their respective packages (@cmwaters)
@@ -34,6 +34,7 @@
 - [p2p/pex] \#6509 Improve addrBook.hash performance (@cuonglm)
 - [crypto/merkle] \#6443 & \#6513 Improve HashAlternatives performance (@cuonglm, @marbar3778)
 - [rpc] \#9650 Enable caching of RPC responses (@JayT106)
+- [rpc] New confifurable option `experimental_websocket_write_timeout` to confugure write timeout for publishing data via websocket (events)
 
 ### BUG FIXES
 

--- a/config/config.go
+++ b/config/config.go
@@ -383,6 +383,10 @@ type RPCConfig struct {
 	// connections may be dropped unnecessarily.
 	WebSocketWriteBufferSize int `mapstructure:"experimental_websocket_write_buffer_size"`
 
+	// Configurable write timeout for subscription websocket. Useful to increase in case
+	// of large transactions in websocket chokes under high load.
+	WebSocketWriteTimeout time.Duration `mapstructure:"experimental_websocket_write_timeout"`
+
 	// If a WebSocket client cannot read fast enough, at present we may
 	// silently drop events instead of generating an error or disconnecting the
 	// client.

--- a/node/node.go
+++ b/node/node.go
@@ -576,6 +576,7 @@ func (n *Node) startRPC() ([]net.Listener, error) {
 			}),
 			rpcserver.ReadLimit(config.MaxBodyBytes),
 			rpcserver.WriteChanCapacity(n.config.RPC.WebSocketWriteBufferSize),
+			rpcserver.WriteWait(n.config.RPC.WebSocketWriteTimeout),
 		)
 		wm.SetLogger(wmLogger)
 		mux.HandleFunc("/websocket", wm.WebsocketHandler)

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -181,7 +181,9 @@ func OnDisconnect(onDisconnect func(remoteAddr string)) func(*wsConnection) {
 // It should only be used in the constructor - not Goroutine-safe.
 func WriteWait(writeWait time.Duration) func(*wsConnection) {
 	return func(wsc *wsConnection) {
-		wsc.writeWait = writeWait
+		if writeWait.Nanoseconds() > 0 {
+			wsc.writeWait = writeWait
+		}
 	}
 }
 


### PR DESCRIPTION
For now if transactions contains a lot of data - websocket stops send TX events due to write timeout.
This PR adds configurable option to increase that timeout.