### PR TITLE
Fix broken documentation links

### DIFF
--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -99,4 +99,4 @@ configuration file that we can update with PRs.
 Because the build processes are identical (as is the information contained
 herein), this file should be kept in sync as much as possible with its
 [counterpart in the Cosmos SDK
-repo](https://github.com/cosmos/cosmos-sdk/blob/master/docs/DOCS_README.md).
+repo](https://github.com/cosmos/cosmos-sdk/blob/main/docs/spec/_ics/README.md).

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -7,5 +7,5 @@ Docs:
 - [Connection](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/connection.md) for details on how connections and multiplexing work
 - [Peer](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/node.md) for details on peer ID, handshakes, and peer exchange
 - [Node](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/node.md) for details about different types of nodes and how they should work
-- [Pex](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/reactors/pex/pex.md) for details on peer discovery and exchange
+- [Pex](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/messages/pex.md) for details on peer discovery and exchange
 - [Config](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/config.md) for details on some config option

--- a/spec/p2p/node.md
+++ b/spec/p2p/node.md
@@ -12,7 +12,7 @@ Seeds should operate full nodes with the PEX reactor in a "crawler" mode
 that continuously explores to validate the availability of peers.
 
 Seeds should only respond with some top percentile of the best peers it knows about.
-See [the peer-exchange docs](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/reactors/pex/pex.md) for
+See [the peer-exchange docs](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/messages/pex.md) for
  details on peer quality.
 
 ## New Full Node

--- a/spec/p2p/peer.md
+++ b/spec/p2p/peer.md
@@ -2,7 +2,7 @@
 
 This document explains how Tendermint Peers are identified and how they connect to one another.
 
-For details on peer discovery, see the [peer exchange (PEX) reactor doc](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/reactors/pex/pex.md).
+For details on peer discovery, see the [peer exchange (PEX) reactor doc](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/peer.md).
 
 ## Peer Identity
 


### PR DESCRIPTION
Fix broken documentation links
  - Replaced `https://github.com/cosmos/cosmos-sdk/blob/master/docs/DOCS_README.md`
   with `https://github.com/cosmos/cosmos-sdk/blob/main/docs/spec/_ics/README.md`.
   
  - Replaced `https://github.com/tendermint/tendermint/blob/v0.34.x/spec/reactors/pex/pex.md` 
  with `https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/messages/pex.md`.
  
    - Replaced `https://github.com/tendermint/tendermint/blob/v0.34.x/spec/reactors/pex/pex.md`
   with `https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/messages/pex.md`.
   
  - Replaced `https://github.com/tendermint/tendermint/blob/v0.34.x/spec/reactors/pex/pex.md` 
  with `https://github.com/tendermint/tendermint/blob/v0.34.x/spec/p2p/peer.md`.