### PR TITLE
change 2) to 3) to make ordering incremental in config.toml comments

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -436,7 +436,7 @@ chunk_fetchers = "{{ .StateSync.ChunkFetchers }}"
 # Fast Sync version to use:
 #   1) "v0" (default) - the legacy fast sync implementation
 #   2) "v1" - refactor of v0 version for better testability
-#   2) "v2" - complete redesign of v0, optimized for testability & readability
+#   3) "v2" - complete redesign of v0, optimized for testability & readability
 version = "{{ .FastSync.Version }}"
 
 #######################################################


### PR DESCRIPTION
## Description

This is a trivial change to the numbering of items in the comments that end up in the `config.toml` file. This change is purely aesthetic and should have no actual material impact to anything.

