### PR TITLE
fix: add runtime.Gosched() between mutex unlock/lock in block part handler

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"runtime/debug"
 	"sort"
 	"sync"
@@ -150,7 +151,7 @@ type State struct {
 	internalMsgQueue chan msgInfo
 	timeoutTicker    TimeoutTicker
 
-	// information about about added votes and block parts are written on this channel
+	// information about added votes and block parts are written on this channel
 	// so statistics can be computed by reactor
 	statsMsgQueue chan msgInfo
 
@@ -1023,7 +1024,7 @@ func (cs *State) handleMsg(ctx context.Context, mi msgInfo) {
 		// RoundState with the updated copy or by emitting RoundState events in
 		// more places for routines depending on it to listen for.
 		cs.mtx.Unlock()
-
+		runtime.Gosched()
 		cs.mtx.Lock()
 		if added && cs.ProposalBlockParts.IsComplete() {
 			cs.handleCompleteProposal(ctx, msg.Height)


### PR DESCRIPTION
## Description

The handleMsg() function in consensus/state.go unlocks and immediately re-locks cs.mtx to allow other goroutines to read the updated RoundState. However, without an explicit runtime.Gosched(), the Go scheduler may immediately re-acquire the lock in the same goroutine, defeating the purpose of the yield window.

## Changes

- Added runtime.Gosched() between cs.mtx.Unlock() and cs.mtx.Lock() to explicitly yield the CPU
- Fixed duplicate word typo in comment above statsMsgQueue

## Testing

- Existing consensus tests continue to pass
- The change is consistent with the documented intent of the unlock/lock pattern

Replaces #10198 (auto-closed as stale).