### PR TITLE
chore: retract v0.35.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -272,3 +272,5 @@ require (
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 	mvdan.cc/unparam v0.0.0-20220706161116-678bad134442 // indirect
 )
+
+retract [v0.35.0, v0.35.9] // See https://github.com/tendermint/tendermint/discussions/9155


### PR DESCRIPTION
closes: #9766 

Nice catch @tac0turtle !

I'd been running into this too.  Since v0.34.24 is the latest release, when it looked for latest, it was referencing the go.mod in v0.34.x branch.  :)

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

