### PR TITLE
Typo in Comments and Functions

### DIFF
--- a/light/detector.go
+++ b/light/detector.go
@@ -23,7 +23,7 @@ import (
 // trace that was produced from the primary. If successful, it produces two sets of evidence
 // and sends them to the opposite provider before halting.
 //
-// If there are no conflictinge headers, the light client deems the verified target header
+// If there are no conflicting headers, the light client deems the verified target header
 // trusted and saves it to the trusted store.
 func (c *Client) detectDivergence(ctx context.Context, primaryTrace []*types.LightBlock, now time.Time) error {
 	if primaryTrace == nil || len(primaryTrace) < 2 {
@@ -74,7 +74,7 @@ func (c *Client) detectDivergence(ctx context.Context, primaryTrace []*types.Lig
 			witnessesToRemove = append(witnessesToRemove, e.WitnessIndex)
 
 		case errBadWitness:
-			// these are all melevolent errors and should result in removing the
+			// these are all malevolent errors and should result in removing the
 			// witness
 			c.logger.Info("witness returned an error during header comparison, removing...",
 				"witness", c.witnesses[e.WitnessIndex], "err", err)
@@ -217,7 +217,7 @@ func (c *Client) sendEvidence(ctx context.Context, ev *types.LightClientAttackEv
 func (c *Client) handleConflictingHeaders(
 	ctx context.Context,
 	primaryTrace []*types.LightBlock,
-	challendingBlock *types.LightBlock,
+	challengingBlock *types.LightBlock,
 	witnessIndex int,
 	now time.Time,
 ) error {
@@ -225,7 +225,7 @@ func (c *Client) handleConflictingHeaders(
 	witnessTrace, primaryBlock, err := c.examineConflictingHeaderAgainstTrace(
 		ctx,
 		primaryTrace,
-		challendingBlock,
+		challengingBlock,
 		supportingWitness,
 		now,
 	)
@@ -374,7 +374,7 @@ func (c *Client) examineConflictingHeaderAgainstTrace(
 }
 
 // getTargetBlockOrLatest gets the latest height, if it is greater than the target height then it queries
-// the target heght else it returns the latest. returns true if it successfully managed to acquire the target
+// the target height else it returns the latest. returns true if it successfully managed to acquire the target
 // height.
 func (c *Client) getTargetBlockOrLatest(
 	ctx context.Context,
@@ -394,7 +394,7 @@ func (c *Client) getTargetBlockOrLatest(
 
 	if lightBlock.Height > height {
 		// the witness has caught up. We recursively call the function again. However in order
-		// to avoud a wild goose chase where the witness sends us one header below and one header
+		// to avoid a wild goose chase where the witness sends us one header below and one header
 		// above the height we set a timeout to the context
 		lightBlock, err := witness.LightBlock(ctx, height)
 		return true, lightBlock, err


### PR DESCRIPTION
List of typos in comments and functions.
* L26: `conflictinge` seems to be `conflicting`
* L77: `melevolent` seems to be `malevolent`
* L218, L226: `challendingBlock` seems to be `challengingBlock`
* L375: `heght` seems to be `height`
* L395: `avoud` seems to be `avoid`

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #tendermint-core channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/tendermint/tendermint/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/tendermint/projects/15/views/5

-->

---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

