### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/introduction/quick-start.md
+++ b/docs/introduction/quick-start.md
@@ -59,7 +59,7 @@ Configuring a cluster is covered further below.
 Start Tendermint with a simple in-process application:
 
 ```sh
-tendermint node --proxy_app=kvstore
+tendermint start --proxy_app=kvstore
 ```
 
 > Note: `kvstore` is a non persistent app, if you would like to run an application with persistence run `--proxy_app=persistent_kvstore`


### PR DESCRIPTION
## Invalid subcommand

`tendermit node` is invalid and `tendermint start` should be correct

