### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/consensus/wal_test.go
+++ b/consensus/wal_test.go
@@ -3,7 +3,6 @@ package consensus
 import (
 	"bytes"
 	"crypto/rand"
-	"os"
 	"path/filepath"
 
 	// "sync"
@@ -26,9 +25,7 @@ const (
 )
 
 func TestWALTruncate(t *testing.T) {
-	walDir, err := os.MkdirTemp("", "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	walFile := filepath.Join(walDir, "wal")
 
@@ -108,9 +105,8 @@ func TestWALEncoderDecoder(t *testing.T) {
 }
 
 func TestWALWrite(t *testing.T) {
-	walDir, err := os.MkdirTemp("", "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
+
 	walFile := filepath.Join(walDir, "wal")
 
 	wal, err := NewWAL(walFile)
@@ -176,9 +172,7 @@ func TestWALSearchForEndHeight(t *testing.T) {
 }
 
 func TestWALPeriodicSync(t *testing.T) {
-	walDir, err := os.MkdirTemp("", "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	walFile := filepath.Join(walDir, "wal")
 	wal, err := NewWAL(walFile, autofile.GroupCheckDuration(1*time.Millisecond))

--- a/statesync/chunks_test.go
+++ b/statesync/chunks_test.go
@@ -35,9 +35,7 @@ func TestNewChunkQueue_TempDir(t *testing.T) {
 		Hash:     []byte{7},
 		Metadata: nil,
 	}
-	dir, err := os.MkdirTemp("", "newchunkqueue")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	queue, err := newChunkQueue(snapshot, dir)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

TempDir returns a temporary directory for the test to use.The directory is automatically removed when the test and
all its subtests complete. More info  https://pkg.go.dev/testing#B.TempDir


Closes: #XXX

