### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -766,7 +767,7 @@ func (sw *Switch) addOutboundPeerWithConfig(
 	// XXX(xla): Remove the leakage of test concerns in implementation.
 	if cfg.TestDialFail {
 		go sw.reconnectToPeer(addr)
-		return fmt.Errorf("dial err (peerConfig.DialFail == true)")
+		return errors.New("dial err (peerConfig.DialFail == true)")
 	}
 
 	p, err := sw.transport.Dial(*addr, peerConfig{

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -18,7 +18,7 @@ func NetInfo(ctx *rpctypes.Context) (*ctypes.ResultNetInfo, error) {
 	for _, peer := range peersList {
 		nodeInfo, ok := peer.NodeInfo().(p2p.DefaultNodeInfo)
 		if !ok {
-			return nil, fmt.Errorf("peer.NodeInfo() is not DefaultNodeInfo")
+			return nil, errors.New("peer.NodeInfo() is not DefaultNodeInfo")
 		}
 		peers = append(peers, ctypes.Peer{
 			NodeInfo:         nodeInfo,


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters