### PR TITLE
fix: goroutines leak when subscribe tm events

### DIFF
--- a/libs/pubsub/query/query.peg.go
+++ b/libs/pubsub/query/query.peg.go
@@ -320,7 +320,7 @@ func (t *tokens32) Add(rule pegRule, begin, end, depth uint32, index int) {
 }
 
 func (t *tokens32) Tokens() <-chan token32 {
-	s := make(chan token32, 16)
+	s := make(chan token32, len(t.tree))
 	go func() {
 		for _, v := range t.tree {
 			s <- v.getToken32()


### PR DESCRIPTION
When client submit a query event in tendermint websocket that parsed to more than 16 tokens, it will cause tendermint to leak goroutines -> crash due to out of memory.

For examples:
`❯ wscat --connect ws://0.0.0.0:26657/websocket

Connected (press CTRL+C to quit)
> { "jsonrpc": "2.0", "method": "subscribe", "id": 0, "params": { "query": "tm.event='NewBlock' AND tm.event='NewBlock' AND tm.event='NewBlock' AND tm.event='NewBlock'" } }`

pprof:
goroutine profile: total 3227
3172 @ 0x104c60514 0x104c2a59c 0x104c2a148 0x10529c9d4 0x104c91974
#	0x10529c9d3	github.com/tendermint/tendermint/libs/pubsub/query.(*tokens32).Tokens.func1+0xa3

The reason is Tokens() return a channel, but consumer of that function might not consume all return value of, that will cause goroutine to hang forever

My quickfix is make channel size equal number token parsed by parser, so that channel will always be closed.
