### PR TITLE
Rejects empty transactions in the example kvstore

### DIFF
--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -122,6 +122,10 @@ func (app *Application) DeliverTx(req types.RequestDeliverTx) types.ResponseDeli
 }
 
 func (app *Application) CheckTx(req types.RequestCheckTx) types.ResponseCheckTx {
+	if len(req.Tx) == 0 {
+		return types.ResponseCheckTx{Code: code.CodeTypeUnauthorized}
+	}
+
 	if req.Type == types.CheckTxType_Recheck {
 		if _, ok := app.txToRemove[string(req.Tx)]; ok {
 			return types.ResponseCheckTx{Code: code.CodeTypeExecuted, GasWanted: 1}

--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -324,11 +324,15 @@ func (app *PersistentKVStoreApplication) execPrepareTx(tx []byte) types.Response
 }
 
 // substPrepareTx substitutes all the transactions prefixed with 'prepare' in the
-// proposal for transactions with the prefix stripped.
+// proposal for transactions with the prefix stripped, while discarding invalid empty transactions.
 func (app *PersistentKVStoreApplication) substPrepareTx(blockData [][]byte, maxTxBytes int64) [][]byte {
 	txs := make([][]byte, 0, len(blockData))
 	var totalBytes int64
 	for _, tx := range blockData {
+		if len(tx) == 0 {
+			continue
+		}
+
 		txMod := tx
 		if isPrepareTx(tx) {
 			txMod = bytes.Replace(tx, []byte(PreparePrefix), []byte(ReplacePrefix), 1)


### PR DESCRIPTION
In the kvstore, empty transactions accepted in the mempool and in prepareProposal, but not in processProposal. Hence, if an empty transaction is submitted to the system, it might keep being put into proposal which will always be rejected, effectively halting the chain.

This PR prevents empty transactions from being added to the pool and in the proposals. The check in prepareProposal isn't actually needed, but serves as an example that transactions should be checked for validity both when entering the pool and when being added to a proposal.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #tendermint-core channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/tendermint/tendermint/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/tendermint/projects/15/views/5

-->

---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

