### PR TITLE
Fix Typos in Comments and Improve Print Message Formatting

### DIFF
--- a/abci/types/application.go
+++ b/abci/types/application.go
@@ -28,7 +28,7 @@ type Application interface {
 	ListSnapshots(RequestListSnapshots) ResponseListSnapshots                // List available snapshots
 	OfferSnapshot(RequestOfferSnapshot) ResponseOfferSnapshot                // Offer a snapshot to the application
 	LoadSnapshotChunk(RequestLoadSnapshotChunk) ResponseLoadSnapshotChunk    // Load a snapshot chunk
-	ApplySnapshotChunk(RequestApplySnapshotChunk) ResponseApplySnapshotChunk // Apply a shapshot chunk
+	ApplySnapshotChunk(RequestApplySnapshotChunk) ResponseApplySnapshotChunk // Apply a snapshot chunk
 }
 
 //-------------------------------------------------------

--- a/abci/types/types.pb.go
+++ b/abci/types/types.pb.go
@@ -1970,7 +1970,7 @@ type ResponseCheckTx struct {
 	Sender    string  `protobuf:"bytes,9,opt,name=sender,proto3" json:"sender,omitempty"`
 	Priority  int64   `protobuf:"varint,10,opt,name=priority,proto3" json:"priority,omitempty"`
 	// mempool_error is set by Tendermint.
-	// ABCI applictions creating a ResponseCheckTX should not set mempool_error.
+	// ABCI applications creating a ResponseCheckTX should not set mempool_error.
 	MempoolError string `protobuf:"bytes,11,opt,name=mempool_error,json=mempoolError,proto3" json:"mempool_error,omitempty"`
 }
 

--- a/test/maverick/consensus/replay_file.go
+++ b/test/maverick/consensus/replay_file.go
@@ -145,7 +145,7 @@ func (pb *playback) replayReset(count int, newStepSub types.Subscription) error 
 	pb.fp = fp
 	pb.dec = NewWALDecoder(fp)
 	count = pb.count - count
-	fmt.Printf("Reseting from %d to %d\n", pb.count, count)
+	fmt.Printf("Resetting from %d to %d\n", pb.count, count)
 	pb.count = 0
 	pb.cs = newCS
 	var msg *tmcon.TimedWALMessage


### PR DESCRIPTION

---

**Description:**  
This pull request addresses minor issues in the codebase:
- Corrects typos in comments and variable names (e.g., "applctions" → "applications", "shapshot" → "snapshot").
- Improves the clarity of a print statement in the replay logic.


---

