### PR TITLE
Divergences in comparison with #9620. Part 3: Fix problems found in blocksync reactor

### DIFF
--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -358,16 +358,16 @@ FOR_LOOP:
 			// then we are guaranteed to have extensions for the last block (if required) even
 			// if we did not blocksync any block.
 			//
-                       var needsExtension := true;
-                       if state.LastBlockHeight == 0 ||
-                                !state.ConsensusParams.ABCI.VoteExtensionsEnabled(state.LastBlockHeight) ||
-                                blocksSynced > 0 ||
-                                initialCommitHasExtensions {
-                                needsExtension = false
-                       }
+			missingExtension := true
+			if state.LastBlockHeight == 0 ||
+				!state.ConsensusParams.ABCI.VoteExtensionsEnabled(state.LastBlockHeight) ||
+				blocksSynced > 0 ||
+				initialCommitHasExtensions {
+				missingExtension = false
+			}
 
 			// If require extensions, but since we don't have them yet, then we cannot switch to consensus yet.
-			if needsExtension {
+			if missingExtension {
 				bcR.Logger.Info(
 					"no extended commit yet",
 					"height", height,
@@ -424,8 +424,7 @@ FOR_LOOP:
 				// Panicking because this is an obvious bug in the block pool, which is totally under our control
 				panic(fmt.Errorf("heights of first and second block are not consecutive; expected %d, got %d", state.LastBlockHeight, first.Height))
 			}
-			if first != nil && extCommit == nil &&
-				state.ConsensusParams.ABCI.VoteExtensionsEnabled(first.Height) {
+			if extCommit == nil && state.ConsensusParams.ABCI.VoteExtensionsEnabled(first.Height) {
 				// See https://github.com/tendermint/tendermint/pull/8433#discussion_r866790631
 				panic(fmt.Errorf("peeked first block without extended commit at height %d - possible node store corruption", first.Height))
 			}

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -358,13 +358,16 @@ FOR_LOOP:
 			// then we are guaranteed to have extensions for the last block (if required) even
 			// if we did not blocksync any block.
 			//
-			// If none of these conditions is met, that means that we require VoteExtensions
-			// but we don't have them, so we cannot switch to consensus yet.
-			if state.LastBlockHeight > 0 &&
-				state.ConsensusParams.ABCI.VoteExtensionsEnabled(state.LastBlockHeight) &&
-				blocksSynced == 0 &&
-				!initialCommitHasExtensions {
+                       var needsExtension := true;
+                       if state.LastBlockHeight == 0 ||
+                                !state.ConsensusParams.ABCI.VoteExtensionsEnabled(state.LastBlockHeight) ||
+                                blocksSynced > 0 ||
+                                initialCommitHasExtensions {
+                                needsExtension = false
+                       }
 
+			// If require extensions, but since we don't have them yet, then we cannot switch to consensus yet.
+			if needsExtension {
 				bcR.Logger.Info(
 					"no extended commit yet",
 					"height", height,

--- a/types/params.go
+++ b/types/params.go
@@ -73,6 +73,9 @@ type ABCIParams struct {
 // VoteExtensionsEnabled returns true if vote extensions are enabled at height h
 // and false otherwise.
 func (a ABCIParams) VoteExtensionsEnabled(h int64) bool {
+	if h < 1 {
+		panic(fmt.Errorf("cannot check if vote extensions enabled for height %d (< 1)", h))
+	}
 	if a.VoteExtensionsEnableHeight == 0 {
 		return false
 	}

--- a/types/vote.go
+++ b/types/vote.go
@@ -246,6 +246,10 @@ func (vote *Vote) VerifyVoteAndExtension(chainID string, pubKey crypto.PubKey) e
 	}
 	// We only verify vote extension signatures for non-nil precommits.
 	if vote.Type == tmproto.PrecommitType && !ProtoBlockIDIsNil(&v.BlockID) {
+		if len(vote.ExtensionSignature) == 0 {
+			return errors.New("expected vote extension signature")
+		}
+
 		extSignBytes := VoteExtensionSignBytes(chainID, v)
 		if !pubKey.VerifySignature(extSignBytes, vote.ExtensionSignature) {
 			return ErrVoteInvalidSignature


### PR DESCRIPTION
Contributes to #9887

This PR fixes and tests the problems found in the blocksync reactor when comparing the cherry-picked branch with #9620 (diff-of-diffs).

The newly added UT will panic if the fix in the blocksync reactor is removed.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

