### PR TITLE
docs: Fix pre-build script

### DIFF
--- a/docs/pre.sh
+++ b/docs/pre.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+mkdir -p .vuepress/public/rpc/
 cp -a ../rpc/openapi/* .vuepress/public/rpc/


### PR DESCRIPTION
Our documentation build process is rather finicky. I noticed yet another build failure that doesn't actually cause the docs site build to fail - see https://github.com/tendermint/tendermint/actions/runs/3578638807/jobs/6019002654

Basically the `docs/post.sh` script deletes the `.vuepress/public/rpc` directory after generating the docs for a specific version of Tendermint, and then the `docs/pre.sh` script attempts to copy the next version's OpenAPI script into `.vuepress/public/rpc` but that directory doesn't exist.

For some reason this doesn't cause the npm build process to fail - it just results in the OpenAPI doc not being available.

This is hard to test locally because our docs build process currently relies on checking out specific branches to do the full docs site build: https://github.com/tendermint/tendermint/blob/4290ad29829fde50d8a32ef8e11295c4d28c481b/Makefile#L290-L300

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

