### PR TITLE
ci: Better Slack failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
           fi
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Capture git repo info
         id: git-info
         run: |
-          echo "::set-output name=branch::`git branch --show-current`"
+          echo "branch=`git branch --show-current`" >> $GITHUB_OUTPUT
 
       - name: Build
         working-directory: test/e2e

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -31,7 +31,6 @@ jobs:
         id: git-info
         run: |
           echo "::set-output name=branch::`git branch --show-current`"
-          echo "::set-output name=commit::`git rev-parse HEAD`"
 
       - name: Build
         working-directory: test/e2e
@@ -49,7 +48,6 @@ jobs:
 
     outputs:
       git-branch: ${{ steps.git-info.outputs.branch }}
-      git-commit: ${{ steps.git-info.outputs.commit }}
 
   e2e-nightly-fail:
     needs: e2e-nightly-test
@@ -63,7 +61,7 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
           BRANCH: ${{ needs.e2e-nightly-test.outputs.git-branch }}
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          COMMIT_URL: "${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.e2e-nightly-test.outputs.git-commit }}"
+          COMMITS_URL: "${{ github.server_url }}/${{ github.repository }}/commits/${{ needs.e2e-nightly-test.outputs.git-branch }}"
         with:
           payload: |
             {
@@ -72,7 +70,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMIT_URL }}|commit> related to the failure."
+                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMITS_URL }}|latest commits> possibly related to the failure."
                   }
                 }
               ]

--- a/.github/workflows/e2e-nightly-37x.yml
+++ b/.github/workflows/e2e-nightly-37x.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Capture git repo info
         id: git-info
         run: |
-          echo "::set-output name=branch::`git branch --show-current`"
+          echo "branch=`git branch --show-current`" >> $GITHUB_OUTPUT
 
       - name: Build
         working-directory: test/e2e

--- a/.github/workflows/e2e-nightly-37x.yml
+++ b/.github/workflows/e2e-nightly-37x.yml
@@ -31,7 +31,6 @@ jobs:
         id: git-info
         run: |
           echo "::set-output name=branch::`git branch --show-current`"
-          echo "::set-output name=commit::`git rev-parse HEAD`"
 
       - name: Build
         working-directory: test/e2e
@@ -49,7 +48,6 @@ jobs:
 
     outputs:
       git-branch: ${{ steps.git-info.outputs.branch }}
-      git-commit: ${{ steps.git-info.outputs.commit }}
 
   e2e-nightly-fail:
     needs: e2e-nightly-test
@@ -63,7 +61,7 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
           BRANCH: ${{ needs.e2e-nightly-test.outputs.git-branch }}
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          COMMIT_URL: "${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.e2e-nightly-test.outputs.git-commit }}"
+          COMMITS_URL: "${{ github.server_url }}/${{ github.repository }}/commits/${{ needs.e2e-nightly-test.outputs.git-branch }}"
         with:
           payload: |
             {
@@ -72,7 +70,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMIT_URL }}|commit> related to the failure."
+                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMITS_URL }}|latest commits> possibly related to the failure."
                   }
                 }
               ]

--- a/.github/workflows/e2e-nightly-main.yml
+++ b/.github/workflows/e2e-nightly-main.yml
@@ -52,7 +52,7 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
           BRANCH: ${{ github.ref_name }}
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          COMMIT_URL: "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
+          COMMITS_URL: "${{ github.server_url }}/${{ github.repository }}/commits/${{ github.ref_name }}"
         with:
           payload: |
             {
@@ -61,7 +61,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMIT_URL }}|commit> related to the failure."
+                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMITS_URL }}|latest commits> possibly related to the failure."
                   }
                 }
               ]

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Set crashers count
         working-directory: test/fuzz
-        run: echo "::set-output name=count::$(find . -type d -name 'crashers' | xargs -I % sh -c 'ls % | wc -l' | awk '{total += $1} END {print total}')"
+        run: echo "count=$(find . -type d -name 'crashers' | xargs -I % sh -c 'ls % | wc -l' | awk '{total += $1} END {print total}')" >> $GITHUB_OUTPUT
         id: set-crashers-count
 
     outputs:


### PR DESCRIPTION
The primary aim of this PR is to improve the failure messages we get a little. Seeing the latest commit is often useless, and it's probably better to just get a direct link to a list of commits for that specific branch so we can see what's been committed since the previous nightly run.

This PR also makes one minor improvement in the use of the now-deprecated `set-output` syntax for workflows, upgrading it to use the new approach as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

