### PR TITLE
docs: Expand on genesis_chunked description

### DIFF
--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -918,8 +918,10 @@ paths:
       tags:
         - Info
       description: |
-        Get genesis document in multiple chunks to make it
-        easier to iterate through larger genesis structures.
+        Get genesis document in multiple chunks to make it easier to iterate
+        through larger genesis structures. Each chunk is produced by converting
+        the genesis document to JSON and then splitting the resulting payload
+        into 16MB blocks, and then Base64-encoding each block.
 
         Upon success, the `Cache-Control` header will be set with the default
         maximum age.
@@ -933,7 +935,7 @@ paths:
             example: 1
       responses:
         "200":
-          description: Genesis results.
+          description: Genesis chunk response.
           content:
             application/json:
               schema:


### PR DESCRIPTION
Builds on #9674, adding more of the description from https://github.com/tendermint/tendermint/blob/4290ad29829fde50d8a32ef8e11295c4d28c481b/rpc/core/types/responses.go#L26-L29

No need to backport this, I'll add this to #9791 and #9792 before merging them.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

