### PR TITLE
Update what-is-tendermint.md. Mistake on EVM supported languages.

### DIFF
--- a/docs/introduction/what-is-tendermint.md
+++ b/docs/introduction/what-is-tendermint.md
@@ -144,7 +144,7 @@ Another problem with monolithic design is that it limits you to the
 language of the blockchain stack (or vice versa). In the case of
 Ethereum which supports a Turing-complete bytecode virtual-machine, it
 limits you to languages that compile down to that bytecode; today, those
-are Serpent and Solidity.
+are Vyper and Solidity.
 
 In contrast, our approach is to decouple the consensus engine and P2P
 layers from the details of the application state of the particular


### PR DESCRIPTION

## Description

Correction about language support in Ethereum Virtual Machine.

Changed Serpent and Solidity to Vyper and Solidity.


Closes: #XXX

