### PR TITLE
e2e: create client when sending transaction

### DIFF
--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -26,6 +26,7 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	logger.Info("load", "msg", log.NewLazySprintf("Starting transaction load (%v workers)...", workerPoolSize))
 	started := time.Now()
 	u := [16]byte(uuid.New()) // generate run ID on startup
 

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -128,6 +128,7 @@ func loadProcess(ctx context.Context, txCh <-chan types.Tx, chSuccess chan<- str
 		if client == nil {
 			client, err = n.Client()
 			if err != nil {
+				logger.Info("non-fatal error creating node client", "error", err)
 				continue
 			}
 		}


### PR DESCRIPTION
Fixes the issue observed in an [e2e test run](https://github.com/tendermint/tendermint/actions/runs/3588927225). The issue arises when the e2e runner process cannot connect to the remote node. In the previous version of this code, the runner would simply skip the transaction if the client couldn't connect. This pull request resurrects that behavior.

---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

