### PR TITLE
node: wire up logger to mempool reactor

### DIFF
--- a/node/setup.go
+++ b/node/setup.go
@@ -226,6 +226,7 @@ func createMempoolAndMempoolReactor(
 	memplMetrics *mempl.Metrics,
 	logger log.Logger,
 ) (mempl.Mempool, p2p.Reactor) {
+	logger = logger.With("module", "mempool")
 	switch config.Mempool.Version {
 	case cfg.MempoolV1:
 		mp := mempoolv1.NewTxMempool(
@@ -245,6 +246,7 @@ func createMempoolAndMempoolReactor(
 		if config.Consensus.WaitForTxs() {
 			mp.EnableTxsAvailable()
 		}
+		reactor.SetLogger(logger)
 
 		return mp, reactor
 
@@ -267,6 +269,7 @@ func createMempoolAndMempoolReactor(
 		if config.Consensus.WaitForTxs() {
 			mp.EnableTxsAvailable()
 		}
+		reactor.SetLogger(logger)
 
 		return mp, reactor
 


### PR DESCRIPTION
Seems as if the logger was never wired up to the mempool reactor so logs weren't being published by that reactor.

This PR wires it up correctly. I've validated this by running the e2e tests afterwards and checking that the logs actually publish mempool reactor info.

This should also be backported to v0.34.x 
