### PR TITLE
workflow: correct the name for the e2e app in the workflow

### DIFF
--- a/.github/workflows/testapp-docker.yml
+++ b/.github/workflows/testapp-docker.yml
@@ -1,6 +1,6 @@
-name: Testapp Docker
-# Build & Push rebuilds the Testapp docker image on every push to main and creation of tags
-# and pushes the image to https://hub.docker.com/r/tendermint/testapp
+name: Docker E2E Node
+# Build & Push rebuilds the e2e Testapp docker image on every push to main and creation of tags
+# and pushes the image to https://hub.docker.com/r/tendermint/e2e-node
 on:
   push:
     branches:
@@ -19,7 +19,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=tendermint/testapp
+          DOCKER_IMAGE=tendermint/e2e-node
           VERSION=noop
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
The docker image was mistakenly named `testapp`, whereas the correct name is `e2e-node`. This is the name used by the docker-compose file referenced in the e2e tests:
https://github.com/tendermint/tendermint/blob/3324f49fb7e7b40189726746493e83b82a61b558/test/e2e/pkg/infra/docker/docker.go#L60

---

#### PR checklist

- [ ] Tests written/updated, or no tests needed
- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [ ] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

