### PR TITLE
Mention tx_max_bytes in the tutorials

### DIFF
--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -461,7 +461,8 @@ When Tendermint Core sees that valid transactions (validated through `CheckTx`) 
 included in blocks, it groups some of these transactions and then gives the application a chance 
 to modify the group by invoking `PrepareProposal`.
 
-The application is free to modify the group before returning from the call.
+The application is free to modify the group before returning from the call, as long as the resulting set
+does not use more bytes than `RequestPrepareProposal.max_tx_bytes'
 For example, the application may reorder, add, or even remove transactions from the group to improve the
 execution of the block once accepted.
 In the following code, the application simply returns the unmodified group of transactions:

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -460,7 +460,8 @@ When Tendermint Core sees that valid transactions (validated through `CheckTx`) 
 included in blocks, it groups some of these transactions and then gives the application a chance 
 to modify the group by invoking `PrepareProposal`.
 
-The application is free to modify the group before returning from the call.
+The application is free to modify the group before returning from the call, as long as the resulting set
+does not use more bytes than `RequestPrepareProposal.max_tx_bytes'
 For example, the application may reorder, add, or even remove transactions from the group to improve the
 execution of the block once accepted.
 In the following code, the application simply returns the unmodified group of transactions:


### PR DESCRIPTION
Updates the discussion of prepareProposal in the go tutorials to mention tx_max_bytes limitation to transaction set size.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #tendermint-core channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/tendermint/tendermint/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/tendermint/projects/15/views/5

-->

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

