### PR TITLE
e2e: Remove extraneous abci_protocol params in CI test

### DIFF
--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -8,6 +8,8 @@ initial_state = { initial01 = "a", initial02 = "b", initial03 = "c" }
 prepare_proposal_delay = "100ms"
 process_proposal_delay = "100ms"
 check_tx_delay = "0ms"
+# The most common case (e.g. Cosmos SDK-based chains).
+abci_protocol = "builtin"
 
 [validators]
 validator01 = 100
@@ -41,7 +43,6 @@ perturb = ["disconnect"]
 [node.validator02]
 seeds = ["seed01"]
 database = "boltdb"
-abci_protocol = "tcp"
 privval_protocol = "tcp"
 persist_interval = 0
 perturb = ["restart"]
@@ -49,8 +50,6 @@ perturb = ["restart"]
 [node.validator03]
 seeds = ["seed01"]
 database = "badgerdb"
-# FIXME: should be grpc, disabled due to https://github.com/tendermint/tendermint/issues/5439
-#abci_protocol = "grpc"
 privval_protocol = "unix"
 persist_interval = 3
 retain_blocks = 10
@@ -59,7 +58,6 @@ perturb = ["kill"]
 [node.validator04]
 persistent_peers = ["validator01"]
 database = "rocksdb"
-abci_protocol = "builtin"
 perturb = ["pause"]
 
 [node.validator05]
@@ -68,8 +66,6 @@ start_at = 1005 # Becomes part of the validator set at 1010
 persistent_peers = ["validator01", "full01"]
 database = "cleveldb"
 mempool_version = "v1"
-# FIXME: should be grpc, disabled due to https://github.com/tendermint/tendermint/issues/5439
-#abci_protocol = "grpc"
 privval_protocol = "tcp"
 perturb = ["kill", "pause", "disconnect", "restart"]
 


### PR DESCRIPTION
Closes #9894.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

