### PR TITLE
e2e: test runner generates loadtime formatted transactions.

### DIFF
--- a/test/e2e/networks/simple.toml
+++ b/test/e2e/networks/simple.toml
@@ -2,4 +2,3 @@
 [node.validator02]
 [node.validator03]
 [node.validator04]
-

--- a/test/e2e/networks/simple.toml
+++ b/test/e2e/networks/simple.toml
@@ -2,3 +2,4 @@
 [node.validator02]
 [node.validator03]
 [node.validator04]
+

--- a/test/e2e/networks/simple.toml
+++ b/test/e2e/networks/simple.toml
@@ -3,3 +3,5 @@
 [node.validator03]
 [node.validator04]
 
+
+

--- a/test/e2e/networks/simple.toml
+++ b/test/e2e/networks/simple.toml
@@ -2,6 +2,3 @@
 [node.validator02]
 [node.validator03]
 [node.validator04]
-
-
-

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -69,9 +69,9 @@ type Manifest struct {
 	CheckTxDelay         time.Duration `toml:"check_tx_delay"`
 	// TODO: add vote extension and finalize block delay (@cmwaters)
 
-	LoadTxSizeBytes      int `toml:"load_tx_size_bytes"`
-	LoadTxBatchSizeBytes int `toml:"load_tx_batch_size"`
-	LoadTxConnections    int `toml:"load_tx_connections"`
+	LoadTxSizeBytes   int `toml:"load_tx_size_bytes"`
+	LoadTxBatchSize   int `toml:"load_tx_batch_size"`
+	LoadTxConnections int `toml:"load_tx_connections"`
 }
 
 // ManifestNode represents a node in a testnet manifest.

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -68,6 +68,9 @@ type Manifest struct {
 	ProcessProposalDelay time.Duration `toml:"process_proposal_delay"`
 	CheckTxDelay         time.Duration `toml:"check_tx_delay"`
 	// TODO: add vote extension and finalize block delay (@cmwaters)
+
+	LoadTxSizeBytes int           `toml:"load_tx_size_bytes"`
+	LoadTxPeriod    time.Duration `toml:"load_tx_period"`
 }
 
 // ManifestNode represents a node in a testnet manifest.

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -149,6 +149,11 @@ type ManifestNode struct {
 	// pause:      temporarily pauses (freezes) the node
 	// restart:    restarts the node, shutting it down with SIGTERM
 	Perturb []string `toml:"perturb"`
+
+	// SendNoLoad determines if the e2e test should send load to this node.
+	// It defaults to false so unless the configured, the node will
+	// receive load.
+	SendNoLoad bool `toml:"send_no_laod"`
 }
 
 // Save saves the testnet manifest to a file.

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -69,8 +69,9 @@ type Manifest struct {
 	CheckTxDelay         time.Duration `toml:"check_tx_delay"`
 	// TODO: add vote extension and finalize block delay (@cmwaters)
 
-	LoadTxSizeBytes int           `toml:"load_tx_size_bytes"`
-	LoadTxPeriod    time.Duration `toml:"load_tx_period"`
+	LoadTxSizeBytes      int `toml:"load_tx_size_bytes"`
+	LoadTxBatchSizeBytes int `toml:"load_tx_batch_size"`
+	LoadTxConnections    int `toml:"load_tx_connections"`
 }
 
 // ManifestNode represents a node in a testnet manifest.

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -22,7 +22,7 @@ const (
 	randomSeed     int64  = 2308084734268
 	proxyPortFirst uint32 = 5701
 
-	defaultBatchSize   = 1
+	defaultBatchSize   = 2
 	defaultConnections = 1
 	defaultTxSizeBytes = 1024
 )
