### PR TITLE
Fix function `TrySendEnvelopeShim`

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -87,7 +87,7 @@ func SendEnvelopeShim(p Peer, e Envelope, lg log.Logger) bool {
 // Deprecated: Will be removed in v0.37.
 func TrySendEnvelopeShim(p Peer, e Envelope, lg log.Logger) bool {
 	if es, ok := p.(EnvelopeSender); ok {
-		return es.SendEnvelope(e)
+		return es.TrySendEnvelope(e)
 	}
 	msg := e.Message
 	if w, ok := msg.(Wrapper); ok {


### PR DESCRIPTION
`TrySendEnvelopeShim` is a temporary function introduced in `v0.34.23` to make the new `Envelope`-based infra for sending/broadcasting messages over p2p compatible with the existing releases in the `v0.34.x` branch.
This function does not exist in any further release branch (`v0.37.x`, etc)

`TrySendEnvelopeShim` is supposed to be non-blocking, and should therefore call `TrySendEnvelope` rather than `SendEnvelope`

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

