### PR TITLE
Fix typo in new option in e2e manifest node

### DIFF
--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -153,7 +153,7 @@ type ManifestNode struct {
 	// SendNoLoad determines if the e2e test should send load to this node.
 	// It defaults to false so unless the configured, the node will
 	// receive load.
-	SendNoLoad bool `toml:"send_no_laod"`
+	SendNoLoad bool `toml:"send_no_load"`
 }
 
 // Save saves the testnet manifest to a file.

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -288,7 +288,7 @@ func NewCLI() *CLI {
 	Max Block Interval
 over a 100 block sampling period.
 		
-Does not run any perbutations.
+Does not run any perturbations.
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := Cleanup(cli.testnet); err != nil {
@@ -304,7 +304,7 @@ Does not run any perbutations.
 			go func() {
 				err := Load(ctx, cli.testnet)
 				if err != nil {
-					logger.Error(fmt.Sprintf("Transaction load failed: %v", err.Error()))
+					logger.Error(fmt.Sprintf("Transaction load errored: %v", err.Error()))
 				}
 				chLoadResult <- err
 			}()


### PR DESCRIPTION
The "toml" annotation of "send no load" had a typo (`send_no_laod`).

This is suspected to have caused failures in e2e, however I couldn't reproduce the error locally, so not sure this will fix it. Still, the typo needs to be fixed in any case.


---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

