### PR TITLE
docs: Fix search configuration

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -9,8 +9,8 @@ module.exports = {
     editLinks: true,
     label: 'core',
     algolia: {
-      id: "BH4D9OD16A",
-      key: "59f0e2deb984aa9cdf2b3a5fd24ac501",
+      id: "QQFROLBNZC",
+      key: "f1b68b96fb31d8aa4a54412c44917a26",
       index: "tendermint"
     },
     versions: [


### PR DESCRIPTION
Updates the Algolia search config so that our search will actually work with an appropriate index. Needs to be backported to v0.37 and v0.34.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

