### PR TITLE
v1 mempool: remove memory leak warning

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -687,9 +687,6 @@ type MempoolConfig struct {
 	// Mempool version to use:
 	//  1) "v0" - (default) FIFO mempool.
 	//  2) "v1" - prioritized mempool.
-	// WARNING: There's a known memory leak with the prioritized mempool
-	// that the team are working on. Read more here:
-	// https://github.com/tendermint/tendermint/issues/8775
 	Version   string `mapstructure:"version"`
 	RootDir   string `mapstructure:"home"`
 	Recheck   bool   `mapstructure:"recheck"`


### PR DESCRIPTION
## Description

I believe we forgot to remove this warning (it's not present in `main`) after patching the priority mempool. 

