### PR TITLE
ci: Configure docs build workflow to use legacy OpenSSL provider

### DIFF
--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -35,6 +35,8 @@ jobs:
           # versions will be available for the build.
           fetch-depth: 0
       - name: Build documentation
+        env:
+          NODE_OPTIONS: "--openssl-legacy-provider"
         run: |
           git config --global --add safe.directory "$PWD"
           make build-docs


### PR DESCRIPTION
I see our docs build is failing: https://github.com/tendermint/tendermint/actions/runs/3570216583/jobs/6000981820

The cause seems related to [this issue](https://stackoverflow.com/questions/70582072/npm-run-fails-with-err-ossl-evp-unsupported). Running this workflow manually with this fix solves it: https://github.com/tendermint/tendermint/actions/runs/3570298021

The longer-term solution is to get away from using NodeJS entirely in our docs build process.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

