### PR TITLE
docs: Fix OpenAPI pre-processing script

### DIFF
--- a/docs/pre.sh
+++ b/docs/pre.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cp -a ../rpc/openapi/ .vuepress/public/rpc/
+cp -a ../rpc/openapi/* .vuepress/public/rpc/


### PR DESCRIPTION
Stacked on top of #9674.

The pre-processing script was copying the entire `rpc/openapi` folder into `docs/.vuepress/public`, instead of just copying the `openapi.yaml` file.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

