### PR TITLE
ci: add Go vulnerability checker per PR and to Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,3 +80,5 @@ jobs:
         run: test/app/test.sh
         shell: bash
         if: "env.GIT_DIFF != ''"
+      - name: "Go vulnerability check"
+        run: make vulncheck

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ ifeq (linux/riscv64,$(findstring linux/riscv64,$(TARGETPLATFORM)))
 	GOARCH=riscv64
 endif
 
-all: check build test install
+all: check build test install vulncheck
 .PHONY: all
 
 include tests.mk
@@ -120,6 +120,10 @@ include tests.mk
 build:
 	CGO_ENABLED=$(CGO_ENABLED) go build $(BUILD_FLAGS) -tags '$(BUILD_TAGS)' -o $(OUTPUT) ./cmd/tendermint/
 .PHONY: build
+
+vulncheck: $(BUILDDIR)/
+	GOBIN=$(BUILDDIR) go install golang.org/x/vuln/cmd/govulncheck@latest
+	$(BUILDDIR)/govulncheck ./...
 
 install:
 	CGO_ENABLED=$(CGO_ENABLED) go install $(BUILD_FLAGS) -tags $(BUILD_TAGS) ./cmd/tendermint


### PR DESCRIPTION
Adds the ability to run the Go vulnerability checker to be run on all tests in continuous integration. This helps us flag vulnerable code proactively and massively increase supply chain security.

Fixes #9872