### PR TITLE
mempool: fix mempool flaky test

### DIFF
--- a/mempool/v0/reactor_test.go
+++ b/mempool/v0/reactor_test.go
@@ -221,7 +221,9 @@ func TestBroadcastTxForPeerStopsWhenReactorStops(t *testing.T) {
 
 	// stop reactors
 	for _, r := range reactors {
-		if err := r.Stop(); err != nil {
+		// we stop the reactor from the Switch due to the reactor doesn't stop
+		// the peer connection in Stop implementation
+		if err := r.Switch.Stop(); err != nil {
 			assert.NoError(t, err)
 		}
 	}


### PR DESCRIPTION
Closes #9479 

The mempool(v0) reactor couldn't call Switch stop to disconnect the peer connections during the test. It will remain unclosed channels

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

