### PR TITLE
Added `RequestBeginBlock.IsProofBlock` for `create_empty_blocks=false`

### DIFF
--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -397,7 +397,7 @@ FOR_LOOP:
 
 			// TODO: same thing for app - but we would need a way to
 			// get the hash without persisting the state
-			state, _, err = bcR.blockExec.ApplyBlock(state, firstID, first)
+			state, _, err = bcR.blockExec.ApplyBlock(state, firstID, first, false)
 			if err != nil {
 				// TODO This is bad, are we zombie?
 				panic(fmt.Sprintf("Failed to process committed block (%d:%X): %v", first.Height, first.Hash(), err))

--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -123,7 +123,7 @@ func newBlockchainReactor(
 		thisParts := thisBlock.MakePartSet(types.BlockPartSizeBytes)
 		blockID := types.BlockID{Hash: thisBlock.Hash(), PartSetHeader: thisParts.Header()}
 
-		state, _, err = blockExec.ApplyBlock(state, blockID, thisBlock)
+		state, _, err = blockExec.ApplyBlock(state, blockID, thisBlock, false)
 		if err != nil {
 			panic(fmt.Errorf("error apply block: %w", err))
 		}

--- a/blockchain/v1/reactor.go
+++ b/blockchain/v1/reactor.go
@@ -484,7 +484,7 @@ func (bcR *BlockchainReactor) processBlock() error {
 
 	bcR.store.SaveBlock(first, firstParts, second.LastCommit)
 
-	bcR.state, _, err = bcR.blockExec.ApplyBlock(bcR.state, firstID, first)
+	bcR.state, _, err = bcR.blockExec.ApplyBlock(bcR.state, firstID, first, false)
 	if err != nil {
 		panic(fmt.Sprintf("failed to process committed block (%d:%X): %v", first.Height, first.Hash(), err))
 	}

--- a/blockchain/v1/reactor_test.go
+++ b/blockchain/v1/reactor_test.go
@@ -144,7 +144,7 @@ func newBlockchainReactor(
 		thisParts := thisBlock.MakePartSet(types.BlockPartSizeBytes)
 		blockID := types.BlockID{Hash: thisBlock.Hash(), PartSetHeader: thisParts.Header()}
 
-		state, _, err = blockExec.ApplyBlock(state, blockID, thisBlock)
+		state, _, err = blockExec.ApplyBlock(state, blockID, thisBlock, false)
 		if err != nil {
 			panic(fmt.Errorf("error apply block: %w", err))
 		}

--- a/blockchain/v2/processor_context.go
+++ b/blockchain/v2/processor_context.go
@@ -30,7 +30,7 @@ func newProcessorContext(st blockStore, ex blockApplier, s state.State) *pContex
 }
 
 func (pc *pContext) applyBlock(blockID types.BlockID, block *types.Block) error {
-	newState, _, err := pc.applier.ApplyBlock(pc.state, blockID, block)
+	newState, _, err := pc.applier.ApplyBlock(pc.state, blockID, block, false)
 	pc.state = newState
 	return err
 }

--- a/blockchain/v2/reactor.go
+++ b/blockchain/v2/reactor.go
@@ -55,7 +55,7 @@ type blockVerifier interface {
 }
 
 type blockApplier interface {
-	ApplyBlock(state state.State, blockID types.BlockID, block *types.Block) (state.State, int64, error)
+	ApplyBlock(state state.State, blockID types.BlockID, block *types.Block, isProofBlock bool) (state.State, int64, error)
 }
 
 // XXX: unify naming in this package around tmState

--- a/blockchain/v2/reactor_test.go
+++ b/blockchain/v2/reactor_test.go
@@ -69,7 +69,7 @@ type mockBlockApplier struct{}
 
 // XXX: Add whitelist/blacklist?
 func (mba *mockBlockApplier) ApplyBlock(
-	state sm.State, blockID types.BlockID, block *types.Block,
+	state sm.State, blockID types.BlockID, block *types.Block, isProofBlock bool,
 ) (sm.State, int64, error) {
 	state.LastBlockHeight++
 	return state, 0, nil
@@ -565,7 +565,7 @@ func newReactorStore(
 		thisParts := thisBlock.MakePartSet(types.BlockPartSizeBytes)
 		blockID := types.BlockID{Hash: thisBlock.Hash(), PartSetHeader: thisParts.Header()}
 
-		state, _, err = blockExec.ApplyBlock(state, blockID, thisBlock)
+		state, _, err = blockExec.ApplyBlock(state, blockID, thisBlock, false)
 		if err != nil {
 			panic(fmt.Errorf("error apply block: %w", err))
 		}

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -500,7 +500,7 @@ func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.Ap
 	blockExec.SetEventBus(h.eventBus)
 
 	var err error
-	state, _, err = blockExec.ApplyBlock(state, meta.BlockID, block)
+	state, _, err = blockExec.ApplyBlock(state, meta.BlockID, block, false)
 	if err != nil {
 		return sm.State{}, err
 	}

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -792,7 +792,7 @@ func applyBlock(stateStore sm.Store, st sm.State, blk *types.Block, proxyApp pro
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
 
 	blkID := types.BlockID{Hash: blk.Hash(), PartSetHeader: blk.MakePartSet(testPartSize).Header()}
-	newState, _, err := blockExec.ApplyBlock(st, blkID, blk)
+	newState, _, err := blockExec.ApplyBlock(st, blkID, blk, false)
 	if err != nil {
 		panic(err)
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1651,6 +1651,7 @@ func (cs *State) finalizeCommit(height int64) {
 		retainHeight int64
 	)
 
+	isProofBlock := cs.config.WaitForTxs() && len(block.Txs) == 0 && cs.needProofBlock(height)
 	stateCopy, retainHeight, err = cs.blockExec.ApplyBlock(
 		stateCopy,
 		types.BlockID{
@@ -1658,6 +1659,8 @@ func (cs *State) finalizeCommit(height int64) {
 			PartSetHeader: blockParts.Header(),
 		},
 		block,
+		// marks this block as a proof-only block, modules should avoid write ops
+		isProofBlock,
 	)
 	if err != nil {
 		logger.Error("failed to apply block", "err", err)

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -79,6 +79,7 @@ message RequestBeginBlock {
   tendermint.types.Header header               = 2 [(gogoproto.nullable) = false];
   LastCommitInfo          last_commit_info     = 3 [(gogoproto.nullable) = false];
   repeated Evidence       byzantine_validators = 4 [(gogoproto.nullable) = false];
+  bool                   is_proof_block             = 5;
 }
 
 enum CheckTxType {

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -79,7 +79,7 @@ message RequestBeginBlock {
   tendermint.types.Header header               = 2 [(gogoproto.nullable) = false];
   LastCommitInfo          last_commit_info     = 3 [(gogoproto.nullable) = false];
   repeated Evidence       byzantine_validators = 4 [(gogoproto.nullable) = false];
-  bool                   is_proof_block             = 5;
+  bool                    is_proof_block       = 5;
 }
 
 enum CheckTxType {

--- a/state/execution.go
+++ b/state/execution.go
@@ -129,7 +129,7 @@ func (blockExec *BlockExecutor) ValidateBlock(state State, block *types.Block) e
 // from outside this package to process and commit an entire block.
 // It takes a blockID to avoid recomputing the parts hash.
 func (blockExec *BlockExecutor) ApplyBlock(
-	state State, blockID types.BlockID, block *types.Block,
+	state State, blockID types.BlockID, block *types.Block, isProofBlock bool,
 ) (State, int64, error) {
 
 	if err := validateBlock(state, block); err != nil {
@@ -138,7 +138,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 
 	startTime := time.Now().UnixNano()
 	abciResponses, err := execBlockOnProxyApp(
-		blockExec.logger, blockExec.proxyApp, block, blockExec.store, state.InitialHeight,
+		blockExec.logger, blockExec.proxyApp, block, blockExec.store, state.InitialHeight, isProofBlock,
 	)
 	endTime := time.Now().UnixNano()
 	blockExec.metrics.BlockProcessingTime.Observe(float64(endTime-startTime) / 1000000)
@@ -262,6 +262,7 @@ func execBlockOnProxyApp(
 	block *types.Block,
 	store Store,
 	initialHeight int64,
+	isProofBlock bool,
 ) (*tmstate.ABCIResponses, error) {
 	var validTxs, invalidTxs = 0, 0
 
@@ -309,6 +310,7 @@ func execBlockOnProxyApp(
 		Header:              *pbh,
 		LastCommitInfo:      commitInfo,
 		ByzantineValidators: byzVals,
+		IsProofBlock:        isProofBlock,
 	})
 	if err != nil {
 		logger.Error("error in proxyAppConn.BeginBlock", "err", err)
@@ -534,7 +536,7 @@ func ExecCommitBlock(
 	store Store,
 	initialHeight int64,
 ) ([]byte, error) {
-	_, err := execBlockOnProxyApp(logger, appConnConsensus, block, store, initialHeight)
+	_, err := execBlockOnProxyApp(logger, appConnConsensus, block, store, initialHeight, false)
 	if err != nil {
 		logger.Error("failed executing block on proxy app", "height", block.Height, "err", err)
 		return nil, err

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -51,7 +51,7 @@ func TestApplyBlock(t *testing.T) {
 	block := makeBlock(state, 1)
 	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 
-	state, retainHeight, err := blockExec.ApplyBlock(state, blockID, block)
+	state, retainHeight, err := blockExec.ApplyBlock(state, blockID, block, false)
 	require.Nil(t, err)
 	assert.EqualValues(t, retainHeight, 1)
 
@@ -212,7 +212,7 @@ func TestBeginBlockByzantineValidators(t *testing.T) {
 	block.Header.EvidenceHash = block.Evidence.Hash()
 	blockID = types.BlockID{Hash: block.Hash(), PartSetHeader: block.MakePartSet(testPartSize).Header()}
 
-	state, retainHeight, err := blockExec.ApplyBlock(state, blockID, block)
+	state, retainHeight, err := blockExec.ApplyBlock(state, blockID, block, false)
 	require.Nil(t, err)
 	assert.EqualValues(t, retainHeight, 1)
 
@@ -396,7 +396,7 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 		{PubKey: pk, Power: 10},
 	}
 
-	state, _, err = blockExec.ApplyBlock(state, blockID, block)
+	state, _, err = blockExec.ApplyBlock(state, blockID, block, false)
 	require.Nil(t, err)
 	// test new validator was added to NextValidators
 	if assert.Equal(t, state.Validators.Size()+1, state.NextValidators.Size()) {
@@ -454,7 +454,7 @@ func TestEndBlockValidatorUpdatesResultingInEmptySet(t *testing.T) {
 		{PubKey: vp, Power: 0},
 	}
 
-	assert.NotPanics(t, func() { state, _, err = blockExec.ApplyBlock(state, blockID, block) })
+	assert.NotPanics(t, func() { state, _, err = blockExec.ApplyBlock(state, blockID, block, false) })
 	assert.NotNil(t, err)
 	assert.NotEmpty(t, state.NextValidators.Validators)
 }

--- a/state/helpers_test.go
+++ b/state/helpers_test.go
@@ -60,7 +60,7 @@ func makeAndApplyGoodBlock(state sm.State, height int64, lastCommit *types.Commi
 	}
 	blockID := types.BlockID{Hash: block.Hash(),
 		PartSetHeader: types.PartSetHeader{Total: 3, Hash: tmrand.Bytes(32)}}
-	state, _, err := blockExec.ApplyBlock(state, blockID, block)
+	state, _, err := blockExec.ApplyBlock(state, blockID, block, false)
 	if err != nil {
 		return state, types.BlockID{}, err
 	}

--- a/test/maverick/consensus/replay.go
+++ b/test/maverick/consensus/replay.go
@@ -501,7 +501,7 @@ func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.Ap
 	blockExec.SetEventBus(h.eventBus)
 
 	var err error
-	state, _, err = blockExec.ApplyBlock(state, meta.BlockID, block)
+	state, _, err = blockExec.ApplyBlock(state, meta.BlockID, block, false)
 	if err != nil {
 		return sm.State{}, err
 	}

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -1532,7 +1532,7 @@ func (cs *State) finalizeCommit(height int64) {
 	stateCopy, retainHeight, err = cs.blockExec.ApplyBlock(
 		stateCopy,
 		types.BlockID{Hash: block.Hash(), PartSetHeader: blockParts.Header()},
-		block)
+		block, false)
 	if err != nil {
 		cs.Logger.Error("Error on ApplyBlock", "err", err)
 		return


### PR DESCRIPTION
## Description

Closes: [cosmos-sdk#10240](https://github.com/cosmos/cosmos-sdk/issues/10240)

This PR extends `abci.RequestBeginBlock` with `IsProofBlock`, used when `create_empty_blocks=false`.

Main changes in:
- `consensus/state.go`
- `proto/tendermint/abci/types.proto`

The `IsProofBlock` flag is used by modules in `BeginBlocker`s to avoid write ops for those blocks. "Proof blocks" happen when:
- no txs in the mempool
- current apphash differs form the prev block's apphash
- empty blocks should NOT be created

"Proof block" is currently defined in `tendermint/consensus/state.go:1041`:
https://github.com/tendermint/tendermint/blob/35581cf54ec436b8c37fabb43fdaa3f48339a170/consensus/state.go#L1039-L1049
and used for `create_empty_blocks` in `enterNewRound`:
https://github.com/tendermint/tendermint/blob/35581cf54ec436b8c37fabb43fdaa3f48339a170/consensus/state.go#L1028-L1035

### Related links
- [PR for Cosmos SDK](https://github.com/cosmos/cosmos-sdk/pull/15148)
- [Ticket 10240](https://github.com/cosmos/cosmos-sdk/issues/10240)
- [Ticket 12356](https://github.com/cosmos/cosmos-sdk/issues/12356)

### TODO
- [ ] regression test
