### PR TITLE
ci: Add manual multi-version E2E workflow to v0.34.x branch

### DIFF
--- a/.github/workflows/e2e-manual-multiversion.yml
+++ b/.github/workflows/e2e-manual-multiversion.yml
@@ -1,0 +1,38 @@
+# Manually run the nightly E2E tests for a particular branch, but test with
+# multiple versions.
+name: e2e-manual-multiversion
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e-manual-multiversion-test:
+    # Run parallel jobs for the listed testnet groups (must match the
+    # ./build/generator -g flag)
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ['00', '01', '02', '03']
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+
+      - uses: actions/checkout@v3
+
+      - name: Build
+        working-directory: test/e2e
+        # Run make jobs in parallel, since we can't run steps in parallel.
+        run: make -j2 docker generator runner tests
+
+      - name: Generate testnets
+        working-directory: test/e2e
+        # When changing -g, also change the matrix groups above
+        # Generate multi-version tests with double the quantity of E2E nodes
+        # based on the current branch as compared to the latest version.
+        run: ./build/generator -g 4 -m "latest:1,local:2" -d networks/nightly/
+
+      - name: Run ${{ matrix.p2p }} p2p testnets
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml


### PR DESCRIPTION
After merging #9928 and #9935, I tried running the new GitHub workflow (as defined on `main`) for the `v0.34.x` branch, but GitHub requires the same-named workflow to be present on the `v0.34.x` branch.

I thought I could just run the same workflow on a different branch, but apparently not.

This PR also adapts the workflow slightly, reducing the number of groups generated to 4 to correspond to the `e2e-manual` workflow currently on the `v0.34.x` branch.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

