### PR TITLE
Reduce Request Rate for Public RPCs to prevent statesync failure

### DIFF
--- a/rpc/jsonrpc/client/http_uri_client.go
+++ b/rpc/jsonrpc/client/http_uri_client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	types "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
@@ -54,6 +55,7 @@ func NewURI(remote string) (*URIClient, error) {
 func (c *URIClient) Call(ctx context.Context, method string,
 	params map[string]interface{}, result interface{}) (interface{}, error) {
 
+	<-time.After(1 * time.Second)
 	values, err := argsToURLValues(params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode params: %w", err)


### PR DESCRIPTION
# Evmos Validators 
You may use the following patch in the short term:
```
go mod edit -replace github.com/tendermint/tendermint=github.com/chillyvee/tendermint@cv0.34.22.notsofast.1
```

# Background

Validators need to statesync with light client verification against public rate limited RPCs

This is especially the case for high abuse public endpoints such as Evmos.

For example these POST requests all are sent within 1 second
```
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":3,"method":"commit","params":{"height":"7730001"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":4,"method":"validators","params":{"height":"7730001","page":"1","per_page":"100"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":5,"method":"validators","params":{"height":"7730001","page":"2","per_page":"100"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":3,"method":"commit","params":{"height":"7730001"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":4,"method":"validators","params":{"height":"7730001","page":"1","per_page":"100"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":5,"method":"validators","params":{"height":"7730001","page":"2","per_page":"100"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":6,"method":"commit","params":{"height":"7730002"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":7,"method":"validators","params":{"height":"7730002","page":"1","per_page":"100"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":8,"method":"validators","params":{"height":"7730002","page":"2","per_page":"100"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":6,"method":"commit","params":{"height":"7730002"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":7,"method":"validators","params":{"height":"7730002","page":"1","per_page":"100"}}
client.Call: address: https://rpc-evmos-ia.cosmosia.notional.ventures:443, body: {"jsonrpc":"2.0","id":8,"method":"validators","params":{"height":"7730002","page":"2","per_page":"100"}}
```

This results in errors such as:
```
<html>
<head><title>429 Too Many Requests</title></head>
<body>
<center><h1>429 Too Many Requests</h1></center>
<hr><center>nginx/1.18.0 (Ubuntu)</center>
</body>
</html>
```

# Current patch effectiveness

Works and does not appear to affect any other runtime operation

# Configuration discussion

Preferred section of config.toml? [statesync]? Something more general?

Feedback on a better configuration method is welcome to limit this to statesync only / set a shorter/longer delay and to determine how local/global such a setting should be.

# Implementation discussion for code reviewers

Since light client requests are limited in quantity, a simple implementation can insert a delay between requests which will minimally impact even non-rate limited RPC endpoints.

Is this light client used for other purposes? 

Any need to refactor batched requests in order for this PR to be acceptable?

Should we move this one step higher into the caller for validator info?  Or should we make a rate limit manager to sit between statesync and the light client?

Yes this implementation is a "hack", but solutions should have an agreed direction prior to implementation.

---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

