### PR TITLE
Remove useless whitespace in Websocket output (backport #9720)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,9 @@
 
 ### IMPROVEMENTS
 
+- `[rpc]` \#9724 Remove useless whitespace in RPC output (@adizere,
+  @thanethomson)
+
 ### BUG FIXES
 
 - `[rpc]` \#9692 Remove `Cache-Control` header response from `/check_tx`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,14 @@
 This guide provides instructions for upgrading to specific versions of
 Tendermint Core.
 
+## v0.34.24
+
+Note that in [\#9724](https://github.com/tendermint/tendermint/pull/9724) we
+un-prettified the JSON output (i.e. removed all indentation) of the HTTP and
+WebSocket RPC for performance and subscription stability reasons. We recommend
+using a tool such as [jq](https://github.com/stedolan/jq) to obtain prettified
+output if you rely on that prettified output in some way.
+
 ## v0.34.20
 
 ### Feature: Priority Mempool

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -104,7 +104,7 @@ func WriteRPCResponseHTTPError(
 		panic("tried to write http error response without RPC error")
 	}
 
-	jsonBytes, err := json.MarshalIndent(res, "", "  ")
+	jsonBytes, err := json.Marshal(res)
 	if err != nil {
 		return fmt.Errorf("json marshal: %w", err)
 	}
@@ -140,7 +140,7 @@ func writeRPCResponseHTTP(w http.ResponseWriter, headers []httpHeader, res ...ty
 		v = res
 	}
 
-	jsonBytes, err := json.MarshalIndent(v, "", "  ")
+	jsonBytes, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Errorf("json marshal: %w", err)
 	}

--- a/rpc/jsonrpc/server/http_server_test.go
+++ b/rpc/jsonrpc/server/http_server_test.go
@@ -121,13 +121,7 @@ func TestWriteRPCResponseHTTP(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	assert.Equal(t, "public, max-age=86400", resp.Header.Get("Cache-control"))
-	assert.Equal(t, `{
-  "jsonrpc": "2.0",
-  "id": -1,
-  "result": {
-    "value": "hello"
-  }
-}`, string(body))
+	assert.Equal(t, `{"jsonrpc":"2.0","id":-1,"result":{"value":"hello"}}`, string(body))
 
 	// multiple arguments
 	w = httptest.NewRecorder()
@@ -142,22 +136,7 @@ func TestWriteRPCResponseHTTP(t *testing.T) {
 
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	assert.Equal(t, `[
-  {
-    "jsonrpc": "2.0",
-    "id": -1,
-    "result": {
-      "value": "hello"
-    }
-  },
-  {
-    "jsonrpc": "2.0",
-    "id": -1,
-    "result": {
-      "value": "world"
-    }
-  }
-]`, string(body))
+	assert.Equal(t, `[{"jsonrpc":"2.0","id":-1,"result":{"value":"hello"}},{"jsonrpc":"2.0","id":-1,"result":{"value":"world"}}]`, string(body))
 }
 
 func TestWriteRPCResponseHTTPError(t *testing.T) {
@@ -173,13 +152,5 @@ func TestWriteRPCResponseHTTPError(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	assert.Equal(t, `{
-  "jsonrpc": "2.0",
-  "id": -1,
-  "error": {
-    "code": -32603,
-    "message": "Internal error",
-    "data": "foo"
-  }
-}`, string(body))
+	assert.Equal(t, `{"jsonrpc":"2.0","id":-1,"error":{"code":-32603,"message":"Internal error","data":"foo"}}`, string(body))
 }

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -431,7 +431,10 @@ func (wsc *wsConnection) writeRoutine() {
 				return
 			}
 		case msg := <-wsc.writeChan:
-			jsonBytes, err := json.MarshalIndent(msg, "", "  ")
+			// Use json.MarshalIndent instead of Marshal for pretty output.
+			// Pretty output not necessary, since most consumers of WS events are
+			// automated processes, not humans.
+			jsonBytes, err := json.Marshal(msg)
 			if err != nil {
 				wsc.Logger.Error("Failed to marshal RPCResponse to JSON", "err", err)
 				continue


### PR DESCRIPTION
Not sure why Mergify failed to open the automatic backport of #9720 to `v0.34.x`, so I just cherry-picked the commit manually.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

