### PR TITLE
Fix Typographical Errors and Improve Documentation Consistency

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,7 +32,7 @@ This code of conduct applies to all projects run by the Tendermint/COSMOS team a
 
 # Moderation
 
-These are the policies for upholding our community’s standards of conduct. If you feel that a thread needs moderation, please contact the above mentioned person.
+These are the policies for upholding our community’s standards of conduct. If you feel that a thread needs moderation, please contact the above-mentioned person.
 
 1. Remarks that violate the Tendermint/COSMOS standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,7 +283,7 @@ Minor releases are done differently from major releases: They are built off of l
 
 1. start from the existing release branch you want to backport changes to (e.g. v0.30)
    Branch to a release/vX.X.X branch locally (e.g. release/v0.30.7)
-2. Cherry pick the commit(s) that contain the changes you want to backport (usually these commits are from squash-merged PRs which were already reviewed)
+2. Cherry-pick the commit(s) that contain the changes you want to backport (usually these commits are from squash-merged PRs which were already reviewed)
 3. Follow steps 2 and 3 from [Major Release](#major-release)
 4. Push changes to release/vX.X.X branch
 5. Open a PR against the existing vX.X branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,7 +276,7 @@ Minor releases are done differently from major releases: They are built off of l
 6. Create a pull request back to master with the CHANGELOG & version changes from the latest release.
    - Remove all `R:minor` labels from the pull requests that were included in the release.
    - Do not merge the release branch into master.
-7. Delete the former long lived release candidate branch once the release has been made.
+7. Delete the former long-lived release candidate branch once the release has been made.
 8. Create a new release candidate branch to be used for the next release.
 
 #### Backport Release

--- a/docs/introduction/quick-start.md
+++ b/docs/introduction/quick-start.md
@@ -62,7 +62,7 @@ Start Tendermint with a simple in-process application:
 tendermint node --proxy_app=kvstore
 ```
 
-> Note: `kvstore` is a non persistent app, if you would like to run an application with persistence run `--proxy_app=persistent_kvstore`
+> Note: `kvstore` is a non-persistent app, if you would like to run an application with persistence run `--proxy_app=persistent_kvstore`
 
 and blocks will start to stream in:
 

--- a/docs/introduction/what-is-tendermint.md
+++ b/docs/introduction/what-is-tendermint.md
@@ -79,7 +79,7 @@ Tendermint is in essence similar software, but with two key differences:
 Tendermint emerged in the tradition of cryptocurrencies like Bitcoin,
 Ethereum, etc. with the goal of providing a more efficient and secure
 consensus algorithm than Bitcoin's Proof of Work. In the early days,
-Tendermint had a simple currency built in, and to participate in
+Tendermint had a simple currency built-in, and to participate in
 consensus, users had to "bond" units of the currency into a security
 deposit which could be revoked if they misbehaved -this is what made
 Tendermint a Proof-of-Stake algorithm.


### PR DESCRIPTION
This pull request addresses various typographical errors across several documentation files and improves the consistency of hyphenated terms. The changes include:

1. **CODE_OF_CONDUCT.md**: Fixed the hyphenation in "above-mentioned".
2. **CONTRIBUTING.md**: Corrected "long lived" to "long-lived" and "Cherry pick" to "Cherry-pick".
3. **quick-start.md**: Fixed "non persistent" to "non-persistent".
4. **what-is-tendermint.md**: Corrected "built in" to "built-in".

### Files Changed:
- `CODE_OF_CONDUCT.md`
- `CONTRIBUTING.md`
- `docs/introduction/quick-start.md`
- `docs/introduction/what-is-tendermint.md`

These changes ensure proper spelling and hyphenation for improved readability and documentation standards.