@@ -147,7 +147,7 @@ func LoadTestnet(manifest Manifest, fname string, ifd InfrastructureData) (*Test
 		testnet.ABCIProtocol = string(ProtocolBuiltin)
 	}
 	if testnet.LoadTxConnections == 0 {
-		testnet.LoadTxConnections = 1
+		testnet.LoadTxConnections = defaultConnections
 	}
 	if testnet.LoadTxBatchSize == 0 {
 		testnet.LoadTxBatchSize = defaultBatchSize

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -21,6 +21,10 @@ import (
 const (
 	randomSeed     int64  = 2308084734268
 	proxyPortFirst uint32 = 5701
+
+	defaultBatchSize   = 50
+	defaultConnections = 1
+	defaultTxSizeBytes = 1024
 )
 
 type (
@@ -63,7 +67,7 @@ type Testnet struct {
 	Nodes                []*Node
 	KeyType              string
 	Evidence             int
-	LoadTxSize           int
+	LoadTxSizeBytes      int
 	LoadTxBatchSize      int
 	LoadTxConnections    int
 	ABCIProtocol         string
@@ -125,8 +129,8 @@ func LoadTestnet(manifest Manifest, fname string, ifd InfrastructureData) (*Test
 		ValidatorUpdates:     map[int64]map[*Node]int64{},
 		Nodes:                []*Node{},
 		Evidence:             manifest.Evidence,
-		LoadTxSize:           manifest.LoadTxSizeBytes,
-		LoadTxBatchSize:      manifest.LoadTxBatchSizeBytes,
+		LoadTxSizeBytes:      manifest.LoadTxSizeBytes,
+		LoadTxBatchSize:      manifest.LoadTxBatchSize,
 		LoadTxConnections:    manifest.LoadTxConnections,
 		ABCIProtocol:         manifest.ABCIProtocol,
 		PrepareProposalDelay: manifest.PrepareProposalDelay,
@@ -141,6 +145,15 @@ func LoadTestnet(manifest Manifest, fname string, ifd InfrastructureData) (*Test
 	}
 	if testnet.ABCIProtocol == "" {
 		testnet.ABCIProtocol = string(ProtocolBuiltin)
+	}
+	if testnet.LoadTxConnections == 0 {
+		testnet.LoadTxConnections = 1
+	}
+	if testnet.LoadTxBatchSize == 0 {
+		testnet.LoadTxBatchSize = defaultBatchSize
+	}
+	if testnet.LoadTxSizeBytes == 0 {
+		testnet.LoadTxSizeBytes = defaultTxSizeBytes
 	}
 
 	// Set up nodes, in alphabetical order (IPs and ports get same order).

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -22,7 +22,7 @@ const (
 	randomSeed     int64  = 2308084734268
 	proxyPortFirst uint32 = 5701
 
-	defaultBatchSize   = 50
+	defaultBatchSize   = 1
 	defaultConnections = 1
 	defaultTxSizeBytes = 1024
 )

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -63,6 +63,8 @@ type Testnet struct {
 	Nodes                []*Node
 	KeyType              string
 	Evidence             int
+	LoadTxSize           int
+	LoadTxPeriod         time.Duration
 	ABCIProtocol         string
 	PrepareProposalDelay time.Duration
 	ProcessProposalDelay time.Duration
@@ -119,6 +121,8 @@ func LoadTestnet(manifest Manifest, fname string, ifd InfrastructureData) (*Test
 		ValidatorUpdates:     map[int64]map[*Node]int64{},
 		Nodes:                []*Node{},
 		Evidence:             manifest.Evidence,
+		LoadTxSize:           manifest.LoadTxSizeBytes,
+		LoadTxPeriod:         manifest.LoadTxPeriod,
 		ABCIProtocol:         manifest.ABCIProtocol,
 		PrepareProposalDelay: manifest.PrepareProposalDelay,
 		ProcessProposalDelay: manifest.ProcessProposalDelay,

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -64,7 +64,8 @@ type Testnet struct {
 	KeyType              string
 	Evidence             int
 	LoadTxSize           int
-	LoadTxPeriod         time.Duration
+	LoadTxBatchSize      int
+	LoadTxConnections    int
 	ABCIProtocol         string
 	PrepareProposalDelay time.Duration
 	ProcessProposalDelay time.Duration
@@ -122,7 +123,8 @@ func LoadTestnet(manifest Manifest, fname string, ifd InfrastructureData) (*Test
 		Nodes:                []*Node{},
 		Evidence:             manifest.Evidence,
 		LoadTxSize:           manifest.LoadTxSizeBytes,
-		LoadTxPeriod:         manifest.LoadTxPeriod,
+		LoadTxBatchSize:      manifest.LoadTxBatchSizeBytes,
+		LoadTxConnections:    manifest.LoadTxConnections,
 		ABCIProtocol:         manifest.ABCIProtocol,
 		PrepareProposalDelay: manifest.PrepareProposalDelay,
 		ProcessProposalDelay: manifest.ProcessProposalDelay,

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -95,6 +95,9 @@ type Node struct {
 	Seeds            []*Node
 	PersistentPeers  []*Node
 	Perturbations    []Perturbation
+
+	// SendNoLoad determines if the e2e test should send load to this node.
+	SendNoLoad bool
 }
 
 // LoadTestnet loads a testnet from a manifest file, using the filename to
@@ -173,6 +176,7 @@ func LoadTestnet(manifest Manifest, fname string, ifd InfrastructureData) (*Test
 			SnapshotInterval: nodeManifest.SnapshotInterval,
 			RetainBlocks:     nodeManifest.RetainBlocks,
 			Perturbations:    []Perturbation{},
+			SendNoLoad:       nodeManifest.SendNoLoad,
 		}
 		if node.StartAt == testnet.InitialHeight {
 			node.StartAt = 0 // normalize to 0 for initial nodes, since code expects this

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -73,7 +73,7 @@ func loadGenerate(ctx context.Context, txCh chan<- types.Tx, testnet *e2e.Testne
 		// This gives a reasonable load without putting too much data in the app.
 		tx, err := payload.NewBytes(&payload.Payload{
 			Id:          id,
-			Size:        uint64(testnet.LoadTxSize),
+			Size:        uint64(testnet.LoadTxSizeBytes),
 			Rate:        uint64(testnet.LoadTxBatchSize),
 			Connections: uint64(testnet.LoadTxConnections),
 		})

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -105,7 +105,7 @@ func NewCLI() *CLI {
 			ctx, loadCancel := context.WithCancel(context.Background())
 			defer loadCancel()
 			go func() {
-				err := Load(ctx, cli.testnet, 1)
+				err := Load(ctx, cli.testnet)
 				if err != nil {
 					logger.Error(fmt.Sprintf("Transaction load failed: %v", err.Error()))
 				}
@@ -216,20 +216,10 @@ func NewCLI() *CLI {
 	})
 
 	cli.root.AddCommand(&cobra.Command{
-		Use:   "load [multiplier]",
-		Args:  cobra.MaximumNArgs(1),
+		Use:   "load",
 		Short: "Generates transaction load until the command is canceled",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			m := 1
-
-			if len(args) == 1 {
-				m, err = strconv.Atoi(args[0])
-				if err != nil {
-					return err
-				}
-			}
-
-			return Load(context.Background(), cli.testnet, m)
+			return Load(context.Background(), cli.testnet)
 		},
 	})
 
@@ -312,7 +302,7 @@ Does not run any perbutations.
 			ctx, loadCancel := context.WithCancel(context.Background())
 			defer loadCancel()
 			go func() {
-				err := Load(ctx, cli.testnet, 1)
+				err := Load(ctx, cli.testnet)
 				if err != nil {
 					logger.Error(fmt.Sprintf("Transaction load failed: %v", err.Error()))
 				}


### PR DESCRIPTION
This pull request updates the e2e test to use the `loadtime` transaction format and updates the configuration to allow for parity with the `loadtime` load generation.

### Added configuration parameters

`load_tx_size_bytes`: This size, in bytes, of each generated transaction. Defaults to 1024 bytes.
`load_tx_batch_size`: How many transactions to generate every 1 second.
`load_tx_connections`: How many connections to make to each node.
`node.no_send_load`: Whether or not to send load to this node.

### Difference with `loadtime` tool

Note that there is a slight difference between this configuration scheme and the scheme used in the `loadtime` tool. The `loadtime` tool generates `batch_size` _per connection_ per second. This code generates a total of `load_tx_batch_size` total every second. To mimic the behavior of the `loadtime` tool simply multiply by the total number of connections. This was done to maintain the legacy behavior of the tool which generated a total network-wide connection load instead of a per-connection load.

### Replicating the v0.37.x load test.

The v0.37.x load tests, as outlined in [methods.md](https://github.com/tendermint/tendermint/blob/9d01a6880e38b79ec31849e436677c70ccd0e588/docs/qa/method.md), opened a set of connections to a single node instead of to all nodes on the network. The e2e test previously opened a set of connections to all nodes on the network and this default behavior was maintained by this change. To replicate the the v0.37.x load test, set all nodes but one to have a `no_send_load` parameter of `true`, setting `no_send_load = true` on the one node that should receive load. Connection number can be configured exactly as was done in v0.37.x, and batch size should be set to the product of the number of connections with the original batch size. For example, if v0.37.x's load test had a batch size of 200 and a connection number of 4, the batch size should instead be set to 800.

closes: #9778

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

