### PR TITLE
Prioritize IPv4 addresses in DNS resolution

### DIFF
--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -98,7 +98,17 @@ func NewNetAddressString(addr string) (*NetAddress, error) {
 		if err != nil {
 			return nil, ErrNetAddressLookup{host, err}
 		}
-		ip = ips[0]
+		// Prefer IPv4 addresses
+		for _, addr := range ips {
+			if addr.To4() != nil {
+				ip = addr
+				break
+			}
+		}
+		// If no IPv4 found, use the first available address
+		if ip == nil && len(ips) > 0 {
+			ip = ips[0]
+		}
 	}
 
 	port, err := strconv.ParseUint(portStr, 10, 16)


### PR DESCRIPTION
Improve network connectivity by preferring IPv4 addresses during DNS lookup in NewNetAddressString function. This change helps prevent connection issues in environments with limited IPv6 support while maintaining fallback to IPv6 when needed.